### PR TITLE
[tpu-inference] Add block-diffusion serving strategy

### DIFF
--- a/tests/core/test_multi_token_scheduler.py
+++ b/tests/core/test_multi_token_scheduler.py
@@ -1,0 +1,205 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+from types import SimpleNamespace
+
+
+def _load_utils_with_fake_vllm(monkeypatch):
+
+    class Scheduler:
+
+        def __init__(self, vllm_config):
+            del vllm_config
+            self.num_lookahead_tokens = 2
+
+        def _update_request_with_output(self,
+                                        request,
+                                        new_token_ids,
+                                        is_stale=False,
+                                        **kwargs):
+            del is_stale, kwargs
+            retained = list(new_token_ids[:request.retain_tokens])
+            request.output_token_ids.extend(retained)
+            return retained, len(retained) != len(new_token_ids)
+
+    class AsyncScheduler:
+
+        def _update_request_with_output(self,
+                                        request,
+                                        new_token_ids,
+                                        is_stale=False,
+                                        **kwargs):
+            del kwargs
+            if is_stale:
+                return list(new_token_ids), False
+            request.num_output_placeholders -= len(new_token_ids)
+            return list(new_token_ids), False
+
+    modules = {
+        "vllm":
+        types.ModuleType("vllm"),
+        "vllm.v1":
+        types.ModuleType("vllm.v1"),
+        "vllm.v1.core":
+        types.ModuleType("vllm.v1.core"),
+        "vllm.v1.core.sched":
+        types.ModuleType("vllm.v1.core.sched"),
+        "vllm.v1.core.sched.scheduler":
+        types.ModuleType("vllm.v1.core.sched.scheduler"),
+        "vllm.v1.core.sched.async_scheduler":
+        types.ModuleType("vllm.v1.core.sched.async_scheduler"),
+    }
+    modules["vllm.v1.core.sched.scheduler"].Scheduler = Scheduler
+    modules[
+        "vllm.v1.core.sched.async_scheduler"].AsyncScheduler = AsyncScheduler
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    path = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+            "core" / "sched" / "utils.py")
+    spec = importlib.util.spec_from_file_location("scheduler_utils_under_test",
+                                                  path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module, Scheduler, AsyncScheduler
+
+
+def test_continue_decode_lookahead_is_preserved(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_continue_decode()
+
+    scheduler = Scheduler(
+        SimpleNamespace(additional_config={
+            "enable_continue_decode": True,
+            "max_decode_steps": 10,
+        }))
+
+    assert scheduler.num_lookahead_tokens == 9
+
+
+def test_explicit_multi_token_lookahead_takes_precedence(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+
+    scheduler = Scheduler(
+        SimpleNamespace(
+            additional_config={
+                "enable_continue_decode": True,
+                utils.MULTI_TOKEN_LOOKAHEAD_CONFIG: 31,
+            }))
+
+    assert scheduler.num_lookahead_tokens == 31
+
+
+def test_output_accounting_uses_tokens_retained_after_eos(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = Scheduler(
+        SimpleNamespace(additional_config={
+            utils.MULTI_TOKEN_LOOKAHEAD_CONFIG: 3,
+        }))
+    request = SimpleNamespace(
+        retain_tokens=2,
+        output_token_ids=[],
+        num_computed_tokens=1,
+    )
+
+    retained, stopped = scheduler._update_request_with_output(
+        request, [10, 11, 12, 13])
+
+    assert retained == [10, 11]
+    assert stopped is True
+    assert request.num_computed_tokens == 2
+
+
+def test_stale_output_does_not_advance_computed_tokens(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = Scheduler(
+        SimpleNamespace(additional_config={
+            utils.MULTI_TOKEN_LOOKAHEAD_CONFIG: 3,
+        }))
+    request = SimpleNamespace(
+        retain_tokens=3,
+        output_token_ids=[],
+        num_computed_tokens=1,
+    )
+
+    scheduler._update_request_with_output(request, [10, 11, 12], is_stale=True)
+
+    assert request.num_computed_tokens == 1
+
+
+def test_async_placeholder_accounting_consumes_one_scheduled_step(monkeypatch):
+    utils, _, AsyncScheduler = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = AsyncScheduler()
+    scheduler._multi_token_decode_enabled = True
+    request = SimpleNamespace(num_output_placeholders=1)
+
+    scheduler._update_request_with_output(request, [10, 11, 12, 13])
+
+    assert request.num_output_placeholders == 0
+
+
+def test_stale_async_output_does_not_change_placeholders(monkeypatch):
+    utils, _, AsyncScheduler = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = AsyncScheduler()
+    scheduler._multi_token_decode_enabled = True
+    request = SimpleNamespace(num_output_placeholders=0)
+
+    scheduler._update_request_with_output(request, [10, 11, 12], is_stale=True)
+
+    assert request.num_output_placeholders == 0
+    assert scheduler._cd_stale_in_flight is False
+
+
+def test_normal_scheduler_is_unchanged_after_class_patch(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = Scheduler(SimpleNamespace(additional_config={}))
+    request = SimpleNamespace(
+        retain_tokens=3,
+        output_token_ids=[],
+        num_computed_tokens=1,
+    )
+
+    scheduler._update_request_with_output(request, [1, 2, 3])
+
+    assert request.num_computed_tokens == 1
+
+
+def test_patch_is_idempotent(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    utils.patch_vllm_scheduler_for_continue_decode()
+    scheduler = Scheduler(
+        SimpleNamespace(additional_config={
+            "enable_continue_decode": True,
+        }))
+    request = SimpleNamespace(
+        retain_tokens=3,
+        output_token_ids=[],
+        num_computed_tokens=1,
+    )
+
+    scheduler._update_request_with_output(request, [1, 2, 3])
+
+    assert request.num_computed_tokens == 3

--- a/tests/core/test_sched_utils.py
+++ b/tests/core/test_sched_utils.py
@@ -36,8 +36,12 @@ def restore_scheduler_patch():
     (Scheduler._update_request_with_output, Scheduler.__init__,
      AsyncScheduler._update_request_with_output) = originals
     for cls in (Scheduler, AsyncScheduler):
-        if "_continue_decode_patched" in cls.__dict__:
-            del cls._continue_decode_patched
+        for attribute in (
+                "_continue_decode_patched",
+                "_multi_token_decode_patched",
+        ):
+            if attribute in cls.__dict__:
+                delattr(cls, attribute)
 
 
 def _make_request(num_computed_tokens=10, num_output_placeholders=1):
@@ -54,6 +58,7 @@ def _make_scheduler(cls):
     # Instance attributes read by the base implementation are set explicitly.
     scheduler = mock.MagicMock(spec=cls)
     scheduler.max_model_len = 1024
+    scheduler._multi_token_decode_enabled = True
     return scheduler
 
 

--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -23,7 +23,8 @@ from jax.sharding import Mesh
 from tpu_inference.layers.common.attention_interface import (
     attention, mla_attention, sharded_ragged_paged_attention)
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, SharedAttentionMetadata)
+    AttentionMaskKind, AttentionMaskSpec, AttentionMetadata,
+    SharedAttentionMetadata)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.runner.kv_cache import get_kv_cache_shape_with_mesh
 
@@ -62,7 +63,11 @@ def mesh():
 # ---- Test for `attention` ----
 
 
-def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
+def _test_attention(monkeypatch,
+                    mesh,
+                    head_dim,
+                    use_sinks=False,
+                    attention_mask_spec=None):
     """
     Tests the main `attention` function.
 
@@ -106,6 +111,9 @@ def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
         )
 
     # Create AttentionMetadata
+    metadata_kwargs = {}
+    if attention_mask_spec is not None:
+        metadata_kwargs["attention_mask_spec"] = attention_mask_spec
     attention_metadata = AttentionMetadata(
         input_positions=jnp.arange(TOTAL_TOKENS, dtype=jnp.int32),
         block_tables=jnp.zeros((MAX_NUM_SEQS * MAX_BLOCKS_PER_SEQ, ),
@@ -113,6 +121,7 @@ def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
         seq_lens=jnp.array([5, 5, 0, 0], dtype=jnp.int32),
         query_start_loc=jnp.array([0, 5, 10, 10, 10], dtype=jnp.int32),
         request_distribution=jnp.array([0, 0, NUM_SEQS], dtype=jnp.int32),
+        **metadata_kwargs,
     )
     shared_attention_metadata = SharedAttentionMetadata(
         input_positions=jnp.arange(TOTAL_TOKENS, dtype=jnp.int32),
@@ -137,6 +146,11 @@ def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
     # 3. Assert
     # Check that both mocked kernels were called
     mock_paged_attn_kernel.assert_called_once()
+    expected_causal = (attention_mask_spec is None
+                       or attention_mask_spec.kind is AttentionMaskKind.CAUSAL)
+    if head_dim != 64:
+        assert mock_paged_attn_kernel.call_args.kwargs[
+            "use_causal_mask"] is expected_causal
 
     # Check output shapes
     assert final_kv_cache.shape == kv_cache.shape
@@ -156,6 +170,26 @@ def test_attention_hd64(monkeypatch, mesh):
 
 def test_attention_sink(monkeypatch, mesh):
     _test_attention(monkeypatch, mesh, 64, True)
+
+
+def test_attention_bidirectional_from_metadata(monkeypatch, mesh):
+    _test_attention(
+        monkeypatch,
+        mesh,
+        128,
+        attention_mask_spec=AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL),
+    )
+
+
+def test_attention_bidirectional_hd64_fails_loudly(monkeypatch, mesh):
+    with pytest.raises(NotImplementedError, match="head_dim==64"):
+        _test_attention(
+            monkeypatch,
+            mesh,
+            64,
+            attention_mask_spec=AttentionMaskSpec(
+                AttentionMaskKind.BIDIRECTIONAL),
+        )
 
 
 def test_attention_sink_no_64_raises_error(monkeypatch, mesh):

--- a/tests/layers/common/test_attention_mask_spec.py
+++ b/tests/layers/common/test_attention_mask_spec.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+import jax
+import jax.numpy as jnp
+
+
+def _cdiv(numerator, denominator):
+    return (numerator + denominator - 1) // denominator
+
+
+def _load_attention_metadata():
+    module_names = ("vllm", "vllm.utils", "vllm.utils.math_utils")
+    previous_modules = {name: sys.modules.get(name) for name in module_names}
+    math_utils = types.ModuleType("vllm.utils.math_utils")
+    math_utils.cdiv = _cdiv
+    sys.modules["vllm"] = types.ModuleType("vllm")
+    sys.modules["vllm.utils"] = types.ModuleType("vllm.utils")
+    sys.modules["vllm.utils.math_utils"] = math_utils
+    path = (pathlib.Path(__file__).resolve().parents[3] / "tpu_inference" /
+            "layers" / "common" / "attention_metadata.py")
+    spec = importlib.util.spec_from_file_location(
+        "attention_metadata_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for name, previous in previous_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+    return module
+
+
+attention_metadata = _load_attention_metadata()
+AttentionMaskKind = attention_metadata.AttentionMaskKind
+AttentionMaskSpec = attention_metadata.AttentionMaskSpec
+AttentionMetadata = attention_metadata.AttentionMetadata
+resolve_use_causal_mask = attention_metadata.resolve_use_causal_mask
+
+
+def _metadata(mask_spec=None):
+    kwargs = {}
+    if mask_spec is not None:
+        kwargs["attention_mask_spec"] = mask_spec
+    return AttentionMetadata(
+        input_positions=jnp.arange(4, dtype=jnp.int32),
+        block_tables=jnp.zeros((4, ), dtype=jnp.int32),
+        seq_lens=jnp.array([4], dtype=jnp.int32),
+        query_start_loc=jnp.array([0, 4], dtype=jnp.int32),
+        request_distribution=jnp.array([0, 0, 1], dtype=jnp.int32),
+        **kwargs,
+    )
+
+
+def test_attention_mask_defaults_to_causal():
+    assert resolve_use_causal_mask(_metadata()) is True
+
+
+def test_bidirectional_mask_is_explicit_static_metadata():
+    causal = _metadata()
+    bidirectional = _metadata(
+        AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL))
+
+    assert resolve_use_causal_mask(bidirectional) is False
+    assert jax.tree_util.tree_structure(
+        causal) != jax.tree_util.tree_structure(bidirectional)
+
+
+def test_explicit_kernel_override_takes_precedence():
+    bidirectional = _metadata(
+        AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL))
+
+    assert resolve_use_causal_mask(bidirectional, override=True) is True

--- a/tests/layers/test_jax.py
+++ b/tests/layers/test_jax.py
@@ -133,6 +133,16 @@ class TestJaxModule(unittest.TestCase):
         # 'a' and 'b' point to the same module; only the first is yielded.
         self.assertEqual(names.count("a") + names.count("b"), 1)
 
+    def test_modules_matches_named_modules_without_names(self):
+        """vLLM cleanup can traverse JAX models through the torch-compatible API."""
+
+        module = NestedModule()
+
+        self.assertEqual(
+            list(module.modules()),
+            [child for _, child in module.named_modules()],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import jax.numpy as jnp
@@ -55,7 +56,33 @@ class TestTpuPlatform:
         vllm_config.kv_transfer_config = None
         vllm_config.additional_config = {}
         vllm_config.scheduler_config.async_scheduling = False
+        vllm_config.scheduler_config.enable_chunked_prefill = False
         return vllm_config
+
+    @staticmethod
+    def _enable_block_diffusion(vllm_config):
+        vllm_config.additional_config = {
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "block_size": 32,
+                "mask_token_id": 151669,
+                "sub_block_size": 8,
+            },
+        }
+        vllm_config.parallel_config.pipeline_parallel_size = 1
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.model_config.runner_type = "generate"
+        vllm_config.model_config.is_multimodal_model = False
+        vllm_config.model_config.hf_config.head_dim = 128
+        vllm_config.scheduler_config.async_scheduling = False
+        vllm_config.scheduler_config.enable_chunked_prefill = False
+        vllm_config.scheduler_config.max_num_batched_tokens = 2048
+        vllm_config.scheduler_config.max_num_seqs = 128
+        vllm_config.speculative_config = None
+        vllm_config.lora_config = None
+        vllm_config.kv_transfer_config = None
+        vllm_config.cache_config = None
 
     @pytest.mark.parametrize("chip_name,expected_dtype", [
         ("v6e", torch.float8_e5m2),
@@ -690,6 +717,90 @@ class TestTpuPlatform:
         with pytest.raises(ValueError, match=expected_error):
             TpuPlatform.check_and_update_config(vllm_config)
         mock_patch.assert_not_called()
+
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    @patch(
+        "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
+    )
+    @patch(
+        "tpu_inference.core.sched.utils.patch_vllm_scheduler_for_multi_token_decode"
+    )
+    def test_check_and_update_config_block_diffusion_success(
+            self, mock_patch, mock_dp_update, mock_sharding, vllm_config):
+        self._enable_block_diffusion(vllm_config)
+
+        with patch("tpu_inference.platforms.tpu_platform.logger.warning_once"
+                   ) as mock_warning:
+            TpuPlatform.check_and_update_config(vllm_config)
+
+        assert vllm_config.additional_config[
+            "multi_token_decode_lookahead"] == 31
+        assert vllm_config.scheduler_config.max_num_seqs == 64
+        mock_patch.assert_called_once()
+        mock_warning.assert_called_once()
+        assert "experimental" in mock_warning.call_args.args[0].lower()
+
+    @pytest.mark.parametrize(
+        "unsupported,expected_error",
+        [
+            ("kv_transfer", "does not support KV transfer"),
+            ("requested_dp", "requires data_parallel_size=1"),
+            ("sharding_dp", "requires data_parallel_size=1"),
+            ("chunked_prefill", "requires chunked prefill to be disabled"),
+            ("token_budget", "minimum padded batch"),
+        ],
+    )
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    @patch(
+        "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
+    )
+    @patch(
+        "tpu_inference.core.sched.utils.patch_vllm_scheduler_for_multi_token_decode"
+    )
+    def test_check_and_update_config_block_diffusion_rejects_unsupported_modes(
+        self,
+        mock_patch,
+        mock_dp_update,
+        mock_sharding,
+        vllm_config,
+        unsupported,
+        expected_error,
+    ):
+        self._enable_block_diffusion(vllm_config)
+        mock_sharding.from_vllm_config.return_value.total_dp_size = 1
+        if unsupported == "kv_transfer":
+            vllm_config.kv_transfer_config = SimpleNamespace(
+                kv_connector="TPUConnector")
+        elif unsupported == "requested_dp":
+            vllm_config.parallel_config.data_parallel_size = 2
+        elif unsupported == "sharding_dp":
+            mock_sharding.from_vllm_config.return_value.total_dp_size = 2
+        elif unsupported == "chunked_prefill":
+            vllm_config.scheduler_config.enable_chunked_prefill = True
+        elif unsupported == "token_budget":
+            vllm_config.scheduler_config.max_num_batched_tokens = 255
+
+        with pytest.raises(ValueError, match=expected_error):
+            TpuPlatform.check_and_update_config(vllm_config)
+
+        mock_patch.assert_not_called()
+
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    def test_check_and_update_config_rejects_two_multi_token_modes(
+            self, mock_sharding, vllm_config):
+        vllm_config.additional_config = {
+            "enable_continue_decode": True,
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "block_size": 32,
+                "mask_token_id": 151669,
+            },
+        }
+        vllm_config.cache_config = None
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            TpuPlatform.check_and_update_config(vllm_config)
 
 
 class TestTorchAcceleratorGetMemoryInfoShim:

--- a/tests/runner/test_diffusion_algorithm.py
+++ b/tests/runner/test_diffusion_algorithm.py
@@ -1,0 +1,375 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+def _load_pure_diffusion_modules():
+    root = pathlib.Path(__file__).resolve().parents[2]
+    module_paths = {
+        "tpu_inference.runner.experimental.diffusion.config":
+        root / "tpu_inference" / "runner" / "experimental" / "diffusion" /
+        "config.py",
+        "tpu_inference.runner.experimental.diffusion.algorithm":
+        root / "tpu_inference" / "runner" / "experimental" / "diffusion" /
+        "algorithm.py",
+        "tpu_inference.runner.experimental.diffusion.program":
+        root / "tpu_inference" / "runner" / "experimental" / "diffusion" /
+        "program.py",
+    }
+    for package in ("tpu_inference", "tpu_inference.runner",
+                    "tpu_inference.runner.experimental",
+                    "tpu_inference.runner.experimental.diffusion"):
+        if package not in sys.modules:
+            module = types.ModuleType(package)
+            module.__path__ = []
+            sys.modules[package] = module
+    loaded = {}
+    for name, path in module_paths.items():
+        spec = importlib.util.spec_from_file_location(name, path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        loaded[name] = module
+    return loaded
+
+
+_MODULES = _load_pure_diffusion_modules()
+_CONFIG = _MODULES["tpu_inference.runner.experimental.diffusion.config"]
+_ALGORITHM = _MODULES["tpu_inference.runner.experimental.diffusion.algorithm"]
+_PROGRAM = _MODULES["tpu_inference.runner.experimental.diffusion.program"]
+
+LogitAlignment = _CONFIG.LogitAlignment
+NextBlockPolicy = _CONFIG.NextBlockPolicy
+low_confidence_commit = _ALGORITHM.low_confidence_commit
+denoise_block = _PROGRAM.denoise_block
+
+
+def _thresholds(batch_size, value=0.9):
+    return jnp.full((batch_size, ), value, dtype=jnp.float32)
+
+
+def _temperatures(batch_size):
+    return jnp.zeros((batch_size, ), dtype=jnp.float32)
+
+
+def test_low_confidence_commit_threshold_and_forced_progress():
+    logits = jnp.array([
+        [[10.0, 0.0, -10.0], [0.1, 0.0, -10.0], [0.0, 0.1, -10.0]],
+        [[0.1, 0.0, -10.0], [0.0, 0.1, -10.0], [10.0, 0.0, -10.0]],
+    ])
+    eligible = jnp.ones((2, 3), dtype=bool)
+
+    tokens, remaining = low_confidence_commit(
+        logits,
+        eligible,
+        jnp.array([True, True]),
+        _thresholds(2),
+        _temperatures(2),
+        2,
+    )
+
+    np.testing.assert_array_equal(tokens, [[0, 0, 1], [0, 1, 0]])
+    assert remaining[0].sum() == 2
+    assert remaining[1].sum() == 2
+
+
+def test_low_confidence_commit_keeps_inactive_rows_unchanged():
+    logits = jnp.ones((2, 3, 4), dtype=jnp.float32)
+    eligible = jnp.ones((2, 3), dtype=bool)
+
+    _, remaining = low_confidence_commit(
+        logits,
+        eligible,
+        jnp.array([True, False]),
+        _thresholds(2),
+        _temperatures(2),
+        3,
+    )
+
+    assert remaining[0].sum() == 2
+    assert remaining[1].sum() == 0
+
+
+def test_mask_token_is_excluded_from_commits_and_next_anchor():
+    mask_token_id = 7
+    target_token_id = 5
+
+    def mask_favoring_forward(model_state, canvas, positions, kv_caches,
+                              active_rows, forward_context):
+        del model_state, positions, active_rows, forward_context
+        logits = jnp.zeros((*canvas.shape, 8), dtype=jnp.float32)
+        logits = logits.at[..., mask_token_id].set(100.0)
+        logits = logits.at[..., target_token_id].set(20.0)
+        return logits, kv_caches
+
+    output = denoise_block(
+        mask_favoring_forward,
+        low_confidence_commit,
+        None,
+        jnp.array([[4, 7, 7, 7]], dtype=jnp.int32),
+        jnp.array([[False, True, True, True]]),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.zeros((1, 4), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=mask_token_id,
+        sub_block_size=4,
+    )
+
+    np.testing.assert_array_equal(output.canvas, [[4, 5, 5, 5]])
+    np.testing.assert_array_equal(output.next_anchor, [target_token_id])
+
+
+def _position_forward(vocab_size):
+
+    def forward(model_state, canvas, positions, _kv_caches, active_rows,
+                forward_context):
+        del model_state, active_rows, forward_context
+        targets = positions % vocab_size
+        logits = jax.nn.one_hot(targets, vocab_size) * 20.0
+        return logits, canvas
+
+    return forward
+
+
+def test_denoise_block_supports_shifted_logits_and_inactive_rows():
+    initial_canvas = jnp.array([[7, 15, 15, 15], [9, 8, 7, 6]],
+                               dtype=jnp.int32)
+    initial_mask = jnp.array([[False, True, True, True],
+                              [False, False, False, False]])
+    positions = jnp.array([[10, 11, 12, 13], [20, 21, 22, 23]],
+                          dtype=jnp.int32)
+
+    output = denoise_block(
+        _position_forward(vocab_size=16),
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        initial_mask,
+        positions,
+        jnp.zeros_like(initial_canvas),
+        jnp.array([True, False]),
+        _thresholds(2),
+        _temperatures(2),
+        None,
+        logit_alignment=LogitAlignment.SHIFTED,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=15,
+        sub_block_size=2,
+    )
+
+    np.testing.assert_array_equal(output.canvas[0], [7, 10, 11, 12])
+    np.testing.assert_array_equal(output.canvas[1], initial_canvas[1])
+    assert int(output.next_anchor[0]) == 13
+    assert int(output.next_anchor[1]) == 0
+
+
+def test_shifted_logits_reject_a_masked_seed_position():
+    with pytest.raises(ValueError, match="position 0.*unmasked seed"):
+        denoise_block(
+            _position_forward(vocab_size=16),
+            low_confidence_commit,
+            None,
+            jnp.full((1, 4), 15, dtype=jnp.int32),
+            jnp.ones((1, 4), dtype=bool),
+            jnp.arange(4, dtype=jnp.int32)[None, :],
+            jnp.zeros((1, 4), dtype=jnp.int32),
+            jnp.array([True]),
+            _thresholds(1),
+            _temperatures(1),
+            None,
+            logit_alignment=LogitAlignment.SHIFTED,
+            next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+            mask_token_id=15,
+            sub_block_size=2,
+        )
+
+
+def test_sub_blocks_are_denoised_in_order():
+    vocab_size = 32
+
+    def dependent_forward(model_state, canvas, positions, _kv_caches,
+                          active_rows, forward_context):
+        del model_state, positions, active_rows, forward_context
+        first_half_committed = jnp.sum(canvas[:, :2], axis=-1) % vocab_size
+        targets = jnp.stack([
+            jnp.full_like(first_half_committed, 2),
+            jnp.full_like(first_half_committed, 3),
+            first_half_committed,
+            first_half_committed,
+        ],
+                            axis=1)
+        logits = jax.nn.one_hot(targets, vocab_size) * 20.0
+        return logits, canvas
+
+    output = denoise_block(
+        dependent_forward,
+        low_confidence_commit,
+        None,
+        jnp.full((1, 4), 31, dtype=jnp.int32),
+        jnp.ones((1, 4), dtype=bool),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.zeros((1, 4), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.ALL_MASKED,
+        mask_token_id=31,
+        sub_block_size=2,
+    )
+
+    np.testing.assert_array_equal(output.canvas[0], [2, 3, 5, 5])
+
+
+def test_final_forward_refreshes_committed_kv_and_next_anchor():
+    vocab_size = 32
+
+    def canvas_dependent_forward(model_state, canvas, positions, _kv_caches,
+                                 active_rows, forward_context):
+        del model_state, positions, active_rows, forward_context
+        base_targets = jnp.array([[1, 2, 3, 4]], dtype=jnp.int32)
+        next_target = jnp.sum(canvas, axis=-1) % vocab_size
+        targets = base_targets.at[:, -1].set(next_target)
+        logits = jax.nn.one_hot(targets, vocab_size) * 20.0
+        return logits, canvas
+
+    output = denoise_block(
+        canvas_dependent_forward,
+        low_confidence_commit,
+        None,
+        jnp.full((1, 4), 31, dtype=jnp.int32),
+        jnp.ones((1, 4), dtype=bool),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.zeros((1, 4), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=31,
+        sub_block_size=4,
+    )
+
+    np.testing.assert_array_equal(output.kv_caches, output.canvas)
+    assert int(output.next_anchor[0]) == int(output.canvas.sum() % vocab_size)
+
+
+def test_step_cap_force_fills_and_final_forward_refreshes_kv():
+
+    initial_canvas = jnp.array([[4, 7, 7, 7]], dtype=jnp.int32)
+
+    def low_confidence_forward(model_state, canvas, positions, kv_caches,
+                               active_rows, forward_context):
+        del model_state, positions, forward_context
+        logits = jnp.zeros((*canvas.shape, 8), dtype=jnp.float32)
+        updated_kv = jnp.where(active_rows[:, None], canvas, kv_caches)
+        return logits, updated_kv
+
+    output = denoise_block(
+        low_confidence_forward,
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        jnp.array([[False, True, True, True]]),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.full((1, 4), -1, dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1, value=0.99),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.ALL_MASKED,
+        mask_token_id=7,
+        sub_block_size=4,
+        max_denoise_steps=1,
+    )
+
+    np.testing.assert_array_equal(output.canvas, [[4, 0, 0, 0]])
+    np.testing.assert_array_equal(output.kv_caches, output.canvas)
+    np.testing.assert_array_equal(output.denoise_steps, [1])
+
+    def next_block_token(cache):
+        logits = jax.nn.one_hot(jnp.sum(cache, axis=-1) % 8, 8)
+        return jnp.argmax(logits, axis=-1)
+
+    # The last three positions were bulk-committed after the only denoise
+    # forward. A stale provisional cache still contains MASK values and changes
+    # the next block prediction; the final forward exposes the committed tokens.
+    np.testing.assert_array_equal(next_block_token(output.kv_caches), [4])
+    np.testing.assert_array_equal(next_block_token(initial_canvas), [1])
+
+
+def test_heterogeneous_rows_preserve_inactive_kv():
+
+    def active_aware_forward(model_state, canvas, positions, kv_caches,
+                             active_rows, forward_context):
+        del model_state, positions, forward_context
+        logits = jnp.zeros((*canvas.shape, 8), dtype=jnp.float32)
+        updated_kv = jnp.where(active_rows[:, None], canvas, kv_caches)
+        return logits, updated_kv
+
+    initial_canvas = jnp.array([
+        [4, 7, 6, 5],
+        [3, 7, 7, 7],
+        [9, 8, 7, 6],
+    ],
+                               dtype=jnp.int32)
+    initial_kv = jnp.array([
+        [90, 91, 92, 93],
+        [80, 81, 82, 83],
+        [70, 71, 72, 73],
+    ],
+                           dtype=jnp.int32)
+    output = denoise_block(
+        active_aware_forward,
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        jnp.array([
+            [False, True, False, False],
+            [False, True, True, True],
+            [True, True, True, True],
+        ]),
+        jnp.broadcast_to(jnp.arange(4, dtype=jnp.int32), (3, 4)),
+        initial_kv,
+        jnp.array([True, True, False]),
+        _thresholds(3, value=0.99),
+        _temperatures(3),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.ALL_MASKED,
+        mask_token_id=7,
+        sub_block_size=4,
+    )
+
+    np.testing.assert_array_equal(output.canvas[2], initial_canvas[2])
+    np.testing.assert_array_equal(output.kv_caches[:2], output.canvas[:2])
+    np.testing.assert_array_equal(output.kv_caches[2], initial_kv[2])
+    np.testing.assert_array_equal(output.denoise_steps, [1, 3, 0])

--- a/tests/runner/test_diffusion_batch.py
+++ b/tests/runner/test_diffusion_batch.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+
+
+def _load_batch_module():
+    path = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+            "runner" / "experimental" / "diffusion" / "batch.py")
+    spec = importlib.util.spec_from_file_location("diffusion_batch_under_test",
+                                                  path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+batch = _load_batch_module()
+
+
+def test_aligned_prompt_is_split_into_complete_blocks():
+    plan = batch.plan_seeded_prompt(list(range(8)), 4, 99)
+
+    assert plan.full_blocks == ((0, 1, 2, 3), (4, 5, 6, 7))
+    assert plan.partial_canvas is None
+    assert plan.remainder_size == 0
+
+
+def test_prompt_remainder_is_preserved_in_first_canvas():
+    plan = batch.plan_seeded_prompt(list(range(6)), 4, 99)
+
+    assert plan.full_blocks == ((0, 1, 2, 3), )
+    assert plan.partial_canvas == (4, 5, 99, 99)
+    assert plan.partial_mask == (False, False, True, True)
+    assert plan.remainder_size == 2
+
+
+def test_partial_block_is_flushed_at_the_next_scheduler_boundary():
+    first, pending = batch.start_partial_block_output([4, 5, 6, 7], 2, 8)
+
+    assert first == [6]
+    assert batch.flush_partial_block_output(pending) == [7, 8]
+
+
+def test_seeded_decode_emits_new_canvas_tokens_and_uncached_anchor():
+    emitted = batch.complete_seeded_decode_block([10, 11, 12, 13], 14)
+
+    assert emitted == [11, 12, 13, 14]
+
+
+def test_cache_capacity_accounts_for_the_uncached_final_anchor():
+    assert batch.required_cache_end(32, 32, 32) == 64
+    assert batch.required_cache_end(33, 32, 32) == 64
+    assert batch.required_cache_end(33, 33, 32) == 96

--- a/tests/runner/test_diffusion_config.py
+++ b/tests/runner/test_diffusion_config.py
@@ -204,3 +204,20 @@ def test_model_spec_rejects_incompatible_sub_block_size():
             sub_block_size=4,
             supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
         )
+
+
+def test_model_spec_rejects_shifted_all_masked_canvas():
+    with pytest.raises(ValueError, match="requires seed_and_mask"):
+        DiffusionModelSpec(
+            name="invalid",
+            block_size=4,
+            mask_token_id=7,
+            attention_policy=AttentionPolicy.BLOCK_CAUSAL,
+            logit_alignment=LogitAlignment.SHIFTED,
+            canvas_policy=CanvasPolicy.ALL_MASKED,
+            prompt_remainder_policy=(
+                PromptRemainderPolicy.REQUIRE_BLOCK_ALIGNED),
+            next_block_policy=NextBlockPolicy.ALL_MASKED,
+            sub_block_size=4,
+            supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
+        )

--- a/tests/runner/test_diffusion_request_validation.py
+++ b/tests/runner/test_diffusion_request_validation.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+def _load_validation_with_fake_vllm(monkeypatch):
+
+    class InputProcessor:
+
+        def __init__(self, additional_config):
+            self.vllm_config = SimpleNamespace(
+                additional_config=additional_config)
+
+        def process_inputs(self, *args, **kwargs):
+            return args, kwargs
+
+    modules = {
+        "vllm":
+        types.ModuleType("vllm"),
+        "vllm.v1":
+        types.ModuleType("vllm.v1"),
+        "vllm.v1.engine":
+        types.ModuleType("vllm.v1.engine"),
+        "vllm.v1.engine.input_processor":
+        types.ModuleType("vllm.v1.engine.input_processor"),
+    }
+    modules["vllm.v1.engine.input_processor"].InputProcessor = InputProcessor
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    path = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+            "runner" / "experimental" / "diffusion" / "request_validation.py")
+    spec = importlib.util.spec_from_file_location(
+        "diffusion_request_validation_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module, InputProcessor
+
+
+def test_resumable_request_is_rejected_only_for_block_diffusion(monkeypatch):
+    validation, InputProcessor = _load_validation_with_fake_vllm(monkeypatch)
+    validation.patch_vllm_input_processor_for_block_diffusion()
+
+    autoregressive = InputProcessor({})
+    assert autoregressive.process_inputs(
+        resumable=True)[1]["resumable"] is True
+
+    diffusion = InputProcessor({"generation_strategy": "block_diffusion"})
+    assert diffusion.process_inputs(resumable=False)[1]["resumable"] is False
+    with pytest.raises(ValueError, match="resumable or streaming-input"):
+        diffusion.process_inputs(resumable=True)
+
+
+def test_resumable_positional_argument_and_patch_idempotence(monkeypatch):
+    validation, InputProcessor = _load_validation_with_fake_vllm(monkeypatch)
+    validation.patch_vllm_input_processor_for_block_diffusion()
+    validation.patch_vllm_input_processor_for_block_diffusion()
+    diffusion = InputProcessor({"generation_strategy": "block_diffusion"})
+
+    positional = tuple(range(10)) + (True, )
+    with pytest.raises(ValueError, match="resumable or streaming-input"):
+        diffusion.process_inputs(*positional)

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import pathlib
+
+RUNNER = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+          "runner" / "tpu_runner.py")
+STRATEGY = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+            "runner" / "experimental" / "diffusion" / "strategy.py")
+
+
+def _method(name):
+    module = ast.parse(RUNNER.read_text())
+    runner_class = next(
+        node for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "TPUModelRunner")
+    for node in runner_class.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"Method {name!r} not found")
+
+
+def _strategy_method(name):
+    module = ast.parse(STRATEGY.read_text())
+    strategy_class = next(node for node in module.body
+                          if isinstance(node, ast.ClassDef)
+                          and node.name == "BlockDiffusionStrategy")
+    for node in strategy_class.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"Strategy method {name!r} not found")
+
+
+def test_runner_resolves_generation_strategy_once_at_startup():
+    init_source = ast.unparse(_method("__init__"))
+
+    assert "resolve_generation_strategy(vllm_config)" in init_source
+    assert "BlockDiffusionStrategy" in init_source
+
+
+def test_diffusion_dispatch_precedes_autoregressive_phase_dispatch():
+    execute_source = ast.unparse(_method("_execute_model"))
+    diffusion_dispatch = execute_source.index(
+        "self.block_diffusion_strategy.execute(scheduler_output)")
+    autoregressive_dispatch = execute_source.index(
+        "self.enable_continue_decode")
+
+    assert diffusion_dispatch < autoregressive_dispatch
+
+
+def test_finished_requests_are_cleaned_before_empty_cycle_return():
+    execute_source = ast.unparse(_method("_execute_model"))
+    cleanup = execute_source.index("on_scheduler_update")
+    empty_cycle = execute_source.index(
+        "if not scheduler_output.total_num_scheduled_tokens")
+
+    assert cleanup < empty_cycle
+
+
+def test_diffusion_precompile_uses_the_runtime_mesh_context():
+    capture_source = ast.unparse(_method("capture_model"))
+
+    assert "with jax.set_mesh(self.mesh)" in capture_source
+    assert "self.block_diffusion_strategy.precompile()" in capture_source
+
+
+def test_diffusion_forward_uses_nested_jit_safe_model_callable():
+    forward_source = ast.unparse(_strategy_method("_model_forward"))
+
+    assert "runner.model.step_fn_no_options" in forward_source
+    assert "runner.model_fn(" not in forward_source

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -13,17 +13,41 @@
 # limitations under the License.
 
 DEFAULT_MAX_DECODE_STEPS = 10
+MULTI_TOKEN_LOOKAHEAD_CONFIG = "multi_token_decode_lookahead"
 
 
-def patch_vllm_scheduler_for_continue_decode():
-    """Monkeypatches vLLM's Scheduler and AsyncScheduler for Continue Decode.
+def _get_multi_token_lookahead(vllm_config) -> int:
+    additional_config = getattr(vllm_config, "additional_config", {}) or {}
+    if MULTI_TOKEN_LOOKAHEAD_CONFIG in additional_config:
+        lookahead = int(additional_config[MULTI_TOKEN_LOOKAHEAD_CONFIG])
+        if lookahead < 0:
+            raise ValueError(
+                f"{MULTI_TOKEN_LOOKAHEAD_CONFIG} must be non-negative")
+        return lookahead
+    if additional_config.get("enable_continue_decode", False):
+        max_decode_steps = int(
+            additional_config.get("max_decode_steps",
+                                  DEFAULT_MAX_DECODE_STEPS))
+        return max(0, max_decode_steps - 1)
+    return 0
 
-    In Continue Decode, the host schedules 1 step while the TPU runner executes
-    up to max_decode_steps (N) decode iterations on-device in a single step.
+
+def _is_multi_token_decode_enabled(vllm_config) -> bool:
+    additional_config = getattr(vllm_config, "additional_config", {}) or {}
+    return (MULTI_TOKEN_LOOKAHEAD_CONFIG in additional_config
+            or bool(additional_config.get("enable_continue_decode", False)))
+
+
+def patch_vllm_scheduler_for_multi_token_decode() -> None:
+    """Patch vLLM scheduler accounting for multi-token model outputs.
+
+    The host schedules one decode position while the model runner may return N
+    tokens. The patch reserves a configured lookahead and reconciles the N - 1
+    additional tokens after stop-token processing.
 
     This function applies three patches:
-    1. patched_init: Forces KVCacheManager to reserve enough KV cache blocks for
-       all N tokens during schedule() (num_lookahead_tokens = max_decode_steps - 1).
+    1. patched_init: Forces KVCacheManager to reserve the configured lookahead
+       during schedule().
     2. patched_update_base: Reconciles request.num_computed_tokens on host by
        adding the extra (N - 1) tokens generated on-device once model output returns.
     3. patched_async_update_request_with_output: Pre-compensates in-flight
@@ -32,8 +56,7 @@ def patch_vllm_scheduler_for_continue_decode():
     """
     from vllm.v1.core.sched.scheduler import Scheduler
 
-    # Avoid patching multiple times
-    if not getattr(Scheduler, "_continue_decode_patched", False):
+    if not getattr(Scheduler, "_multi_token_decode_patched", False):
         original_update_base = Scheduler._update_request_with_output
 
         def patched_update_base(scheduler_self,
@@ -58,9 +81,10 @@ def patch_vllm_scheduler_for_continue_decode():
             # _cd_stale_in_flight instead — check both.
             stale = is_stale or getattr(scheduler_self, "_cd_stale_in_flight",
                                         False)
-            diff = len(res_token_ids) - 1
-            if diff > 0 and not stale:
-                request.num_computed_tokens += diff
+            if getattr(scheduler_self, "_multi_token_decode_enabled", False):
+                diff = len(res_token_ids) - 1
+                if diff > 0 and not stale:
+                    request.num_computed_tokens += diff
 
             return res_token_ids, stopped
 
@@ -71,19 +95,18 @@ def patch_vllm_scheduler_for_continue_decode():
         def patched_init(scheduler_self, vllm_config, *args, **kwargs):
             original_init(scheduler_self, vllm_config, *args, **kwargs)
 
-            additional_config = getattr(vllm_config, "additional_config", {})
-            max_decode_steps = additional_config.get("max_decode_steps",
-                                                     DEFAULT_MAX_DECODE_STEPS)
-            # Reserve max_decode_steps - 1 lookahead tokens so KVCacheManager allocates
-            # sufficient blocks for up to max_decode_steps tokens before execution on TPU.
+            scheduler_self._multi_token_decode_enabled = \
+                _is_multi_token_decode_enabled(vllm_config)
             scheduler_self.num_lookahead_tokens = max(
-                scheduler_self.num_lookahead_tokens, max_decode_steps - 1)
+                scheduler_self.num_lookahead_tokens,
+                _get_multi_token_lookahead(vllm_config),
+            )
 
         Scheduler.__init__ = patched_init
 
     from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 
-    if not getattr(AsyncScheduler, "_continue_decode_patched", False):
+    if not getattr(AsyncScheduler, "_multi_token_decode_patched", False):
         original_async_update_req = AsyncScheduler._update_request_with_output
 
         def patched_async_update_request_with_output(scheduler_self,
@@ -91,7 +114,8 @@ def patch_vllm_scheduler_for_continue_decode():
                                                      new_token_ids,
                                                      is_stale=False,
                                                      **kwargs):
-            if len(new_token_ids) > 1 and not is_stale:
+            if (getattr(scheduler_self, "_multi_token_decode_enabled", False)
+                    and len(new_token_ids) > 1 and not is_stale):
                 # In AsyncScheduler, _update_after_schedule() added 1 in-flight placeholder token.
                 # When N tokens return, original_async_update_req will subtract N from
                 # num_output_placeholders. Pre-compensate by adding (N - 1) first so that
@@ -113,6 +137,13 @@ def patch_vllm_scheduler_for_continue_decode():
                 scheduler_self._cd_stale_in_flight = False
 
         AsyncScheduler._update_request_with_output = patched_async_update_request_with_output
+        AsyncScheduler._multi_token_decode_patched = True
         AsyncScheduler._continue_decode_patched = True
 
+    Scheduler._multi_token_decode_patched = True
     Scheduler._continue_decode_patched = True
+
+
+def patch_vllm_scheduler_for_continue_decode() -> None:
+    """Compatibility alias for existing continue-decode callers."""
+    patch_vllm_scheduler_for_multi_token_decode()

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -35,7 +35,7 @@ from tpu_inference.kernels.mla.v2.kernel import mla_ragged_paged_attention
 from tpu_inference.kernels.mla.v2.tuned_params import (TuningKey,
                                                        get_tuned_params)
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, SharedAttentionMetadata)
+    AttentionMetadata, SharedAttentionMetadata, resolve_use_causal_mask)
 from tpu_inference.layers.common.cp_attention import dcp_forward, pcp_forward
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
@@ -441,6 +441,11 @@ def sharded_ragged_paged_attention(
             "update_kv_cache=False (KV-share) is not supported on the "
             "head_dim==64 RPA kernel.")
 
+    if use_hd64 and not use_causal_mask:
+        raise NotImplementedError(
+            "Bidirectional attention is not supported on the head_dim==64 "
+            "RPA kernel")
+
     def _ragged_paged_attention(*args):
         kwargs = dict(
             sm_scale=sm_scale,
@@ -482,7 +487,7 @@ def attention(
     v_scale: float | None = None,
     sinks: jax.Array | None = None,
     update_kv_cache: bool = True,
-    use_causal_mask: bool = True,
+    use_causal_mask: bool | None = None,
     shared_attention_metadata: SharedAttentionMetadata | None = None,
     attn_logits_soft_cap: float | None = None,
 ) -> Tuple[jax.Array, jax.Array]:
@@ -505,10 +510,14 @@ def attention(
         sm_scale = head_dim_original**-0.5
 
     md = attention_metadata
+    use_causal_mask = resolve_use_causal_mask(md, use_causal_mask)
     # shared_attention_metadata is None for flax models, and is used for vllm models to share the metadata across layers.
     shared_md = shared_attention_metadata if shared_attention_metadata is not None else md
 
     if 'dcp' in mesh.shape and mesh.shape['dcp'] > 1:
+        if not use_causal_mask:
+            raise NotImplementedError(
+                "Bidirectional attention is not supported with DCP")
         return dcp_forward(
             mesh,
             q,

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -15,9 +15,36 @@
 import functools
 import math
 from dataclasses import dataclass
+from enum import Enum
 
 import jax
 from vllm.utils.math_utils import cdiv
+
+
+class AttentionMaskKind(str, Enum):
+    CAUSAL = "causal"
+    BIDIRECTIONAL = "bidirectional"
+
+
+@dataclass(frozen=True)
+class AttentionMaskSpec:
+    kind: AttentionMaskKind = AttentionMaskKind.CAUSAL
+
+    @property
+    def use_causal_mask(self) -> bool:
+        return self.kind is AttentionMaskKind.CAUSAL
+
+
+CAUSAL_ATTENTION_MASK = AttentionMaskSpec()
+
+
+def resolve_use_causal_mask(
+    attention_metadata: "AttentionMetadata",
+    override: bool | None = None,
+) -> bool:
+    if override is not None:
+        return override
+    return attention_metadata.attention_mask_spec.use_causal_mask
 
 
 @functools.partial(
@@ -57,7 +84,11 @@ class PCPMetadata:
         "mamba_state_indices",
         "pcp",
     ],
-    meta_fields=["padded_num_reqs", "pcp_cache_pages"],
+    meta_fields=[
+        "padded_num_reqs",
+        "pcp_cache_pages",
+        "attention_mask_spec",
+    ],
 )
 @dataclass
 class AttentionMetadata(object):
@@ -93,6 +124,8 @@ class AttentionMetadata(object):
 
     # PCP gather-KV only. Number of kv pages occupied by the current request.
     pcp_cache_pages: int | None = None
+
+    attention_mask_spec: AttentionMaskSpec = CAUSAL_ATTENTION_MASK
 
 
 @functools.partial(

--- a/tpu_inference/layers/jax/__init__.py
+++ b/tpu_inference/layers/jax/__init__.py
@@ -28,7 +28,7 @@ class JaxModule(nnx.Module):
                          prefix: str = "",
                          recurse=True) -> Iterator[tuple[str, nnx.Param]]:
         """Yields the named parameters of the module.
-        
+
         Arguments:
             prefix: Prefix to add to the parameter names.
             recurse: If True, then yields parameters of this module and all submodules.
@@ -52,7 +52,7 @@ class JaxModule(nnx.Module):
     def named_children(
             self) -> Iterator[tuple[str, "JaxModule | JaxModuleList"]]:
         """Returns an iterator over immediate children modules.
-        
+
         Yields:
             (string, Module | list): Tuple containing a name and child module
         """
@@ -106,6 +106,15 @@ class JaxModule(nnx.Module):
             child_prefix = f"{prefix}.{name}" if prefix else name
             yield from child.named_modules(memo, child_prefix,
                                            remove_duplicate)
+
+    def modules(self) -> Iterator["JaxModule | JaxModuleList"]:
+        """Yields self and every descendant module.
+
+        Mirrors ``torch.nn.Module.modules`` so vLLM lifecycle code can inspect a
+        JAX model without assuming that it is a PyTorch module.
+        """
+        for _, module in self.named_modules():
+            yield module
 
 
 class JaxModuleList(nnx.List):
@@ -173,3 +182,8 @@ class JaxModuleList(nnx.List):
             module_prefix = f"{prefix}.{idx}" if prefix else str(idx)
             yield from module.named_modules(memo, module_prefix,
                                             remove_duplicate)
+
+    def modules(self) -> Iterator["JaxModule | JaxModuleList"]:
+        """Yields the container and every descendant module."""
+        for _, module in self.named_modules():
+            yield module

--- a/tpu_inference/layers/jax/attention/attention.py
+++ b/tpu_inference/layers/jax/attention/attention.py
@@ -26,7 +26,8 @@ from jax.sharding import PartitionSpec as P
 from tpu_inference import envs, utils
 from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
     ragged_paged_attention
-from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.common.attention_metadata import (
+    AttentionMetadata, resolve_use_causal_mask)
 from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.base import create_param
@@ -272,6 +273,7 @@ class Attention(nnx.Module):
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                use_causal_mask=resolve_use_causal_mask(attention_metadata),
                 **block_size_kwargs,
             )
 

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -300,6 +300,8 @@ class TpuPlatform(Platform):
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
 
+        requested_data_parallel_size = \
+            vllm_config.parallel_config.data_parallel_size
         cls._resolve_multiprocess_dp(vllm_config)
 
         if vllm_envs.VLLM_TPU_USING_PATHWAYS:
@@ -445,6 +447,40 @@ class TpuPlatform(Platform):
 
         enable_continue_decode = vllm_config.additional_config.get(
             "enable_continue_decode", False)
+        from tpu_inference.runner.experimental.diffusion.config import (
+            GenerationStrategy, resolve_generation_strategy)
+        generation_strategy = resolve_generation_strategy(vllm_config)
+        enable_block_diffusion = (generation_strategy.strategy
+                                  is GenerationStrategy.BLOCK_DIFFUSION)
+        if enable_continue_decode and enable_block_diffusion:
+            raise ValueError(
+                "continue_decode and block_diffusion are mutually exclusive")
+        if enable_block_diffusion:
+            logger.warning_once(
+                "Block-diffusion serving is experimental and may change "
+                "without notice.")
+            assert generation_strategy.diffusion is not None
+            diffusion = generation_strategy.diffusion
+            from tpu_inference.runner.experimental.diffusion import \
+                request_validation
+            request_validation.patch_vllm_input_processor_for_block_diffusion()
+            from tpu_inference.runner.utils import MIN_NUM_SEQS
+            diffusion_batch_capacity = (
+                scheduler_config.max_num_batched_tokens //
+                diffusion.model.block_size)
+            if diffusion_batch_capacity < MIN_NUM_SEQS:
+                raise ValueError(
+                    "block_diffusion requires max_num_batched_tokens to fit "
+                    f"the minimum padded batch of {MIN_NUM_SEQS} diffusion "
+                    "blocks")
+            scheduler_config.max_num_seqs = min(
+                scheduler_config.max_num_seqs,
+                diffusion_batch_capacity,
+            )
+            from tpu_inference.core.sched.utils import \
+                MULTI_TOKEN_LOOKAHEAD_CONFIG
+            vllm_config.additional_config[
+                MULTI_TOKEN_LOOKAHEAD_CONFIG] = diffusion.model.block_size - 1
         is_pooling_model = vllm_config.model_config.runner_type == "pooling"
 
         # Late initialization to avoid circular import.
@@ -452,18 +488,73 @@ class TpuPlatform(Platform):
             update_vllm_config_for_dp_scheduler
         update_vllm_config_for_dp_scheduler(vllm_config)
 
-        if enable_continue_decode:
+        if enable_continue_decode or enable_block_diffusion:
+            mode = ("continue_decode"
+                    if enable_continue_decode else "block_diffusion")
             if parallel_config.pipeline_parallel_size > 1:
                 raise ValueError(
-                    "continue_decode is not supported with pipeline parallelism"
-                )
+                    f"{mode} is not supported with pipeline parallelism")
             if is_pooling_model:
-                raise ValueError(
-                    "continue_decode is not supported for pooling models")
+                raise ValueError(f"{mode} is not supported for pooling models")
 
-            from tpu_inference.core.sched.utils import \
-                patch_vllm_scheduler_for_continue_decode
-            patch_vllm_scheduler_for_continue_decode()
+            if enable_block_diffusion:
+                if kv_transfer_config is not None:
+                    raise ValueError(
+                        "block_diffusion does not support KV transfer")
+                if scheduler_config.async_scheduling:
+                    raise ValueError(
+                        "block_diffusion is not supported with async scheduling"
+                    )
+                if vllm_config.speculative_config is not None:
+                    raise ValueError(
+                        "block_diffusion is not supported with speculative decoding"
+                    )
+                if vllm_config.lora_config is not None:
+                    raise ValueError(
+                        "block_diffusion is not supported with LoRA")
+                if vllm_config.model_config.is_multimodal_model:
+                    raise ValueError(
+                        "block_diffusion is not supported for multimodal models"
+                    )
+                total_dp_size = getattr(vllm_config.sharding_config,
+                                        "total_dp_size", 1)
+                if (requested_data_parallel_size > 1 or
+                    (isinstance(total_dp_size, int) and total_dp_size > 1)):
+                    raise ValueError(
+                        "block_diffusion currently requires data_parallel_size=1"
+                    )
+                if getattr(scheduler_config, "enable_chunked_prefill", False):
+                    raise ValueError(
+                        "block_diffusion currently requires chunked prefill "
+                        "to be disabled")
+                if envs.USE_BATCHED_RPA_KERNEL:
+                    raise ValueError(
+                        "block_diffusion requires the default RPA kernel")
+                hf_config = vllm_config.model_config.hf_config
+                text_config = getattr(hf_config, "text_config", hf_config)
+                head_dim = getattr(text_config, "head_dim", None)
+                if head_dim is None:
+                    hidden_size = getattr(text_config, "hidden_size", None)
+                    num_heads = getattr(text_config, "num_attention_heads",
+                                        None)
+                    if hidden_size is not None and num_heads:
+                        head_dim = hidden_size // num_heads
+                if head_dim == 64:
+                    raise ValueError(
+                        "block_diffusion is not supported with head_dim=64")
+                if getattr(vllm_config.cache_config, "enable_prefix_caching",
+                           False):
+                    raise ValueError(
+                        "block_diffusion is not supported with prefix caching")
+
+            if enable_continue_decode:
+                from tpu_inference.core.sched.utils import \
+                    patch_vllm_scheduler_for_continue_decode
+                patch_vllm_scheduler_for_continue_decode()
+            else:
+                from tpu_inference.core.sched.utils import \
+                    patch_vllm_scheduler_for_multi_token_decode
+                patch_vllm_scheduler_for_multi_token_decode()
 
     @classmethod
     def update_block_size_for_backend(cls, vllm_config: VllmConfig) -> None:

--- a/tpu_inference/runner/experimental/diffusion/__init__.py
+++ b/tpu_inference/runner/experimental/diffusion/__init__.py
@@ -16,15 +16,21 @@
 This package is opt-in and has no API compatibility guarantee.
 """
 
-from tpu_inference.runner.experimental.diffusion.config import (
-    AttentionPolicy, CanvasPolicy, DiffusionAlgorithm, DiffusionConfig,
-    DiffusionModelSpec, DiffusionRuntimeConfig, GenerationStrategy,
-    GenerationStrategyConfig, LogitAlignment, PromptRemainderPolicy,
-    register_diffusion_model_adapter, resolve_generation_strategy)
+from .algorithm import CommitFn, get_commit_algorithm, low_confidence_commit
+from .config import (AttentionPolicy, CanvasPolicy, DiffusionAlgorithm,
+                     DiffusionConfig, DiffusionModelSpec,
+                     DiffusionRuntimeConfig, GenerationStrategy,
+                     GenerationStrategyConfig, LogitAlignment, NextBlockPolicy,
+                     PromptRemainderPolicy, register_diffusion_model_adapter,
+                     resolve_generation_strategy)
+from .program import BlockForwardFn, DenoiseBlockOutput, denoise_block
 
 __all__ = [
     "AttentionPolicy",
+    "BlockForwardFn",
     "CanvasPolicy",
+    "CommitFn",
+    "DenoiseBlockOutput",
     "DiffusionAlgorithm",
     "DiffusionConfig",
     "DiffusionModelSpec",
@@ -32,7 +38,11 @@ __all__ = [
     "GenerationStrategy",
     "GenerationStrategyConfig",
     "LogitAlignment",
+    "NextBlockPolicy",
     "PromptRemainderPolicy",
+    "denoise_block",
+    "get_commit_algorithm",
+    "low_confidence_commit",
     "register_diffusion_model_adapter",
     "resolve_generation_strategy",
 ]

--- a/tpu_inference/runner/experimental/diffusion/__init__.py
+++ b/tpu_inference/runner/experimental/diffusion/__init__.py
@@ -25,6 +25,12 @@ from .config import (AttentionPolicy, CanvasPolicy, DiffusionAlgorithm,
                      resolve_generation_strategy)
 from .program import BlockForwardFn, DenoiseBlockOutput, denoise_block
 
+from .batch import (  # isort: skip
+    PendingBlockOutput, PromptBlockPlan, complete_seeded_decode_block,
+    flush_partial_block_output, plan_seeded_prompt, required_cache_end,
+    start_partial_block_output,
+)
+
 __all__ = [
     "AttentionPolicy",
     "BlockForwardFn",
@@ -39,10 +45,17 @@ __all__ = [
     "GenerationStrategyConfig",
     "LogitAlignment",
     "NextBlockPolicy",
+    "PendingBlockOutput",
+    "PromptBlockPlan",
     "PromptRemainderPolicy",
+    "complete_seeded_decode_block",
     "denoise_block",
+    "flush_partial_block_output",
     "get_commit_algorithm",
     "low_confidence_commit",
+    "plan_seeded_prompt",
+    "required_cache_end",
     "register_diffusion_model_adapter",
     "resolve_generation_strategy",
+    "start_partial_block_output",
 ]

--- a/tpu_inference/runner/experimental/diffusion/algorithm.py
+++ b/tpu_inference/runner/experimental/diffusion/algorithm.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+
+import jax
+import jax.numpy as jnp
+
+from .config import DiffusionAlgorithm
+
+CommitFn = Callable[
+    [jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, int],
+    tuple[jax.Array, jax.Array],
+]
+
+
+def _exclude_mask_token(
+    logits: jax.Array,
+    mask_token_id: int,
+) -> jax.Array:
+    """Remove the diffusion MASK token from the candidate distribution."""
+    if logits.ndim != 3:
+        raise ValueError("logits must have shape [batch, length, vocab]")
+    vocab_size = logits.shape[-1]
+    if vocab_size < 2:
+        raise ValueError("logits must contain at least two vocabulary entries")
+    if not 0 <= mask_token_id < vocab_size:
+        raise ValueError("mask_token_id must be within the logits vocabulary")
+
+    candidate_logits = logits.astype(jnp.float32)
+    candidate_logits = candidate_logits.at[..., mask_token_id].set(-jnp.inf)
+
+    # Keep one non-MASK candidate finite so argmax cannot select MASK even when
+    # every model logit is -inf.
+    fallback_token_id = 1 if mask_token_id == 0 else 0
+    fallback_logits = candidate_logits[..., fallback_token_id]
+    fallback_logits = jnp.where(
+        jnp.isneginf(fallback_logits) | jnp.isnan(fallback_logits),
+        jnp.finfo(jnp.float32).min,
+        fallback_logits,
+    )
+    return candidate_logits.at[..., fallback_token_id].set(fallback_logits)
+
+
+def low_confidence_commit(
+    logits: jax.Array,
+    eligible_mask: jax.Array,
+    active_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    mask_token_id: int,
+) -> tuple[jax.Array, jax.Array]:
+    """Select greedy tokens and retain positions that need more denoising.
+
+    Temperature rescales confidence and can therefore change which positions
+    cross the commit threshold. Token selection remains deterministic argmax:
+    this algorithm has no RNG and temperature does not sample alternate tokens.
+    """
+    if eligible_mask.shape != logits.shape[:2]:
+        raise ValueError("eligible_mask must match logits [batch, length]")
+
+    active_rows = jnp.asarray(active_rows, dtype=bool)
+    confidence_threshold = jnp.asarray(confidence_threshold, dtype=jnp.float32)
+    temperature = jnp.asarray(temperature, dtype=jnp.float32)
+    safe_temperature = jnp.where(temperature > 0.0, temperature, 1.0)
+    scaled_logits = logits.astype(jnp.float32) / safe_temperature[:, None,
+                                                                  None]
+    scaled_logits = _exclude_mask_token(scaled_logits, mask_token_id)
+
+    token_ids = jnp.argmax(scaled_logits, axis=-1).astype(jnp.int32)
+    max_logits = jnp.max(scaled_logits, axis=-1)
+    log_confidence = max_logits - jax.nn.logsumexp(scaled_logits, axis=-1)
+    log_threshold = jnp.log(jnp.clip(confidence_threshold, min=0.0,
+                                     max=1.0))[:, None]
+
+    eligible = jnp.asarray(eligible_mask, dtype=bool) & active_rows[:, None]
+    commit = eligible & (log_confidence > log_threshold)
+
+    masked_confidence = jnp.where(eligible, log_confidence, -jnp.inf)
+    forced_indices = jnp.argmax(masked_confidence, axis=-1)
+    forced = jax.nn.one_hot(forced_indices, logits.shape[1], dtype=bool)
+    forced &= jnp.any(eligible, axis=-1)[:, None]
+    commit |= forced
+
+    remaining = eligible & ~commit
+    return token_ids, remaining
+
+
+_COMMIT_ALGORITHMS: dict[DiffusionAlgorithm, CommitFn] = {
+    DiffusionAlgorithm.LOW_CONFIDENCE: low_confidence_commit,
+}
+
+
+def get_commit_algorithm(algorithm: DiffusionAlgorithm) -> CommitFn:
+    try:
+        return _COMMIT_ALGORITHMS[algorithm]
+    except KeyError as exc:
+        raise ValueError(
+            f"No commit implementation is registered for {algorithm.value!r}"
+        ) from exc

--- a/tpu_inference/runner/experimental/diffusion/batch.py
+++ b/tpu_inference/runner/experimental/diffusion/batch.py
@@ -1,0 +1,103 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Host-side state helpers for experimental block-diffusion serving."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PromptBlockPlan:
+    full_blocks: tuple[tuple[int, ...], ...]
+    partial_canvas: tuple[int, ...] | None
+    partial_mask: tuple[bool, ...] | None
+    remainder_size: int
+
+
+@dataclass
+class PendingBlockOutput:
+    tokens: list[int]
+    next_anchor: int
+
+
+def required_cache_end(
+    prompt_length: int,
+    max_new_tokens: int,
+    block_size: int,
+) -> int:
+    if prompt_length < 0 or max_new_tokens < 0 or block_size < 1:
+        raise ValueError(
+            "Lengths must be non-negative and block_size positive")
+    num_cached_tokens = prompt_length + max(0, max_new_tokens - 1)
+    return ((num_cached_tokens + block_size - 1) // block_size * block_size)
+
+
+def plan_seeded_prompt(
+    prompt_token_ids: list[int],
+    block_size: int,
+    mask_token_id: int,
+) -> PromptBlockPlan:
+    if not prompt_token_ids:
+        raise ValueError("Block diffusion requires a non-empty prompt")
+    if block_size < 1:
+        raise ValueError("block_size must be positive")
+
+    num_full_blocks, remainder_size = divmod(len(prompt_token_ids), block_size)
+    full_blocks = tuple(
+        tuple(prompt_token_ids[index * block_size:(index + 1) * block_size])
+        for index in range(num_full_blocks))
+    if remainder_size == 0:
+        return PromptBlockPlan(
+            full_blocks=full_blocks,
+            partial_canvas=None,
+            partial_mask=None,
+            remainder_size=0,
+        )
+
+    remainder = prompt_token_ids[num_full_blocks * block_size:]
+    partial_canvas = tuple(remainder) + (mask_token_id, ) * (block_size -
+                                                             remainder_size)
+    partial_mask = (False, ) * remainder_size + (True, ) * (block_size -
+                                                            remainder_size)
+    return PromptBlockPlan(
+        full_blocks=full_blocks,
+        partial_canvas=partial_canvas,
+        partial_mask=partial_mask,
+        remainder_size=remainder_size,
+    )
+
+
+def start_partial_block_output(
+    committed_canvas: list[int],
+    remainder_size: int,
+    next_anchor: int,
+) -> tuple[list[int], PendingBlockOutput]:
+    generated = committed_canvas[remainder_size:]
+    if not generated:
+        raise ValueError(
+            "A partial prompt block must generate at least one token")
+    pending = PendingBlockOutput(tokens=generated[1:], next_anchor=next_anchor)
+    return [generated[0]], pending
+
+
+def flush_partial_block_output(state: PendingBlockOutput) -> list[int]:
+    return [*state.tokens, state.next_anchor]
+
+
+def complete_seeded_decode_block(
+    committed_canvas: list[int],
+    next_anchor: int,
+) -> list[int]:
+    if not committed_canvas:
+        raise ValueError("committed_canvas must not be empty")
+    return [*committed_canvas[1:], next_anchor]

--- a/tpu_inference/runner/experimental/diffusion/config.py
+++ b/tpu_inference/runner/experimental/diffusion/config.py
@@ -80,6 +80,11 @@ class DiffusionModelSpec:
         if self.block_size % self.sub_block_size:
             raise ValueError(
                 "Diffusion sub_block_size must divide block_size exactly")
+        if (self.logit_alignment is LogitAlignment.SHIFTED
+                and self.canvas_policy is not CanvasPolicy.SEED_AND_MASK):
+            raise ValueError(
+                "Shifted logit alignment requires seed_and_mask canvas semantics"
+            )
         if not self.supported_algorithms:
             raise ValueError(
                 "Diffusion model spec must support at least one algorithm")

--- a/tpu_inference/runner/experimental/diffusion/program.py
+++ b/tpu_inference/runner/experimental/diffusion/program.py
@@ -1,0 +1,250 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+from collections.abc import Callable
+from typing import Any, NamedTuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from .algorithm import CommitFn, _exclude_mask_token
+from .config import LogitAlignment, NextBlockPolicy
+
+BlockForwardFn = Callable[
+    [Any, jax.Array, jax.Array, Any, jax.Array, Any],
+    tuple[jax.Array, Any],
+]
+
+
+class DenoiseBlockOutput(NamedTuple):
+    canvas: jax.Array
+    next_anchor: jax.Array
+    denoise_steps: jax.Array
+    kv_caches: Any
+
+
+def _align_logits(
+    logits: jax.Array,
+    alignment: LogitAlignment,
+) -> jax.Array:
+    if alignment is LogitAlignment.SAME_POSITION:
+        return logits
+    if alignment is LogitAlignment.SHIFTED:
+        indices = jnp.maximum(
+            jnp.arange(logits.shape[1], dtype=jnp.int32) - 1, 0)
+        return logits[:, indices, :]
+    raise ValueError(f"Unsupported logit alignment: {alignment}")
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=(
+        "forward_fn",
+        "commit_fn",
+        "logit_alignment",
+        "next_block_policy",
+        "mask_token_id",
+        "sub_block_size",
+        "max_denoise_steps",
+    ),
+)
+def _denoise_block_jit(
+    forward_fn: BlockForwardFn,
+    commit_fn: CommitFn,
+    model_state: Any,
+    initial_canvas: jax.Array,
+    initial_mask: jax.Array,
+    positions: jax.Array,
+    kv_caches: Any,
+    active_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    forward_context: Any,
+    *,
+    logit_alignment: LogitAlignment,
+    next_block_policy: NextBlockPolicy,
+    mask_token_id: int,
+    sub_block_size: int,
+    max_denoise_steps: int = 0,
+) -> DenoiseBlockOutput:
+    """Jitted block denoising implementation.
+
+    ``forward_fn`` must leave cache entries for false ``active_rows`` unchanged.
+    The cache is opaque to this program, so inactive-row isolation belongs to
+    the forward implementation that maps logical rows to physical cache pages.
+
+    ``max_denoise_steps`` limits while-loop iterations for each sub-block, not
+    for the full model block. Zero uses ``sub_block_size`` iterations. The full
+    block can therefore run ``num_sub_blocks * steps_per_sub_block`` denoising
+    forwards, followed by one final forward that commits the completed KV state.
+    """
+    if initial_canvas.ndim != 2:
+        raise ValueError("initial_canvas must have shape [batch, block_size]")
+    if initial_mask.shape != initial_canvas.shape:
+        raise ValueError("initial_mask must match initial_canvas")
+    if positions.shape != initial_canvas.shape:
+        raise ValueError("positions must match initial_canvas")
+    if sub_block_size < 1 or initial_canvas.shape[1] % sub_block_size:
+        raise ValueError("sub_block_size must divide the model block size")
+
+    batch_size, block_size = initial_canvas.shape
+    del batch_size
+    active_rows = jnp.asarray(active_rows, dtype=bool)
+    canvas = initial_canvas.astype(jnp.int32)
+    mask = jnp.asarray(initial_mask, dtype=bool) & active_rows[:, None]
+    denoise_steps = jnp.zeros((canvas.shape[0], ), dtype=jnp.int32)
+    steps_per_sub_block = (sub_block_size
+                           if max_denoise_steps <= 0 else max_denoise_steps)
+    num_sub_blocks = block_size // sub_block_size
+
+    def denoise_sub_block(sub_block_index, carry):
+        canvas, mask, denoise_steps, kv = carry
+        start = sub_block_index * sub_block_size
+        sub_block_positions = (
+            (jnp.arange(block_size) >= start) &
+            (jnp.arange(block_size) < start + sub_block_size))
+        eligible = mask & sub_block_positions[None, :]
+        last_tokens = canvas
+
+        state = (
+            canvas,
+            mask,
+            denoise_steps,
+            kv,
+            eligible,
+            last_tokens,
+            jnp.array(0, dtype=jnp.int32),
+        )
+
+        def has_work(state):
+            _, _, _, _, eligible, _, iteration = state
+            return ((iteration < steps_per_sub_block) & jnp.any(eligible))
+
+        def denoise_step(state):
+            canvas, mask, steps, kv, eligible, _, iteration = state
+            row_has_work = jnp.any(eligible, axis=-1)
+            logits, kv = forward_fn(model_state, canvas, positions, kv,
+                                    active_rows, forward_context)
+            aligned_logits = _align_logits(logits, logit_alignment)
+            token_ids, remaining = commit_fn(
+                aligned_logits,
+                eligible,
+                active_rows,
+                confidence_threshold,
+                temperature,
+                mask_token_id,
+            )
+            committed = eligible & ~remaining
+            canvas = jnp.where(committed, token_ids, canvas)
+            mask &= ~committed
+            steps += row_has_work.astype(jnp.int32)
+            return (canvas, mask, steps, kv, remaining, token_ids,
+                    iteration + 1)
+
+        state = jax.lax.while_loop(has_work, denoise_step, state)
+        canvas, mask, denoise_steps, kv, remaining, last_tokens, _ = state
+
+        canvas = jnp.where(remaining, last_tokens, canvas)
+        mask &= ~remaining
+        return canvas, mask, denoise_steps, kv
+
+    canvas, mask, denoise_steps, kv_caches = jax.lax.fori_loop(
+        0,
+        num_sub_blocks,
+        denoise_sub_block,
+        (canvas, mask, denoise_steps, kv_caches),
+    )
+
+    final_logits, kv_caches = forward_fn(model_state, canvas, positions,
+                                         kv_caches, active_rows,
+                                         forward_context)
+    if next_block_policy is NextBlockPolicy.LAST_LOGIT_ANCHOR:
+        anchor_logits = _exclude_mask_token(final_logits[:, -1:, :],
+                                            mask_token_id)
+        next_anchor = jnp.argmax(anchor_logits[:, 0, :],
+                                 axis=-1).astype(jnp.int32)
+    elif next_block_policy is NextBlockPolicy.ALL_MASKED:
+        next_anchor = jnp.zeros((canvas.shape[0], ), dtype=jnp.int32)
+    else:
+        raise ValueError(f"Unsupported next block policy: {next_block_policy}")
+    next_anchor = jnp.where(active_rows, next_anchor, 0)
+    return DenoiseBlockOutput(
+        canvas=canvas,
+        next_anchor=next_anchor,
+        denoise_steps=denoise_steps,
+        kv_caches=kv_caches,
+    )
+
+
+def denoise_block(
+    forward_fn: BlockForwardFn,
+    commit_fn: CommitFn,
+    model_state: Any,
+    initial_canvas: jax.Array,
+    initial_mask: jax.Array,
+    positions: jax.Array,
+    kv_caches: Any,
+    active_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    forward_context: Any,
+    *,
+    logit_alignment: LogitAlignment,
+    next_block_policy: NextBlockPolicy,
+    mask_token_id: int,
+    sub_block_size: int,
+    max_denoise_steps: int = 0,
+) -> DenoiseBlockOutput:
+    """Validate and denoise one model block.
+
+    Shifted logits predict canvas position ``i + 1`` from logits position ``i``.
+    Position zero therefore has no aligned prediction and must be an immutable
+    seed for every active row. This host-side check fails before compilation or
+    token commitment instead of silently consuming the wrong logits.
+    """
+    if initial_canvas.ndim != 2:
+        raise ValueError("initial_canvas must have shape [batch, block_size]")
+    if initial_mask.shape != initial_canvas.shape:
+        raise ValueError("initial_mask must match initial_canvas")
+    if active_rows.shape != (initial_canvas.shape[0], ):
+        raise ValueError("active_rows must match the canvas batch size")
+    if logit_alignment is LogitAlignment.SHIFTED:
+        seed_mask, active = jax.device_get((initial_mask[:, 0], active_rows))
+        if np.any(
+                np.asarray(seed_mask, dtype=bool)
+                & np.asarray(active, dtype=bool)):
+            raise ValueError(
+                "Shifted logit alignment requires position 0 to be an "
+                "unmasked seed for every active row")
+
+    return _denoise_block_jit(
+        forward_fn,
+        commit_fn,
+        model_state,
+        initial_canvas,
+        initial_mask,
+        positions,
+        kv_caches,
+        active_rows,
+        confidence_threshold,
+        temperature,
+        forward_context,
+        logit_alignment=logit_alignment,
+        next_block_policy=next_block_policy,
+        mask_token_id=mask_token_id,
+        sub_block_size=sub_block_size,
+        max_denoise_steps=max_denoise_steps,
+    )

--- a/tpu_inference/runner/experimental/diffusion/request_validation.py
+++ b/tpu_inference/runner/experimental/diffusion/request_validation.py
@@ -1,0 +1,46 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Request validation for experimental block-diffusion serving."""
+
+import functools
+
+
+def patch_vllm_input_processor_for_block_diffusion() -> None:
+    """Reject resumable requests before they reach the diffusion runner."""
+    from vllm.v1.engine.input_processor import InputProcessor
+
+    if getattr(InputProcessor, "_block_diffusion_validation_patched", False):
+        return
+
+    original_process_inputs = InputProcessor.process_inputs
+
+    @functools.wraps(original_process_inputs)
+    def patched_process_inputs(processor_self, *args, **kwargs):
+        if "resumable" in kwargs:
+            resumable = bool(kwargs["resumable"])
+        else:
+            # `resumable` is the eleventh positional argument after `self`.
+            resumable = len(args) > 10 and bool(args[10])
+        additional_config = getattr(processor_self.vllm_config,
+                                    "additional_config", {}) or {}
+        raw_strategy = additional_config.get("generation_strategy")
+        strategy = getattr(raw_strategy, "value", raw_strategy)
+        if resumable and strategy == "block_diffusion":
+            raise ValueError(
+                "block_diffusion does not support resumable or streaming-input "
+                "requests")
+        return original_process_inputs(processor_self, *args, **kwargs)
+
+    InputProcessor.process_inputs = patched_process_inputs
+    InputProcessor._block_diffusion_validation_patched = True

--- a/tpu_inference/runner/experimental/diffusion/strategy.py
+++ b/tpu_inference/runner/experimental/diffusion/strategy.py
@@ -1,0 +1,544 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Experimental block-diffusion strategy for the existing TPU runner."""
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from vllm.forward_context import set_forward_context
+from vllm.v1.outputs import ModelRunnerOutput
+
+from tpu_inference.layers.common.attention_metadata import (AttentionMaskKind,
+                                                            AttentionMaskSpec,
+                                                            AttentionMetadata)
+from tpu_inference.utils import device_array
+
+from .algorithm import get_commit_algorithm
+from .batch import (PendingBlockOutput, complete_seeded_decode_block,
+                    flush_partial_block_output, plan_seeded_prompt,
+                    required_cache_end, start_partial_block_output)
+from .config import (CanvasPolicy, DiffusionConfig, NextBlockPolicy,
+                     PromptRemainderPolicy)
+from .program import denoise_block
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+    from tpu_inference.runner.tpu_runner import TPUModelRunner
+
+
+class BlockDiffusionStrategy:
+
+    def __init__(self, runner: "TPUModelRunner",
+                 config: DiffusionConfig) -> None:
+        self.runner = runner
+        self.config = config
+        self._pending_outputs: dict[str, PendingBlockOutput] = {}
+        self._forward_fn = self._model_forward
+        self._commit_fn = get_commit_algorithm(config.runtime.algorithm)
+
+        model = config.model
+        if model.canvas_policy is not CanvasPolicy.SEED_AND_MASK:
+            raise ValueError(
+                "The TPU serving strategy currently requires seed_and_mask "
+                "canvas semantics")
+        if model.prompt_remainder_policy is not \
+                PromptRemainderPolicy.INCLUDE_IN_FIRST_CANVAS:
+            raise ValueError(
+                "The TPU serving strategy currently requires prompt "
+                "remainders in the first canvas")
+        if model.next_block_policy is not NextBlockPolicy.LAST_LOGIT_ANCHOR:
+            raise ValueError(
+                "The seed_and_mask serving strategy requires a last-logit "
+                "next-block anchor")
+        if config.runtime.temperature != 0.0:
+            raise ValueError(
+                "Stochastic diffusion sampling is not supported yet; set "
+                "diffusion.temperature to 0")
+
+    @property
+    def block_size(self) -> int:
+        return self.config.model.block_size
+
+    def _validate_runner_capabilities(self) -> None:
+        runner = self.runner
+        if runner.dp_size != 1:
+            raise ValueError(
+                "Block diffusion currently supports data_parallel_size=1")
+        if "dcp" in runner.mesh.shape and runner.mesh.shape["dcp"] > 1:
+            raise ValueError("Block diffusion does not support DCP")
+        if len(runner.kv_cache_config.kv_cache_groups) != 1:
+            raise ValueError(
+                "Block diffusion requires exactly one KV cache group")
+        if runner.kv_cache_config.has_mamba_layers:
+            raise ValueError(
+                "Block diffusion does not support hybrid or Mamba models")
+
+    def _validate_requests(self, req_ids: list[str]) -> None:
+        input_batch = self.runner.input_batch
+        for req_id in req_ids:
+            req_index = input_batch.req_id_to_index[req_id]
+            request = self.runner.requests[req_id]
+            sampling_params = request.sampling_params
+            if (req_id in input_batch.num_logprobs
+                    or req_id in input_batch.num_prompt_logprobs):
+                raise ValueError(
+                    "Block diffusion does not support token logprobs yet")
+            if req_id in input_batch.has_allowed_token_ids:
+                raise ValueError(
+                    "Block diffusion does not support allowed_token_ids")
+            if req_index in input_batch.bad_words_token_ids:
+                raise ValueError(
+                    "Block diffusion does not support bad_words filtering")
+            if input_batch.logit_bias[req_index]:
+                raise ValueError(
+                    "Block diffusion does not support per-request logit_bias")
+            if req_id in input_batch.random_reqs:
+                raise ValueError(
+                    "Block diffusion currently requires greedy sampling; set "
+                    "temperature=0")
+            if (sampling_params.presence_penalty != 0.0
+                    or sampling_params.frequency_penalty != 0.0
+                    or sampling_params.repetition_penalty != 1.0):
+                raise ValueError(
+                    "Block diffusion does not support sampling penalties")
+            if sampling_params.min_tokens != 0:
+                raise ValueError(
+                    "Block diffusion does not support min_tokens yet")
+
+            if sampling_params.max_tokens is None:
+                raise ValueError(
+                    "Block diffusion requires an explicit max_tokens limit")
+            max_tokens = int(sampling_params.max_tokens)
+            max_tokens = min(
+                max_tokens,
+                max(0, self.runner.max_model_len - request.num_prompt_tokens),
+            )
+            cache_end = required_cache_end(request.num_prompt_tokens,
+                                           max_tokens, self.block_size)
+            if cache_end > self.runner.max_model_len:
+                raise ValueError(
+                    f"Block diffusion request {req_id!r} requires cache "
+                    f"through position {cache_end}, beyond "
+                    f"max_model_len={self.runner.max_model_len}")
+
+    def _build_batch(
+        self,
+        req_ids: list[str],
+        block_starts: list[int],
+        canvases: list[list[int]],
+        masks: list[list[bool]] | None = None,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, AttentionMetadata]:
+        runner = self.runner
+        batch_size = runner.max_num_reqs
+        block_size = self.block_size
+        num_active = len(req_ids)
+        if num_active > batch_size:
+            raise ValueError("Diffusion batch exceeds max_num_reqs")
+
+        canvas = np.zeros((batch_size, block_size), dtype=np.int32)
+        mask = np.zeros((batch_size, block_size), dtype=np.bool_)
+        positions = np.zeros((batch_size, block_size), dtype=np.int32)
+        seq_lens = np.zeros((batch_size, ), dtype=np.int32)
+        active_rows = np.zeros((batch_size, ), dtype=np.bool_)
+        query_start_loc = np.full((batch_size + 1, ),
+                                  num_active * block_size,
+                                  dtype=np.int32)
+        query_start_loc[:num_active + 1] = np.arange(
+            num_active + 1, dtype=np.int32) * block_size
+
+        source_block_tables = runner.input_batch.block_table[0].get_cpu_tensor(
+        )
+        block_tables = np.zeros_like(source_block_tables)
+        offsets = np.arange(block_size, dtype=np.int32)
+        for row, (req_id, block_start,
+                  row_canvas) in enumerate(zip(req_ids, block_starts,
+                                               canvases)):
+            if len(row_canvas) != block_size:
+                raise ValueError("Every diffusion canvas must be one block")
+            req_index = runner.input_batch.req_id_to_index[req_id]
+            block_end = block_start + block_size
+            if block_end > runner.max_model_len:
+                raise ValueError(
+                    f"Diffusion block for request {req_id!r} ends at "
+                    f"{block_end}, beyond max_model_len={runner.max_model_len}"
+                )
+            cache_block_size = runner.block_size
+            required_cache_blocks = (block_end + cache_block_size -
+                                     1) // cache_block_size
+            allocated_cache_blocks = int(runner.input_batch.block_table[0].
+                                         num_blocks_per_row[req_index])
+            if required_cache_blocks > allocated_cache_blocks:
+                raise ValueError(
+                    f"Diffusion block for request {req_id!r} needs "
+                    f"{required_cache_blocks} KV blocks, but the scheduler "
+                    f"allocated {allocated_cache_blocks}")
+            canvas[row] = row_canvas
+            if masks is not None:
+                mask[row] = masks[row]
+            positions[row] = block_start + offsets
+            seq_lens[row] = block_start + block_size
+            active_rows[row] = True
+            block_tables[row] = source_block_tables[req_index]
+
+        request_distribution = np.array([0, 0, num_active], dtype=np.int32)
+        (canvas, mask, positions, seq_lens, active_rows, query_start_loc,
+         request_distribution,
+         block_tables) = device_array(self.runner.mesh, (
+             canvas,
+             mask,
+             positions,
+             seq_lens,
+             active_rows,
+             query_start_loc,
+             request_distribution,
+             block_tables.reshape(-1),
+         ))
+        metadata = AttentionMetadata(
+            input_positions=positions.reshape(-1),
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            query_start_loc=query_start_loc,
+            request_distribution=request_distribution,
+            padded_num_reqs=batch_size,
+            attention_mask_spec=AttentionMaskSpec(
+                AttentionMaskKind.BIDIRECTIONAL),
+        )
+        return canvas, mask, positions, active_rows, metadata
+
+    def _model_forward(
+        self,
+        state_leaves: Any,
+        canvas: jax.Array,
+        positions: jax.Array,
+        kv_caches: Any,
+        active_rows: jax.Array,
+        attention_metadata: AttentionMetadata,
+    ) -> tuple[jax.Array, Any]:
+        del active_rows
+        runner = self.runner
+        flat_canvas = canvas.reshape(-1)
+        flat_positions = positions.reshape(-1)
+        attention_metadata = replace(attention_metadata,
+                                     input_positions=flat_positions)
+        kv_caches, hidden_states, _, _ = runner.model.step_fn_no_options(
+            state_leaves,
+            kv_caches,
+            flat_canvas,
+            attention_metadata,
+            None,
+            flat_positions,
+            tuple(runner.layer_name_to_kvcache_index.items()),
+            None,
+            None,
+            runner.is_first_rank,
+            runner.is_last_rank,
+        )
+        logits = runner.compute_logits_fn(state_leaves, hidden_states, None)
+        return logits.reshape(canvas.shape[0], canvas.shape[1], -1), kv_caches
+
+    def _forward_blocks(
+        self,
+        req_ids: list[str],
+        block_starts: list[int],
+        canvases: list[list[int]],
+    ) -> np.ndarray:
+        canvas, _, positions, active_rows, metadata = self._build_batch(
+            req_ids, block_starts, canvases)
+        logits, self.runner.kv_caches = self._forward_fn(
+            self.runner.state_leaves,
+            canvas,
+            positions,
+            self.runner.kv_caches,
+            active_rows,
+            metadata,
+        )
+        return np.asarray(jax.device_get(logits[:len(req_ids)]))
+
+    def _denoise_blocks(
+        self,
+        req_ids: list[str],
+        block_starts: list[int],
+        canvases: list[list[int]],
+        masks: list[list[bool]],
+    ) -> tuple[np.ndarray, np.ndarray]:
+        canvas, mask, positions, active_rows, metadata = self._build_batch(
+            req_ids, block_starts, canvases, masks)
+        batch_size = self.runner.max_num_reqs
+        thresholds = jnp.full(
+            (batch_size, ),
+            self.config.runtime.confidence_threshold,
+            dtype=jnp.float32,
+        )
+        temperatures = jnp.zeros((batch_size, ), dtype=jnp.float32)
+        output = denoise_block(
+            self._forward_fn,
+            self._commit_fn,
+            self.runner.state_leaves,
+            canvas,
+            mask,
+            positions,
+            self.runner.kv_caches,
+            active_rows,
+            thresholds,
+            temperatures,
+            metadata,
+            mask_token_id=self.config.model.mask_token_id,
+            logit_alignment=self.config.model.logit_alignment,
+            next_block_policy=self.config.model.next_block_policy,
+            sub_block_size=self.config.model.sub_block_size,
+            max_denoise_steps=self.config.runtime.max_denoise_steps,
+        )
+        self.runner.kv_caches = output.kv_caches
+        canvas_host, anchors_host = jax.device_get(
+            (output.canvas[:len(req_ids)], output.next_anchor[:len(req_ids)]))
+        return np.asarray(canvas_host), np.asarray(anchors_host)
+
+    def _process_prefill(self, req_ids: list[str]) -> dict[str, list[int]]:
+        plans = {}
+        for req_id in req_ids:
+            request = self.runner.requests[req_id]
+            scheduled = self._scheduler_output.num_scheduled_tokens[req_id]
+            history_token_ids = [
+                *request.prompt_token_ids,
+                *request.output_token_ids,
+            ]
+            if request.num_computed_tokens != 0 or scheduled != len(
+                    history_token_ids):
+                raise ValueError(
+                    "Block diffusion requires a full unchunked prefill or "
+                    "recompute pass "
+                    f"for request {req_id!r}")
+            self._pending_outputs.pop(req_id, None)
+            plans[req_id] = plan_seeded_prompt(
+                history_token_ids,
+                self.block_size,
+                self.config.model.mask_token_id,
+            )
+
+        aligned_seeds: dict[str, int] = {}
+        max_full_blocks = max(
+            (len(plan.full_blocks) for plan in plans.values()), default=0)
+        for block_index in range(max_full_blocks):
+            group = [
+                req_id for req_id in req_ids
+                if block_index < len(plans[req_id].full_blocks)
+            ]
+            canvases = [
+                list(plans[req_id].full_blocks[block_index])
+                for req_id in group
+            ]
+            logits = self._forward_blocks(
+                group,
+                [block_index * self.block_size] * len(group),
+                canvases,
+            )
+            anchors = np.argmax(logits[:, -1, :], axis=-1)
+            for row, req_id in enumerate(group):
+                plan = plans[req_id]
+                if (plan.remainder_size == 0
+                        and block_index == len(plan.full_blocks) - 1):
+                    aligned_seeds[req_id] = int(anchors[row])
+
+        outputs = {req_id: [aligned_seeds[req_id]] for req_id in aligned_seeds}
+        partial_group = [
+            req_id for req_id in req_ids
+            if plans[req_id].partial_canvas is not None
+        ]
+        if partial_group:
+            canvases = [
+                list(plans[req_id].partial_canvas) for req_id in partial_group
+            ]
+            masks = [
+                list(plans[req_id].partial_mask) for req_id in partial_group
+            ]
+            starts = [
+                len(plans[req_id].full_blocks) * self.block_size
+                for req_id in partial_group
+            ]
+            committed, anchors = self._denoise_blocks(partial_group, starts,
+                                                      canvases, masks)
+            for row, req_id in enumerate(partial_group):
+                output, pending = start_partial_block_output(
+                    committed[row].tolist(),
+                    plans[req_id].remainder_size,
+                    int(anchors[row]),
+                )
+                outputs[req_id] = output
+                self._pending_outputs[req_id] = pending
+        return outputs
+
+    def _process_decode(self, req_ids: list[str]) -> dict[str, list[int]]:
+        outputs: dict[str, list[int]] = {}
+        denoise_group = []
+        for req_id in req_ids:
+            pending = self._pending_outputs.pop(req_id, None)
+            if pending is not None:
+                outputs[req_id] = flush_partial_block_output(pending)
+            else:
+                denoise_group.append(req_id)
+
+        if not denoise_group:
+            return outputs
+
+        canvases = []
+        masks = []
+        starts = []
+        for req_id in denoise_group:
+            request = self.runner.requests[req_id]
+            block_start = request.num_computed_tokens
+            seed = request.get_token_id(block_start)
+            canvases.append([seed] + [self.config.model.mask_token_id] *
+                            (self.block_size - 1))
+            masks.append([False] + [True] * (self.block_size - 1))
+            starts.append(block_start)
+
+        committed, anchors = self._denoise_blocks(denoise_group, starts,
+                                                  canvases, masks)
+        for row, req_id in enumerate(denoise_group):
+            outputs[req_id] = complete_seeded_decode_block(
+                committed[row].tolist(), int(anchors[row]))
+        return outputs
+
+    def _truncate_output(self, req_id: str, tokens: list[int]) -> list[int]:
+        request = self.runner.requests[req_id]
+        assert request.sampling_params.max_tokens is not None
+        max_tokens = int(request.sampling_params.max_tokens)
+        output_remaining = max(0, max_tokens - len(request.output_token_ids))
+        context_remaining = max(0,
+                                self.runner.max_model_len - request.num_tokens)
+        remaining = min(output_remaining, context_remaining)
+        tokens = tokens[:remaining]
+
+        if not request.sampling_params.ignore_eos:
+            eos_token_ids = np.atleast_1d(self.runner.eos_token_id)
+            for index, token in enumerate(tokens):
+                if token in eos_token_ids:
+                    tokens = tokens[:index + 1]
+                    self._pending_outputs.pop(req_id, None)
+                    break
+        if len(tokens) == remaining:
+            self._pending_outputs.pop(req_id, None)
+        return tokens
+
+    def _append_outputs(self, outputs: dict[str,
+                                            list[int]]) -> list[list[int]]:
+        runner = self.runner
+        sampled_token_ids = [[] for _ in range(runner.input_batch.num_reqs)]
+        for req_id, tokens in outputs.items():
+            tokens = self._truncate_output(req_id, tokens)
+            req_index = runner.input_batch.req_id_to_index[req_id]
+            sampled_token_ids[req_index] = tokens
+            if not tokens:
+                continue
+            start = runner.input_batch.num_tokens_no_spec[req_index]
+            end = start + len(tokens)
+            if end > runner.max_model_len:
+                raise ValueError(
+                    f"Diffusion output for request {req_id!r} exceeds "
+                    "max_model_len")
+            runner.input_batch.token_ids_cpu[req_index, start:end] = tokens
+            runner.input_batch.num_tokens_no_spec[req_index] = end
+            runner.input_batch.num_tokens[req_index] = end
+            runner.requests[req_id].output_token_ids.extend(tokens)
+        return sampled_token_ids
+
+    def execute(self, scheduler_output: "SchedulerOutput") -> None:
+        self._validate_runner_capabilities()
+        self._scheduler_output = scheduler_output
+
+        scheduled_req_ids = [
+            req_id for req_id in
+            self.runner.input_batch.req_ids[:self.runner.input_batch.num_reqs]
+            if req_id in scheduler_output.num_scheduled_tokens
+        ]
+        if getattr(scheduler_output, "has_structured_output_requests", False):
+            raise ValueError(
+                "Block diffusion does not support structured output")
+        self._validate_requests(scheduled_req_ids)
+        prefill_req_ids = [
+            req_id for req_id in scheduled_req_ids
+            if self.runner.requests[req_id].num_computed_tokens <
+            self.runner.requests[req_id].num_prompt_tokens
+        ]
+        decode_req_ids = [
+            req_id for req_id in scheduled_req_ids
+            if req_id not in set(prefill_req_ids)
+        ]
+
+        with self.runner.maybe_forbid_compile, \
+             set_forward_context(None, self.runner.vllm_config), \
+             self.runner.maybe_get_kv_connector_output(
+                 scheduler_output) as kv_connector_output:
+            outputs = self._process_prefill(prefill_req_ids)
+            outputs.update(self._process_decode(decode_req_ids))
+
+        sampled_token_ids = self._append_outputs(outputs)
+        num_reqs = self.runner.input_batch.num_reqs
+        self.runner._generation_strategy_output = ModelRunnerOutput(
+            req_ids=self.runner.input_batch.req_ids[:num_reqs],
+            req_id_to_index=self.runner.input_batch.req_id_to_index.copy(),
+            sampled_token_ids=sampled_token_ids,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+            kv_connector_output=kv_connector_output,
+        )
+
+    def on_scheduler_update(self, finished_req_ids: set[str]) -> None:
+        for req_id in finished_req_ids:
+            self._pending_outputs.pop(req_id, None)
+
+    def precompile(self) -> None:
+        self._validate_runner_capabilities()
+        canvas, mask, positions, active_rows, metadata = self._build_batch([],
+                                                                           [],
+                                                                           [],
+                                                                           [])
+        logits, self.runner.kv_caches = self._forward_fn(
+            self.runner.state_leaves,
+            canvas,
+            positions,
+            self.runner.kv_caches,
+            active_rows,
+            metadata,
+        )
+        thresholds = jnp.full(
+            (self.runner.max_num_reqs, ),
+            self.config.runtime.confidence_threshold,
+            dtype=jnp.float32,
+        )
+        output = denoise_block(
+            self._forward_fn,
+            self._commit_fn,
+            self.runner.state_leaves,
+            canvas,
+            mask,
+            positions,
+            self.runner.kv_caches,
+            active_rows,
+            thresholds,
+            jnp.zeros_like(thresholds),
+            metadata,
+            mask_token_id=self.config.model.mask_token_id,
+            logit_alignment=self.config.model.logit_alignment,
+            next_block_policy=self.config.model.next_block_policy,
+            sub_block_size=self.config.model.sub_block_size,
+            max_denoise_steps=self.config.runtime.max_denoise_steps,
+        )
+        self.runner.kv_caches = output.kv_caches
+        jax.block_until_ready((logits, output.canvas))

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -73,6 +73,8 @@ from tpu_inference.models.jax.jax_intermediate_tensor import \
 from tpu_inference.runner import utils as runner_utils
 from tpu_inference.runner.compilation_manager import CompilationManager
 from tpu_inference.runner.decode_loop import TpuSamplingState, continue_decode
+from tpu_inference.runner.experimental.diffusion.config import (
+    GenerationStrategy, resolve_generation_strategy)
 from tpu_inference.runner.input_batch import CachedRequestState, InputBatch
 from tpu_inference.runner.kv_cache_manager import KVCacheManager
 from tpu_inference.runner.lora_utils import LoraUtils
@@ -124,7 +126,7 @@ logging.getLogger("torchax.tensor").setLevel(logging.ERROR)
 
 INVALID_TOKEN_ID = -1
 # Smallest output size
-MIN_NUM_SEQS = 8
+MIN_NUM_SEQS = runner_utils.MIN_NUM_SEQS
 
 
 @functools.partial(jax.jit, static_argnames=["dp_size", "tokens_per_dp"])
@@ -805,6 +807,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
         self.device_config = vllm_config.device_config
+        self.generation_strategy_config = resolve_generation_strategy(
+            vllm_config)
 
         self.devices = devices
         self.dtype = self.model_config.dtype
@@ -845,6 +849,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self._substitute_placeholder_token_fn = _substitute_placeholder_token
         self.execute_model_state: ExecuteModelState | None = None
         self._continue_decode_output = None
+        self._generation_strategy_output = None
         self.batch_counter = 0
 
         self.kv_caches: list[jax.Array] = []
@@ -865,6 +870,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             "max_decode_steps", DEFAULT_MAX_DECODE_STEPS)
         self.eos_token_id = runner_utils.get_eos_token_id(self.model_config)
         self.pad_token_id = runner_utils.get_pad_token_id(self.model_config)
+        if (self.generation_strategy_config.strategy
+                is GenerationStrategy.BLOCK_DIFFUSION):
+            from tpu_inference.runner.experimental.diffusion.strategy import \
+                BlockDiffusionStrategy
+            assert self.generation_strategy_config.diffusion is not None
+            self.block_diffusion_strategy = BlockDiffusionStrategy(
+                self, self.generation_strategy_config.diffusion)
+        else:
+            self.block_diffusion_strategy = None
 
     def _init_random(self):
         if self.model_config.seed is None:
@@ -1322,6 +1336,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
     def capture_model(self) -> None:
         self.compilation_manager.capture_model()
+        if self.block_diffusion_strategy is not None:
+            with jax.set_mesh(self.mesh):
+                self.block_diffusion_strategy.precompile()
 
     @time_function
     def execute_model(
@@ -1353,6 +1370,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self._continue_decode_output is not None:
             output = self._continue_decode_output
             self._continue_decode_output = None
+            return output
+
+        if self._generation_strategy_output is not None:
+            output = self._generation_strategy_output
+            self._generation_strategy_output = None
             return output
 
         if self.execute_model_state is None:
@@ -1555,6 +1577,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
     ) -> JaxIntermediateTensors | ModelRunnerOutput | None:
         self.persistent_batch_manager.update_states(
             scheduler_output, self.get_mrope_input_positions_fn)
+        if self.block_diffusion_strategy is not None:
+            self.block_diffusion_strategy.on_scheduler_update(
+                scheduler_output.finished_req_ids)
         if not scheduler_output.total_num_scheduled_tokens:
             if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
                 self._modify_prev_results()
@@ -1575,6 +1600,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 # raise Exception(
                 #     "Should not schedule a request that does nothing!")
             return EMPTY_MODEL_RUNNER_OUTPUT
+
+        if self.block_diffusion_strategy is not None:
+            return self.block_diffusion_strategy.execute(scheduler_output)
 
         # Check if the entire batch is in the decode phase.
         # request_distribution[0] tracks the number of decode requests.


### PR DESCRIPTION
> [!WARNING]
> Block-diffusion serving is experimental and opt-in. It extends the existing
> `TPUModelRunner` through a strategy object; it does not add or register a new
> runner. Its configuration and API may change without notice.

## Motivation

The configuration, attention, denoising, and scheduler foundations need an opt-in serving path that translates vLLM requests into block-diffusion work and returns generated tokens with correct request accounting.

## Scope

- Add prompt-block planning, per-request diffusion state, batched execution, and output assembly.
- Wire the experimental block-diffusion strategy into TPU platform configuration and the existing `TPUModelRunner`.
- Use a nested-JIT-safe model callable inside the denoising program while retaining the optimized callable for normal autoregressive execution.
- Expose the standard `modules()` traversal API on JAX modules so vLLM lifecycle cleanup can inspect Flax NNX models safely.
- Validate unsupported request, model, scheduler, kernel, and parallelism combinations before execution.

## Design

The platform resolves the generation strategy, emits an experimental-feature warning, sizes request capacity and multi-token lookahead from the model block size, and installs request validation. The existing runner lazy-imports and constructs `BlockDiffusionStrategy` only when selected. The strategy handles full and partial prompt blocks, invokes the jitted denoising program, buffers multi-token output, and removes finished request state. Because JAX compiler options are valid only on a top-level `jit`, the nested diffusion program uses an equivalent model callable without those options; the existing autoregressive path keeps its optimized callable unchanged. JAX modules provide the same `modules()` traversal shape expected by vLLM cleanup, while yielding only the existing JAX module graph.

## Compatibility

Autoregressive behavior is unchanged: it remains the default and follows the existing runner path when block diffusion is not selected. Continue-decode and block diffusion are mutually exclusive.

## Extensibility

Serving consumes the shared model specification and algorithm boundary rather than adapter-specific branches, allowing future adapters and commit algorithms to reuse the request lifecycle.

## Tests

- Current-main focused CPU gate across the stack: 44 passed.
- Block-diffusion CPU tests: 33 passed after the nested-JIT fix.
- JAX module traversal tests: 7 passed, including the vLLM-compatible `modules()` API.
- Existing runner model-loading fallback tests: 5 passed offline with the model configuration cache mounted read-only.
- Selected vLLM 0.23 platform and attention tests: 21 passed.
- Full platform test file before the fork-safety follow-up: 43 passed; 2 environment-only failures occurred because `tpu_info` was unavailable.
- A real 4x4x4 allocation ran 16 independent local 2x2x1 TPU workers. All 16 loaded the Flax NNX model, initialized the KV cache, compiled block diffusion, and exited successfully.
- Every worker completed two concurrent requests with exactly 64 output tokens per request: two 32-token blocks, 128 tokens per worker, no mask-token leakage, and non-empty decoded output.
- All 16 workers logged the explicit pass marker and exit code zero, with no traceback or cleanup `AttributeError`.
- Steady-state two-request generation took 0.647-0.688 seconds per worker (mean 0.665 seconds), or 186.1-197.8 aggregate output tokens/s per worker (mean 192.6). This excludes model initialization and is not a multi-host aggregate or an autoregressive comparison.
- E2E iteration history: isolated the installed runtime from source-checkout shadowing; made per-worker local topology explicit; gated unsupported prefix-cache, chunked-prefill, and async paths; removed top-level-only compiler options from the nested diffusion callable; then made the two-block smoke EOS-independent and added JAX lifecycle traversal compatibility. The final rerun passed after each failure was converted into a guarded contract or regression test.
- Stack checks passed: `isort`, `yapf`, `ruff`, `py_compile`, and `git diff --check`.

## Known limitations

Chunked prefill is unsupported. `enable_chunked_prefill=False` is required for block-diffusion serving.

Pipeline parallelism, data parallelism greater than one, KV transfer, async scheduling, speculative decoding, LoRA, multimodal models, prefix caching, resumable input, streaming input, the batched RPA kernel, and `head_dim == 64` are not supported by this initial serving path.

The completed smoke validates the initial two-request, two-block path on real TPU hardware. It is a functional and baseline-performance result, not a saturation benchmark, dynamic-arrival/refill test, or multi-host request result.

## Stack

- Depends on the previous upstream PR in this stack: https://github.com/vllm-project/tpu-inference/pull/3245. Until that PR merges, GitHub's `main`-based comparison includes the preceding stack commits.
- [Public design document](https://docs.google.com/document/d/1d3qtGrvdcJ0ptluE0EwAaGj4AQyOlIYkYvKo9xPguX8/edit)
