### PR TITLE
compressed tensor nvfp4 support improvement

### DIFF
--- a/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
+++ b/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
@@ -38,8 +38,8 @@ from tests.layers.common import utils as test_utils
 from tests.layers.vllm.nvfp4_utils import (NVFP4_GROUP_SIZE, quantize_to_nvfp4,
                                            ref_dequant_nvfp4)
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
-from tpu_inference.layers.vllm.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4 import \
-    VllmCompressedTensorsW4A4Fp4
+from tpu_inference.layers.vllm.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4 import (
+    VllmCompressedTensorsW4A4Fp4, W4A4ActivationType)
 from tpu_inference.layers.vllm.quantization.configs import \
     VllmQuantLinearConfig
 
@@ -80,8 +80,10 @@ def override_activation_quant_config(vllm_config):
     vllm_config.model_config.hf_text_config.quantization_config = vllm_config.model_config.hf_config.quantization_config
 
 
-def initialize_layer_weights(layer: torch.nn.Module,
-                             use_a16: bool = True) -> torch.Tensor:
+def initialize_layer_weights(
+    layer: torch.nn.Module,
+    activation_type: W4A4ActivationType = W4A4ActivationType.BF16
+) -> torch.Tensor:
     assert isinstance(layer, LinearBase)
     scheme = layer.scheme
     assert isinstance(scheme, VllmCompressedTensorsW4A4Fp4)
@@ -123,7 +125,7 @@ def initialize_layer_weights(layer: torch.nn.Module,
     layer.weight_global_scale = torch.nn.Parameter(weight_global_scale,
                                                    requires_grad=False)
 
-    if not use_a16:
+    if activation_type == W4A4ActivationType.NVFP4:
         layer.input_global_scale = torch.nn.Parameter(torch.tensor(
             [1.0], dtype=torch.float32),
                                                       requires_grad=False)
@@ -133,11 +135,13 @@ def initialize_layer_weights(layer: torch.nn.Module,
     return weight_ref
 
 
-def return_ref_and_layer_output(layer: torch.nn.Module,
-                                use_a16: bool = True,
-                                batch_size: int = 16):
+def return_ref_and_layer_output(
+        layer: torch.nn.Module,
+        activation_type: W4A4ActivationType = W4A4ActivationType.BF16,
+        batch_size: int = 16):
 
-    weight_ref = initialize_layer_weights(layer, use_a16=use_a16)
+    weight_ref = initialize_layer_weights(layer,
+                                          activation_type=activation_type)
     assert isinstance(layer, LinearBase)
     scheme = layer.scheme
     assert isinstance(scheme, VllmCompressedTensorsW4A4Fp4)
@@ -151,9 +155,9 @@ def return_ref_and_layer_output(layer: torch.nn.Module,
     input_tensor = input_tensor.to('cpu')
 
     # Run reference implementation
-    if not use_a16:
+    if activation_type == W4A4ActivationType.NVFP4:
         # Quantize activation to FP4
-        # Since use_a16=False tests FP4xFP4, we need to quantize the activation
+        # Since activation_type=NVFP4 tests FP4xFP4, we need to quantize the activation
         # However, TPU does not natively support FP4xFP4 and raises an error
         # So we skip actual activation quantization in reference for now
         pass
@@ -214,9 +218,9 @@ def setup_environment():
 @pytest.mark.parametrize("enable_sp", [False, True])
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("use_a16", [True])
+@pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
 def test_row_parallel_linear(model, bias, num_devices, enable_sp,
-                             enable_attn_dp, use_a16):
+                             enable_attn_dp, activation_type):
     if enable_attn_dp and num_devices < 2:
         pytest.skip("enable_attn_dp requires at least 2 devices")
 
@@ -245,10 +249,10 @@ def test_row_parallel_linear(model, bias, num_devices, enable_sp,
             return_bias=False,
             quant_config=quant_config,
         )
-        linear_layer.scheme.use_a16 = use_a16
+        linear_layer.scheme.activation_type = activation_type
 
-    ref_output, layer_output = return_ref_and_layer_output(linear_layer,
-                                                           use_a16=use_a16)
+    ref_output, layer_output = return_ref_and_layer_output(
+        linear_layer, activation_type=activation_type)
     torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.35)
 
 
@@ -257,9 +261,9 @@ def test_row_parallel_linear(model, bias, num_devices, enable_sp,
 @pytest.mark.parametrize("enable_sp", [False, True])
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("use_a16", [True])
+@pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
 def test_column_parallel_linear(model, bias, num_devices, enable_sp,
-                                enable_attn_dp, use_a16):
+                                enable_attn_dp, activation_type):
     if enable_attn_dp and num_devices < 2:
         pytest.skip("enable_attn_dp requires at least 2 devices")
 
@@ -288,10 +292,10 @@ def test_column_parallel_linear(model, bias, num_devices, enable_sp,
             return_bias=False,
             quant_config=quant_config,
         )
-        linear_layer.scheme.use_a16 = use_a16
+        linear_layer.scheme.activation_type = activation_type
 
-    ref_output, layer_output = return_ref_and_layer_output(linear_layer,
-                                                           use_a16=use_a16)
+    ref_output, layer_output = return_ref_and_layer_output(
+        linear_layer, activation_type=activation_type)
     torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.35)
 
 
