### PR TITLE
Optimize PCP performance by dynamically choosing between gather-KV and gather-Q for cache phase

### DIFF
--- a/tests/layers/common/test_pcp_attention_interface.py
+++ b/tests/layers/common/test_pcp_attention_interface.py
@@ -145,6 +145,27 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
         out[pps:2 * pps] = pi
         return jnp.asarray(out)
 
+    def _cache_at_pages(self, k, v, ntok, pcp, pps, npages, phys):
+        """Build an `npages`-page global pcp cache in which the request's
+        logical page i is stored at physical page `phys[i]` (so the block
+        table is non-contiguous), leaving the other pages unused."""
+        dims = self._cache_dims(1)
+        shards = []
+        for r in range(pcp):
+            idx = np.arange(r, ntok, pcp)
+            kv = np.asarray(merge_kv(k[idx], v[idx])) if len(idx) else None
+            shard = np.full((npages, PAGE, *dims), np.nan, np.float32)
+            if kv is not None:
+                n = kv.shape[0]
+                kv = np.pad(kv, ((0, cdiv(n, PAGE) * PAGE - n), (0, 0), (0, 0),
+                                 (0, 0)),
+                            constant_values=np.nan)
+                kv = kv.reshape(-1, PAGE, *dims)
+                for i in range(kv.shape[0]):
+                    shard[phys[i]] = kv[i]
+            shards.append(shard)
+        return jnp.asarray(np.concatenate(shards, axis=1), DTYPE)
+
     def _mesh(self, pcp):
         shape = tuple(pcp if a == "pcp" else 1 for a in MESH_AXIS_NAMES)
         return Mesh(
@@ -219,6 +240,9 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                 query_start_loc=cu_q_lens,
                 kv_cache_lens=kv_cache_lens,
                 q_pos_offsets=q_pos_offsets,
+                # pages the CACHED tokens occupy (a token-ordered page holds
+                # PAGE*pcp tokens); 0 elides the cache phase.
+                cache_pages=cdiv(L, PAGE * pcp),
             ),
         )
         new_cache, out = pcp_forward(self._mesh(pcp),
@@ -302,6 +326,164 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
             page, off = local // PAGE, local % PAGE
             got = cache[page, r * PAGE + off]
             self.assertAllClose(got, ref[i], atol=2e-2, rtol=2e-2)
+
+    @parameterized.parameters((2, False), (4, False), (2, True), (4, True))
+    def test_noncontiguous_block_table(self, pcp, tight_hint):
+        """The cache phase must be correct when the request's pages are an
+        arbitrary, non-contiguous subset of a cache that is bigger than the
+        request -- i.e. what a real server looks like, where one KV cache holds
+        many sequences (in production num_blocks is ~9x the per-request block
+        table width).  Both conditions are needed to exercise gather-KV's page
+        compaction: it selects the request's pages via the block table before
+        the all-gather, so an indexing bug shows up as a numerical mismatch
+        against the plain-attention reference.
+
+        `tight_hint` additionally exercises the `cache_pages` bound: True
+        passes a rung strictly tighter than the block-table width, False passes
+        the full width.
+        """
+        if jax.device_count() < pcp:
+            self.skipTest(f"needs {pcp} devices")
+        rng = np.random.default_rng(0)
+        C = 32
+        num_current = 2 * pcp * C
+        L = 4 * PAGE * pcp  # cached tokens
+        kv_total = L + num_current
+
+        q = self._rand(rng, (num_current, NQ, HD))
+        k = self._rand(rng, (num_current, NKV, HD))
+        v = self._rand(rng, (num_current, NKV, HD))
+        k_prev = self._rand(rng, (L, NKV, HD))
+        v_prev = self._rand(rng, (L, NKV, HD))
+
+        # ---- reference: plain non-PCP attention over the same tokens ----
+        ref_pps = cdiv(kv_total, PAGE)
+        ref_pi = jnp.pad(jnp.arange(ref_pps, dtype=jnp.int32),
+                         (0, MAX_SEQ * ref_pps - ref_pps))
+        exp, _ = ref_ragged_paged_attention(
+            q,
+            k,
+            v,
+            self._ref_cache(k_prev, v_prev, L, ref_pps),
+            jnp.pad(jnp.array([kv_total], jnp.int32), (0, MAX_SEQ - 1)),
+            ref_pi,
+            jnp.pad(jnp.array([0, num_current], jnp.int32), (0, MAX_SEQ - 1)),
+            jnp.array([0, 0, 1], jnp.int32),
+            sm_scale=SM_SCALE)
+
+        # ---- PCP: cache is 4x the request, pages non-contiguous ----
+        pps = cdiv(cdiv(kv_total, pcp), PAGE)
+        npages = 4 * pps  # cache bigger than the request
+        # arbitrary non-identity, non-contiguous physical placement
+        phys = (np.arange(pps) * 3 + 5) % npages
+        assert len(set(phys.tolist())) == pps, "phys must be a permutation"
+        cache = self._cache_at_pages(k_prev, v_prev, L, pcp, pps, npages, phys)
+
+        pi = np.zeros(MAX_SEQ * pps, np.int32)
+        pi[:pps] = phys
+        pi[pps:2 * pps] = phys
+        pi = jnp.asarray(pi)
+
+        def pad1(xs):
+            return jnp.pad(jnp.array(xs, jnp.int32), (0, MAX_SEQ - len(xs)))
+
+        # `cache_pages` is the static bound the runner supplies: the number of
+        # pages the CACHED tokens occupy (page P of the token-ordered cache
+        # holds gpage = PAGE*pcp tokens), rounded up to a power of two.  It is
+        # strictly tighter than pages_per_seq here, so it exercises the bound.
+        gpage = PAGE * pcp
+        live = cdiv(L, gpage)
+        # tight_hint=True exercises the bound (a rung strictly tighter than the
+        # block-table width); False passes the loosest legal value, i.e. the
+        # full width, so the compaction runs without the extra bound.
+        hint = (1 << (max(live - 1, 0)).bit_length()) if tight_hint else pps
+        self.assertGreaterEqual(hint, live, "hint must cover live pages")
+        if tight_hint:
+            self.assertLess(hint, pps,
+                            "hint must be tighter than pages_per_seq")
+
+        cu, qpos = _pcp_meta(pcp, C, num_current)
+        md = AttentionMetadata(
+            input_positions=jnp.zeros(1, jnp.int32),
+            seq_lens=pad1([kv_total, kv_total]),
+            block_tables=pi,
+            request_distribution=jnp.array([0, 0, 2], jnp.int32),
+            pcp=PCPMetadata(
+                query_start_loc=cu,
+                kv_cache_lens=pad1([L, L]),
+                q_pos_offsets=qpos,
+                cache_pages=hint,
+            ),
+        )
+        _, out = pcp_forward(self._mesh(pcp), _to_rank_order(q, pcp, C),
+                             _to_rank_order(k, pcp, C),
+                             _to_rank_order(v, pcp, C), cache, md, SM_SCALE)
+
+        inv = _inv_row(pcp)
+        got = np.asarray(out).reshape(2 * pcp, C, NQ,
+                                      HD)[inv].reshape(num_current, NQ, HD)
+        self.assertTrue(np.all(np.isfinite(got)))
+        self.assertGreater(float(np.abs(got).max()), 0.0)
+        self.assertAllClose(got, np.asarray(exp), atol=2e-2, rtol=2e-2)
+
+    @parameterized.parameters(2, 4)
+    def test_first_chunk_skips_cache_phase(self, pcp):
+        """cache_pages=0 elides the cache phase; with no cached tokens the
+        result must still match plain attention over the current chunk."""
+        if jax.device_count() < pcp:
+            self.skipTest(f"needs {pcp} devices")
+        rng = np.random.default_rng(1)
+        C = 32
+        num_current = 2 * pcp * C
+        kv_total = num_current  # L == 0 -> first chunk, empty cache
+
+        q = self._rand(rng, (num_current, NQ, HD))
+        k = self._rand(rng, (num_current, NKV, HD))
+        v = self._rand(rng, (num_current, NKV, HD))
+
+        ref_pps = cdiv(kv_total, PAGE)
+        ref_pi = jnp.pad(jnp.arange(ref_pps, dtype=jnp.int32),
+                         (0, MAX_SEQ * ref_pps - ref_pps))
+        empty = jnp.full((ref_pps, PAGE, *self._cache_dims(1)), jnp.nan, DTYPE)
+        exp, _ = ref_ragged_paged_attention(
+            q,
+            k,
+            v,
+            empty,
+            jnp.pad(jnp.array([kv_total], jnp.int32), (0, MAX_SEQ - 1)),
+            ref_pi,
+            jnp.pad(jnp.array([0, num_current], jnp.int32), (0, MAX_SEQ - 1)),
+            jnp.array([0, 0, 1], jnp.int32),
+            sm_scale=SM_SCALE)
+
+        pps = cdiv(cdiv(kv_total, pcp), PAGE)
+        npages = 4 * pps
+        cache = jnp.full((npages, PAGE * pcp, *self._cache_dims(1)), jnp.nan,
+                         DTYPE)
+        pi = np.zeros(MAX_SEQ * pps, np.int32)
+        pi[:pps] = np.arange(pps)
+        pi[pps:2 * pps] = np.arange(pps)
+        pi = jnp.asarray(pi)
+
+        def pad1(xs):
+            return jnp.pad(jnp.array(xs, jnp.int32), (0, MAX_SEQ - len(xs)))
+
+        cu, qpos = _pcp_meta(pcp, C, num_current)
+        md = AttentionMetadata(
+            input_positions=jnp.zeros(1, jnp.int32),
+            seq_lens=pad1([kv_total, kv_total]),
+            block_tables=pi,
+            request_distribution=jnp.array([0, 0, 2], jnp.int32),
+            pcp=PCPMetadata(
+                query_start_loc=cu,
+                kv_cache_lens=pad1([0, 0]),
+                q_pos_offsets=qpos,
+                cache_pages=0,
+            ),
+        )
+        _, out = pcp_forward(self._mesh(pcp), _to_rank_order(q, pcp, C),
+                             _to_rank_order(k, pcp, C),
+                             _to_rank_order(v, pcp, C), cache, md, SM_SCALE)
 
 
 if __name__ == "__main__":

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -1016,6 +1016,10 @@ def calculate_tiling(
             tile_k = align_to(dims.size_k,
                               num_k_tiles * num_lanes) // num_k_tiles
 
+    if (rhs_cfgs.has_scale and rhs_cfgs.quant_block_size is not None
+            and not _is_tile_k_quant_block_compatible(tile_k)):
+        tile_k = rhs_cfgs.quant_block_size
+
     if tile_n == 0 or tile_k == 0:
         final_estimate = _gmm_vmem_estimate(tile_m, tile_n, tile_k)
         raise ValueError(f"Could not find valid tile sizes for {dims=} and"

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 
 import functools
+import math
 from dataclasses import dataclass
 
 import jax
+from vllm.utils.math_utils import cdiv
 
 
 @functools.partial(
     jax.tree_util.register_dataclass,
     data_fields=["query_start_loc", "kv_cache_lens", "q_pos_offsets"],
-    meta_fields=[],
+    meta_fields=["cache_pages"],
 )
 @dataclass
 class PCPMetadata:
@@ -36,6 +38,12 @@ class PCPMetadata:
     # (pcp_size, max_num_reqs) int32 — per-rank, per-seq Q position offsets.
     # Sharded as P('pcp', None).
     q_pos_offsets: jax.Array
+    # STATIC (meta field): a rung of `pcp_cache_page_buckets` giving an UPPER
+    # bound on the KV pages this request's cached tokens occupy, used to bound
+    # the gather-KV cache all-gather.  0 means nothing is cached, in which case
+    # the cache phase is elided entirely.  REQUIRED: a default would silently
+    # elide the cache phase for any caller that forgot to set it.
+    cache_pages: int
 
 
 @functools.partial(
@@ -49,7 +57,7 @@ class PCPMetadata:
         "mamba_state_indices",
         "pcp",
     ],
-    meta_fields=["padded_num_reqs"],
+    meta_fields=["padded_num_reqs", "pcp_cache_pages"],
 )
 @dataclass
 class AttentionMetadata(object):
@@ -82,6 +90,9 @@ class AttentionMetadata(object):
     # power of 2 between min and max requests.
     # Env var ATTN_CUSTOM_NUM_REQS_BUCKETS can manually override the buckets.
     padded_num_reqs: int = -1
+
+    # PCP gather-KV only. Number of kv pages occupied by the current request.
+    pcp_cache_pages: int | None = None
 
 
 @functools.partial(
@@ -120,3 +131,32 @@ class SharedAttentionMetadata(object):
     # power of 2 between min and max requests.
     # Env var ATTN_CUSTOM_NUM_REQS_BUCKETS can manually override the buckets.
     padded_num_reqs: int = -1
+
+
+PCP_CACHE_PAGE_BUCKET_COUNT = 5
+
+
+def pcp_cache_page_buckets(max_num_blocks_per_req: int) -> list[int]:
+    """The buckets for the `pcp_cache_pages` value, including 0.
+    """
+    buckets = {0, max_num_blocks_per_req}
+    n = PCP_CACHE_PAGE_BUCKET_COUNT - len(buckets)
+    if n > 0 and max_num_blocks_per_req > 1:
+        step = math.log(max_num_blocks_per_req) / (n + 1)
+        for i in range(1, n + 1):
+            v = 1 << max(0, round(math.exp(step * i)).bit_length() - 1)
+            buckets.add(min(max(v, 1), max_num_blocks_per_req))
+    return sorted(buckets)
+
+
+def round_up_pcp_cache_pages(num_computed_tokens: int, block_size: int,
+                             max_num_blocks_per_req: int) -> int:
+    """Round a request's number of kv pages up to the nearest bucket.
+    """
+    if num_computed_tokens <= 0:
+        return 0
+    live_pages = cdiv(num_computed_tokens, block_size)
+    for b in pcp_cache_page_buckets(max_num_blocks_per_req):
+        if b >= live_pages:
+            return b
+    return max_num_blocks_per_req

--- a/tpu_inference/layers/common/cp_attention.py
+++ b/tpu_inference/layers/common/cp_attention.py
@@ -347,6 +347,19 @@ def pcp_forward(
                   k_scale=k_scale,
                   v_scale=v_scale)
 
+    # Cache-phase strategy, decided per compile from static comm estimates.
+    # all_gather and reduce_scatter are duals and move the same (p-1)/p
+    # fraction, so gather-Q counts both legs; gather-KV moves K and V but has
+    # no output collective.  Volume alone puts the crossover at
+    # ctx = chunk*NQ/NKV, but gather-Q issues TWO collective rounds (two sync
+    # points) plus an LSE reweight, so empirically it needs ~2x the raw volume
+    # advantage before it actually wins.
+    cache_pages = md.pcp.cache_pages
+    _GATHER_Q_OVERHEAD = 2.0
+    comm_q = 2 * padded_q_len * q.shape[1] * q.shape[2]
+    comm_kv = 2 * (cache_pages * kv_cache.shape[1]) * k.shape[1] * q.shape[2]
+    use_gather_kv = comm_kv < _GATHER_Q_OVERHEAD * comm_q
+
     def _shard_fn(q_local, k_local, v_local, kv_cache_local, kv_lens_local,
                   kv_cache_lens_local, page_indices_local, distribution_local,
                   pcp_cu_q_lens_local, pcp_q_pos_offsets_local):
@@ -361,32 +374,89 @@ def pcp_forward(
                                                 *x.shape[1:])[inv_row].reshape(
                                                     padded_q_len, *x.shape[1:])
 
-        # Cache phase: all_gather Q tokens so every rank sees the full sequence.
-        # PCP local q_local has 2*C tokens (head + tail chunk for this rank).
-        # After all_gather along tokens axis: pcp_size * 2 * C = padded_q_len.
-        q_all_tokens = all_gather_tokens(q_local)
-        cu_cache = jnp.zeros_like(
-            pcp_cu_q_lens_local[0]).at[1:].set(padded_q_len)
-        context_out, kv_cache_temp, context_lse = _rpa_cp_call(
-            q_all_tokens,
-            k_local,
-            v_local,
-            kv_cache_local,
-            kv_lens_local,
-            page_indices_local,
-            cu_cache,
-            jnp.array([0, 0, 1], jnp.int32),
-            cp_rank=cp_rank,
-            cp_group_size=pcp_size,
-            kv_cache_lens=kv_cache_lens_local,
-            skip_current_attn=True,
-            use_causal_mask=False,
-            update_kv_cache=False,
-            **common)
+        # ---- Cache phase --------------------------------------------------
+        # Two ways to give every rank what it needs:
+        #   gather-Q : all_gather Q, attend this rank's KV shard, then
+        #              reduce_scatter the partials.  Comm ~ 2*chunk*NQ, i.e.
+        #              INDEPENDENT of context length.
+        #   gather-KV: all_gather the striped KV cache into global token order
+        #              so every rank holds the full cache, then attend the
+        #              LOCAL Q against it as ordinary paged attention.  No
+        #              output collective at all.  Comm ~ ctx*NKV.
+        # gather-KV wins at short/medium context, gather-Q once ctx is long.
+        # The cache phase never writes the cache (update_kv_cache=False), so
+        # the current phase starts from the untouched local shard unless the
+        # gather-Q path threaded a copy through.
+        kv_cache_temp = kv_cache_local
+        if cache_pages == 0:
+            # Nothing cached (first chunk of a chunked prefill): the cache
+            # phase would attend an empty cache, be fully masked, and have its
+            # -inf result discarded by merge_attn_states.  Skip it outright.
+            context_out = context_lse = None
+        elif use_gather_kv:
+            # Compact to this request's live pages, then all_gather with the
+            # pcp axis INNERMOST: for local page p, offset o, rank j the cache
+            # holds global token (p*page_l + o)*pcp + j, so flattening
+            # (p, o, j) is already global token order.  Regroup into pages of
+            # the ORIGINAL width (a pure reshape) and the cache phase becomes
+            # plain paged attention with cp_group_size=1.
+            local_q = q_local.shape[0]
+            cu_kv = jnp.zeros_like(pcp_cu_q_lens_local[0]).at[1:].set(local_q)
+            max_seqs = kv_lens_local.shape[0]
+            kv_src = jnp.take(kv_cache_local,
+                              page_indices_local[:cache_pages],
+                              axis=0)
+            kv_tok = lax.all_gather(kv_src, pcp_axis, axis=2, tiled=False)
+            n_pages_tok = kv_src.shape[0] * pcp_size
+            kv_tok = kv_tok.reshape(n_pages_tok, kv_src.shape[1],
+                                    *kv_src.shape[2:])
+            pi_tok = jnp.tile(
+                jnp.arange(n_pages_tok, dtype=page_indices_local.dtype),
+                max_seqs)
+            context_out, _, context_lse = _rpa_cp_call(
+                q_local,
+                k_local,
+                v_local,
+                kv_tok,
+                kv_lens_local,
+                pi_tok,
+                cu_kv,
+                jnp.array([0, 0, 1], jnp.int32),
+                cp_rank=jnp.zeros((1, ), jnp.int32),
+                cp_group_size=1,
+                kv_cache_lens=kv_cache_lens_local,
+                skip_current_attn=True,
+                use_causal_mask=False,
+                update_kv_cache=False,
+                **common)
+        else:
+            # Cache phase: all_gather Q tokens so every rank sees the full
+            # sequence.  PCP local q_local has 2*C tokens (head + tail chunk
+            # for this rank).  After all_gather along the tokens axis:
+            # pcp_size * 2 * C = padded_q_len.
+            q_all_tokens = all_gather_tokens(q_local)
+            cu_cache = jnp.zeros_like(
+                pcp_cu_q_lens_local[0]).at[1:].set(padded_q_len)
+            context_out, kv_cache_temp, context_lse = _rpa_cp_call(
+                q_all_tokens,
+                k_local,
+                v_local,
+                kv_cache_local,
+                kv_lens_local,
+                page_indices_local,
+                cu_cache,
+                jnp.array([0, 0, 1], jnp.int32),
+                cp_rank=cp_rank,
+                cp_group_size=pcp_size,
+                kv_cache_lens=kv_cache_lens_local,
+                skip_current_attn=True,
+                use_causal_mask=False,
+                update_kv_cache=False,
+                **common)
 
-        # Rank reduce: reduce_scatter so each rank gets its own 2*C token chunk.
-        context_out, context_lse = _pcp_rs_reduce(context_out, context_lse,
-                                                  pcp_axis, pcp_size)
+            # Rank reduce: reduce_scatter so each rank gets its own 2*C chunk.
+            context_out, context_lse = _pcp_rs_reduce(context_out, context_lse,
+                                                      pcp_axis, pcp_size)
 
         # Current phase: local Q (head+tail chunks) attends all-gathered current KV.
         # pcp_cu_q_lens_local[0] = [0, chunk, chunk+tail_real]; pcp_q_pos_offsets_local[0] = [head_offset, tail_offset].
@@ -417,8 +487,12 @@ def pcp_forward(
             write_last_seq_only=True,
             **common)
 
-        out, _ = merge_attn_states(context_out, context_lse, curr_out,
-                                   curr_lse)
+        # With nothing cached the current phase already IS the answer.
+        if context_out is None:
+            out = curr_out
+        else:
+            out, _ = merge_attn_states(context_out, context_lse, curr_out,
+                                       curr_lse)
         return kv_cache_updated, out.astype(q.dtype)
 
     return jax.shard_map(

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -28,7 +28,8 @@ import tpu_inference.envs as envs
 from tpu_inference.core.disagg_utils import is_disagg_enabled
 from tpu_inference.core.sched.utils import DEFAULT_MAX_DECODE_STEPS
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, PCPMetadata, SharedAttentionMetadata)
+    AttentionMetadata, PCPMetadata, SharedAttentionMetadata,
+    pcp_cache_page_buckets)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling import (
     compute_and_gather_logprobs, compute_and_gather_prompt_logprobs, sample)
@@ -360,6 +361,19 @@ class CompilationManager:
                 num_tokens=num_tokens,
             )
 
+    def _pcp_cache_page_buckets(self) -> list[int]:
+        """Rungs of the shared `pcp_cache_pages` ladder to precompile.
+
+        It is a META field of PCPMetadata, so each value is its own compiled
+        program; precompiling the ladder keeps the first request of each rung
+        off the compile path.  Non-PCP runs use a single value (0), where the
+        field is never read.
+        """
+        pcp_size = self.runner.vllm_config.sharding_config.prefill_cp_size
+        if pcp_size <= 1:
+            return [0]
+        return pcp_cache_page_buckets(self.runner.max_num_blocks_per_req)
+
     def _precompile_backbone_helper(self,
                                     name,
                                     *,
@@ -369,7 +383,8 @@ class CompilationManager:
                                     intermediate_tensors=None,
                                     is_first_rank=True,
                                     is_last_rank=True,
-                                    num_reqs: int) -> None:
+                                    num_reqs: int,
+                                    pcp_cache_pages: int = 0) -> None:
         num_tokens = None
         if input_ids is not None:
             num_tokens = input_ids.shape[0]
