### PR TITLE
[CI] Fix test_mesh_devices_sorting by adding extra mesh axis to the test

### DIFF
--- a/tests/runner/test_tpu_runner.py
+++ b/tests/runner/test_tpu_runner.py
@@ -861,8 +861,9 @@ class TestTPUJaxRunner:
         mock_sharding_config.expert_size = 1
         mock_sharding_config.tp_size = 1
         mock_sharding_config.decode_cp_size = 1
+        mock_sharding_config.prefill_cp_size = 1
         vllm_config.sharding_config = mock_sharding_config
-        mesh_shape = (8, 1, 1, 1, 1, 1)
+        mesh_shape = (8, 1, 1, 1, 1, 1, 1)
 
         # Case A: envs.NEW_MODEL_DESIGN = True and envs.TPU_MESH_SORT_BY_COORDS = True
         with patch('tpu_inference.runner.tpu_runner.envs.NEW_MODEL_DESIGN', True), \


### PR DESCRIPTION
# Description

An extra mesh axis was added in PR: https://github.com/vllm-project/tpu-inference/pull/3096.

# Tests

Tested locally with `python3 -m pytest -s -v tests/runner/test_tpu_runner.py::TestTPUJaxRunner::test_mesh_devices_sorting`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