@@ -301,9 +305,9 @@ def test_column_parallel_linear(model, bias, num_devices, enable_sp,
 @pytest.mark.parametrize("fuse_matmuls", [False, True])
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("use_a16", [True])
+@pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
 def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
-                             enable_attn_dp, use_a16):
+                             enable_attn_dp, activation_type):
     if enable_attn_dp and num_devices < 2:
         pytest.skip("enable_attn_dp requires at least 2 devices")
 
@@ -335,10 +339,10 @@ def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
             quant_config=quant_config,
         )
         linear_layer.quant_method.fuse_matmuls = fuse_matmuls
-        linear_layer.scheme.use_a16 = use_a16
+        linear_layer.scheme.activation_type = activation_type
 
-    ref_output, layer_output = return_ref_and_layer_output(linear_layer,
-                                                           use_a16=use_a16)
+    ref_output, layer_output = return_ref_and_layer_output(
+        linear_layer, activation_type=activation_type)
     torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.35)
 
 
@@ -348,9 +352,10 @@ def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
 @pytest.mark.parametrize("enable_sp", [False, True])
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("use_a16", [True])
+@pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
 def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
-                                       enable_sp, enable_attn_dp, use_a16):
+                                       enable_sp, enable_attn_dp,
+                                       activation_type):
     if enable_attn_dp and num_devices < 2:
         pytest.skip("enable_attn_dp requires at least 2 devices")
 
@@ -380,8 +385,8 @@ def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
             quant_config=quant_config,
         )
         linear_layer.quant_method.fuse_matmuls = fuse_matmuls
-        linear_layer.scheme.use_a16 = use_a16
+        linear_layer.scheme.activation_type = activation_type
 
-    ref_output, layer_output = return_ref_and_layer_output(linear_layer,
-                                                           use_a16=use_a16)
+    ref_output, layer_output = return_ref_and_layer_output(
+        linear_layer, activation_type=activation_type)
     torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.15)

--- a/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
+++ b/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import tempfile
 from unittest.mock import MagicMock, patch
 
@@ -219,8 +220,16 @@ def setup_environment():
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
+@pytest.mark.parametrize("requantize_block_size", [None, 32])
 def test_row_parallel_linear(model, bias, num_devices, enable_sp,
-                             enable_attn_dp, activation_type):
+                             enable_attn_dp, activation_type,
+                             requantize_block_size):
+    if requantize_block_size is not None:
+        os.environ["REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE"] = str(
+            requantize_block_size)
+    else:
+        os.environ.pop("REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE", None)
+
     if enable_attn_dp and num_devices < 2:
         pytest.skip("enable_attn_dp requires at least 2 devices")
 
@@ -262,8 +271,16 @@ def test_row_parallel_linear(model, bias, num_devices, enable_sp,
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
+@pytest.mark.parametrize("requantize_block_size", [None, 32])
 def test_column_parallel_linear(model, bias, num_devices, enable_sp,
-                                enable_attn_dp, activation_type):
+                                enable_attn_dp, activation_type,
+                                requantize_block_size):
+    if requantize_block_size is not None:
+        os.environ["REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE"] = str(
+            requantize_block_size)
+    else:
+        os.environ.pop("REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE", None)
+
     if enable_attn_dp and num_devices < 2:
         pytest.skip("enable_attn_dp requires at least 2 devices")
 
@@ -306,8 +323,16 @@ def test_column_parallel_linear(model, bias, num_devices, enable_sp,
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
+@pytest.mark.parametrize("requantize_block_size", [None, 32])
 def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
-                             enable_attn_dp, activation_type):
+                             enable_attn_dp, activation_type,
+                             requantize_block_size):
+    if requantize_block_size is not None:
+        os.environ["REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE"] = str(
+            requantize_block_size)
+    else:
+        os.environ.pop("REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE", None)
+
     if enable_attn_dp and num_devices < 2:
         pytest.skip("enable_attn_dp requires at least 2 devices")
 
@@ -353,9 +378,16 @@ def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
+@pytest.mark.parametrize("requantize_block_size", [None, 32])
 def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
                                        enable_sp, enable_attn_dp,
-                                       activation_type):
+                                       activation_type, requantize_block_size):
+    if requantize_block_size is not None:
+        os.environ["REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE"] = str(
+            requantize_block_size)
+    else:
+        os.environ.pop("REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE", None)
+
     if enable_attn_dp and num_devices < 2:
         pytest.skip("enable_attn_dp requires at least 2 devices")
 
@@ -389,4 +421,4 @@ def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
 
     ref_output, layer_output = return_ref_and_layer_output(
         linear_layer, activation_type=activation_type)
-    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.15)
+    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.35)

--- a/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
+++ b/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
@@ -378,15 +378,22 @@ def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
-@pytest.mark.parametrize("requantize_block_size", [None, 32])
+@pytest.mark.parametrize(
+    "requantize_block_size, enable_quantized_matmul_kernel", [(None, False),
+                                                              (256, True)])
 def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
                                        enable_sp, enable_attn_dp,
