### PR TITLE
Profile for limited step count to avoid xProf 2GB hard limitation

### DIFF
--- a/tests/worker/tpu_worker_test.py
+++ b/tests/worker/tpu_worker_test.py
@@ -428,7 +428,8 @@ class TestTPUWorker:
         assert result == "concrete_model_output"
 
     @patch('tpu_inference.worker.tpu_worker.TPUModelRunner')
-    def test_execute_model_does_not_stop_profiler_early(self, mock_runner_cls, mock_vllm_config):
+    def test_execute_model_does_not_stop_profiler_early(
+            self, mock_runner_cls, mock_vllm_config):
         """Tests that execute_model does not stop profiler if steps haven't reached threshold."""
         worker = TPUWorker(vllm_config=mock_vllm_config,
                            local_rank=0,
@@ -437,17 +438,17 @@ class TestTPUWorker:
                            is_driver_worker=True)
         worker.model_runner = mock_runner_cls.return_value
         worker.model_runner.execute_model.return_value = "concrete_model_output"
-        
+
         # Set up profiling state where counter < active_steps
         worker.is_profiling = True
         worker.active_profiler_steps = 3
         worker.profile_step_counter = 2
-        
+
         worker.profile = MagicMock()
-        
+
         mock_scheduler_input = MagicMock()
         result = worker.execute_model(mock_scheduler_input)
-        
+
         # Verify profiler was NOT stopped
         worker.profile.assert_not_called()
         # Verify step counter was incremented

--- a/tests/worker/tpu_worker_test.py
+++ b/tests/worker/tpu_worker_test.py
@@ -400,7 +400,8 @@ class TestTPUWorker:
         assert result is None
 
     @patch('tpu_inference.worker.tpu_worker.TPUModelRunner')
-    def test_execute_model_stops_profiler_after_steps(self, mock_runner_cls, mock_vllm_config):
+    def test_execute_model_stops_profiler_after_steps(self, mock_runner_cls,
+                                                      mock_vllm_config):
         """Tests that execute_model stops the profiler when active_profiler_steps is reached."""
         worker = TPUWorker(vllm_config=mock_vllm_config,
                            local_rank=0,
@@ -409,18 +410,18 @@ class TestTPUWorker:
                            is_driver_worker=True)
         worker.model_runner = mock_runner_cls.return_value
         worker.model_runner.execute_model.return_value = "concrete_model_output"
-        
+
         # Set up profiling state to trigger the stop condition
         worker.is_profiling = True
         worker.active_profiler_steps = 3
         worker.profile_step_counter = 3
-        
+
         # Mock self.profile to verify it's called
         worker.profile = MagicMock()
-        
+
         mock_scheduler_input = MagicMock()
         result = worker.execute_model(mock_scheduler_input)
-        
+
         # Verify profiler was stopped
         worker.profile.assert_called_once_with(is_start=False)
         # Verify step counter was incremented

--- a/tests/worker/tpu_worker_test.py
+++ b/tests/worker/tpu_worker_test.py
@@ -399,6 +399,61 @@ class TestTPUWorker:
 
         assert result is None
 
