### PR TITLE
[tpu-inference] Generalize multi-token scheduler accounting

### DIFF
--- a/tests/core/test_multi_token_scheduler.py
+++ b/tests/core/test_multi_token_scheduler.py
@@ -1,0 +1,205 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+from types import SimpleNamespace
+
+
+def _load_utils_with_fake_vllm(monkeypatch):
+
+    class Scheduler:
+
+        def __init__(self, vllm_config):
+            del vllm_config
+            self.num_lookahead_tokens = 2
+
+        def _update_request_with_output(self,
+                                        request,
+                                        new_token_ids,
+                                        is_stale=False,
+                                        **kwargs):
+            del is_stale, kwargs
+            retained = list(new_token_ids[:request.retain_tokens])
+            request.output_token_ids.extend(retained)
+            return retained, len(retained) != len(new_token_ids)
+
+    class AsyncScheduler:
+
+        def _update_request_with_output(self,
+                                        request,
+                                        new_token_ids,
+                                        is_stale=False,
+                                        **kwargs):
+            del kwargs
+            if is_stale:
+                return list(new_token_ids), False
+            request.num_output_placeholders -= len(new_token_ids)
+            return list(new_token_ids), False
+
+    modules = {
+        "vllm":
+        types.ModuleType("vllm"),
+        "vllm.v1":
+        types.ModuleType("vllm.v1"),
+        "vllm.v1.core":
+        types.ModuleType("vllm.v1.core"),
+        "vllm.v1.core.sched":
+        types.ModuleType("vllm.v1.core.sched"),
+        "vllm.v1.core.sched.scheduler":
+        types.ModuleType("vllm.v1.core.sched.scheduler"),
+        "vllm.v1.core.sched.async_scheduler":
+        types.ModuleType("vllm.v1.core.sched.async_scheduler"),
+    }
+    modules["vllm.v1.core.sched.scheduler"].Scheduler = Scheduler
+    modules[
+        "vllm.v1.core.sched.async_scheduler"].AsyncScheduler = AsyncScheduler
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    path = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+            "core" / "sched" / "utils.py")
+    spec = importlib.util.spec_from_file_location("scheduler_utils_under_test",
+                                                  path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module, Scheduler, AsyncScheduler
+
+
+def test_continue_decode_lookahead_is_preserved(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_continue_decode()
+
+    scheduler = Scheduler(
+        SimpleNamespace(additional_config={
+            "enable_continue_decode": True,
+            "max_decode_steps": 10,
+        }))
+
+    assert scheduler.num_lookahead_tokens == 9
+
+
+def test_explicit_multi_token_lookahead_takes_precedence(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+
+    scheduler = Scheduler(
+        SimpleNamespace(
+            additional_config={
+                "enable_continue_decode": True,
+                utils.MULTI_TOKEN_LOOKAHEAD_CONFIG: 31,
+            }))
+
+    assert scheduler.num_lookahead_tokens == 31
+
+
+def test_output_accounting_uses_tokens_retained_after_eos(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = Scheduler(
+        SimpleNamespace(additional_config={
+            utils.MULTI_TOKEN_LOOKAHEAD_CONFIG: 3,
+        }))
+    request = SimpleNamespace(
+        retain_tokens=2,
+        output_token_ids=[],
+        num_computed_tokens=1,
+    )
+
+    retained, stopped = scheduler._update_request_with_output(
+        request, [10, 11, 12, 13])
+
+    assert retained == [10, 11]
+    assert stopped is True
+    assert request.num_computed_tokens == 2
+
+
+def test_stale_output_does_not_advance_computed_tokens(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = Scheduler(
+        SimpleNamespace(additional_config={
+            utils.MULTI_TOKEN_LOOKAHEAD_CONFIG: 3,
+        }))
+    request = SimpleNamespace(
+        retain_tokens=3,
+        output_token_ids=[],
+        num_computed_tokens=1,
+    )
+
+    scheduler._update_request_with_output(request, [10, 11, 12], is_stale=True)
+
+    assert request.num_computed_tokens == 1
+
+
+def test_async_placeholder_accounting_consumes_one_scheduled_step(monkeypatch):
+    utils, _, AsyncScheduler = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = AsyncScheduler()
+    scheduler._multi_token_decode_enabled = True
+    request = SimpleNamespace(num_output_placeholders=1)
+
+    scheduler._update_request_with_output(request, [10, 11, 12, 13])
+
+    assert request.num_output_placeholders == 0
+
+
+def test_stale_async_output_does_not_change_placeholders(monkeypatch):
+    utils, _, AsyncScheduler = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = AsyncScheduler()
+    scheduler._multi_token_decode_enabled = True
+    request = SimpleNamespace(num_output_placeholders=0)
+
+    scheduler._update_request_with_output(request, [10, 11, 12], is_stale=True)
+
+    assert request.num_output_placeholders == 0
+    assert scheduler._cd_stale_in_flight is False
+
+
+def test_normal_scheduler_is_unchanged_after_class_patch(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = Scheduler(SimpleNamespace(additional_config={}))
+    request = SimpleNamespace(
+        retain_tokens=3,
+        output_token_ids=[],
+        num_computed_tokens=1,
+    )
+
+    scheduler._update_request_with_output(request, [1, 2, 3])
+
+    assert request.num_computed_tokens == 1
+
+
+def test_patch_is_idempotent(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    utils.patch_vllm_scheduler_for_continue_decode()
+    scheduler = Scheduler(
+        SimpleNamespace(additional_config={
+            "enable_continue_decode": True,
+        }))
+    request = SimpleNamespace(
+        retain_tokens=3,
+        output_token_ids=[],
+        num_computed_tokens=1,
+    )
+
+    scheduler._update_request_with_output(request, [1, 2, 3])
+
+    assert request.num_computed_tokens == 3

--- a/tests/core/test_sched_utils.py
+++ b/tests/core/test_sched_utils.py
@@ -36,8 +36,12 @@ def restore_scheduler_patch():
     (Scheduler._update_request_with_output, Scheduler.__init__,
      AsyncScheduler._update_request_with_output) = originals
     for cls in (Scheduler, AsyncScheduler):
-        if "_continue_decode_patched" in cls.__dict__:
-            del cls._continue_decode_patched
+        for attribute in (
+                "_continue_decode_patched",
+                "_multi_token_decode_patched",
+        ):
+            if attribute in cls.__dict__:
+                delattr(cls, attribute)
 
 
 def _make_request(num_computed_tokens=10, num_output_placeholders=1):
@@ -54,6 +58,7 @@ def _make_scheduler(cls):
     # Instance attributes read by the base implementation are set explicitly.
     scheduler = mock.MagicMock(spec=cls)
     scheduler.max_model_len = 1024
+    scheduler._multi_token_decode_enabled = True
     return scheduler
 
 

--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -23,7 +23,8 @@ from jax.sharding import Mesh
 from tpu_inference.layers.common.attention_interface import (
     attention, mla_attention, sharded_ragged_paged_attention)
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, SharedAttentionMetadata)
+    AttentionMaskKind, AttentionMaskSpec, AttentionMetadata,
+    SharedAttentionMetadata)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.runner.kv_cache import get_kv_cache_shape_with_mesh
 
@@ -62,7 +63,11 @@ def mesh():
 # ---- Test for `attention` ----
 
 
-def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
+def _test_attention(monkeypatch,
+                    mesh,
+                    head_dim,
+                    use_sinks=False,
+                    attention_mask_spec=None):
     """
     Tests the main `attention` function.
 
@@ -106,6 +111,9 @@ def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
         )
 
     # Create AttentionMetadata
+    metadata_kwargs = {}
+    if attention_mask_spec is not None:
+        metadata_kwargs["attention_mask_spec"] = attention_mask_spec
     attention_metadata = AttentionMetadata(
         input_positions=jnp.arange(TOTAL_TOKENS, dtype=jnp.int32),
         block_tables=jnp.zeros((MAX_NUM_SEQS * MAX_BLOCKS_PER_SEQ, ),
@@ -113,6 +121,7 @@ def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
         seq_lens=jnp.array([5, 5, 0, 0], dtype=jnp.int32),
         query_start_loc=jnp.array([0, 5, 10, 10, 10], dtype=jnp.int32),
         request_distribution=jnp.array([0, 0, NUM_SEQS], dtype=jnp.int32),
+        **metadata_kwargs,
     )
     shared_attention_metadata = SharedAttentionMetadata(
         input_positions=jnp.arange(TOTAL_TOKENS, dtype=jnp.int32),
@@ -137,6 +146,11 @@ def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
     # 3. Assert
     # Check that both mocked kernels were called
     mock_paged_attn_kernel.assert_called_once()
+    expected_causal = (attention_mask_spec is None
+                       or attention_mask_spec.kind is AttentionMaskKind.CAUSAL)
+    if head_dim != 64:
+        assert mock_paged_attn_kernel.call_args.kwargs[
+            "use_causal_mask"] is expected_causal
 
     # Check output shapes
     assert final_kv_cache.shape == kv_cache.shape
@@ -156,6 +170,26 @@ def test_attention_hd64(monkeypatch, mesh):
 
 def test_attention_sink(monkeypatch, mesh):
     _test_attention(monkeypatch, mesh, 64, True)
+
+
+def test_attention_bidirectional_from_metadata(monkeypatch, mesh):
+    _test_attention(
+        monkeypatch,
+        mesh,
+        128,
+        attention_mask_spec=AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL),
+    )
+
+
+def test_attention_bidirectional_hd64_fails_loudly(monkeypatch, mesh):
+    with pytest.raises(NotImplementedError, match="head_dim==64"):
+        _test_attention(
+            monkeypatch,
+            mesh,
+            64,
+            attention_mask_spec=AttentionMaskSpec(
+                AttentionMaskKind.BIDIRECTIONAL),
+        )
 
 
 def test_attention_sink_no_64_raises_error(monkeypatch, mesh):

--- a/tests/layers/common/test_attention_mask_spec.py
+++ b/tests/layers/common/test_attention_mask_spec.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+import jax
+import jax.numpy as jnp
+
+
+def _cdiv(numerator, denominator):
+    return (numerator + denominator - 1) // denominator
+
+
+def _load_attention_metadata():
+    module_names = ("vllm", "vllm.utils", "vllm.utils.math_utils")
+    previous_modules = {name: sys.modules.get(name) for name in module_names}
+    math_utils = types.ModuleType("vllm.utils.math_utils")
+    math_utils.cdiv = _cdiv
+    sys.modules["vllm"] = types.ModuleType("vllm")
+    sys.modules["vllm.utils"] = types.ModuleType("vllm.utils")
+    sys.modules["vllm.utils.math_utils"] = math_utils
+    path = (pathlib.Path(__file__).resolve().parents[3] / "tpu_inference" /
+            "layers" / "common" / "attention_metadata.py")
+    spec = importlib.util.spec_from_file_location(
+        "attention_metadata_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for name, previous in previous_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+    return module
+
+
+attention_metadata = _load_attention_metadata()
+AttentionMaskKind = attention_metadata.AttentionMaskKind
+AttentionMaskSpec = attention_metadata.AttentionMaskSpec
+AttentionMetadata = attention_metadata.AttentionMetadata
+resolve_use_causal_mask = attention_metadata.resolve_use_causal_mask
+
+
+def _metadata(mask_spec=None):
+    kwargs = {}
+    if mask_spec is not None:
+        kwargs["attention_mask_spec"] = mask_spec
+    return AttentionMetadata(
+        input_positions=jnp.arange(4, dtype=jnp.int32),
+        block_tables=jnp.zeros((4, ), dtype=jnp.int32),
+        seq_lens=jnp.array([4], dtype=jnp.int32),
+        query_start_loc=jnp.array([0, 4], dtype=jnp.int32),
+        request_distribution=jnp.array([0, 0, 1], dtype=jnp.int32),
+        **kwargs,
+    )
+
+
+def test_attention_mask_defaults_to_causal():
+    assert resolve_use_causal_mask(_metadata()) is True
+
+
+def test_bidirectional_mask_is_explicit_static_metadata():
+    causal = _metadata()
+    bidirectional = _metadata(
+        AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL))
+
+    assert resolve_use_causal_mask(bidirectional) is False
+    assert jax.tree_util.tree_structure(
+        causal) != jax.tree_util.tree_structure(bidirectional)
+
+
+def test_explicit_kernel_override_takes_precedence():
+    bidirectional = _metadata(
+        AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL))
+
+    assert resolve_use_causal_mask(bidirectional, override=True) is True

--- a/tests/runner/test_diffusion_algorithm.py
+++ b/tests/runner/test_diffusion_algorithm.py
@@ -1,0 +1,375 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+def _load_pure_diffusion_modules():
+    root = pathlib.Path(__file__).resolve().parents[2]
+    module_paths = {
+        "tpu_inference.runner.experimental.diffusion.config":
+        root / "tpu_inference" / "runner" / "experimental" / "diffusion" /
+        "config.py",
+        "tpu_inference.runner.experimental.diffusion.algorithm":
+        root / "tpu_inference" / "runner" / "experimental" / "diffusion" /
+        "algorithm.py",
+        "tpu_inference.runner.experimental.diffusion.program":
+        root / "tpu_inference" / "runner" / "experimental" / "diffusion" /
+        "program.py",
+    }
+    for package in ("tpu_inference", "tpu_inference.runner",
+                    "tpu_inference.runner.experimental",
+                    "tpu_inference.runner.experimental.diffusion"):
+        if package not in sys.modules:
+            module = types.ModuleType(package)
+            module.__path__ = []
+            sys.modules[package] = module
+    loaded = {}
+    for name, path in module_paths.items():
+        spec = importlib.util.spec_from_file_location(name, path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        loaded[name] = module
+    return loaded
+
+
+_MODULES = _load_pure_diffusion_modules()
+_CONFIG = _MODULES["tpu_inference.runner.experimental.diffusion.config"]
+_ALGORITHM = _MODULES["tpu_inference.runner.experimental.diffusion.algorithm"]
+_PROGRAM = _MODULES["tpu_inference.runner.experimental.diffusion.program"]
+
+LogitAlignment = _CONFIG.LogitAlignment
+NextBlockPolicy = _CONFIG.NextBlockPolicy
+low_confidence_commit = _ALGORITHM.low_confidence_commit
+denoise_block = _PROGRAM.denoise_block
+
+
+def _thresholds(batch_size, value=0.9):
+    return jnp.full((batch_size, ), value, dtype=jnp.float32)
+
+
+def _temperatures(batch_size):
+    return jnp.zeros((batch_size, ), dtype=jnp.float32)
+
+
+def test_low_confidence_commit_threshold_and_forced_progress():
+    logits = jnp.array([
+        [[10.0, 0.0, -10.0], [0.1, 0.0, -10.0], [0.0, 0.1, -10.0]],
+        [[0.1, 0.0, -10.0], [0.0, 0.1, -10.0], [10.0, 0.0, -10.0]],
+    ])
+    eligible = jnp.ones((2, 3), dtype=bool)
+
+    tokens, remaining = low_confidence_commit(
+        logits,
+        eligible,
+        jnp.array([True, True]),
+        _thresholds(2),
+        _temperatures(2),
+        2,
+    )
+
+    np.testing.assert_array_equal(tokens, [[0, 0, 1], [0, 1, 0]])
+    assert remaining[0].sum() == 2
+    assert remaining[1].sum() == 2
+
+
+def test_low_confidence_commit_keeps_inactive_rows_unchanged():
+    logits = jnp.ones((2, 3, 4), dtype=jnp.float32)
+    eligible = jnp.ones((2, 3), dtype=bool)
+
+    _, remaining = low_confidence_commit(
+        logits,
+        eligible,
+        jnp.array([True, False]),
+        _thresholds(2),
+        _temperatures(2),
+        3,
+    )
+
+    assert remaining[0].sum() == 2
+    assert remaining[1].sum() == 0
+
+
+def test_mask_token_is_excluded_from_commits_and_next_anchor():
+    mask_token_id = 7
+    target_token_id = 5
+
+    def mask_favoring_forward(model_state, canvas, positions, kv_caches,
+                              active_rows, forward_context):
+        del model_state, positions, active_rows, forward_context
+        logits = jnp.zeros((*canvas.shape, 8), dtype=jnp.float32)
+        logits = logits.at[..., mask_token_id].set(100.0)
+        logits = logits.at[..., target_token_id].set(20.0)
+        return logits, kv_caches
+
+    output = denoise_block(
+        mask_favoring_forward,
+        low_confidence_commit,
+        None,
+        jnp.array([[4, 7, 7, 7]], dtype=jnp.int32),
+        jnp.array([[False, True, True, True]]),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.zeros((1, 4), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=mask_token_id,
+        sub_block_size=4,
+    )
+
+    np.testing.assert_array_equal(output.canvas, [[4, 5, 5, 5]])
+    np.testing.assert_array_equal(output.next_anchor, [target_token_id])
+
+
+def _position_forward(vocab_size):
+
+    def forward(model_state, canvas, positions, _kv_caches, active_rows,
+                forward_context):
+        del model_state, active_rows, forward_context
+        targets = positions % vocab_size
+        logits = jax.nn.one_hot(targets, vocab_size) * 20.0
+        return logits, canvas
+
+    return forward
+
+
+def test_denoise_block_supports_shifted_logits_and_inactive_rows():
+    initial_canvas = jnp.array([[7, 15, 15, 15], [9, 8, 7, 6]],
+                               dtype=jnp.int32)
+    initial_mask = jnp.array([[False, True, True, True],
+                              [False, False, False, False]])
+    positions = jnp.array([[10, 11, 12, 13], [20, 21, 22, 23]],
+                          dtype=jnp.int32)
+
+    output = denoise_block(
+        _position_forward(vocab_size=16),
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        initial_mask,
+        positions,
+        jnp.zeros_like(initial_canvas),
+        jnp.array([True, False]),
+        _thresholds(2),
+        _temperatures(2),
+        None,
+        logit_alignment=LogitAlignment.SHIFTED,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=15,
+        sub_block_size=2,
+    )
+
+    np.testing.assert_array_equal(output.canvas[0], [7, 10, 11, 12])
+    np.testing.assert_array_equal(output.canvas[1], initial_canvas[1])
+    assert int(output.next_anchor[0]) == 13
+    assert int(output.next_anchor[1]) == 0
+
+
+def test_shifted_logits_reject_a_masked_seed_position():
+    with pytest.raises(ValueError, match="position 0.*unmasked seed"):
+        denoise_block(
+            _position_forward(vocab_size=16),
+            low_confidence_commit,
+            None,
+            jnp.full((1, 4), 15, dtype=jnp.int32),
+            jnp.ones((1, 4), dtype=bool),
+            jnp.arange(4, dtype=jnp.int32)[None, :],
+            jnp.zeros((1, 4), dtype=jnp.int32),
+            jnp.array([True]),
+            _thresholds(1),
+            _temperatures(1),
+            None,
+            logit_alignment=LogitAlignment.SHIFTED,
+            next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+            mask_token_id=15,
+            sub_block_size=2,
+        )
+
+
+def test_sub_blocks_are_denoised_in_order():
+    vocab_size = 32
+
+    def dependent_forward(model_state, canvas, positions, _kv_caches,
+                          active_rows, forward_context):
+        del model_state, positions, active_rows, forward_context
+        first_half_committed = jnp.sum(canvas[:, :2], axis=-1) % vocab_size
+        targets = jnp.stack([
+            jnp.full_like(first_half_committed, 2),
+            jnp.full_like(first_half_committed, 3),
+            first_half_committed,
+            first_half_committed,
+        ],
+                            axis=1)
+        logits = jax.nn.one_hot(targets, vocab_size) * 20.0
+        return logits, canvas
+
+    output = denoise_block(
+        dependent_forward,
+        low_confidence_commit,
+        None,
+        jnp.full((1, 4), 31, dtype=jnp.int32),
+        jnp.ones((1, 4), dtype=bool),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.zeros((1, 4), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.ALL_MASKED,
+        mask_token_id=31,
+        sub_block_size=2,
+    )
+
+    np.testing.assert_array_equal(output.canvas[0], [2, 3, 5, 5])
+
+
+def test_final_forward_refreshes_committed_kv_and_next_anchor():
+    vocab_size = 32
+
+    def canvas_dependent_forward(model_state, canvas, positions, _kv_caches,
+                                 active_rows, forward_context):
+        del model_state, positions, active_rows, forward_context
+        base_targets = jnp.array([[1, 2, 3, 4]], dtype=jnp.int32)
+        next_target = jnp.sum(canvas, axis=-1) % vocab_size
+        targets = base_targets.at[:, -1].set(next_target)
+        logits = jax.nn.one_hot(targets, vocab_size) * 20.0
+        return logits, canvas
+
+    output = denoise_block(
+        canvas_dependent_forward,
+        low_confidence_commit,
+        None,
+        jnp.full((1, 4), 31, dtype=jnp.int32),
+        jnp.ones((1, 4), dtype=bool),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.zeros((1, 4), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=31,
+        sub_block_size=4,
+    )
+
+    np.testing.assert_array_equal(output.kv_caches, output.canvas)
+    assert int(output.next_anchor[0]) == int(output.canvas.sum() % vocab_size)
+
+
+def test_step_cap_force_fills_and_final_forward_refreshes_kv():
+
+    initial_canvas = jnp.array([[4, 7, 7, 7]], dtype=jnp.int32)
+
+    def low_confidence_forward(model_state, canvas, positions, kv_caches,
+                               active_rows, forward_context):
+        del model_state, positions, forward_context
+        logits = jnp.zeros((*canvas.shape, 8), dtype=jnp.float32)
+        updated_kv = jnp.where(active_rows[:, None], canvas, kv_caches)
+        return logits, updated_kv
+
+    output = denoise_block(
+        low_confidence_forward,
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        jnp.array([[False, True, True, True]]),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.full((1, 4), -1, dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1, value=0.99),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.ALL_MASKED,
+        mask_token_id=7,
+        sub_block_size=4,
+        max_denoise_steps=1,
+    )
+
+    np.testing.assert_array_equal(output.canvas, [[4, 0, 0, 0]])
+    np.testing.assert_array_equal(output.kv_caches, output.canvas)
+    np.testing.assert_array_equal(output.denoise_steps, [1])
+
+    def next_block_token(cache):
+        logits = jax.nn.one_hot(jnp.sum(cache, axis=-1) % 8, 8)
+        return jnp.argmax(logits, axis=-1)
+
+    # The last three positions were bulk-committed after the only denoise
+    # forward. A stale provisional cache still contains MASK values and changes
+    # the next block prediction; the final forward exposes the committed tokens.
+    np.testing.assert_array_equal(next_block_token(output.kv_caches), [4])
+    np.testing.assert_array_equal(next_block_token(initial_canvas), [1])
+
+
+def test_heterogeneous_rows_preserve_inactive_kv():
+
+    def active_aware_forward(model_state, canvas, positions, kv_caches,
+                             active_rows, forward_context):
+        del model_state, positions, forward_context
+        logits = jnp.zeros((*canvas.shape, 8), dtype=jnp.float32)
+        updated_kv = jnp.where(active_rows[:, None], canvas, kv_caches)
+        return logits, updated_kv
+
+    initial_canvas = jnp.array([
+        [4, 7, 6, 5],
+        [3, 7, 7, 7],
+        [9, 8, 7, 6],
+    ],
+                               dtype=jnp.int32)
+    initial_kv = jnp.array([
+        [90, 91, 92, 93],
+        [80, 81, 82, 83],
+        [70, 71, 72, 73],
+    ],
+                           dtype=jnp.int32)
+    output = denoise_block(
+        active_aware_forward,
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        jnp.array([
+            [False, True, False, False],
+            [False, True, True, True],
+            [True, True, True, True],
+        ]),
+        jnp.broadcast_to(jnp.arange(4, dtype=jnp.int32), (3, 4)),
+        initial_kv,
+        jnp.array([True, True, False]),
+        _thresholds(3, value=0.99),
+        _temperatures(3),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.ALL_MASKED,
+        mask_token_id=7,
+        sub_block_size=4,
+    )
+
+    np.testing.assert_array_equal(output.canvas[2], initial_canvas[2])
+    np.testing.assert_array_equal(output.kv_caches[:2], output.canvas[:2])
+    np.testing.assert_array_equal(output.kv_caches[2], initial_kv[2])
+    np.testing.assert_array_equal(output.denoise_steps, [1, 3, 0])

--- a/tests/runner/test_diffusion_config.py
+++ b/tests/runner/test_diffusion_config.py
@@ -204,3 +204,20 @@ def test_model_spec_rejects_incompatible_sub_block_size():
             sub_block_size=4,
             supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
         )
+
+
+def test_model_spec_rejects_shifted_all_masked_canvas():
+    with pytest.raises(ValueError, match="requires seed_and_mask"):
+        DiffusionModelSpec(
+            name="invalid",
+            block_size=4,
+            mask_token_id=7,
+            attention_policy=AttentionPolicy.BLOCK_CAUSAL,
+            logit_alignment=LogitAlignment.SHIFTED,
+            canvas_policy=CanvasPolicy.ALL_MASKED,
+            prompt_remainder_policy=(
+                PromptRemainderPolicy.REQUIRE_BLOCK_ALIGNED),
+            next_block_policy=NextBlockPolicy.ALL_MASKED,
+            sub_block_size=4,
+            supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
+        )

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -13,17 +13,41 @@
 # limitations under the License.
 
 DEFAULT_MAX_DECODE_STEPS = 10
+MULTI_TOKEN_LOOKAHEAD_CONFIG = "multi_token_decode_lookahead"
 
 
-def patch_vllm_scheduler_for_continue_decode():
-    """Monkeypatches vLLM's Scheduler and AsyncScheduler for Continue Decode.
+def _get_multi_token_lookahead(vllm_config) -> int:
+    additional_config = getattr(vllm_config, "additional_config", {}) or {}
+    if MULTI_TOKEN_LOOKAHEAD_CONFIG in additional_config:
+        lookahead = int(additional_config[MULTI_TOKEN_LOOKAHEAD_CONFIG])
+        if lookahead < 0:
+            raise ValueError(
+                f"{MULTI_TOKEN_LOOKAHEAD_CONFIG} must be non-negative")
+        return lookahead
+    if additional_config.get("enable_continue_decode", False):
+        max_decode_steps = int(
+            additional_config.get("max_decode_steps",
+                                  DEFAULT_MAX_DECODE_STEPS))
+        return max(0, max_decode_steps - 1)
+    return 0
 
-    In Continue Decode, the host schedules 1 step while the TPU runner executes
-    up to max_decode_steps (N) decode iterations on-device in a single step.
+
+def _is_multi_token_decode_enabled(vllm_config) -> bool:
+    additional_config = getattr(vllm_config, "additional_config", {}) or {}
+    return (MULTI_TOKEN_LOOKAHEAD_CONFIG in additional_config
+            or bool(additional_config.get("enable_continue_decode", False)))
+
+
+def patch_vllm_scheduler_for_multi_token_decode() -> None:
+    """Patch vLLM scheduler accounting for multi-token model outputs.
+
+    The host schedules one decode position while the model runner may return N
+    tokens. The patch reserves a configured lookahead and reconciles the N - 1
+    additional tokens after stop-token processing.
 
     This function applies three patches:
-    1. patched_init: Forces KVCacheManager to reserve enough KV cache blocks for
-       all N tokens during schedule() (num_lookahead_tokens = max_decode_steps - 1).
+    1. patched_init: Forces KVCacheManager to reserve the configured lookahead
+       during schedule().
     2. patched_update_base: Reconciles request.num_computed_tokens on host by
        adding the extra (N - 1) tokens generated on-device once model output returns.
     3. patched_async_update_request_with_output: Pre-compensates in-flight
@@ -32,8 +56,7 @@ def patch_vllm_scheduler_for_continue_decode():
     """
     from vllm.v1.core.sched.scheduler import Scheduler
 
-    # Avoid patching multiple times
-    if not getattr(Scheduler, "_continue_decode_patched", False):
+    if not getattr(Scheduler, "_multi_token_decode_patched", False):
         original_update_base = Scheduler._update_request_with_output
 
         def patched_update_base(scheduler_self,
@@ -58,9 +81,10 @@ def patch_vllm_scheduler_for_continue_decode():
             # _cd_stale_in_flight instead — check both.
             stale = is_stale or getattr(scheduler_self, "_cd_stale_in_flight",
                                         False)
-            diff = len(res_token_ids) - 1
-            if diff > 0 and not stale:
-                request.num_computed_tokens += diff
+            if getattr(scheduler_self, "_multi_token_decode_enabled", False):
+                diff = len(res_token_ids) - 1
+                if diff > 0 and not stale:
+                    request.num_computed_tokens += diff
 
             return res_token_ids, stopped
 
@@ -71,19 +95,18 @@ def patch_vllm_scheduler_for_continue_decode():
         def patched_init(scheduler_self, vllm_config, *args, **kwargs):
             original_init(scheduler_self, vllm_config, *args, **kwargs)
 
-            additional_config = getattr(vllm_config, "additional_config", {})
-            max_decode_steps = additional_config.get("max_decode_steps",
-                                                     DEFAULT_MAX_DECODE_STEPS)
-            # Reserve max_decode_steps - 1 lookahead tokens so KVCacheManager allocates
-            # sufficient blocks for up to max_decode_steps tokens before execution on TPU.
+            scheduler_self._multi_token_decode_enabled = \
+                _is_multi_token_decode_enabled(vllm_config)
             scheduler_self.num_lookahead_tokens = max(
-                scheduler_self.num_lookahead_tokens, max_decode_steps - 1)
+                scheduler_self.num_lookahead_tokens,
+                _get_multi_token_lookahead(vllm_config),
+            )
 
         Scheduler.__init__ = patched_init
 
     from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 
-    if not getattr(AsyncScheduler, "_continue_decode_patched", False):
+    if not getattr(AsyncScheduler, "_multi_token_decode_patched", False):
         original_async_update_req = AsyncScheduler._update_request_with_output
 
         def patched_async_update_request_with_output(scheduler_self,
@@ -91,7 +114,8 @@ def patch_vllm_scheduler_for_continue_decode():
                                                      new_token_ids,
                                                      is_stale=False,
                                                      **kwargs):
-            if len(new_token_ids) > 1 and not is_stale:
+            if (getattr(scheduler_self, "_multi_token_decode_enabled", False)
+                    and len(new_token_ids) > 1 and not is_stale):
                 # In AsyncScheduler, _update_after_schedule() added 1 in-flight placeholder token.
                 # When N tokens return, original_async_update_req will subtract N from
                 # num_output_placeholders. Pre-compensate by adding (N - 1) first so that
@@ -113,6 +137,13 @@ def patch_vllm_scheduler_for_continue_decode():
                 scheduler_self._cd_stale_in_flight = False
 
         AsyncScheduler._update_request_with_output = patched_async_update_request_with_output
+        AsyncScheduler._multi_token_decode_patched = True
         AsyncScheduler._continue_decode_patched = True
 
+    Scheduler._multi_token_decode_patched = True
     Scheduler._continue_decode_patched = True
+
+
+def patch_vllm_scheduler_for_continue_decode() -> None:
+    """Compatibility alias for existing continue-decode callers."""
+    patch_vllm_scheduler_for_multi_token_decode()

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -35,7 +35,7 @@ from tpu_inference.kernels.mla.v2.kernel import mla_ragged_paged_attention
 from tpu_inference.kernels.mla.v2.tuned_params import (TuningKey,
                                                        get_tuned_params)
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, SharedAttentionMetadata)
+    AttentionMetadata, SharedAttentionMetadata, resolve_use_causal_mask)
 from tpu_inference.layers.common.cp_attention import dcp_forward, pcp_forward
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
@@ -441,6 +441,11 @@ def sharded_ragged_paged_attention(
             "update_kv_cache=False (KV-share) is not supported on the "
             "head_dim==64 RPA kernel.")
 
+    if use_hd64 and not use_causal_mask:
+        raise NotImplementedError(
+            "Bidirectional attention is not supported on the head_dim==64 "
+            "RPA kernel")
+
     def _ragged_paged_attention(*args):
         kwargs = dict(
             sm_scale=sm_scale,
@@ -482,7 +487,7 @@ def attention(
     v_scale: float | None = None,
     sinks: jax.Array | None = None,
     update_kv_cache: bool = True,
-    use_causal_mask: bool = True,
+    use_causal_mask: bool | None = None,
     shared_attention_metadata: SharedAttentionMetadata | None = None,
     attn_logits_soft_cap: float | None = None,
 ) -> Tuple[jax.Array, jax.Array]:
@@ -505,10 +510,14 @@ def attention(
         sm_scale = head_dim_original**-0.5
 
     md = attention_metadata
+    use_causal_mask = resolve_use_causal_mask(md, use_causal_mask)
     # shared_attention_metadata is None for flax models, and is used for vllm models to share the metadata across layers.
     shared_md = shared_attention_metadata if shared_attention_metadata is not None else md
 
     if 'dcp' in mesh.shape and mesh.shape['dcp'] > 1:
+        if not use_causal_mask:
+            raise NotImplementedError(
+                "Bidirectional attention is not supported with DCP")
         return dcp_forward(
             mesh,
             q,

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -15,9 +15,36 @@
 import functools
 import math
 from dataclasses import dataclass
+from enum import Enum
 
 import jax
 from vllm.utils.math_utils import cdiv
+
+
+class AttentionMaskKind(str, Enum):
+    CAUSAL = "causal"
+    BIDIRECTIONAL = "bidirectional"
+
+
+@dataclass(frozen=True)
+class AttentionMaskSpec:
+    kind: AttentionMaskKind = AttentionMaskKind.CAUSAL
+
+    @property
+    def use_causal_mask(self) -> bool:
+        return self.kind is AttentionMaskKind.CAUSAL
+
+
+CAUSAL_ATTENTION_MASK = AttentionMaskSpec()
+
+
+def resolve_use_causal_mask(
+    attention_metadata: "AttentionMetadata",
+    override: bool | None = None,
+) -> bool:
+    if override is not None:
+        return override
+    return attention_metadata.attention_mask_spec.use_causal_mask
 
 
 @functools.partial(
@@ -57,7 +84,11 @@ class PCPMetadata:
         "mamba_state_indices",
         "pcp",
     ],
-    meta_fields=["padded_num_reqs", "pcp_cache_pages"],
+    meta_fields=[
+        "padded_num_reqs",
+        "pcp_cache_pages",
+        "attention_mask_spec",
+    ],
 )
 @dataclass
 class AttentionMetadata(object):
@@ -93,6 +124,8 @@ class AttentionMetadata(object):
 
     # PCP gather-KV only. Number of kv pages occupied by the current request.
     pcp_cache_pages: int | None = None
+
+    attention_mask_spec: AttentionMaskSpec = CAUSAL_ATTENTION_MASK
 
 
 @functools.partial(

--- a/tpu_inference/layers/jax/attention/attention.py
+++ b/tpu_inference/layers/jax/attention/attention.py
@@ -26,7 +26,8 @@ from jax.sharding import PartitionSpec as P
 from tpu_inference import envs, utils
 from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
     ragged_paged_attention
-from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.common.attention_metadata import (
+    AttentionMetadata, resolve_use_causal_mask)
 from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.base import create_param
@@ -272,6 +273,7 @@ class Attention(nnx.Module):
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                use_causal_mask=resolve_use_causal_mask(attention_metadata),
                 **block_size_kwargs,
             )
 

--- a/tpu_inference/runner/experimental/diffusion/__init__.py
+++ b/tpu_inference/runner/experimental/diffusion/__init__.py
@@ -16,15 +16,21 @@
 This package is opt-in and has no API compatibility guarantee.
 """
 
-from tpu_inference.runner.experimental.diffusion.config import (
-    AttentionPolicy, CanvasPolicy, DiffusionAlgorithm, DiffusionConfig,
-    DiffusionModelSpec, DiffusionRuntimeConfig, GenerationStrategy,
-    GenerationStrategyConfig, LogitAlignment, PromptRemainderPolicy,
-    register_diffusion_model_adapter, resolve_generation_strategy)
+from .algorithm import CommitFn, get_commit_algorithm, low_confidence_commit
+from .config import (AttentionPolicy, CanvasPolicy, DiffusionAlgorithm,
+                     DiffusionConfig, DiffusionModelSpec,
+                     DiffusionRuntimeConfig, GenerationStrategy,
+                     GenerationStrategyConfig, LogitAlignment, NextBlockPolicy,
+                     PromptRemainderPolicy, register_diffusion_model_adapter,
+                     resolve_generation_strategy)
+from .program import BlockForwardFn, DenoiseBlockOutput, denoise_block
 
 __all__ = [
     "AttentionPolicy",
+    "BlockForwardFn",
     "CanvasPolicy",
+    "CommitFn",
+    "DenoiseBlockOutput",
     "DiffusionAlgorithm",
     "DiffusionConfig",
     "DiffusionModelSpec",
@@ -32,7 +38,11 @@ __all__ = [
     "GenerationStrategy",
     "GenerationStrategyConfig",
     "LogitAlignment",
+    "NextBlockPolicy",
     "PromptRemainderPolicy",
+    "denoise_block",
+    "get_commit_algorithm",
+    "low_confidence_commit",
     "register_diffusion_model_adapter",
     "resolve_generation_strategy",
 ]

--- a/tpu_inference/runner/experimental/diffusion/algorithm.py
+++ b/tpu_inference/runner/experimental/diffusion/algorithm.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+
+import jax
+import jax.numpy as jnp
+
+from .config import DiffusionAlgorithm
+
+CommitFn = Callable[
+    [jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, int],
+    tuple[jax.Array, jax.Array],
+]
+
+
+def _exclude_mask_token(
+    logits: jax.Array,
+    mask_token_id: int,
+) -> jax.Array:
+    """Remove the diffusion MASK token from the candidate distribution."""
+    if logits.ndim != 3:
+        raise ValueError("logits must have shape [batch, length, vocab]")
+    vocab_size = logits.shape[-1]
+    if vocab_size < 2:
+        raise ValueError("logits must contain at least two vocabulary entries")
+    if not 0 <= mask_token_id < vocab_size:
+        raise ValueError("mask_token_id must be within the logits vocabulary")
+
+    candidate_logits = logits.astype(jnp.float32)
+    candidate_logits = candidate_logits.at[..., mask_token_id].set(-jnp.inf)
+
+    # Keep one non-MASK candidate finite so argmax cannot select MASK even when
+    # every model logit is -inf.
+    fallback_token_id = 1 if mask_token_id == 0 else 0
+    fallback_logits = candidate_logits[..., fallback_token_id]
+    fallback_logits = jnp.where(
+        jnp.isneginf(fallback_logits) | jnp.isnan(fallback_logits),
+        jnp.finfo(jnp.float32).min,
+        fallback_logits,
+    )
+    return candidate_logits.at[..., fallback_token_id].set(fallback_logits)
+
+
+def low_confidence_commit(
+    logits: jax.Array,
+    eligible_mask: jax.Array,
+    active_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    mask_token_id: int,
+) -> tuple[jax.Array, jax.Array]:
+    """Select greedy tokens and retain positions that need more denoising.
+
+    Temperature rescales confidence and can therefore change which positions
+    cross the commit threshold. Token selection remains deterministic argmax:
+    this algorithm has no RNG and temperature does not sample alternate tokens.
+    """
+    if eligible_mask.shape != logits.shape[:2]:
+        raise ValueError("eligible_mask must match logits [batch, length]")
+
+    active_rows = jnp.asarray(active_rows, dtype=bool)
+    confidence_threshold = jnp.asarray(confidence_threshold, dtype=jnp.float32)
+    temperature = jnp.asarray(temperature, dtype=jnp.float32)
+    safe_temperature = jnp.where(temperature > 0.0, temperature, 1.0)
+    scaled_logits = logits.astype(jnp.float32) / safe_temperature[:, None,
+                                                                  None]
+    scaled_logits = _exclude_mask_token(scaled_logits, mask_token_id)
+
+    token_ids = jnp.argmax(scaled_logits, axis=-1).astype(jnp.int32)
+    max_logits = jnp.max(scaled_logits, axis=-1)
+    log_confidence = max_logits - jax.nn.logsumexp(scaled_logits, axis=-1)
+    log_threshold = jnp.log(jnp.clip(confidence_threshold, min=0.0,
+                                     max=1.0))[:, None]
+
+    eligible = jnp.asarray(eligible_mask, dtype=bool) & active_rows[:, None]
+    commit = eligible & (log_confidence > log_threshold)
+
+    masked_confidence = jnp.where(eligible, log_confidence, -jnp.inf)
+    forced_indices = jnp.argmax(masked_confidence, axis=-1)
+    forced = jax.nn.one_hot(forced_indices, logits.shape[1], dtype=bool)
+    forced &= jnp.any(eligible, axis=-1)[:, None]
+    commit |= forced
+
+    remaining = eligible & ~commit
+    return token_ids, remaining
+
+
+_COMMIT_ALGORITHMS: dict[DiffusionAlgorithm, CommitFn] = {
+    DiffusionAlgorithm.LOW_CONFIDENCE: low_confidence_commit,
+}
+
+
+def get_commit_algorithm(algorithm: DiffusionAlgorithm) -> CommitFn:
+    try:
+        return _COMMIT_ALGORITHMS[algorithm]
+    except KeyError as exc:
+        raise ValueError(
+            f"No commit implementation is registered for {algorithm.value!r}"
+        ) from exc

--- a/tpu_inference/runner/experimental/diffusion/config.py
+++ b/tpu_inference/runner/experimental/diffusion/config.py
@@ -80,6 +80,11 @@ class DiffusionModelSpec:
         if self.block_size % self.sub_block_size:
             raise ValueError(
                 "Diffusion sub_block_size must divide block_size exactly")
+        if (self.logit_alignment is LogitAlignment.SHIFTED
+                and self.canvas_policy is not CanvasPolicy.SEED_AND_MASK):
+            raise ValueError(
+                "Shifted logit alignment requires seed_and_mask canvas semantics"
+            )
         if not self.supported_algorithms:
             raise ValueError(
                 "Diffusion model spec must support at least one algorithm")

--- a/tpu_inference/runner/experimental/diffusion/program.py
+++ b/tpu_inference/runner/experimental/diffusion/program.py
@@ -1,0 +1,250 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+from collections.abc import Callable
+from typing import Any, NamedTuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from .algorithm import CommitFn, _exclude_mask_token
+from .config import LogitAlignment, NextBlockPolicy
+
+BlockForwardFn = Callable[
+    [Any, jax.Array, jax.Array, Any, jax.Array, Any],
+    tuple[jax.Array, Any],
+]
+
+
+class DenoiseBlockOutput(NamedTuple):
+    canvas: jax.Array
+    next_anchor: jax.Array
+    denoise_steps: jax.Array
+    kv_caches: Any
+
+
+def _align_logits(
+    logits: jax.Array,
+    alignment: LogitAlignment,
+) -> jax.Array:
+    if alignment is LogitAlignment.SAME_POSITION:
+        return logits
+    if alignment is LogitAlignment.SHIFTED:
+        indices = jnp.maximum(
+            jnp.arange(logits.shape[1], dtype=jnp.int32) - 1, 0)
+        return logits[:, indices, :]
+    raise ValueError(f"Unsupported logit alignment: {alignment}")
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=(
+        "forward_fn",
+        "commit_fn",
+        "logit_alignment",
+        "next_block_policy",
+        "mask_token_id",
+        "sub_block_size",
+        "max_denoise_steps",
+    ),
+)
+def _denoise_block_jit(
+    forward_fn: BlockForwardFn,
+    commit_fn: CommitFn,
+    model_state: Any,
+    initial_canvas: jax.Array,
+    initial_mask: jax.Array,
+    positions: jax.Array,
+    kv_caches: Any,
+    active_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    forward_context: Any,
+    *,
+    logit_alignment: LogitAlignment,
+    next_block_policy: NextBlockPolicy,
+    mask_token_id: int,
+    sub_block_size: int,
+    max_denoise_steps: int = 0,
+) -> DenoiseBlockOutput:
+    """Jitted block denoising implementation.
+
+    ``forward_fn`` must leave cache entries for false ``active_rows`` unchanged.
+    The cache is opaque to this program, so inactive-row isolation belongs to
+    the forward implementation that maps logical rows to physical cache pages.
+
+    ``max_denoise_steps`` limits while-loop iterations for each sub-block, not
+    for the full model block. Zero uses ``sub_block_size`` iterations. The full
+    block can therefore run ``num_sub_blocks * steps_per_sub_block`` denoising
+    forwards, followed by one final forward that commits the completed KV state.
+    """
+    if initial_canvas.ndim != 2:
+        raise ValueError("initial_canvas must have shape [batch, block_size]")
+    if initial_mask.shape != initial_canvas.shape:
+        raise ValueError("initial_mask must match initial_canvas")
+    if positions.shape != initial_canvas.shape:
+        raise ValueError("positions must match initial_canvas")
+    if sub_block_size < 1 or initial_canvas.shape[1] % sub_block_size:
+        raise ValueError("sub_block_size must divide the model block size")
+
+    batch_size, block_size = initial_canvas.shape
+    del batch_size
+    active_rows = jnp.asarray(active_rows, dtype=bool)
+    canvas = initial_canvas.astype(jnp.int32)
+    mask = jnp.asarray(initial_mask, dtype=bool) & active_rows[:, None]
+    denoise_steps = jnp.zeros((canvas.shape[0], ), dtype=jnp.int32)
+    steps_per_sub_block = (sub_block_size
+                           if max_denoise_steps <= 0 else max_denoise_steps)
+    num_sub_blocks = block_size // sub_block_size
+
+    def denoise_sub_block(sub_block_index, carry):
+        canvas, mask, denoise_steps, kv = carry
+        start = sub_block_index * sub_block_size
+        sub_block_positions = (
+            (jnp.arange(block_size) >= start) &
+            (jnp.arange(block_size) < start + sub_block_size))
+        eligible = mask & sub_block_positions[None, :]
+        last_tokens = canvas
+
+        state = (
+            canvas,
+            mask,
+            denoise_steps,
+            kv,
+            eligible,
+            last_tokens,
+            jnp.array(0, dtype=jnp.int32),
+        )
+
+        def has_work(state):
+            _, _, _, _, eligible, _, iteration = state
+            return ((iteration < steps_per_sub_block) & jnp.any(eligible))
+
+        def denoise_step(state):
+            canvas, mask, steps, kv, eligible, _, iteration = state
+            row_has_work = jnp.any(eligible, axis=-1)
+            logits, kv = forward_fn(model_state, canvas, positions, kv,
+                                    active_rows, forward_context)
+            aligned_logits = _align_logits(logits, logit_alignment)
+            token_ids, remaining = commit_fn(
+                aligned_logits,
+                eligible,
+                active_rows,
+                confidence_threshold,
+                temperature,
+                mask_token_id,
+            )
+            committed = eligible & ~remaining
+            canvas = jnp.where(committed, token_ids, canvas)
+            mask &= ~committed
+            steps += row_has_work.astype(jnp.int32)
+            return (canvas, mask, steps, kv, remaining, token_ids,
+                    iteration + 1)
+
+        state = jax.lax.while_loop(has_work, denoise_step, state)
+        canvas, mask, denoise_steps, kv, remaining, last_tokens, _ = state
+
+        canvas = jnp.where(remaining, last_tokens, canvas)
+        mask &= ~remaining
+        return canvas, mask, denoise_steps, kv
+
+    canvas, mask, denoise_steps, kv_caches = jax.lax.fori_loop(
+        0,
+        num_sub_blocks,
+        denoise_sub_block,
+        (canvas, mask, denoise_steps, kv_caches),
+    )
+
+    final_logits, kv_caches = forward_fn(model_state, canvas, positions,
+                                         kv_caches, active_rows,
+                                         forward_context)
+    if next_block_policy is NextBlockPolicy.LAST_LOGIT_ANCHOR:
+        anchor_logits = _exclude_mask_token(final_logits[:, -1:, :],
+                                            mask_token_id)
+        next_anchor = jnp.argmax(anchor_logits[:, 0, :],
+                                 axis=-1).astype(jnp.int32)
+    elif next_block_policy is NextBlockPolicy.ALL_MASKED:
+        next_anchor = jnp.zeros((canvas.shape[0], ), dtype=jnp.int32)
+    else:
+        raise ValueError(f"Unsupported next block policy: {next_block_policy}")
+    next_anchor = jnp.where(active_rows, next_anchor, 0)
+    return DenoiseBlockOutput(
+        canvas=canvas,
+        next_anchor=next_anchor,
+        denoise_steps=denoise_steps,
+        kv_caches=kv_caches,
+    )
+
+
+def denoise_block(
+    forward_fn: BlockForwardFn,
+    commit_fn: CommitFn,
+    model_state: Any,
+    initial_canvas: jax.Array,
+    initial_mask: jax.Array,
+    positions: jax.Array,
+    kv_caches: Any,
+    active_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    forward_context: Any,
+    *,
+    logit_alignment: LogitAlignment,
+    next_block_policy: NextBlockPolicy,
+    mask_token_id: int,
+    sub_block_size: int,
+    max_denoise_steps: int = 0,
+) -> DenoiseBlockOutput:
+    """Validate and denoise one model block.
+
+    Shifted logits predict canvas position ``i + 1`` from logits position ``i``.
+    Position zero therefore has no aligned prediction and must be an immutable
+    seed for every active row. This host-side check fails before compilation or
+    token commitment instead of silently consuming the wrong logits.
+    """
+    if initial_canvas.ndim != 2:
+        raise ValueError("initial_canvas must have shape [batch, block_size]")
+    if initial_mask.shape != initial_canvas.shape:
+        raise ValueError("initial_mask must match initial_canvas")
+    if active_rows.shape != (initial_canvas.shape[0], ):
+        raise ValueError("active_rows must match the canvas batch size")
+    if logit_alignment is LogitAlignment.SHIFTED:
+        seed_mask, active = jax.device_get((initial_mask[:, 0], active_rows))
+        if np.any(
+                np.asarray(seed_mask, dtype=bool)
+                & np.asarray(active, dtype=bool)):
+            raise ValueError(
+                "Shifted logit alignment requires position 0 to be an "
+                "unmasked seed for every active row")
+
+    return _denoise_block_jit(
+        forward_fn,
+        commit_fn,
+        model_state,
+        initial_canvas,
+        initial_mask,
+        positions,
+        kv_caches,
+        active_rows,
+        confidence_threshold,
+        temperature,
+        forward_context,
+        logit_alignment=logit_alignment,
+        next_block_policy=next_block_policy,
+        mask_token_id=mask_token_id,
+        sub_block_size=sub_block_size,
+        max_denoise_steps=max_denoise_steps,
+    )


### PR DESCRIPTION
## Motivation

vLLM scheduler accounting assumes one scheduled decode position produces one token, while continue-decode and block diffusion can return multiple tokens from one model-runner step.

## Scope

- Generalize the continue-decode scheduler patch for multi-token model outputs.
- Reserve configurable KV-cache lookahead.
- Reconcile computed-token and async-placeholder accounting after stop-token handling.

## Design

An opt-in `multi_token_decode_lookahead` value controls cache reservation. Scheduler instances record whether multi-token accounting is enabled, and idempotent wrappers apply the additional `N - 1` accounting only for enabled requests. The continue-decode entry point remains as a compatibility alias.

## Compatibility

Autoregressive behavior is unchanged when multi-token decoding is not configured. Existing continue-decode configuration preserves its previous lookahead behavior.

## Extensibility

The scheduler contract is generation-strategy agnostic: any runner that returns multiple tokens can opt into the same reservation and reconciliation path.

## Tests

- Relevant CPU test selection at this stack point: 32 passed, including stale
  sync and async output-accounting coverage from current vLLM.
- Stack checks passed: `isort`, `yapf`, `ruff`, `py_compile`, and `git diff --check`.

## Known limitations

This change adapts the current vLLM scheduler interfaces and does not enable a new generation strategy by itself.

## Stack

- Depends on the previous upstream PR in this stack: https://github.com/vllm-project/tpu-inference/pull/3244. Until that PR merges, GitHub's `main`-based comparison includes the preceding stack commits.
- [Public design document](https://docs.google.com/document/d/1d3qtGrvdcJ0ptluE0EwAaGj4AQyOlIYkYvKo9xPguX8/edit)