-                                       activation_type, requantize_block_size):
+                                       activation_type, requantize_block_size,
+                                       enable_quantized_matmul_kernel):
     if requantize_block_size is not None:
         os.environ["REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE"] = str(
             requantize_block_size)
     else:
         os.environ.pop("REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE", None)
+    if enable_quantized_matmul_kernel:
+        os.environ["ENABLE_QUANTIZED_MATMUL_KERNEL"] = "1"
+    else:
+        os.environ.pop("ENABLE_QUANTIZED_MATMUL_KERNEL", None)
 
     if enable_attn_dp and num_devices < 2:
         pytest.skip("enable_attn_dp requires at least 2 devices")
@@ -422,3 +429,84 @@ def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
     ref_output, layer_output = return_ref_and_layer_output(
         linear_layer, activation_type=activation_type)
     torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.35)
+
+
+def test_get_scheme():
+
+    from tpu_inference.layers.vllm.quantization.compressed_tensors.compressed_tensors import \
+        VllmCompressedTensorsConfig
+
+    def get_scheme(input_quant):
+        config_dict = {
+            "quant_method": "compressed-tensors",
+            "format": "float-quantized",
+            "config_groups": {
+                "group_0": {
+                    "targets": ["Linear"],
+                    "weights": {
+                        "num_bits": 4,
+                        "type": "float",
+                        "symmetric": True,
+                        "strategy": "tensor_group",
+                        "group_size": 16,
+                    }
+                }
+            }
+        }
+        if input_quant is not None:
+            config_dict["config_groups"]["group_0"][
+                "input_activations"] = input_quant
+
+        config = VllmCompressedTensorsConfig.from_config(config_dict)
+        config.vllm_config = MagicMock()
+        config.mesh = MagicMock()
+
+        # Mock layer for get_scheme
+        layer = MagicMock(spec=LinearBase)
+        layer.input_size = 16
+        layer.output_size = 16
+        layer.weight_packed = torch.nn.Parameter(torch.empty(16, 16))
+        return config.get_scheme(layer, layer_name="Linear")
+
+    # 1. nvfp4 weights + fp8 dynamic input yields FP8
+    scheme = get_scheme({
+        "num_bits": 8,
+        "type": "float",
+        "symmetric": True,
+        "strategy": "tensor",
+        "dynamic": True,
+    })
+    assert scheme.activation_type == W4A4ActivationType.FP8
+
+    # 2. nvfp4 input yields NVFP4
+    scheme = get_scheme({
+        "num_bits": 4,
+        "type": "float",
+        "symmetric": True,
+        "strategy": "tensor_group",
+        "group_size": 16,
+        "dynamic": True,
+    })
+    assert scheme.activation_type == W4A4ActivationType.NVFP4
+
+    # 3. input_quant is None yields BF16
+    scheme = get_scheme(None)
+    assert scheme.activation_type == W4A4ActivationType.BF16
+
+    # 4. unsupported input_quant (e.g., int8, or fp8 with dynamic=False) raises
+    with pytest.raises(ValueError):
+        get_scheme({
+            "num_bits": 8,
+            "type": "int",
+            "symmetric": True,
+            "strategy": "tensor",
+            "dynamic": True,
+        })
+    with pytest.raises(ValueError):
+        get_scheme({
+            "num_bits": 8,
+            "type": "float",
+            "symmetric": True,
+            "strategy": "tensor",
+            "dynamic": False,
+        })

--- a/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
+++ b/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
@@ -388,19 +388,20 @@ def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
 @pytest.mark.parametrize(
     "requantize_block_size, enable_quantized_matmul_kernel", [(None, False),
                                                               (256, True)])
-def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
-                                       enable_sp, enable_attn_dp,
+def test_merged_column_parallel_linear(monkeypatch, model, bias, num_devices,
+                                       fuse_matmuls, enable_sp, enable_attn_dp,
                                        activation_type, requantize_block_size,
                                        enable_quantized_matmul_kernel):
     if requantize_block_size is not None:
-        os.environ["REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE"] = str(
-            requantize_block_size)
+        monkeypatch.setenv("REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE",
+                           str(requantize_block_size))
     else:
-        os.environ.pop("REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE", None)
+        monkeypatch.delenv("REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE",
+                           raising=False)
     if enable_quantized_matmul_kernel:
-        os.environ["ENABLE_QUANTIZED_MATMUL_KERNEL"] = "1"
+        monkeypatch.setenv("ENABLE_QUANTIZED_MATMUL_KERNEL", "1")
     else:
-        os.environ.pop("ENABLE_QUANTIZED_MATMUL_KERNEL", None)
+        monkeypatch.delenv("ENABLE_QUANTIZED_MATMUL_KERNEL", raising=False)
 
     if enable_attn_dp and num_devices < 2:
         pytest.skip("enable_attn_dp requires at least 2 devices")

