### PR TITLE
Remove float32 cast before quantizing block

### DIFF
--- a/tpu_inference/kernels/quantized_matmul/blockwise_kernel.py
+++ b/tpu_inference/kernels/quantized_matmul/blockwise_kernel.py
@@ -144,7 +144,7 @@ def quantized_matmul_kernel(
 
             for i in range(steps_k):
                 k_start, k_end = i * block_size, (i + 1) * block_size
-                lhs_sub = lhs_ref[:, k_start:k_end].astype(jnp.float32)
+                lhs_sub = lhs_ref[:, k_start:k_end]
                 lhs_q, lhs_scale = util.quantize_block(lhs_sub, 1, x_q_dtype)
                 lhs_scale = lhs_scale.astype(acc_dtype)
 


### PR DESCRIPTION
# Description

Casting a tensor from bf16 to f32 does not improve its precision (since original data was already truncated to bf16), but processing of the f32 type is significantly slower (double the VPU work).

# Tests

All quantized_matmul tests pass

# Performance impact

2.0-2.5x improvement taking absolute of a bf16 tensor