### PR TITLE
fp8 KV cache: cast k/v to cache dtype in sharded_ragged_paged_attention

### DIFF
--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -261,6 +261,110 @@ def test_sharded_ragged_paged_attention_gqa_replication(monkeypatch, gqa_mesh):
     assert jnp.array_equal(replicated_v, expected_v)
 
 
+def test_sharded_ragged_paged_attention_fp8_cache_casts_kv(
+        monkeypatch, gqa_mesh):
+    """fp8 KV cache: bf16 k/v are cast to the fp8 cache dtype before the kernel.
+
+    The RPA v3 kernel enforces kv_cache.dtype == k.dtype == v.dtype and expects
+    KV quantization to happen outside the kernel. This checks that
+    sharded_ragged_paged_attention casts bf16 k/v to the fp8 cache dtype so the
+    kernel's invariant holds (regression test for the fp8 dtype-mismatch crash).
+    """
+    head_dim = 128
+    num_kv_heads = 4  # == tp_size, so no GQA replication interferes
+    q = jnp.ones((TOTAL_TOKENS, NUM_HEADS, head_dim), dtype=jnp.bfloat16)
+    k = jnp.ones((TOTAL_TOKENS, num_kv_heads, head_dim), dtype=jnp.bfloat16)
+    v = jnp.ones((TOTAL_TOKENS, num_kv_heads, head_dim), dtype=jnp.bfloat16)
+    # fp8 KV cache
+    kv_cache = jnp.zeros((num_kv_heads, NUM_BLOCKS, BLOCK_SIZE, head_dim),
+                         dtype=jnp.float8_e4m3fn)
+    kv_lens = jnp.zeros((MAX_NUM_SEQS, ), dtype=jnp.int32)
+    page_indices = jnp.zeros((MAX_NUM_SEQS, MAX_BLOCKS_PER_SEQ),
+                             dtype=jnp.int32)
+    cu_q_lens = jnp.zeros((MAX_NUM_SEQS + 1, ), dtype=jnp.int32)
+    distribution = jnp.zeros((3, ), dtype=jnp.int32)
+
+    mock_shard_map_callable = MagicMock(return_value=(jnp.ones_like(q),
+                                                      kv_cache))
+    mock_shard_map = MagicMock(return_value=mock_shard_map_callable)
+    monkeypatch.setattr("jax.shard_map", mock_shard_map)
+
+    sharded_ragged_paged_attention(
+        mesh=gqa_mesh,
+        q=q,
+        k=k,
+        v=v,
+        kv_cache=kv_cache,
+        kv_lens=kv_lens,
+        page_indices=page_indices,
+        cu_q_lens=cu_q_lens,
+        distribution=distribution,
+        attention_sink=None,
+        sm_scale=1.0,
+    )
+
+    mock_shard_map_callable.assert_called_once()
+    call_args = mock_shard_map_callable.call_args[0]
+    kernel_k = call_args[1]
+    kernel_v = call_args[2]
+    # k/v must be cast to the fp8 cache dtype so the kernel invariant holds.
+    assert kernel_k.dtype == kv_cache.dtype
+    assert kernel_v.dtype == kv_cache.dtype
+
+
+def test_sharded_ragged_paged_attention_matching_dtype_no_cast(
+        monkeypatch, gqa_mesh):
+    """No-op when k/v already match the cache dtype (e.g. pre-quantized paths).
+
+    The cast must not fire when dtypes already agree, so callers that
+    pre-quantize via quantize_kv are unaffected. Here a bf16 cache with bf16
+    k/v must pass k/v through unchanged.
+    """
+    head_dim = 128
+    num_kv_heads = 4
+    q = jnp.ones((TOTAL_TOKENS, NUM_HEADS, head_dim), dtype=jnp.bfloat16)
+    k = (jnp.arange(TOTAL_TOKENS * num_kv_heads * head_dim,
+                    dtype=jnp.bfloat16).reshape(
+                        (TOTAL_TOKENS, num_kv_heads, head_dim)))
+    v = -k
+    kv_cache = jnp.zeros((num_kv_heads, NUM_BLOCKS, BLOCK_SIZE, head_dim),
+                         dtype=jnp.bfloat16)
+    kv_lens = jnp.zeros((MAX_NUM_SEQS, ), dtype=jnp.int32)
+    page_indices = jnp.zeros((MAX_NUM_SEQS, MAX_BLOCKS_PER_SEQ),
+                             dtype=jnp.int32)
+    cu_q_lens = jnp.zeros((MAX_NUM_SEQS + 1, ), dtype=jnp.int32)
+    distribution = jnp.zeros((3, ), dtype=jnp.int32)
+
+    mock_shard_map_callable = MagicMock(return_value=(jnp.ones_like(q),
+                                                      kv_cache))
+    mock_shard_map = MagicMock(return_value=mock_shard_map_callable)
+    monkeypatch.setattr("jax.shard_map", mock_shard_map)
+
+    sharded_ragged_paged_attention(
+        mesh=gqa_mesh,
+        q=q,
+        k=k,
+        v=v,
+        kv_cache=kv_cache,
+        kv_lens=kv_lens,
+        page_indices=page_indices,
+        cu_q_lens=cu_q_lens,
+        distribution=distribution,
+        attention_sink=None,
+        sm_scale=1.0,
+    )
+
+    mock_shard_map_callable.assert_called_once()
+    call_args = mock_shard_map_callable.call_args[0]
+    kernel_k = call_args[1]
+    kernel_v = call_args[2]
+    # Unchanged: same dtype and same values (no clip/cast applied).
+    assert kernel_k.dtype == jnp.bfloat16
+    assert kernel_v.dtype == jnp.bfloat16
+    assert jnp.array_equal(kernel_k, k)
+    assert jnp.array_equal(kernel_v, v)
+
+
 def test_sharded_ragged_paged_attention_gqa_incompatible_raises_error(
     gqa_mesh, ):
     """

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -417,6 +417,31 @@ def sharded_ragged_paged_attention(
     )
     out_specs = (qkv_spec, kv_cache_spec)
 
+    # fp8 KV-cache compatibility. The RPA v3 kernel
+    # (kernels/ragged_paged_attention/v3/kernel.py:static_validate_inputs)
+    # requires kv_cache.dtype == k.dtype == v.dtype and, per its own comment,
+    # "expects the kv quantization happens outside of the RPA kernel". When the
+    # KV cache is allocated in fp8 (kv_cache_dtype=fp8) but a caller reaches this
+    # kernel with bf16 k/v -- e.g. model paths that do not pre-quantize K/V,
+    # KV-shared layers, or the warm-up/dummy capture forward -- the kernel raises
+    # a dtype ValueError. This is the common choke point every RPA caller funnels
+    # through, and it sits after the GQA jnp.repeat so the cast also covers
+    # replicated KV heads. Cast k/v to the fp8 cache dtype here so the kernel's
+    # dtype invariant holds. No-op when dtypes already match (paths that
+    # pre-quantize via quantize_kv are unaffected). Scales are threaded through
+    # k_scale/v_scale unchanged; when a caller passes none, fp8 store/read is at
+    # scale 1.0.
+    if (kv_cache.dtype != k.dtype
+            and jnp.issubdtype(kv_cache.dtype, jnp.floating)
+            and kv_cache.dtype.itemsize == 1  # fp8 (e4m3/e5m2)
+        ):
+        _fp8_info = jnp.finfo(kv_cache.dtype)
+        _lo, _hi = float(_fp8_info.min), float(_fp8_info.max)
+        # Clip before cast (matches quantization.static_per_tensor_quantize_tensor)
+        # so out-of-range magnitudes saturate instead of becoming inf/nan.
+        k = jnp.clip(k, _lo, _hi).astype(kv_cache.dtype)
+        v = jnp.clip(v, _lo, _hi).astype(kv_cache.dtype)
+
     args = (q, k, v, kv_cache, kv_lens, page_indices, cu_q_lens, distribution)
 
     use_hd64 = q.shape[-1] == 64


### PR DESCRIPTION
# Description

The RPA v3 kernel (`kernels/ragged_paged_attention/v3/kernel.py`, `static_validate_inputs`) enforces the invariant `kv_cache.dtype == k.dtype == v.dtype` and, per its own inline comment, *"expects the kv quantization happens outside of the RPA kernel."* However `sharded_ragged_paged_attention` in `layers/common/attention_interface.py` — the common entry point that RPA callers funnel through — passes `k`/`v` to the kernel unchanged.

When the KV cache is allocated in fp8 (`kv_cache_dtype=fp8`) but a caller reaches the kernel with bf16 `k`/`v`, the kernel raises:

```
ValueError: Expected kv_cache.dtype=dtype(float8_e4m3fn) to be equal to
            k.dtype=dtype(bfloat16) and v.dtype=dtype(bfloat16).
```

This blocks fp8 KV cache for any path that does not itself pre-quantize `k`/`v` before the kernel — including model adapters that call `sharded_ragged_paged_attention` directly, KV-shared layers, and the warm-up/dummy capture forward during engine initialization.

**Fix:** cast `k`/`v` to the fp8 cache dtype at the `sharded_ragged_paged_attention` choke point, immediately before the kernel call. Placed **after** the GQA `jnp.repeat` so replicated KV heads are covered, and a **no-op when dtypes already match**, so paths that pre-quantize via `quantize_kv` are unaffected. Clip-before-cast matches `quantization.static_per_tensor_quantize_tensor` semantics so out-of-range magnitudes saturate instead of producing `inf`/`nan`. This realizes the kernel's documented contract ("kv quantization happens outside the kernel") for callers that don't pre-quantize.

# Tests

Added two unit tests in `tests/layers/common/test_attention_interface.py` (mirroring the existing `test_sharded_ragged_paged_attention_gqa_replication` mock pattern — capture the tensors forwarded into the kernel via a mocked `jax.shard_map`):

- `test_sharded_ragged_paged_attention_fp8_cache_casts_kv` — with an fp8 `kv_cache` and bf16 `k`/`v`, asserts the `k`/`v` reaching the kernel are cast to the fp8 cache dtype.
- `test_sharded_ragged_paged_attention_matching_dtype_no_cast` — with a bf16 cache and bf16 `k`/`v`, asserts `k`/`v` pass through unchanged (dtype and values), i.e. the cast is a strict no-op when dtypes agree.

Run:
```
pytest tests/layers/common/test_attention_interface.py -k "fp8_cache_casts_kv or matching_dtype_no_cast" -v
```

Also validated end-to-end at runtime on a TPU v7x (64-chip, TP=8) RL rollout serving a Gemma-family model via the MaxText vLLM adapter (`kv_cache_dtype=fp8`):
- **Before (unpatched):** the engine warm-up capture forward crashed with the dtype `ValueError` above (KV cache allocated fp8, `regular_attn_dtype=float8_e4m3fn`, HBM ~72 GiB/chip — but the warm-up forward reached the kernel with bf16 k/v).
- **After (patched):** the run initializes and trains cleanly with fp8 KV active, zero dtype errors anywhere in the log:
  - fp8 KV cache init: `Using fp8 data type to store kv cache`, `total_hbm_used_gb=357.48 GiB` (vs ~385 GiB bf16), GPU KV cache size **30,951,296 tokens** (≈ 2× the bf16 capacity for the same HBM budget).
  - Engine warm-up capture forward completes; model init, sampler/backbone precompile, and the RL training loop all proceed.
  - First rollout completes on the fp8 KV cache (real decode, ~87% prefix-cache hit) and the first training step + checkpoint land.
  - **Accuracy is healthy — fp8 lossy KV did not collapse generation:** first-completion reward `0.8182`, with a normal spread of per-completion scores and structurally valid outputs (not NaN, not a degenerate all-zero collapse).

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
- [x] I have added tests that prove my fix is effective.