@@ -413,6 +428,7 @@ class CompilationManager:
                                            np.zeros((pcp_size, n_reqs),
                                                     dtype=np.int32),
                                            sharding=pcp_spec),
+                cache_pages=pcp_cache_pages,
             )
         # Dummy mamba_state_indices for compile-cache pre-tracing. Only
         # populate for hybrid attn+mamba models — for pure-attention models we
@@ -692,15 +708,17 @@ class CompilationManager:
                             "hidden_states": hidden_states,
                             "residual": residual
                         })
-                self._precompile_backbone_helper(
-                    f"worker{self.runner.rank} backbone",
-                    input_ids=input_ids,
-                    positions=positions,
-                    inputs_embeds=None,
-                    intermediate_tensors=intermediate_tensors,
-                    is_first_rank=is_first_rank,
-                    is_last_rank=is_last_rank,
-                    num_reqs=num_reqs)
+                for _cache_pages in self._pcp_cache_page_buckets():
+                    self._precompile_backbone_helper(
+                        f"worker{self.runner.rank} backbone",
+                        input_ids=input_ids,
+                        positions=positions,
+                        inputs_embeds=None,
+                        intermediate_tensors=intermediate_tensors,
+                        is_first_rank=is_first_rank,
+                        is_last_rank=is_last_rank,
+                        num_reqs=num_reqs,
+                        pcp_cache_pages=_cache_pages)
 
     def _precompile_backbone_with_inputs_embeds(self) -> None:
         hidden_size = self.runner.model_config.get_hidden_size()

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -53,7 +53,8 @@ import tpu_inference.envs as envs
 from tpu_inference import utils as common_utils
 from tpu_inference.core.sched.utils import DEFAULT_MAX_DECODE_STEPS
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, PCPMetadata, SharedAttentionMetadata)
+    AttentionMetadata, PCPMetadata, SharedAttentionMetadata,
+    round_up_pcp_cache_pages)
 from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
                                                   MESH_AXIS_NAMES_2D,
                                                   ShardingAxisName,