+    @patch('tpu_inference.worker.tpu_worker.TPUModelRunner')
+    def test_execute_model_stops_profiler_after_steps(self, mock_runner_cls, mock_vllm_config):
+        """Tests that execute_model stops the profiler when active_profiler_steps is reached."""
+        worker = TPUWorker(vllm_config=mock_vllm_config,
+                           local_rank=0,
+                           rank=0,
+                           distributed_init_method="test",
+                           is_driver_worker=True)
+        worker.model_runner = mock_runner_cls.return_value
+        worker.model_runner.execute_model.return_value = "concrete_model_output"
+        
+        # Set up profiling state to trigger the stop condition
+        worker.is_profiling = True
+        worker.active_profiler_steps = 3
+        worker.profile_step_counter = 3
+        
+        # Mock self.profile to verify it's called
+        worker.profile = MagicMock()
+        
+        mock_scheduler_input = MagicMock()
+        result = worker.execute_model(mock_scheduler_input)
+        
+        # Verify profiler was stopped
+        worker.profile.assert_called_once_with(is_start=False)
+        # Verify step counter was incremented
+        assert worker.profile_step_counter == 4
+        assert result == "concrete_model_output"
+
+    @patch('tpu_inference.worker.tpu_worker.TPUModelRunner')
+    def test_execute_model_does_not_stop_profiler_early(self, mock_runner_cls, mock_vllm_config):
+        """Tests that execute_model does not stop profiler if steps haven't reached threshold."""
+        worker = TPUWorker(vllm_config=mock_vllm_config,
+                           local_rank=0,
+                           rank=0,
+                           distributed_init_method="test",
+                           is_driver_worker=True)
+        worker.model_runner = mock_runner_cls.return_value
+        worker.model_runner.execute_model.return_value = "concrete_model_output"
+        
+        # Set up profiling state where counter < active_steps
+        worker.is_profiling = True
+        worker.active_profiler_steps = 3
+        worker.profile_step_counter = 2
+        
+        worker.profile = MagicMock()
+        
+        mock_scheduler_input = MagicMock()
+        result = worker.execute_model(mock_scheduler_input)
+        
+        # Verify profiler was NOT stopped
+        worker.profile.assert_not_called()
+        # Verify step counter was incremented
+        assert worker.profile_step_counter == 3
+        assert result == "concrete_model_output"
+
     def test_take_draft_token_ids(self, mock_vllm_config):
         """Tests that take_draft_token_ids correctly passes through from the runner."""
         worker = TPUWorker(vllm_config=mock_vllm_config,

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -71,6 +71,7 @@ if TYPE_CHECKING:
     VLLM_MOE_CHUNK_SIZE: int = 0
     ONEHOT_MOE_PERMUTE_THRESHOLD: int = 0
     PROFILE_SINGLE_DEVICE: bool = False
+    VLLM_ACTIVE_PROFILER_STEPS: int = -1
     LORA_MODULE_PATH: str = ""
     SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES: str = "auto"
     SLICE_ROPE_CACHE: bool = False
@@ -419,6 +420,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Profile a single device instead of all devices.
     "PROFILE_SINGLE_DEVICE":
     env_bool("PROFILE_SINGLE_DEVICE", default=False),
+    # Number of active profiling steps to capture.
+    "VLLM_ACTIVE_PROFILER_STEPS":
+    lambda: int(os.getenv("VLLM_ACTIVE_PROFILER_STEPS") or "-1"),
     "LORA_MODULE_PATH":
     lambda: os.getenv("LORA_MODULE_PATH", ""),
     "MLA_KV_PACKING_SIZE":

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -670,13 +670,12 @@ class TPUWorker(WorkerBase):
             self.profile_step_counter = 0
             self.active_profiler_steps = envs.VLLM_ACTIVE_PROFILER_STEPS
         else:
+            self.is_profiling = False
             try:
                 logger.info("Stopping JAX profiler trace.")
                 jax.profiler.stop_trace()
             except Exception as e:
-                logger.warning("Failed to stop JAX profiler trace: %s", e)
-            finally:
-                self.is_profiling = False
+                logger.warning("Failed to stop JAX profiler trace: %s", e)                
 
     def load_model(self) -> None:
         self.model_runner.load_model()

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -259,6 +259,8 @@ class TPUWorker(WorkerBase):
 
         # step_counter is used to calculate uuid to transfer intermediate tensors.
         self.step_counter = 0
+        self.is_profiling = False
+        self.profile_step_counter = 0
 
     def initialize_cache(self, num_gpu_blocks: int,
                          num_cpu_blocks: int) -> None:
@@ -586,6 +588,15 @@ class TPUWorker(WorkerBase):
         output = self.model_runner.execute_model(scheduler_output,
                                                  intermediate_tensors)
 
+        if self.is_profiling:
+            if self.active_profiler_steps > 0 and self.profile_step_counter >= self.active_profiler_steps:
+                logger.info(
+                    "Stopping profiler automatically after %d steps.",
+                    self.profile_step_counter,
+                )
+                self.profile(is_start=False)
+            self.profile_step_counter += 1
+
         if isinstance(output, JaxIntermediateTensors):
             assert self.parallel_config.pipeline_parallel_size > 1
             assert not get_pp_group().is_last_rank
@@ -622,6 +633,7 @@ class TPUWorker(WorkerBase):
                 is_start: bool = True,
                 profile_prefix: str | None = None):
         if is_start:
+            logger.info("Starting JAX profiler trace, saving to %s", self.profile_dir)
             standard_opts, advanced_opts = _parse_profile_options(
                 profile_prefix)
             options = jax.profiler.ProfileOptions()
@@ -653,8 +665,18 @@ class TPUWorker(WorkerBase):
 
             jax.profiler.start_trace(self.profile_dir,
                                      profiler_options=options)
+            
+            self.is_profiling = True
+            self.profile_step_counter = 0
+            self.active_profiler_steps = envs.VLLM_ACTIVE_PROFILER_STEPS
         else:
-            jax.profiler.stop_trace()
+            try:
+                logger.info("Stopping JAX profiler trace.")
+                jax.profiler.stop_trace()
+            except Exception as e:
+                logger.warning("Failed to stop JAX profiler trace: %s", e)
+            finally:
+                self.is_profiling = False
 
     def load_model(self) -> None:
         self.model_runner.load_model()

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -633,7 +633,8 @@ class TPUWorker(WorkerBase):
                 is_start: bool = True,
                 profile_prefix: str | None = None):
         if is_start:
