### PR TITLE
Add 'spmd' multi-host backend (bare jax.distributed, no Ray)

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -225,9 +225,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Worker ID for multi-host TPU setups
     "TPU_WORKER_ID":
     lambda: os.getenv("TPU_WORKER_ID", None),
-    # Backend for multi-host communication on TPU
+    # Backend for multi-host communication on TPU.
+    #   "ray"  : vLLM's RayDistributedExecutor owns the TPU hosts (spawns Ray
+    #            actor workers). Best for standalone multi-host serving.
+    #   "spmd" : bare jax.distributed (SPMD / multi-controller). Every host runs
+    #            the same process and owns only its locally-addressable devices;
+    #            no Ray actors are spawned and UniProcExecutor is kept per host.
+    #            Useful when the engine is embedded in an already-initialized
+    #            jax.distributed program (e.g. a colocated RL trainer) that owns
+    #            the devices, so a separate Ray worker group cannot re-acquire
+    #            them. The multi-host device-placement helpers below key off this.
     "TPU_MULTIHOST_BACKEND":
-    env_with_choices("TPU_MULTIHOST_BACKEND", "", ["ray"]),
+    env_with_choices("TPU_MULTIHOST_BACKEND", "", ["ray", "spmd"]),
     # Use vLLM-native multi-process data parallelism (one engine process per
     # DP rank, single load-balanced API endpoint) instead of tpu-inference's
     # single-process SPMD data parallelism. Each DP rank is pinned to a