@@ -2916,6 +2917,12 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                            kv_cache_lens_np,
                                            sharding=repl),
                 q_pos_offsets=pcp_q_pos_offsets,
+                # Snap the request's live cached-page count up to the shared
+                # ladder that precompilation warms (0 == nothing cached, which
+                # elides the cache phase entirely).
+                cache_pages=round_up_pcp_cache_pages(
+                    num_computed, self.block_size,
+                    self.max_num_blocks_per_req),
             )
         spec_decode_metadata = None
         if self.speculative_config:


### PR DESCRIPTION
## Summary

This PR adds a **gather-KV** strategy for the single-request PCP (prefill context parallel) attention cache phase, with automatic per-compile dispatch between it and the existing gather-Q path.

The all-gather PCP cache phase today replicates **Q** across the pcp ranks, attends the local KV shard, and LSE reduce-scatters the partials. Its communication is `~2·chunk·NQ` (Q all-gather + output reduce-scatter) and is
**independent of context length**, which makes it expensive at short/medium context.

**gather-KV** instead all-gathers the striped **KV cache** into global token order so every rank holds the full cache, then attends the local Q against it as ordinary paged attention — no output collective, no per-rank bookkeeping.
Communication becomes `~ctx·NKV`. It wins at short/medium context and low KV head counts; gather-Q wins once context is large.

