### PR TITLE
Update Mistral-Small-4 test to only check correctness on tpu7x

### DIFF
--- a/.buildkite/models/mistralai_Mistral-Small-4-119B-2603_text-only.yml
+++ b/.buildkite/models/mistralai_Mistral-Small-4-119B-2603_text-only.yml
@@ -13,8 +13,8 @@
 # limitations under the License.
 
 steps:
-  - label: "${TPU_VERSION:-tpu6e} Accuracy for mistralai/Mistral-Small-4-119B-2603/text-only"
-    key: "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Correctness for mistralai/Mistral-Small-4-119B-2603/text-only"
+    key: "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Correctness"
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
@@ -25,18 +25,16 @@ steps:
       MINIMUM_ACCURACY_THRESHOLD: 0  # TODO : replace 0 with your accuracy threshold
     commands:
       - |
-        if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Accuracy" "not enough HBM"
+        if [ "${TPU_VERSION:-tpu6e}" != "tpu7x" ]; then
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Correctness" "skipped (only for tpu7x)"
         else
-          # 1. Run the fast correctness test first to catch basic integration bugs quickly (TP=8)
+          # 1. Run the fast correctness test
           .buildkite/scripts/run_in_docker.sh \
             bash -c 'python3 /workspace/tpu_inference/tests/e2e/mistral_small_4_correctness.py'
-          # 2. Run the heavy accuracy evaluation
-          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
         fi
-  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for mistralai/Mistral-Small-4-119B-2603/text-only"
-    key: "${TPU_VERSION:-tpu6e}_record_mistralai_Mistral-Small-4-119B-2603_text-only_Accuracy"
-    depends_on: "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Accuracy"
+  - label: "${TPU_VERSION:-tpu6e} Record correctness result for mistralai/Mistral-Small-4-119B-2603/text-only"
+    key: "${TPU_VERSION:-tpu6e}_record_mistralai_Mistral-Small-4-119B-2603_text-only_Correctness"
+    depends_on: "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Correctness"
     env:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "mistralai/Mistral-Small-4-119B-2603/text-only"
@@ -46,6 +44,6 @@ steps:
       queue: cpu
     commands:
       - |
-        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Accuracy
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Correctness
 
 


### PR DESCRIPTION
# Description

This addresses the CI softly failing on the nightly pipeline for Mistral-Small-4 due to the `test_accuracy.sh` step [Out-Of-Memory crashing](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/23037/table?jid=019f8e18-debf-460f-9c3d-6f0c1941edef&tab=output) on the queues.

This PR:

1. Removes the raw accuracy hook since the goal is solely a correctness integration check.
2. Renames the Buildkite workflow labels strictly to "Correctness".
3. Applies a bash-level skip to only validate against `tpu7x`, bypassing strict/unnecessary HBM constraints on earlier chips.

# Tests

Validation relies entirely on remote continuous integration on Buildkite queues.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