--- a/tpu_inference/layers/common/utils.py
+++ b/tpu_inference/layers/common/utils.py
@@ -139,10 +139,15 @@ def general_device_put(tensor: jax.Array,
 
     def _put(t):
         multihost_backend = envs.TPU_MULTIHOST_BACKEND
-        # If we are not in multi-host setup, or the tensor is not fully addressable,
-        # we can use jax.device_put directly.
-        if multihost_backend != "ray" or (isinstance(t, jax.Array)
-                                          and not t.is_fully_addressable):
+        # The multi-host branch below (jax.make_array_from_callback) is pure JAX
+        # SPMD: each process contributes only its locally-addressable shards. It
+        # is correct for any multi-controller deployment -- both "ray" (Ray owns
+        # the hosts) and "spmd" (bare jax.distributed). If we are not in a
+        # multi-host setup, or the tensor is not fully addressable, we can use
+        # jax.device_put directly.
+        is_multihost = multihost_backend in ("ray", "spmd")
+        if (not is_multihost) or (isinstance(t, jax.Array)
+                                  and not t.is_fully_addressable):
             if layout is not None:
                 return jax.device_put(t, Format(layout, sharding))
             else:

--- a/tpu_inference/models/jax/utils/weight_utils.py
+++ b/tpu_inference/models/jax/utils/weight_utils.py
@@ -565,8 +565,12 @@ def load_hf_weights(
         max_workers = min(64, len(weights_files))
         # NOTE(xiang): Disable multi-threading mode if running on multi-host.
         # Because multi-threading would cause different JAX processes to load
-        # different weights at the same time.
-        if envs.TPU_MULTIHOST_BACKEND == "ray":
+        # different weights at the same time. This applies to every
+        # multi-controller backend -- both "ray" and bare jax.distributed
+        # ("spmd") -- since each process must load weight files in the same
+        # deterministic order for the per-host make_array_from_callback shards
+        # to line up.
+        if envs.TPU_MULTIHOST_BACKEND in ("ray", "spmd"):
             max_workers = 1
         with ThreadPoolExecutor(max_workers=max_workers) as executor:
             futures = [

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -363,6 +363,19 @@ class TpuPlatform(Platform):
                 parallel_config.distributed_executor_backend = RayDistributedExecutor
                 logger.info(
                     "Force using RayDistributedExecutor for JAX on multihost.")
+        elif multihost_backend == "spmd":
+            # Bare jax.distributed (SPMD / multi-controller): the surrounding
+            # program has already called jax.distributed.initialize(), so every
+            # host runs this same process and owns only its locally-addressable
+            # devices. We must NOT spawn a Ray worker group (it would try to
+            # re-acquire devices already held by this process, e.g. a colocated
+            # jax.distributed RL trainer). Keep the per-process UniProcExecutor;
+            # the multi-host device-placement helpers (general_device_put,
+            # weight loading) key off TPU_MULTIHOST_BACKEND to fill only the
+            # locally-addressable shards via jax.make_array_from_callback.
+            logger.info("Using UniProcExecutor for JAX SPMD multi-host "
+                        "(bare jax.distributed, no Ray).")
+            parallel_config.distributed_executor_backend = "uni"
         else:
             logger.warning(
                 f"Unknown TPU multihost backend: {multihost_backend}. "


### PR DESCRIPTION
## Add `spmd` multi-host backend (bare `jax.distributed`, no Ray)

### Problem

`tpu-inference` supports two execution models on TPU: `UniProcExecutor` (single host,
`TPU_MULTIHOST_BACKEND` unset) and `RayDistributedExecutor` (`TPU_MULTIHOST_BACKEND=ray`,
which spawns a Ray actor worker group that *acquires* the TPU hosts). There is no way to
run multi-host **without Ray owning the devices**.

That blocks embedding the engine inside an already-initialized `jax.distributed` (SPMD /
multi-controller) program — e.g. a colocated RL trainer that has already called
`jax.distributed.initialize()` and owns all local TPU devices. Under
`TPU_MULTIHOST_BACKEND=ray` the Ray worker group tries to re-acquire those devices and
conflicts with the trainer; under the unset (single-host) backend, `general_device_put`
takes the plain `jax.device_put` path and fails on a >1-process mesh:

```
ValueError: device_put's second argument must be a Device or a Sharding which
represents addressable devices, but got NamedSharding(mesh=Mesh('data': 16, ...
'model': 8, ...))
```

The multi-host device-placement helper `general_device_put` already has the correct code
(`jax.make_array_from_callback`, each process fills only its locally-addressable shards)
— but it is gated on `TPU_MULTIHOST_BACKEND == "ray"`, and that helper is pure JAX SPMD
(no Ray primitives).

### Change

Adds a third backend value, `spmd`:
- **envs.py**: `TPU_MULTIHOST_BACKEND` accepts `"spmd"` in addition to `"ray"`.
- **platforms/tpu_platform.py**: `"spmd"` keeps the per-process `UniProcExecutor` (no Ray
  worker group spawned — the surrounding `jax.distributed` program is the process launcher).
- **layers/common/utils.py**: `general_device_put` treats `{ray, spmd}` as multi-host,
  taking the `make_array_from_callback` path.
- **models/jax/utils/weight_utils.py**: single-thread HF weight loading for `{ray, spmd}`
  so every process loads files in the same deterministic order.

No behavior change for existing backends: unset stays single-host, `ray` is untouched.
`spmd` is opt-in.

### Validation

Runtime-validated on a gemma-4-2B RL rollout on a 64-chip TPU v7x slice (16 hosts × 8
local devices), plain `jax.distributed` JobSet (no Ray), colocated with a `jax.distributed`
trainer, `TPU_MULTIHOST_BACKEND=spmd`:
- Model weights place correctly on the SPMD sampler mesh via `make_array_from_callback`
  (the `device_put` `ValueError` above no longer occurs).
- `UniProcExecutor` is kept per host — no Ray actors, no device-ownership conflict.
- vLLM V1 engine initializes (`init engine ... took ~3.8 s`), KV cache allocates
  (`GPU KV cache size: 43,190,783 tokens`), and the per-host DP16×TP8 rollout mesh
  (`Mesh('data': 16, 'model': 8)`) comes up cleanly across all 128 JAX devices.

### Scope / notes for reviewers

- This exposes the *existing* SPMD device-placement path under a named backend; it adds no
  new device logic. The single-thread weight-load guard is the same correctness constraint
  the `ray` path already relies on, extended to `spmd`.
- This covers the engine's own device placement (model load, KV cache, mesh). A colocated
  RL trainer that periodically reshards trainer weights into the rollout engine across two
  *different* meshes still needs a cross-mesh reshard primitive (today provided by
  `pathwaysutils` under the Pathways backend); that reshard path is outside this change.
  This PR makes the engine itself run under bare `jax.distributed`, which is the prerequisite.