`pcp_ragged_paged_attention` picks per compile by comparing the two static communication estimates. 

## Implementation details

- All-gather the cache with the pcp axis innermost so the flattened layout is already global token order; the cache phase becomes plain paged attention with `cp_group_size=1`.
- Only the request's live pages are gathered. The block table is sized for `max_model_len`; a new static `pcp_cache_pages` meta field (from the runner, power-of-two bucketed) bounds the gather to the pages actually in use, so a short request on a large-`max_model_len` server does not move the whole cache.  
- First-chunk skip: when there are no cached tokens (first chunk prefill chunk),the cache phase is elided entirely.
- Precompilation enumerates the `pcp_cache_pages` buckets, since it is a meta field (each value is its own compiled program). This increases precompilation time. 


Dynamic Ag-q / Ag-kv E2E benchmark
-------------------

- Model: Qwen/Qwen3-235B-A22B-Instruct-2507-FP8
- Output length: 1 
- Chunked prefill chunk size: 16k · 
- num-prompts: 10


```

Input length 256k

┌────────────────────────────────┬────────────┬─────────────────┐
│                                │    TP=4    │  PCP=2 × TP=4   │
├────────────────────────────────┼────────────┼─────────────────┤
│ Successful requests            │ 10         │ 10              │
├────────────────────────────────┼────────────┼─────────────────┤
│ Benchmark duration (s)         │ 1411.86    │ 699.18          │
├────────────────────────────────┼────────────┼─────────────────┤
│ Total input tokens             │ 2621340    │ 2621340         │
├────────────────────────────────┼────────────┼─────────────────┤
│ Total token throughput (tok/s) │ 1856.67    │ 3749.17 (2.02×) │
├────────────────────────────────┼────────────┼─────────────────┤
│ Mean TTFT (ms)                 │ 793010.30  │ 396298.63       │
├────────────────────────────────┼────────────┼─────────────────┤
│ Median TTFT (ms)               │ 793033.94  │ 396320.17       │
├────────────────────────────────┼────────────┼─────────────────┤
│ P99 TTFT (ms)                  │ 1399427.85 │ 693080.19       │
├────────────────────────────────┼────────────┼─────────────────┤
│ Mean E2EL (ms)                 │ 793010.30  │ 396298.63       │
├────────────────────────────────┼────────────┼─────────────────┤
│ TTFT                           │ ~141 s     │ ~70 s           │
└────────────────────────────────┴────────────┴─────────────────┘


Input length 4k

┌────────────────────────────────┬──────────┬────────────────────────┐
│                                │   TP=4   │      PCP=2 × TP=4      │
├────────────────────────────────┼──────────┼────────────────────────┤
│ Successful requests            │ 10       │ 10                     │
├────────────────────────────────┼──────────┼────────────────────────┤
│ Benchmark duration (s)         │ 3.38     │ 2.76                   │
├────────────────────────────────┼──────────┼────────────────────────┤
│ Total token throughput (tok/s) │ 12109.61 │ 14847.73 (1.23×)       │
├────────────────────────────────┼──────────┼────────────────────────┤
│ Mean TTFT (ms)                 │ 1989.61  │ 1753.46 (11.9% faster) │
└────────────────────────────────┴──────────┴────────────────────────┘

Input length 1k

┌────────────────────────────────┬─────────┬───────────────────────┐
│                                │  TP=4   │     PCP=2 × TP=4      │
├────────────────────────────────┼─────────┼───────────────────────┤
│ Successful requests            │ 10      │ 10                    │
├────────────────────────────────┼─────────┼───────────────────────┤
│ Benchmark duration (s)         │ 1.05    │ 0.85                  │
├────────────────────────────────┼─────────┼───────────────────────┤
│ Total token throughput (tok/s) │ 9750.08 │ 12004.10 (1.23×)      │
├────────────────────────────────┼─────────┼───────────────────────┤
│ Mean TTFT (ms)                 │ 581.88  │ 473.67 (18.6% faster) │
└────────────────────────────────┴─────────┴───────────────────────┘

```

