### PR TITLE
[tpu-inference] Drive attention masks from metadata

### DIFF
--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -23,7 +23,8 @@ from jax.sharding import Mesh
 from tpu_inference.layers.common.attention_interface import (
     attention, mla_attention, sharded_ragged_paged_attention)
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, SharedAttentionMetadata)
+    AttentionMaskKind, AttentionMaskSpec, AttentionMetadata,
+    SharedAttentionMetadata)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.runner.kv_cache import get_kv_cache_shape_with_mesh
 
@@ -62,7 +63,11 @@ def mesh():
 # ---- Test for `attention` ----
 
 
-def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
+def _test_attention(monkeypatch,
+                    mesh,
+                    head_dim,
+                    use_sinks=False,
+                    attention_mask_spec=None):
     """
     Tests the main `attention` function.
 
@@ -106,6 +111,9 @@ def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
         )
 
     # Create AttentionMetadata
+    metadata_kwargs = {}
+    if attention_mask_spec is not None:
+        metadata_kwargs["attention_mask_spec"] = attention_mask_spec
     attention_metadata = AttentionMetadata(
         input_positions=jnp.arange(TOTAL_TOKENS, dtype=jnp.int32),
         block_tables=jnp.zeros((MAX_NUM_SEQS * MAX_BLOCKS_PER_SEQ, ),
@@ -113,6 +121,7 @@ def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
         seq_lens=jnp.array([5, 5, 0, 0], dtype=jnp.int32),
         query_start_loc=jnp.array([0, 5, 10, 10, 10], dtype=jnp.int32),
         request_distribution=jnp.array([0, 0, NUM_SEQS], dtype=jnp.int32),
+        **metadata_kwargs,
     )
     shared_attention_metadata = SharedAttentionMetadata(
         input_positions=jnp.arange(TOTAL_TOKENS, dtype=jnp.int32),
@@ -137,6 +146,11 @@ def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
     # 3. Assert
     # Check that both mocked kernels were called
     mock_paged_attn_kernel.assert_called_once()
+    expected_causal = (attention_mask_spec is None
+                       or attention_mask_spec.kind is AttentionMaskKind.CAUSAL)
+    if head_dim != 64:
+        assert mock_paged_attn_kernel.call_args.kwargs[
+            "use_causal_mask"] is expected_causal
 
     # Check output shapes
     assert final_kv_cache.shape == kv_cache.shape
@@ -156,6 +170,26 @@ def test_attention_hd64(monkeypatch, mesh):
 
 def test_attention_sink(monkeypatch, mesh):
     _test_attention(monkeypatch, mesh, 64, True)
+
+
+def test_attention_bidirectional_from_metadata(monkeypatch, mesh):
+    _test_attention(
+        monkeypatch,
+        mesh,
+        128,
+        attention_mask_spec=AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL),
+    )
+
+
+def test_attention_bidirectional_hd64_fails_loudly(monkeypatch, mesh):
+    with pytest.raises(NotImplementedError, match="head_dim==64"):
+        _test_attention(
+            monkeypatch,
+            mesh,
+            64,
+            attention_mask_spec=AttentionMaskSpec(
+                AttentionMaskKind.BIDIRECTIONAL),
+        )
 
 
 def test_attention_sink_no_64_raises_error(monkeypatch, mesh):

--- a/tests/layers/common/test_attention_mask_spec.py
+++ b/tests/layers/common/test_attention_mask_spec.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+import jax
+import jax.numpy as jnp
+
+
+def _cdiv(numerator, denominator):
+    return (numerator + denominator - 1) // denominator
+
+
+def _load_attention_metadata():
+    module_names = ("vllm", "vllm.utils", "vllm.utils.math_utils")
+    previous_modules = {name: sys.modules.get(name) for name in module_names}
+    math_utils = types.ModuleType("vllm.utils.math_utils")
+    math_utils.cdiv = _cdiv
+    sys.modules["vllm"] = types.ModuleType("vllm")
+    sys.modules["vllm.utils"] = types.ModuleType("vllm.utils")
+    sys.modules["vllm.utils.math_utils"] = math_utils
+    path = (pathlib.Path(__file__).resolve().parents[3] / "tpu_inference" /
+            "layers" / "common" / "attention_metadata.py")
+    spec = importlib.util.spec_from_file_location(
+        "attention_metadata_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for name, previous in previous_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+    return module
+
+
+attention_metadata = _load_attention_metadata()
+AttentionMaskKind = attention_metadata.AttentionMaskKind
+AttentionMaskSpec = attention_metadata.AttentionMaskSpec
+AttentionMetadata = attention_metadata.AttentionMetadata
+resolve_use_causal_mask = attention_metadata.resolve_use_causal_mask
+
+
+def _metadata(mask_spec=None):
+    kwargs = {}
+    if mask_spec is not None:
+        kwargs["attention_mask_spec"] = mask_spec
+    return AttentionMetadata(
+        input_positions=jnp.arange(4, dtype=jnp.int32),
+        block_tables=jnp.zeros((4, ), dtype=jnp.int32),
+        seq_lens=jnp.array([4], dtype=jnp.int32),
+        query_start_loc=jnp.array([0, 4], dtype=jnp.int32),
+        request_distribution=jnp.array([0, 0, 1], dtype=jnp.int32),
+        **kwargs,
+    )
+
+
+def test_attention_mask_defaults_to_causal():
+    assert resolve_use_causal_mask(_metadata()) is True
+
+
+def test_bidirectional_mask_is_explicit_static_metadata():
+    causal = _metadata()
+    bidirectional = _metadata(
+        AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL))
+
+    assert resolve_use_causal_mask(bidirectional) is False
+    assert jax.tree_util.tree_structure(
+        causal) != jax.tree_util.tree_structure(bidirectional)
+
+
+def test_explicit_kernel_override_takes_precedence():
+    bidirectional = _metadata(
+        AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL))
+
+    assert resolve_use_causal_mask(bidirectional, override=True) is True

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -35,7 +35,7 @@ from tpu_inference.kernels.mla.v2.kernel import mla_ragged_paged_attention
 from tpu_inference.kernels.mla.v2.tuned_params import (TuningKey,
                                                        get_tuned_params)
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, SharedAttentionMetadata)
+    AttentionMetadata, SharedAttentionMetadata, resolve_use_causal_mask)
 from tpu_inference.layers.common.cp_attention import dcp_forward, pcp_forward
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
@@ -441,6 +441,11 @@ def sharded_ragged_paged_attention(
             "update_kv_cache=False (KV-share) is not supported on the "
             "head_dim==64 RPA kernel.")
 
+    if use_hd64 and not use_causal_mask:
+        raise NotImplementedError(
+            "Bidirectional attention is not supported on the head_dim==64 "
+            "RPA kernel")
+
     def _ragged_paged_attention(*args):
         kwargs = dict(
             sm_scale=sm_scale,
@@ -482,7 +487,7 @@ def attention(
     v_scale: float | None = None,
     sinks: jax.Array | None = None,
     update_kv_cache: bool = True,
-    use_causal_mask: bool = True,
+    use_causal_mask: bool | None = None,
     shared_attention_metadata: SharedAttentionMetadata | None = None,
     attn_logits_soft_cap: float | None = None,
 ) -> Tuple[jax.Array, jax.Array]:
@@ -505,10 +510,14 @@ def attention(
         sm_scale = head_dim_original**-0.5
 
     md = attention_metadata
+    use_causal_mask = resolve_use_causal_mask(md, use_causal_mask)
     # shared_attention_metadata is None for flax models, and is used for vllm models to share the metadata across layers.
     shared_md = shared_attention_metadata if shared_attention_metadata is not None else md
 
     if 'dcp' in mesh.shape and mesh.shape['dcp'] > 1:
+        if not use_causal_mask:
+            raise NotImplementedError(
+                "Bidirectional attention is not supported with DCP")
         return dcp_forward(
             mesh,
             q,

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -15,9 +15,36 @@
 import functools
 import math
 from dataclasses import dataclass
+from enum import Enum
 
 import jax
 from vllm.utils.math_utils import cdiv
+
+
+class AttentionMaskKind(str, Enum):
+    CAUSAL = "causal"
+    BIDIRECTIONAL = "bidirectional"
+
+
+@dataclass(frozen=True)
+class AttentionMaskSpec:
+    kind: AttentionMaskKind = AttentionMaskKind.CAUSAL
+
+    @property
+    def use_causal_mask(self) -> bool:
+        return self.kind is AttentionMaskKind.CAUSAL
+
+
+CAUSAL_ATTENTION_MASK = AttentionMaskSpec()
+
+
+def resolve_use_causal_mask(
+    attention_metadata: "AttentionMetadata",
+    override: bool | None = None,
+) -> bool:
+    if override is not None:
+        return override
+    return attention_metadata.attention_mask_spec.use_causal_mask
 
 
 @functools.partial(
@@ -57,7 +84,11 @@ class PCPMetadata:
         "mamba_state_indices",
         "pcp",
     ],
-    meta_fields=["padded_num_reqs", "pcp_cache_pages"],
+    meta_fields=[
+        "padded_num_reqs",
+        "pcp_cache_pages",
+        "attention_mask_spec",
+    ],
 )
 @dataclass
 class AttentionMetadata(object):
@@ -93,6 +124,8 @@ class AttentionMetadata(object):
 
     # PCP gather-KV only. Number of kv pages occupied by the current request.
     pcp_cache_pages: int | None = None
+
+    attention_mask_spec: AttentionMaskSpec = CAUSAL_ATTENTION_MASK
 
 
 @functools.partial(

--- a/tpu_inference/layers/jax/attention/attention.py
+++ b/tpu_inference/layers/jax/attention/attention.py
@@ -26,7 +26,8 @@ from jax.sharding import PartitionSpec as P
 from tpu_inference import envs, utils
 from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
     ragged_paged_attention
-from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.common.attention_metadata import (
+    AttentionMetadata, resolve_use_causal_mask)
 from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.base import create_param
@@ -272,6 +273,7 @@ class Attention(nnx.Module):
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                use_causal_mask=resolve_use_causal_mask(attention_metadata),
                 **block_size_kwargs,
             )
 


### PR DESCRIPTION
## Motivation

Block diffusion needs masking policy to travel with attention metadata instead of being hard-coded at individual attention call sites.

## Scope

- Add a static causal-mask flag to the existing attention metadata.
- Resolve masking from metadata while retaining an explicit caller override.
- Reject bidirectional masking on attention paths that cannot implement it correctly.

## Design

`use_causal_mask` is static pytree metadata and defaults to `True`. The common attention entry point uses an explicit caller override when present; otherwise it passes the metadata value to the selected implementation.

## Compatibility

Autoregressive behavior is unchanged because newly constructed metadata is causal by default. Existing callers that pass `use_causal_mask` explicitly retain precedence.

## Tests

- Relevant CPU tests passed.
- Stack checks passed: `isort`, `yapf`, `ruff`, `py_compile`, and `git diff --check`.

## Known limitations

Bidirectional attention is not supported with DCP or the `head_dim == 64` RPA path; those combinations fail early.

## Stack

- Depends on merged upstream PR https://github.com/vllm-project/tpu-inference/pull/3242, which is now included in `main`.
- [Public design document](https://docs.google.com/document/d/1d3qtGrvdcJ0ptluE0EwAaGj4AQyOlIYkYvKo9xPguX8/edit)