--- a/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
+++ b/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
@@ -439,7 +439,7 @@ def merged_column_parallel_linear_helper(monkeypatch, model, bias, num_devices,
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
 @pytest.mark.parametrize(
-    "requantize_block_size, enable_quantized_matmul_kernel", [(None, True),
+    "requantize_block_size, enable_quantized_matmul_kernel", [(None, False),
                                                               (256, False)])
 def test_merged_column_parallel_linear(monkeypatch, model, bias, num_devices,
                                        fuse_matmuls, enable_sp, enable_attn_dp,
@@ -466,7 +466,7 @@ def test_merged_column_parallel_linear(monkeypatch, model, bias, num_devices,
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("activation_type", [W4A4ActivationType.FP8])
 @pytest.mark.parametrize(
-    "requantize_block_size, enable_quantized_matmul_kernel", [(None, False),
+    "requantize_block_size, enable_quantized_matmul_kernel", [(None, True),
                                                               (256, True)])
 def test_merged_column_parallel_linear_v7(monkeypatch, model, bias,
                                           num_devices, fuse_matmuls, enable_sp,

--- a/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
+++ b/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
@@ -219,7 +219,8 @@ def setup_environment():
 @pytest.mark.parametrize("enable_sp", [False, True])
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
+@pytest.mark.parametrize("activation_type",
+                         [W4A4ActivationType.FP8, W4A4ActivationType.BF16])
 @pytest.mark.parametrize("requantize_block_size", [None, 32])
 def test_row_parallel_linear(model, bias, num_devices, enable_sp,
                              enable_attn_dp, activation_type,
@@ -262,7 +263,8 @@ def test_row_parallel_linear(model, bias, num_devices, enable_sp,
 
     ref_output, layer_output = return_ref_and_layer_output(
         linear_layer, activation_type=activation_type)
-    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.35)
+    atol = 0.5 if activation_type == W4A4ActivationType.FP8 else 0.35
+    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=atol)
 
 
 @pytest.mark.parametrize("bias", [False, True])
@@ -270,7 +272,8 @@ def test_row_parallel_linear(model, bias, num_devices, enable_sp,
 @pytest.mark.parametrize("enable_sp", [False, True])
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
+@pytest.mark.parametrize("activation_type",
+                         [W4A4ActivationType.FP8, W4A4ActivationType.BF16])
 @pytest.mark.parametrize("requantize_block_size", [None, 32])
 def test_column_parallel_linear(model, bias, num_devices, enable_sp,
                                 enable_attn_dp, activation_type,
@@ -313,7 +316,8 @@ def test_column_parallel_linear(model, bias, num_devices, enable_sp,
 
     ref_output, layer_output = return_ref_and_layer_output(
         linear_layer, activation_type=activation_type)
-    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.35)
+    atol = 0.5 if activation_type == W4A4ActivationType.FP8 else 0.35
+    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=atol)
 
 
 @pytest.mark.parametrize("bias", [False, True])
@@ -322,7 +326,8 @@ def test_column_parallel_linear(model, bias, num_devices, enable_sp,
 @pytest.mark.parametrize("fuse_matmuls", [False, True])
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
+@pytest.mark.parametrize("activation_type",
+                         [W4A4ActivationType.FP8, W4A4ActivationType.BF16])
 @pytest.mark.parametrize("requantize_block_size", [None, 32])
 def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
                              enable_attn_dp, activation_type,
@@ -368,7 +373,8 @@ def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
 
     ref_output, layer_output = return_ref_and_layer_output(
         linear_layer, activation_type=activation_type)
-    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.35)
+    atol = 0.5 if activation_type == W4A4ActivationType.FP8 else 0.35
+    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=atol)
 
 
 @pytest.mark.parametrize("bias", [False, True])
@@ -377,7 +383,8 @@ def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
 @pytest.mark.parametrize("enable_sp", [False, True])
 @pytest.mark.parametrize("enable_attn_dp", [False, True])
 @pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
+@pytest.mark.parametrize("activation_type",
+                         [W4A4ActivationType.FP8, W4A4ActivationType.BF16])
 @pytest.mark.parametrize(
     "requantize_block_size, enable_quantized_matmul_kernel", [(None, False),
                                                               (256, True)])
@@ -417,7 +424,7 @@ def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
     with set_current_vllm_config(vllm_config):
         linear_layer = MergedColumnParallelLinear(
             input_size=2048,
-            output_sizes=[7168] * 2,
+            output_sizes=[64] * 2,
             bias=bias,
             params_dtype=dtype,
             return_bias=False,
@@ -428,7 +435,8 @@ def test_merged_column_parallel_linear(model, bias, num_devices, fuse_matmuls,
 
     ref_output, layer_output = return_ref_and_layer_output(
         linear_layer, activation_type=activation_type)
-    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=0.35)
+    atol = 0.5 if activation_type == W4A4ActivationType.FP8 else 0.35
+    torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=atol)
 
 
 def test_get_scheme():
@@ -493,7 +501,7 @@ def test_get_scheme():
     scheme = get_scheme(None)
     assert scheme.activation_type == W4A4ActivationType.BF16
 
-    # 4. unsupported input_quant (e.g., int8, or fp8 with dynamic=False) raises
+    # 4. unsupported input_quant raises error
     with pytest.raises(ValueError):
         get_scheme({
             "num_bits": 8,

--- a/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
+++ b/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
@@ -439,8 +439,8 @@ def merged_column_parallel_linear_helper(monkeypatch, model, bias, num_devices,
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
 @pytest.mark.parametrize(
-    "requantize_block_size, enable_quantized_matmul_kernel", [(None, False),
-                                                              (256, True)])
+    "requantize_block_size, enable_quantized_matmul_kernel", [(None, True),
+                                                              (256, False)])
 def test_merged_column_parallel_linear(monkeypatch, model, bias, num_devices,
                                        fuse_matmuls, enable_sp, enable_attn_dp,
                                        activation_type, requantize_block_size,
@@ -452,7 +452,7 @@ def test_merged_column_parallel_linear(monkeypatch, model, bias, num_devices,
                                          enable_quantized_matmul_kernel)
 
 
-# W4A4ActivationType.FP8 + 256 block size would trigger the quantized matmul
+# gmmv2 + 256 block size would trigger the quantized matmul
 # path in gmm_v2, which would need to cast packed f4e2m1 to fp8. This operation
 # would lead to a Mosaic error on v6e
 # https://screenshot-v2.corp.google.com/0o6oukm5252h8

--- a/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
+++ b/tests/layers/vllm/test_compressed_tensors_w4a4_nvfp4.py
@@ -20,6 +20,7 @@ import jax
 import pytest
 import torch
 import torchax
+from jax._src import test_util as jtu
 from jax.sharding import PartitionSpec
 from torchax.interop import torch_view
 from torchax.ops.mappings import j2t, t2j
@@ -377,21 +378,11 @@ def test_qkv_parallel_linear(model, bias, num_devices, enable_sp, fuse_matmuls,
     torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=atol)
 
 
-@pytest.mark.parametrize("bias", [False, True])
-@pytest.mark.parametrize("num_devices", [1, min(4, jax.local_device_count())])
-@pytest.mark.parametrize("fuse_matmuls", [False, True])
-@pytest.mark.parametrize("enable_sp", [False, True])
-@pytest.mark.parametrize("enable_attn_dp", [False, True])
-@pytest.mark.parametrize("model", MODELS)
-@pytest.mark.parametrize("activation_type",
-                         [W4A4ActivationType.FP8, W4A4ActivationType.BF16])
-@pytest.mark.parametrize(
-    "requantize_block_size, enable_quantized_matmul_kernel", [(None, False),
-                                                              (256, True)])
-def test_merged_column_parallel_linear(monkeypatch, model, bias, num_devices,
-                                       fuse_matmuls, enable_sp, enable_attn_dp,
-                                       activation_type, requantize_block_size,
-                                       enable_quantized_matmul_kernel):
+def merged_column_parallel_linear_helper(monkeypatch, model, bias, num_devices,
+                                         fuse_matmuls, enable_sp,
+                                         enable_attn_dp, activation_type,
+                                         requantize_block_size,
+                                         enable_quantized_matmul_kernel):
     if requantize_block_size is not None:
         monkeypatch.setenv("REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE",
                            str(requantize_block_size))
@@ -438,6 +429,55 @@ def test_merged_column_parallel_linear(monkeypatch, model, bias, num_devices,
         linear_layer, activation_type=activation_type)
     atol = 0.5 if activation_type == W4A4ActivationType.FP8 else 0.35
     torch.testing.assert_close(ref_output, layer_output, rtol=0.1, atol=atol)
+
+
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("num_devices", [1, min(4, jax.local_device_count())])
+@pytest.mark.parametrize("fuse_matmuls", [False, True])
+@pytest.mark.parametrize("enable_sp", [False, True])
+@pytest.mark.parametrize("enable_attn_dp", [False, True])
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("activation_type", [W4A4ActivationType.BF16])
+@pytest.mark.parametrize(
+    "requantize_block_size, enable_quantized_matmul_kernel", [(None, False),
+                                                              (256, True)])
+def test_merged_column_parallel_linear(monkeypatch, model, bias, num_devices,
+                                       fuse_matmuls, enable_sp, enable_attn_dp,
+                                       activation_type, requantize_block_size,
+                                       enable_quantized_matmul_kernel):
+    merged_column_parallel_linear_helper(monkeypatch, model, bias, num_devices,
+                                         fuse_matmuls, enable_sp,
+                                         enable_attn_dp, activation_type,
+                                         requantize_block_size,
+                                         enable_quantized_matmul_kernel)
+
+
+# W4A4ActivationType.FP8 + 256 block size would trigger the quantized matmul
+# path in gmm_v2, which would need to cast packed f4e2m1 to fp8. This operation
+# would lead to a Mosaic error on v6e
+# https://screenshot-v2.corp.google.com/0o6oukm5252h8
+@pytest.mark.skipif(not jtu.is_device_tpu_at_least(version=7),
+                    reason="Expect TPUv7+")
+@pytest.mark.parametrize("bias", [False, True])
+@pytest.mark.parametrize("num_devices", [1, min(4, jax.local_device_count())])
+@pytest.mark.parametrize("fuse_matmuls", [False, True])
+@pytest.mark.parametrize("enable_sp", [False, True])
+@pytest.mark.parametrize("enable_attn_dp", [False, True])
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("activation_type", [W4A4ActivationType.FP8])
+@pytest.mark.parametrize(
+    "requantize_block_size, enable_quantized_matmul_kernel", [(None, False),
+                                                              (256, True)])
+def test_merged_column_parallel_linear_v7(monkeypatch, model, bias,
+                                          num_devices, fuse_matmuls, enable_sp,
+                                          enable_attn_dp, activation_type,
+                                          requantize_block_size,
+                                          enable_quantized_matmul_kernel):
+    merged_column_parallel_linear_helper(monkeypatch, model, bias, num_devices,
+                                         fuse_matmuls, enable_sp,
+                                         enable_attn_dp, activation_type,
+                                         requantize_block_size,
+                                         enable_quantized_matmul_kernel)
 
 
 def test_get_scheme():

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -292,6 +292,11 @@ environment_variables: dict[str, Callable[[], Any]] = {
     "REQUANTIZE_BLOCK_SIZE":
     lambda: int(block_size) if
     (block_size := os.getenv("REQUANTIZE_BLOCK_SIZE")) is not None else None,
+    # Specify requantization block size for compressed tensor NVFP4 weights
+    "REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE":
+    lambda: int(block_size)
+    if (block_size := os.getenv("REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE"
+                                )) is not None else None,
     # Specify dtype for quantized linear weights
     "REQUANTIZE_WEIGHT_DTYPE":
     lambda: os.getenv("REQUANTIZE_WEIGHT_DTYPE", "float8_e4m3fn"),

--- a/tpu_inference/layers/common/linear.py
+++ b/tpu_inference/layers/common/linear.py
@@ -134,7 +134,8 @@ def sharded_quantized_matmul(x: jax.Array,
                              weight_sharding: P | NamedSharding,
                              *,
                              mesh: Mesh | None = None,
-                             defer_all_reduce: bool = False) -> jax.Array:
+                             defer_all_reduce: bool = False,
+                             maybe_quantize_x: bool = True) -> jax.Array:
     """
     Wrapper around the quantized matmul kernel.
 
@@ -149,6 +150,8 @@ def sharded_quantized_matmul(x: jax.Array,
             axis is sharded. The output then holds per-shard partial sums; the
             caller is responsible for reducing them later (e.g. to fuse the
             reduction with a subsequent collective).
+        maybe_quantize_x: (Optional) If True, the underlying matmul implementation will try to quantize the activation when appropriate.
+            Whether and how activation is quantized is contingent on the weight quantization.
 
     Returns:
         Output of the quantized matmul.
@@ -200,10 +203,13 @@ def sharded_quantized_matmul(x: jax.Array,
                 group_offset=jnp.array([0], dtype=jnp.int32),
                 zero_initialize=False,
                 preferred_element_type=x.dtype,
-                maybe_quantize_lhs=True,
+                maybe_quantize_lhs=maybe_quantize_x,
             )
         else:
-            output = xla_quantized_matmul(x, w_q, w_s)
+            output = xla_quantized_matmul(x,
+                                          w_q,
+                                          w_s,
+                                          quantize_activation=maybe_quantize_x)
         if in_axis and not defer_all_reduce:
             output = jax.lax.psum(output, axis_name=in_axis)
         return output

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/compressed_tensors.py
@@ -15,6 +15,7 @@
 from typing import Optional
 
 import torch
+from compressed_tensors.quantization import QuantizationType
 from jax.sharding import PartitionSpec
 from vllm.model_executor.layers.attention import Attention
 from vllm.model_executor.layers.fused_moe import RoutedExperts
@@ -32,8 +33,8 @@ from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
 from tpu_inference.layers.common.quant_methods import COMPRESSED_TENSORS
 from tpu_inference.layers.vllm.quantization.compressed_tensors.compressed_tensors_moe import \
     VllmCompressedTensorsMoEMethod
-from tpu_inference.layers.vllm.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4 import \
-    VllmCompressedTensorsW4A4Fp4
+from tpu_inference.layers.vllm.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4 import (
+    VllmCompressedTensorsW4A4Fp4, W4A4ActivationType)
 from tpu_inference.layers.vllm.quantization.compressed_tensors.schemes.compressed_tensors_w4a8_fp8 import \
     VllmCompressedTensorsW4A8Fp8
 from tpu_inference.layers.vllm.quantization.compressed_tensors.schemes.compressed_tensors_w8a8_fp8 import \
@@ -108,19 +109,27 @@ class VllmCompressedTensorsConfig(CompressedTensorsConfig, VllmQuantConfig):
         if self._is_nvfp4_format(weight_quant):
             if input_quant is None:
                 return VllmCompressedTensorsW4A4Fp4(
-                    use_a16=True,
+                    activation_type=W4A4ActivationType.BF16,
                     is_static_input_scheme=False,
                     linear_config=linear_config,
                 )
-            if not self._is_nvfp4_format(input_quant):
-                raise ValueError(
-                    "For NVFP4 weights, input quantization must also be NVFP4 format, ",
-                    "None for NVFP4A16",
+            if self._is_nvfp4_format(input_quant):
+                return VllmCompressedTensorsW4A4Fp4(
+                    activation_type=W4A4ActivationType.NVFP4,
+                    is_static_input_scheme=input_quant
+                    and not input_quant.dynamic,
+                    linear_config=linear_config,
                 )
-            return VllmCompressedTensorsW4A4Fp4(
-                use_a16=False,
-                is_static_input_scheme=input_quant and not input_quant.dynamic,
-                linear_config=linear_config,
+            if input_quant.type == QuantizationType.FLOAT and input_quant.num_bits == 8 and input_quant.dynamic:
+                return VllmCompressedTensorsW4A4Fp4(
+                    activation_type=W4A4ActivationType.FP8,
+                    is_static_input_scheme=input_quant
+                    and not input_quant.dynamic,
+                    linear_config=linear_config,
+                )
+            raise ValueError(
+                "For NVFP4 weights, input quantization must be NVFP4, FP8 or ",
+                "None for NVFP4A16",
             )
 
         if self._is_fp8_w8a8(weight_quant, input_quant):

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -24,11 +24,14 @@ from torchax.interop import jax_view, torch_view
 from vllm.model_executor.layers.quantization.compressed_tensors.schemes.compressed_tensors_w4a4_nvfp4 import \
     CompressedTensorsW4A4Fp4
 
+from tpu_inference import envs
 from tpu_inference.layers.common.linear import sharded_quantized_matmul
 from tpu_inference.layers.common.process_weights.linear_weights import (
     LinearWeights, process_linear_weights, shard_linear_weights,
     to_parameter_list)
-from tpu_inference.layers.common.quantization import u8_unpack_e2m1
+from tpu_inference.layers.common.quantization import (dequantize_tensor,
+                                                      quantize_tensor,
+                                                      u8_unpack_e2m1)
 from tpu_inference.layers.common.utils import \
     slice_sharded_tensor_for_concatenation
 from tpu_inference.layers.vllm.quantization.configs import \
@@ -136,12 +139,30 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
         ) -> LinearWeights:
             # Unpack uint8 to FP4
             fp4 = u8_unpack_e2m1(weight_packed)  # [out, in]
-            fp4 = jnp.transpose(fp4)  # [in, out]
 
             # Combine FP8 block scale & FP32 global scale
             # weight_scale is [out, in // group_size]
             block_scale = weight_scale.astype(
                 jnp.float32) * weight_global_scale
+
+            requantize_block_size = envs.REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE
+            if requantize_block_size is not None:
+                # 1. dequantize the nvfp4 weights
+                dequantized_fp32 = dequantize_tensor(
+                    fp4,
+                    block_scale,
+                    axis=1,
+                    out_dtype=jnp.float32,
+                )
+                # 2. requantize it to a new group size, still keeping the weights in fp4
+                fp4, block_scale = quantize_tensor(
+                    jnp.float4_e2m1fn,
+                    dequantized_fp32,
+                    axis=1,
+                    block_size=requantize_block_size,
+                )
+
+            fp4 = jnp.transpose(fp4)  # [in, out]
             block_scale = jnp.transpose(block_scale)  # [in // group_size, out]
 
             return process_linear_weights(

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from enum import Enum
 from typing import Optional
 
 import jax
@@ -39,11 +40,17 @@ P = PartitionSpec
 logger = init_logger(__name__)
 
 
+class W4A4ActivationType(str, Enum):
+    BF16 = "bf16"
+    NVFP4 = "nvfp4"
+    FP8 = "fp8"
+
+
 class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
 
     def __init__(
         self,
-        use_a16: bool,
+        activation_type: W4A4ActivationType,
         is_static_input_scheme: bool,
         linear_config: VllmQuantLinearConfig,
     ):
@@ -51,10 +58,15 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
             raise NotImplementedError(
                 "Static input scheme is not yet supported for W4A4 NVFP4.")
 
-        # TODO(lxhfirenking): Add native support for nvfp4 activation.
-        if not use_a16:
+        if activation_type == W4A4ActivationType.NVFP4:
             logger.warning(
-                "fp4xfp4 multiplications are not natively supported by TPU hardware, so activations are always kept at bf16 for now."
+                "fp4xfp4 multiplications are not natively supported by TPU hardware. "
+                "The current sharded_quantized_matmul implementation will attempt to fall"
+                "back to fp8xfp8 instead.")
+        if activation_type == W4A4ActivationType.FP8:
+            logger.warning(
+                "Attempting to quantize activation to fp8. The actual quantization strategy "
+                "and block size are dependent on underlying kernel implementation."
             )
 
         # We need to monkeypatch expose_input_quant_key to handle None kernel
@@ -74,8 +86,12 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
 
         vllm_ct_w4a4.expose_input_quant_key = safe_expose_input_quant_key
 
-        super().__init__(use_a16=use_a16)
+        # The base class assumes that if activation is not use_a16, it must use nvfp4 and
+        # will attemp to load activation weight scales, so we have to keep it true for all
+        # cases where activation is not nvfp4.
+        super().__init__(use_a16=(activation_type != W4A4ActivationType.NVFP4))
 
+        self.activation_type = activation_type
         self.linear_config = linear_config
 
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
@@ -87,7 +103,7 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
         weight_global_scale = layer.weight_global_scale.max().to(torch.float32)
         weight_global_scale = 1.0 / weight_global_scale
 
-        if not self.use_a16:
+        if self.activation_type == W4A4ActivationType.NVFP4:
             input_global_scale_inv = layer.input_global_scale.max().to(
                 torch.float32)
             input_global_scale = 1.0 / input_global_scale_inv
@@ -165,7 +181,7 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
             if bias is not None:
                 layer.bias = to_parameter_list(weights.bias)
 
-        if not self.use_a16:
+        if self.activation_type == W4A4ActivationType.NVFP4:
             # Note: input_scale should be jax sharded tensor for split
             input_global_scale_j = jax.device_put(
                 t2j(input_global_scale, use_dlpack=False),
@@ -194,6 +210,7 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
             weight_scale_jax,
             self.linear_config.weight_sharding,
             mesh=self.linear_config.mesh,
+            maybe_quantize_x=(self.activation_type != W4A4ActivationType.BF16),
         )
 
         if bias is not None and not layer.skip_bias_add:
@@ -219,6 +236,8 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
                 weight_scale_jax,
                 self.linear_config.weight_sharding,
                 mesh=self.linear_config.mesh,
+                maybe_quantize_x=(self.activation_type
+                                  != W4A4ActivationType.BF16),
             )
 
             if bias is not None and not layer.skip_bias_add:

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -50,6 +50,13 @@ class W4A4ActivationType(str, Enum):
 
 
 class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
+    """
+    This class deviates from upstream by adding support for W4A8 (NVFP4 weights, FP8 activations).
+    Upstream vLLM only supports a4 (nvfp4) and a16 activations with nvfp4 weights, as GPUs have
+    native nvfp4 x nvfp4 support. However, for TPU, the underlying matmul will happen in fp8,
+    so we need to keep activations in fp8. We extend this class to support a8 to avoid copy-pasting
+    too much code.
+    """
 
     def __init__(
         self,


### PR DESCRIPTION
# Description

Increase the fidelity of underlying matmul behavior for compressed tensor checkpoints with nvfp4 weights

1. Only attempt to quantize activation during quantized matmul when the checkpoint config actually asks for it.
2. Add flag that allow user to requantize nvfp4 weights into a larger block size so that to avoid being fully dequantized in gmm_v2 due to the nvfp4's block size of 16.

# Tests

Unit tests.
Tested with nvfp4 quantized gemma4 checkpoint
```
USE_BATCHED_RPA_KERNEL=1 \
REQUANTIZE_COMPRESSED_TENSOR_NVFP4_BLOCK_SIZE=256 \
ENABLE_QUANTIZED_MATMUL_KERNEL=1 \
JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" \
REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" \
MODEL_IMPL_TYPE="vllm" \
vllm serve \
    --max-num-batched-tokens=4096 \
    --max-num-seqs=127 \
    --max-model-len=4096 \
    --no-enable-prefix-caching  \
    --model=RedHatAI/gemma-4-31B-it-NVFP4 \
    --limit-mm-per-prompt '{"image": 8, "video": 0}' \
    --tensor-parallel-size=2 \
    --kv-cache-dtype=fp8
```
Benchmark run
```
python scripts/vllm/benchmarking/benchmark_serving.py \
    --backend vllm-chat \
    --endpoint /v1/chat/completions \
    --model RedHatAI/gemma-4-31B-it-NVFP4\
    --dataset-name mmmu_pro \
    --mmmu-pro-subset 'standard (10 options)' \
    --mmmu-pro-output-len=2000 \
    --run-eval \
    --num-prompts 200 \
    --max-concurrency 32
```
Result
```
============ Serving Benchmark Result ============
Successful requests:                     200       
Benchmark duration (s):                  399.53    
Total input tokens:                      109015    
Total generated tokens:                  164395    
Request throughput (req/s):              0.50      
Output token throughput (tok/s):         411.47    
Total token throughput (tok/s):          684.32    
---------------Time to First Token----------------
Mean TTFT (ms):                          9577.18   
Median TTFT (ms):                        1672.52   
P99 TTFT (ms):                           66840.00  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          68.08     
Median TPOT (ms):                        69.12     
P99 TPOT (ms):                           145.87    
---------------Inter-token Latency----------------
Mean ITL (ms):                           64.43     
Median ITL (ms):                         9.37      
P99 ITL (ms):                            1504.09   
----------------End-to-end Latency----------------
Mean E2EL (ms):                          62527.34  
Median E2EL (ms):                        44519.74  
P99 E2EL (ms):                           193340.94 
==================================================
```
Results without nvfp4 block size changes
```
============ Serving Benchmark Result ============
Successful requests:                     200       
Benchmark duration (s):                  529.31    
Total input tokens:                      109015    
Total generated tokens:                  128500    
Request throughput (req/s):              0.38      
Output token throughput (tok/s):         242.77    
Total token throughput (tok/s):          448.72    
---------------Time to First Token----------------
Mean TTFT (ms):                          12293.43  
Median TTFT (ms):                        1727.48   
P99 TTFT (ms):                           77980.13  
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          112.68    
Median TPOT (ms):                        116.48    
P99 TPOT (ms):                           192.41    
---------------Inter-token Latency----------------
Mean ITL (ms):                           108.57    
Median ITL (ms):                         15.61     
P99 ITL (ms):                            1621.25   
----------------End-to-end Latency----------------
Mean E2EL (ms):                          82049.97  
Median E2EL (ms):                        66919.90  
P99 E2EL (ms):                           252723.92 
==================================================
```