Commands: 

```
python tpu-inference/scripts/vllm/benchmarking/benchmark_serving.py --backend=vllm \
  --model=Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 --dataset-name=random \
  --num-prompts=10 --random-input-len=<LEN> --random-output-len=1

NUM_PRECOMPILE_WORKERS=8 VLLM_ENGINE_READY_TIMEOUT_S=7200 VLLM_TPU_BUCKET_PADDING_GAP=2048 \
PHASED_PROFILING_DIR=gs://wenxindong-vm/trace/pcp/e2e/tp_<LEN> \
NEW_MODEL_DESIGN=1 \
vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
  --max-model-len=262144 --max-num-seqs=1 --no-enable-prefix-caching \
  --gpu-memory-utilization=0.95 --tensor-parallel-size=4 \
  --download_dir=/mnt/disks/persist --max-num-batched-tokens=16384

NUM_PRECOMPILE_WORKERS=8 VLLM_ENGINE_READY_TIMEOUT_S=7200 \
VLLM_TPU_BUCKET_PADDING_GAP=2048 \
PHASED_PROFILING_DIR=gs://wenxindong-vm/trace/pcp/e2e/pcp_<LEN> \
NEW_MODEL_DESIGN=1 \
vllm serve Qwen/Qwen3-235B-A22B-Instruct-2507-FP8 \
  --max-model-len=262144 --max-num-seqs=1 --no-enable-prefix-caching \
  --gpu-memory-utilization=0.95 --tensor-parallel-size=4 \
  --download_dir=/mnt/disks/persist --max-num-batched-tokens=16384 \
  --prefill-context-parallel-size 2

```
Attention Microbenchmark
-----

