### PR TITLE
Fix typos in docs and comments

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ We choose to follow a similar directory structure as vLLM:
 We prefer enabling Pytorch based vLLM models via Torchax first and then following up with integrating JAX-Native/FLAX implementation of the models.
 
 ## Testing
-When checking in a new feature, we expect that you you add relevant unit tests as well as CI tests.  You can read more about the latter [here](https://github.com/vllm-project/tpu-inference/tree/main/.buildkite#adding-a-new-feature-to-ci).
+When checking in a new feature, we expect that you add relevant unit tests as well as CI tests.  You can read more about the latter [here](https://github.com/vllm-project/tpu-inference/tree/main/.buildkite#adding-a-new-feature-to-ci).
 
 ## Setting up linting, formatting, and static type checking
 
@@ -47,4 +47,4 @@ pre-commit run --all-files
 ```
 
 ## Thank You!
-We wanted to thank you for taking the time to read these guidelines and for your interest in contributing to TPU Inference. All of your contributions help make TPU Infernece a great tool and community for everyone!
+We wanted to thank you for taking the time to read these guidelines and for your interest in contributing to TPU Inference. All of your contributions help make TPU Inference a great tool and community for everyone!

--- a/tests/offload/tpu_offload_accuracy_test.py
+++ b/tests/offload/tpu_offload_accuracy_test.py
@@ -178,7 +178,7 @@ def test_kv_cache_cpu_offloading_accuracy_smaller_then_cpu_ram(
 # The test does the following
 #   1. generates tokens for the input prompt
 #   2. clears HBM which forces clean up of KV cache from HBM, since KV cache size > CPU RAM the tokens spills over CPU RAM
-#   3. re-calculates tokens for input prompt, since teh KV cache size > CPU RAM, it loads any available tokens from CPU RAM and re-calculates remaining tokens lost due to spillover
+#   3. re-calculates tokens for input prompt, since the KV cache size > CPU RAM, it loads any available tokens from CPU RAM and re-calculates remaining tokens lost due to spillover
 #   4. verifies tokens generated for 1. and 3. are identical when KV cache>CPU RAM
 def test_kv_cache_cpu_offloading_accuracy_larger_than_cpu_ram(
     monkeypatch: pytest.MonkeyPatch, ):

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -4,7 +4,7 @@
 Proxy server routes the request to P with max_output_tokens=1
 
 P workflow:
-    P recives the request
+    P receives the request
 
     P scheduler checks if the prefill is full done in `request_finished()`
     If done:
@@ -18,7 +18,7 @@ P workflow:
     P worker checks if the request has been pulled by D
     If done:
         P worker puts the request-id in `done_sending()`
-        P scheduler frees blocks for the requet in done sending.
+        P scheduler frees blocks for the request in done sending.
     Else:
         P holds the blocks for the request until it's pulled by D
 
@@ -28,10 +28,10 @@ P workflow:
         The waiting buffer will get freed after notified by D or expired.
     )
 
-Proxy server recives the response from P and forwards it to D
+Proxy server receives the response from P and forwards it to D
 
 D workflow:
-    D recives the request
+    D receives the request
 
     D scheduler calculates the num of tokens needing to pull from P in `get_num_new_matched_tokens()`
     D checks if need to pull from P
@@ -488,7 +488,7 @@ class TPUConnectorWorker:
         # req_id: (kv, indices)
         self.reqs_ready_to_insert: dict[ReqId, tuple[list[jax.Array],
                                                      jax.Array]] = {}
-        # the KV cache strafer uuid to request mapping
+        # the KV cache transfer uuid to request mapping
         # the reason is vllm add prefix + external uuid suffix for each request id
         # for example: prefill req_id:cmpl-cd70b21e-0f2b-46ed-910c-9525f706389a-0-99ae74c8
         # decode req_id:cmpl-cd70b21e-0f2b-46ed-910c-9525f706389a-0-23cb9419
@@ -601,7 +601,7 @@ class TPUConnectorWorker:
             if uuid in self.kv_pull_uuid_to_req_id_map:
                 req_id = self.kv_pull_uuid_to_req_id_map[uuid]
                 logger.info(
-                    f"TPUConnector Worker {self.node_id} --> zmq recieve | req_id={req_id} | uuid={uuid}"
+                    f"TPUConnector Worker {self.node_id} --> zmq receive | req_id={req_id} | uuid={uuid}"
                 )
                 if req_id in self.reqs_wait_pull:
                     # Set the expiration time of this request to -1, mark to be done
@@ -613,11 +613,11 @@ class TPUConnectorWorker:
                     self.kv_pull_uuid_to_req_id_map.pop(uuid)
                 else:
                     logger.warning(
-                        f"TPUConnector Worker {self.node_id} --> Disagg producer recives a non-exist pulling finished notification request {req_id} | uuid {uuid}"
+                        f"TPUConnector Worker {self.node_id} --> Disagg producer receives a non-exist pulling finished notification request {req_id} | uuid {uuid}"
                     )
             else:
                 logger.warning(
-                    f"TPUConnector Worker {self.node_id} --> Disagg producer recives a non-exist pulling finished notification uuid {uuid}"
+                    f"TPUConnector Worker {self.node_id} --> Disagg producer receives a non-exist pulling finished notification uuid {uuid}"
                 )
             time.sleep(0)
             # The response is not really needed.
@@ -912,7 +912,7 @@ class TPUConnectorWorker:
         if not self.reqs_wait_pull and not self.reqs_pulling:
             return done_sending, done_recving
 
-        # Mark a req as done recieving after its pulling thread returns.
+        # Mark a req as done receiving after its pulling thread returns.
         # This req can then be scheduled for decoding in the next scheduler step.
         for req_id in list(self.reqs_pulling.keys()):
             if self.reqs_pulling[req_id][1] is None:
@@ -922,7 +922,7 @@ class TPUConnectorWorker:
                     self.reqs_pulling[req_id][1] = kv
                     done_recving.add(req_id)
 
-        # Mark a req as done seding when it's expired.
+        # Mark a req as done sending when it's expired.
         # This req can then be released blocks in the current scheduler step.
         now = time.perf_counter()
         for req_id in list(self.reqs_wait_pull):

--- a/tpu_inference/layers/jax/quantization/fp8.py
+++ b/tpu_inference/layers/jax/quantization/fp8.py
@@ -478,7 +478,7 @@ class Fp8FusedMoEMethod(QuantizeMethodBase):
 
     def load_weights(self, *, layer: JaxMoE, original_load_weights_fn,
                      weights: Iterable) -> set:
-        """Load scale paramters and delegate the weight paramters to `original_load_weights_fn`"""
+        """Load scale parameters and delegate the weight parameters to `original_load_weights_fn`"""
 
         # Remaining non-scale parameters will be loaded using original load_weights function.
         remaining_weights = dict()


### PR DESCRIPTION
## Summary

Fix typos across documentation and source comments.

## Changes

- **CONTRIBUTING.md**: Fix duplicate word ("you you" -> "you") and misspelling ("Infernece" -> "Inference")
- **tpu_inference/layers/jax/quantization/fp8.py**: Fix "paramters" -> "parameters" in docstring
- **tpu_inference/distributed/tpu_connector.py**: Fix multiple misspellings in comments ("recives" -> "receives", "requet" -> "request", "strafer" -> "transfer", "recieve" -> "receive", "recieving" -> "receiving", "seding" -> "sending")
- **tests/offload/tpu_offload_accuracy_test.py**: Fix "teh" -> "the" in comment

## Testing

N/A — typo fixes in comments and docs only, verified by grep.