-            logger.info("Starting JAX profiler trace, saving to %s", self.profile_dir)
+            logger.info("Starting JAX profiler trace, saving to %s",
+                        self.profile_dir)
             standard_opts, advanced_opts = _parse_profile_options(
                 profile_prefix)
             options = jax.profiler.ProfileOptions()
@@ -665,7 +666,7 @@ class TPUWorker(WorkerBase):
 
             jax.profiler.start_trace(self.profile_dir,
                                      profiler_options=options)
-            
+
             self.is_profiling = True
             self.profile_step_counter = 0
             self.active_profiler_steps = envs.VLLM_ACTIVE_PROFILER_STEPS
@@ -675,7 +676,8 @@ class TPUWorker(WorkerBase):
                 logger.info("Stopping JAX profiler trace.")
                 jax.profiler.stop_trace()
             except Exception as e:
-                logger.warning("Failed to stop JAX profiler trace: %s", e)                
+                logger.warning("Failed to stop JAX profiler trace: %s", 
+                               e)
 
     def load_model(self) -> None:
         self.model_runner.load_model()

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -676,8 +676,7 @@ class TPUWorker(WorkerBase):
                 logger.info("Stopping JAX profiler trace.")
                 jax.profiler.stop_trace()
             except Exception as e:
-                logger.warning("Failed to stop JAX profiler trace: %s", 
-                               e)
+                logger.warning("Failed to stop JAX profiler trace: %s", e)
 
     def load_model(self) -> None:
         self.model_runner.load_model()


### PR DESCRIPTION
## Motivation:

Today, vllm provides a few options to profile it on tpus. In all cases, it captures the entire prefill and decode stages all the way to the last token.

This gets problematic as for long context profile captures even for small model and a single prompt, you quickly hit the 2GB xProf limitation reported in this bug ([b/528711430](b/528711430)).

## To reproduce:
```
VLLM_TORCH_PROFILER_DIR=/tmp/tpu_logs/qwen-06b VLLM_ENGINE_READY_TIMEOUT_S=60000 USE_BATCHED_RPA_KERNEL=1 MODEL_IMPL_TYPE=flax_nnx vllm serve Qwen/Qwen3-0.6B \
        --max-model-len=24576 \
        --max-num-seqs=512 \
        --data-parallel-size 4 \
        --tensor-parallel-size 2 \
        --no-enable-prefix-caching \
        --gpu-memory-utilization=0.9 \
        --async-scheduling \
        --block-size=256 \
        --profiler-config '{"profiler": "torch", "torch_profiler_dir": "/tmp/tpu_logs/qwen-06b"}'
```

This leads to xProf drop the trace and creates 0MB xplane file:

```
ls -lah /tmp/tpu_logs/qwen-06b/plugins/profile/2026_06_28_03_38_57
total 19M
drwxr-xr-x 2 root root  80 Jun 28 03:40 .
drwxr-xr-x 4 root root  80 Jun 28 03:38 ..
-rw-r--r-- 1 root root 19M Jun 28 03:40 vllm-single-node-qwen-06b.trace.json.gz
-rw-r--r-- 1 root root   0 Jun 28 03:39 vllm-single-node-qwen-06b.xplane.pb
```

Once the `random-output-len` is reduced to something smaller like 512, you can avoid this limitation.

This can be problematic as you might need this profile capture as part of an RL pipeline and changing this can lead to changing the way the pipeline operates.

This PR allows to pass an env variable `VLLM_ACTIVE_PROFILER_STEPS` that stops the capture after reaching the value provided, for example `VLLM_ACTIVE_PROFILER_STEPS=100`.

## How to use it:

```
VLLM_TORCH_PROFILER_DIR=/tmp/tpu_logs/qwen-06b VLLM_ACTIVE_PROFILER_STEPS=100 USE_BATCHED_RPA_KERNEL=1 VLLM_XLA_CHECK_RECOMPILATION=1 MODEL_IMPL_TYPE=flax_nnx vllm serve Qwen/Qwen3-0.6B \
        --max-model-len=24576 \
        --max-num-seqs=512 \
        --data-parallel-size 4 \
        --tensor-parallel-size 2 \
        --no-enable-prefix-caching \
        --gpu-memory-utilization=0.9 \
        --async-scheduling \
        --block-size=256 \
        --profiler-config '{"profiler": "torch", "torch_profiler_dir": "/tmp/tpu_logs/qwen-06b"}'
```

Now I can run benchmark at any output length and avoid the 2GB xProf hard limit.