```
CH=16k, NQ=16 NKV=4 HD=256, bf16
┌─────────┬─────────┬─────────┬──────────┬──────────┬──────────┬──────────┬─────────┐
│ context │     tp4 │     tp8 │ pcp2_tp4 │ pcp8_tp1 │ tp4/pcp2 │ tp4/pcp8 │ tp4/tp8 │
├─────────┼─────────┼─────────┼──────────┼──────────┼──────────┼──────────┼─────────┤
│     16k │    1.72 │    0.95 │     1.09 │     1.44 │    1.58× │    1.19× │   1.81× │
│     64k │   20.40 │   10.81 │    11.74 │    11.52 │    1.74× │    1.77× │   1.89× │
│    128k │   78.75 │   40.58 │    42.18 │    44.39 │    1.87× │    1.77× │   1.94× │
│    512k │ 1219.30 │  619.94 │   600.78 │   590.04 │    2.03× │    2.07× │   1.97× │
│      1M │ 4844.36 │ 2453.70 │  2336.24 │  2199.48 │    2.07× │    2.20× │   1.98× │
│      2M │   19312 │  9758   │  9202.46 │  8451.03 │    2.10× │    2.29× │   1.98× │
└─────────┴─────────┴─────────┴──────────┴──────────┴──────────┴──────────┴─────────┘
```

Optimizing performance on short context is the goal of future work. 

```
CH=16k, NQ=16 NKV=4 HD=256, bf16
┌─────┬───────┬───────┬──────────┬──────────┬──────────┬──────────┬─────────┐
│ ctx │  tp4  │  tp8  │ pcp2_tp4 │ pcp8_tp1 │ tp4/pcp2 │ tp4/pcp8 │ tp4/tp8 │
├─────┼───────┼───────┼──────────┼──────────┼──────────┼──────────┼─────────┤
│ 1k  │ 0.305 │ 0.517 │ 0.782    │ 0.748    │ 0.39×    │ 0.41×    │ 0.59×   │
├─────┼───────┼───────┼──────────┼──────────┼──────────┼──────────┼─────────┤
│ 2k  │ 0.279 │ 0.536 │ 0.714    │ 0.750    │ 0.39×    │ 0.37×    │ 0.52×   │
├─────┼───────┼───────┼──────────┼──────────┼──────────┼──────────┼─────────┤
│ 4k  │ 0.335 │ 0.569 │ 0.719    │ 0.733    │ 0.47×    │ 0.46×    │ 0.59×   │
├─────┼───────┼───────┼──────────┼──────────┼──────────┼──────────┼─────────┤
│ 8k  │ 0.571 │ 0.613 │ 0.798    │ 0.770    │ 0.72×    │ 0.74×    │ 0.93×   │
├─────┼───────┼───────┼──────────┼──────────┼──────────┼──────────┼─────────┤
│ 16k │ 1.716 │ 0.949 │ 1.079    │ 1.358    │ 1.59×    │ 1.26×    │ 1.81×   │
└─────┴───────┴───────┴──────────┴──────────┴──────────┴──────────┴─────────┘

```

Model quality
-----

```
SKIP_JAX_PRECOMPILE=1 NEW_MODEL_DESIGN=1 vllm serve Qwen/Qwen3-8B-Base \
  --max-model-len=4096 --max-num-batched-tokens=4096 --max_num_seqs=1 \
  --gpu-memory-utilization=0.9 --tensor-parallel-size=4 \
  --prefill-context-parallel-size 2

lm_eval --model local-chat-completions \
  --model_args base_url="http://localhost:8000/v1/chat/completions",model="Qwen/Qwen3-8B-Base",eos_string="<|im_end|>",num_concurrent=256 \
  --tasks gsm8k --apply_chat_template --fewshot_as_multiturn --limit 200

```

```
|Tasks|Version|     Filter     |n-shot|  Metric   |   |Value|   |Stderr|
|-----|------:|----------------|-----:|-----------|---|----:|---|-----:|
|gsm8k|      3|flexible-extract|     5|exact_match|↑  |0.835|±  |0.0263|
|     |       |strict-match    |     5|exact_match|↑  |0.835|±  |0.0263|
```


## Testing

- Added unit tests

