### PR TITLE
Add production Buildkite-on-Kubernetes setup runbook, cross-project Terraform, and cache write-back

### DIFF
--- a/.buildkite/kubernetes/production/PRODUCTION_READINESS.md
+++ b/.buildkite/kubernetes/production/PRODUCTION_READINESS.md
@@ -1,0 +1,264 @@
+# Production-readiness review
+
+Status: gaps identified; production launch not approved.
+
+## Highest-priority findings
+
+### P0: untrusted pipeline code can become cluster control
+
+The pipeline definition lives in the tested checkout. A pull request that can
+change Kubernetes plugin configuration may attempt privileged containers,
+host networking, host paths, alternate images, service accounts, or unexpected
+secrets. Buildkite queue isolation alone is not a Kubernetes security boundary.
+
+Required controls:
+
+- load the trusted Agent Stack/Kubernetes profile from a protected pipeline or
+  platform repository, not directly from unreviewed PR content;
+- use separate queues, namespaces, service accounts, and credentials for trusted
+  and untrusted builds;
+- reject privileged mode, host namespaces, host paths, added capabilities,
+  writable host mounts, and arbitrary service accounts through admission policy;
+- default `automountServiceAccountToken: false` for test Pods;
+- enforce approved image registries and immutable image digests;
+- keep protected secrets unavailable to fork and untrusted PR builds;
+- move Pod Security admission from baseline to restricted after Agent Stack's
+  generated containers have compatible security contexts.
+
+This is the largest issue not exercised by the POC.
+
+### P0: static MultiKueue credential has no production lifecycle
+
+The POC creates a token with `kubectl create token`, embeds it in kubeconfig,
+and stores it in the manager Secret. That token expires unless an unusually
+long duration is accepted, and making it long-lived increases blast radius.
+There is no reconciler to rotate it or update the Secret.
+
+Target fix: Fleet ClusterProfile plus the GKE auth plugin, using Workload
+Identity Federation and short-lived credentials. Kueue 0.19 marks the feature
+alpha, so upgrade and validation are prerequisites. Do not store worker
+kubeconfigs in Terraform state as an intermediate production solution.
+
+### P0: Agent Stack readiness is incompatible with Kueue health
+
+The completed checkout regular container keeps a healthy running Pod
+`Ready=False`. Extending `waitForPodsReady` to three hours prevents premature
+eviction but also weakens stuck-workload detection.
+
+Production requires one of:
+
+- Agent Stack changes checkout to an init-container-compatible lifecycle;
+- Kueue supports an integration-specific readiness definition;
+- a supported Kueue mode disables this readiness check while independent health
+  monitoring and active deadlines provide a reliable replacement.
+
+Deliberately test stuck checkout, stuck image pull, stuck command startup, agent
+disconnect, and controller restart. A long timeout alone is not acceptance.
+
+### P0: secret distribution must be automatic and revocable
+
+MultiKueue does not copy referenced Secrets. Manually porting
+`agent-stack-k8s-secret` made the POC work but is not a production mechanism.
+
+Create values in Secret Manager outside Terraform and synchronize them to every
+cluster. Require rotation, version pin/rollback, missing-secret alerts, audit
+logs, and a tested emergency revocation path. Separate Buildkite agent tokens
+and model credentials by environment and trust level.
+
+## Capacity and scheduling
+
+### Standard GKE recommendation
+
+Use a regional Standard manager and zonal Standard workers. Each worker has:
+
+- a small autoscaled CPU system pool for Kueue, CSI, secret sync, and platform
+  Pods;
+- one TPU pool per supported logical profile;
+- topology configured through node-pool placement policy;
+- reservation affinity configured on the node pool;
+- custom profile labels consumed by ResourceFlavors.
+
+This eliminates Autopilot ComputeClasses and explicit zone/reservation selectors
+from workloads. It also makes the PVC's zone deterministic.
+
+### Quota must come from one capacity inventory
+
+Kueue nominal quota is not a live subscription to Cloud TPU reservations.
+Generate manager and worker quotas from the same reviewed inventory used to
+configure node-pool maxima. Continuously compare:
+
+- reservation capacity and utilization;
+- node-pool autoscaling maxima;
+- manager ClusterQueue quota;
+- worker ClusterQueue quota;
+- running/admitted TPU requests.
+
+Alert on drift. A Terraform variable is a starting source of truth, not runtime
+capacity discovery.
+
+The POC covers CPU, memory, and ephemeral storage with arbitrary generous
+quotas. Production examples cover only `google.com/tpu`; Kubernetes schedules
+ordinary resources. Add them back only if central admission must explicitly
+budget them and the values come from real capacity.
+
+### Do not share a cohort by default across incompatible shapes
+
+The POC puts `v6e-1` and `v6e-8` in cohort `v6e-pool`. Cohort borrowing may
+admit chips against quota belonging to a topology that cannot currently satisfy
+the Job. Keep the profiles independent unless an experiment proves the cloud
+reservation is truly fungible and fragmentation behavior is acceptable. If
+borrowing is enabled, define explicit borrowing/lending limits.
+
+### Bound admission wait
+
+`pendingTimeout: 0` allows indefinite waiting. That is useful during capacity
+debugging but unsuitable as the only production policy. Define queue-time SLOs,
+cancel superseded commits, and emit a clear capacity failure or fallback after
+a profile-specific maximum wait.
+
+## Storage and performance
+
+### Right-size the per-Job disk
+
+Every TPU Job currently requests 500 GiB. Fifteen concurrent tests can request
+7.5 TiB of provisioned disk before scale experiments are considered. Measure
+actual high-water marks and define smaller profile/test-class sizes. Alert on
+orphan PVCs and disk quota.
+
+### Build a trusted cache lifecycle
+
+The empty ephemeral PVC isolates Jobs but discards compilation, model, and
+dataset data. A production design should provide a read-only trusted generation
+plus a writable PR/branch overlay, with CPU-side preparation and explicit
+promotion. Untrusted PRs must never mutate the shared golden generation.
+
+Measure cache correctness and performance before adoption. Cache keys must
+include TPU shape, JAX/XLA/vLLM versions, model, compile flags, and source
+identity. Avoid GCS FUSE for compilation-cache filesystem traffic unless new
+measurements overturn the earlier poor result.
+
+### Replicate images near workers
+
+The POC image repository is in `us-central1` while the worker is in
+`southamerica-west1`. Cross-region pulls add startup time and may add network
+cost. Use Artifact Registry remote/virtual strategy or a regional repository
+per worker region, promote the same digest, and make the platform select the
+regional mirror. Never rebuild semantically different images per region.
+
+### Remove embedded download credentials
+
+The MLPerf preparation script retains public object-store credentials inherited
+from the existing script. Even if they are intentionally public, embedded
+credential-shaped values are difficult to audit and rotate. Prefer a public
+read-only endpoint without credentials or retrieve a narrowly scoped value from
+Secret Manager. Continue checksum verification.
+
+## Networking and security
+
+- Use private nodes, controlled control-plane endpoints, Cloud NAT, and private
+  Google access.
+- Define egress policy. Tests generally need Artifact Registry, model storage,
+  dataset storage, Buildkite, and selected package endpoints—not unrestricted
+  east-west access.
+- Use NetworkPolicy or a policy engine with Dataplane V2 where appropriate.
+- Use Workload Identity Federation; do not use downloaded service-account keys.
+- Give node service accounts logging, monitoring, and registry-read roles only.
+- Review the official ClusterProfile example's project-wide
+  `roles/container.developer` and `roles/gkehub.gatewayEditor`; add IAM
+  Conditions or a dedicated project/fleet when resource names are stable.
+- Apply binary authorization/signature policy to the test image, Agent Stack,
+  Kueue, auth plugin, secret sync, and policy-controller images.
+- Scan images and pin all runtime images by digest.
+- Encrypt and access-control Terraform remote state; state contains cluster
+  metadata even though it must not contain workload secrets.
+
+## Reliability and operations
+
+### Controller availability
+
+Run the manager in a regional cluster with multiple system nodes. Verify Kueue,
+Agent Stack, secret sync, policy webhooks, and Fleet inventory behavior during:
+
+- manager node upgrade;
+- controller leader change;
+- worker control-plane outage;
+- Connect Gateway outage;
+- expired/denied credentials;
+- Kueue and Agent Stack upgrades.
+
+Set PodDisruptionBudgets and topology spread where the charts support replicas.
+Confirm which controllers are actually active/standby rather than assuming
+replica count equals high availability.
+
+### TPU node upgrades
+
+Reserved TPU pools often cannot create a surge node. The Terraform example uses
+zero surge and one unavailable node. Put upgrades in a CI maintenance window,
+drain admission first, and verify no Job is evicted without Buildkite reporting
+the infrastructure cause. If extra capacity exists, change the upgrade policy
+after testing it.
+
+### Cancellation is a release criterion
+
+Cancel during central queueing, dispatch, node scale-up, PVC provisioning, image
+pull, model download, compilation, and test execution. Verify deletion of:
+
+- Buildkite Job/agent;
+- manager Job and Workload;
+- worker Job, Workload, and Pod;
+- generic ephemeral PVC/PV;
+- unused TPU node.
+
+Record time-to-zero-billing and alert on finalizers or orphan resources.
+
+### Observability
+
+Export and correlate these identifiers: Buildkite build/job, manager Job,
+Workload, worker cluster, worker Job/Pod, PVC/PV, node pool, and TPU node.
+Measure separate durations for queue, admission, dispatch, scale-up, PVC,
+image pull, agent startup, downloads, compile, test, and cleanup.
+
+Define SLOs and alerts for:
+
+- MultiKueueCluster disconnected;
+- ClusterProfile missing/stale;
+- no admissible flavor or quota drift;
+- Job admitted but no worker Pod;
+- excessive node provisioning time;
+- agent disconnected while Job runs;
+- cleanup deadline exceeded;
+- cache hit/compile regression;
+- Secret sync or rotation failure.
+
+## CI semantics
+
+- Compare the same commit and cache condition against bare metal before drawing
+  performance conclusions.
+- Stop using blanket `soft_fail` once the migration phase ends. Separate known
+  quarantined tests from infrastructure failures.
+- Make test selection deterministic and observable before adding change-based
+  selection or Buildkite Test Engine.
+- Keep full-matrix/nightly capacity policy distinct from PR latency SLOs.
+- Cancel superseded builds for the same PR unless a test is deliberately being
+  retained for diagnosis.
+- Keep bare metal as a fallback until the new path meets the same reliability
+  and correctness bar.
+
+## Acceptance gates
+
+Production launch requires all of the following:
+
+1. Trusted/untrusted pipeline and Kubernetes admission boundaries are enforced.
+2. No static worker kubeconfig or bearer token is used.
+3. Secret synchronization and emergency revocation are tested.
+4. Readiness has a correct health signal or an explicitly accepted replacement.
+5. Same-commit performance and cost data covers cold and warm cache states.
+6. Cancellation reliably removes every resource within a defined SLO.
+7. Quota/fairness tests cover simultaneous one-chip and eight-chip builds.
+8. At least two worker failure modes are exercised; a second region is tested
+   before multi-region resilience is claimed.
+9. Cluster, Kueue, Agent Stack, plugin, and policy upgrades have rollback plans.
+10. On-call dashboards, alerts, runbooks, ownership, and cost budgets exist.
+
+Until these pass, use a canary queue and keep the production decision open
+between bare metal, hybrid, and Kubernetes-first execution.

--- a/.buildkite/kubernetes/production/README.md
+++ b/.buildkite/kubernetes/production/README.md
@@ -6,6 +6,8 @@ This directory turns the POC findings into a production-oriented target. It
 does not replace the working Autopilot POC. The two designs intentionally live
 side-by-side until the production acceptance gates pass.
 
+- [`SETUP.md`](SETUP.md) is the ordered runbook: what a human runs, in order,
+  with a gate after every step.
 - [`PRODUCTION_READINESS.md`](PRODUCTION_READINESS.md) is the prioritized gap
   analysis and rollout plan.
 - [`terraform`](terraform) creates the Google Cloud foundation: APIs, regional
@@ -13,6 +15,9 @@ side-by-side until the production acceptance gates pass.
   IAM, Artifact Registry, and Secret Manager metadata.
 - [`kueue`](kueue) shows the simplified Standard-GKE scheduling objects and the
   secretless Fleet ClusterProfile connection model.
+- [`cache`](cache) holds the compilation-cache loop: the golden PVC each job
+  clones, the identities that reach GCS, and the CronJob that promotes
+  published entries back into the golden.
 
 ## Target shape
 
@@ -149,13 +154,20 @@ lets scheduling policy roll back independently of a cluster. Kueue and Agent
 Stack Helm releases may be added to a separate platform stack once their exact
 versions and values are approved.
 
-The current Terraform scaffold assumes the manager and workers share one
-Google Cloud project. Supporting the cross-project layout above requires a
-worker-project map (and normally aliased providers), Fleet memberships created
-in the fleet host project with fully qualified worker cluster URIs, and IAM
-bindings applied separately in the fleet host and worker projects. This is an
-infrastructure-module change only; it should not change Buildkite pipeline or
-Kueue workload selection.
+The Terraform supports the cross-project layout above through the optional
+`worker_project` variable and an aliased `google.worker` provider. Worker
+clusters, their node pools, and their node service accounts are created there,
+while the Fleet, manager cluster, and Artifact Registry stay in `project_id`.
+Cross-project deployments also enable the required APIs in the worker project,
+grant the manager Kueue identity `roles/container.developer` there, and add a
+repository-level Artifact Registry reader binding so worker nodes can pull the
+test image from the manager project. Leave `worker_project` null to keep both
+sides in one project. Either way this is an infrastructure-module concern; it
+does not change Buildkite pipeline or Kueue workload selection.
+
+One worker project is assumed for all workers. Spreading workers across several
+projects needs a child module instantiated per project, because Terraform
+cannot select a provider alias per `for_each` key.
 
 Do not put any of these in Terraform state:
 

--- a/.buildkite/kubernetes/production/README.md
+++ b/.buildkite/kubernetes/production/README.md
@@ -87,6 +87,51 @@ pinning the auth plugin by digest, and running failover/rotation tests. Until
 then, keep the POC secret isolated and rotate it automatically; do not call it
 production-ready.
 
+### Cross-project and VPC boundaries
+
+The manager and worker clusters may be in different Google Cloud projects,
+regions, and VPC networks. They do not need VPC peering or direct Pod-to-Pod
+connectivity when MultiKueue uses Fleet-generated `ClusterProfile` objects and
+Connect Gateway. In that model, the manager reaches each worker Kubernetes API
+through Google APIs rather than through the worker control plane's private VPC
+address:
+
+```text
+manager Kueue -> Google APIs -> Fleet Connect Gateway -> worker Kubernetes API
+```
+
+A useful ownership model is:
+
+- a fleet host project contains the Fleet and manager cluster;
+- worker projects contain their GKE clusters, TPU reservations, node pools,
+  disks, quotas, and compute billing;
+- each worker cluster is registered to the manager's Fleet, noting that a
+  cluster can belong to only one Fleet;
+- the manager Kueue identity receives Connect Gateway access in the fleet host
+  project and GKE access in every worker project.
+
+For the current role model, grant the manager-only KSA principal
+`roles/gkehub.gatewayEditor` in the fleet host project and
+`roles/container.developer` in each worker project. These project-wide roles
+are broad; production should narrow them with IAM Conditions or project/fleet
+isolation after validating the exact resource names and permissions. Do not
+reuse this manager KSA name on worker clusters.
+
+Separate VPCs still need outbound access to the required Google APIs, normally
+through public egress or Private Google Access. VPC Service Controls and
+organization policy must permit the GKE, Fleet, and Connect Gateway calls.
+Direct network connectivity becomes necessary only when using kubeconfigs that
+target private worker control-plane addresses, when tests communicate across
+clusters, or when a worker consumes a private cache, model, dataset, registry,
+or other service in another VPC. Those data-plane paths are independent of
+MultiKueue dispatch and may use local replication, Shared VPC, Private Service
+Connect, peering, or VPN according to the service.
+
+Kueue quota remains declarative in each ClusterQueue. Fleet does not discover
+or synchronize TPU reservation or project quota automatically, so the platform
+operator must keep advertised nominal quota aligned with usable capacity in
+each worker project.
+
 ## Terraform boundaries
 
 Terraform owns slow-moving Google resources:
@@ -103,6 +148,14 @@ small internal Helm chart. This avoids Terraform CRD plan-time coupling and
 lets scheduling policy roll back independently of a cluster. Kueue and Agent
 Stack Helm releases may be added to a separate platform stack once their exact
 versions and values are approved.
+
+The current Terraform scaffold assumes the manager and workers share one
+Google Cloud project. Supporting the cross-project layout above requires a
+worker-project map (and normally aliased providers), Fleet memberships created
+in the fleet host project with fully qualified worker cluster URIs, and IAM
+bindings applied separately in the fleet host and worker projects. This is an
+infrastructure-module change only; it should not change Buildkite pipeline or
+Kueue workload selection.
 
 Do not put any of these in Terraform state:
 

--- a/.buildkite/kubernetes/production/README.md
+++ b/.buildkite/kubernetes/production/README.md
@@ -1,0 +1,197 @@
+# Production-oriented Buildkite TPU infrastructure
+
+Status: design and Terraform foundation scaffold; not applied.
+
+This directory turns the POC findings into a production-oriented target. It
+does not replace the working Autopilot POC. The two designs intentionally live
+side-by-side until the production acceptance gates pass.
+
+- [`PRODUCTION_READINESS.md`](PRODUCTION_READINESS.md) is the prioritized gap
+  analysis and rollout plan.
+- [`terraform`](terraform) creates the Google Cloud foundation: APIs, regional
+  manager, zonal Standard workers, CPU and TPU node pools, Fleet registration,
+  IAM, Artifact Registry, and Secret Manager metadata.
+- [`kueue`](kueue) shows the simplified Standard-GKE scheduling objects and the
+  secretless Fleet ClusterProfile connection model.
+
+## Target shape
+
+```mermaid
+flowchart LR
+  B["Buildkite queue: kube"] --> A["Agent Stack<br/>regional Standard manager"]
+  A --> K["Kueue manager<br/>ClusterProfile authentication"]
+  K --> F["GKE Fleet / Connect Gateway"]
+  F --> W1["zonal Standard worker A"]
+  F --> W2["zonal Standard worker B"]
+  W1 --> S1["CPU system pool"]
+  W1 --> T1["reserved v6e-1 pool"]
+  W1 --> T8["reserved v6e-8 pool"]
+```
+
+The manager is regional because it runs control-plane workloads and does not
+bind TPU PVCs. Each worker is zonal because TPU capacity, reservations, and
+`premium-rwo` volumes are zonal. A worker has a small CPU system node pool and
+one Standard TPU node pool per logical profile.
+
+## What Standard GKE removes
+
+Reservation use moves from an Autopilot `ComputeClass` into the TPU node pool's
+`reservation_affinity`. TPU topology moves into the node pool's
+`placement_policy`. The node pool carries a stable label:
+
+```text
+tpu-ci.google.com/profile=v6e-1
+tpu-ci.google.com/profile=v6e-8
+```
+
+Kueue ResourceFlavors select that label. The production Agent Stack plugin
+profile should set the Kueue queue label and request `google.com/tpu`, but should
+not repeat region, zone, reservation, ComputeClass, or GKE topology selectors.
+This makes regional movement a platform change rather than a pipeline change.
+
+Standard GKE does not remove the need for a ResourceFlavor: Kueue still needs a
+logical mapping between admitted quota and schedulable nodes. It only makes the
+flavor smaller and more stable.
+
+## Worker authentication
+
+The POC uses a Secret containing a kubeconfig and bearer token. Do not carry
+that bootstrap into production.
+
+The target uses Fleet-generated `ClusterProfile` objects and the GKE auth
+plugin:
+
+1. Terraform registers manager and workers in the same Fleet.
+2. Manager resource labels ask Fleet to generate `ClusterProfile` inventory in
+   `kueue-system`.
+3. The manager Kueue KSA receives Connect Gateway and GKE access through
+   Workload Identity Federation.
+4. Kueue invokes a pinned `gcp-auth-plugin` executable to obtain short-lived
+   credentials.
+5. `MultiKueueCluster.spec.clusterSource.clusterProfileRef` selects the worker.
+
+No worker bearer token or kubeconfig is placed in Terraform configuration,
+Terraform state, Git, or a Kubernetes Secret.
+
+Install the manager Kueue Helm release with release name or `fullnameOverride`
+`multikueue-fleet`, producing KSA
+`multikueue-fleet-controller-manager`. Keep worker releases named `kueue`.
+This distinction is security-sensitive: workload identity subjects do not
+contain a GKE cluster name, so reusing `kueue-controller-manager` would grant
+the Fleet project roles to worker controllers with the same namespace/KSA.
+
+Important: `MultiKueueClusterProfile` is alpha in Kueue 0.19, the version used
+by the POC. The official GKE integration is the right target, but production
+requires upgrading to a Kueue version where the team accepts its maturity,
+pinning the auth plugin by digest, and running failover/rotation tests. Until
+then, keep the POC secret isolated and rotate it automatically; do not call it
+production-ready.
+
+## Terraform boundaries
+
+Terraform owns slow-moving Google resources:
+
+- service APIs;
+- GKE clusters and node pools;
+- Workload Identity and project IAM;
+- Fleet registration and ClusterProfile inventory labels;
+- Artifact Registry repository;
+- Secret Manager secret container, but never its value.
+
+Kueue queues/flavors and workload policy remain YAML managed by GitOps or a
+small internal Helm chart. This avoids Terraform CRD plan-time coupling and
+lets scheduling policy roll back independently of a cluster. Kueue and Agent
+Stack Helm releases may be added to a separate platform stack once their exact
+versions and values are approved.
+
+Do not put any of these in Terraform state:
+
+- Buildkite agent tokens;
+- worker kubeconfigs or service-account tokens;
+- Hugging Face tokens;
+- private model-registry credentials.
+
+The foundation creates an empty Secret Manager container. Add versions through
+an approved secret workflow. Use GKE native secret sync or External Secrets to
+materialize `agent-stack-k8s-secret` in the manager and every worker, with
+automatic rotation.
+
+## Applying the foundation
+
+This is a new-cluster design. GKE cannot convert an Autopilot cluster into a
+Standard cluster in place. Do not point it at the POC names and expect a safe
+update.
+
+1. Create or select VPC subnets, secondary Pod/Service ranges, Cloud NAT, and
+   private Google access in the network stack.
+2. Create a versioned GCS Terraform-state bucket with narrowly scoped IAM.
+3. Copy `backend.tf.example` to `backend.tf` and set the bucket.
+4. Copy `terraform.tfvars.example` to a non-secret environment tfvars file.
+5. Replace reservation names, ranges, network paths, project, and authorized
+   CIDRs.
+6. Initialize, format, validate, and inspect the plan:
+
+```bash
+cd .buildkite/kubernetes/production/terraform
+terraform init
+terraform fmt -check -recursive
+terraform validate
+terraform plan -out=production.tfplan
+terraform show production.tfplan
+```
+
+7. Apply through the protected infrastructure pipeline with workload identity
+   or service-account impersonation, not a downloaded key.
+8. Add the Buildkite token as a Secret Manager version outside Terraform.
+9. Install secret synchronization, Kueue, the pinned ClusterProfile auth plugin,
+   policy controls, and Agent Stack through the platform deployment process.
+10. Verify Fleet inventory before applying any `MultiKueueCluster`:
+
+```bash
+kubectl -n kueue-system get clusterprofile
+kubectl get multikueuecluster
+```
+
+The example manifests assume the generated worker ClusterProfile is named
+`tpu-ci-southamerica-west1-a`. Use the actual Fleet-generated name.
+Install `manager-config.yaml` as the manager Helm configuration and apply
+`manager-auth-plugin-patch.yaml` through the chart's post-render/Kustomize
+stage after replacing the image placeholder with a signed digest. The GKE
+reference implementation currently requires building this plugin image; do not
+pull a mutable third-party build into the control plane.
+
+## Importing existing production resources
+
+If production clusters, repositories, or Secrets already exist, import them
+into reviewed remote state before applying. Never use Terraform to recreate a
+reservation or secret merely to make the plan green. Reservations remain
+inputs to the TPU node pools; this stack consumes them but does not create or
+resize them.
+
+## Rollout sequence
+
+Use a parallel migration:
+
+1. Create the manager and one worker without changing the existing queue.
+2. Verify ClusterProfile authentication and Kueue smoke Jobs.
+3. Install Agent Stack on a disposable Buildkite queue such as `kube-canary`.
+4. Run controlled same-commit tests and lifecycle fault injection.
+5. Add the real `kube` queue only after cancellation, secret rotation, and
+   readiness behavior are proven.
+6. Add regions one at a time and verify dispatch under unavailable capacity.
+7. Retain the bare-metal pipeline until the decision gates are satisfied.
+
+## Version policy
+
+Pin all of the following in the platform stack and upgrade them deliberately:
+
+- GKE release channel and maintenance windows;
+- Kueue chart and CRDs;
+- ClusterProfile API CRD/controller;
+- GKE auth plugin image digest;
+- Agent Stack chart/controller;
+- policy engine and secret synchronization controller.
+
+The Terraform scaffold allows a provider major range only to keep the example
+maintainable. Commit `.terraform.lock.hcl` after the first reviewed `init` so a
+real environment uses exact provider checksums.

--- a/.buildkite/kubernetes/production/SETUP.md
+++ b/.buildkite/kubernetes/production/SETUP.md
@@ -1,0 +1,273 @@
+# Production setup runbook
+
+Ordered steps to stand up a production-like Buildkite-on-Kubernetes
+environment. [`README.md`](README.md) explains *why* the design looks like
+this; this file is what you execute. [`PRODUCTION_READINESS.md`](PRODUCTION_READINESS.md)
+is the gap list you must close before calling it production.
+
+Every step ends in a **Gate**. A gate that does not pass is a stop, not a
+warning — most failures here are silent (a Pod that never starts, a cache that
+looks warm and misses every lookup, a reservation that quietly bills on-demand).
+
+## Target
+
+| | Manager | Worker |
+| --- | --- | --- |
+| Project | `cloud-ullm-inference-ci-cd` | `cloud-tpu-inference-test` |
+| Location | `us-central1`, regional | `southamerica-west1-a`, zonal |
+| Mode | Standard, autoscaling system pool | Standard |
+| Runs | Agent Stack, Kueue + MultiKueue manager | Kueue, copied Jobs, TPU Pods |
+| TPUs | none | v6e-1 (`1x1`), v6e-8 (`2x4`), from a specific reservation |
+
+Buildkite sees one queue. Kubernetes owns placement: a pipeline step declares a
+TPU profile and never a project, region, zone, or cluster name.
+
+---
+
+## 0. Decide and collect
+
+Resolve these before touching Terraform.
+
+**a. Manager cluster mode.** The Terraform builds a **regional Standard**
+manager with an autoscaling system pool, and that is the recommended default:
+the manager holds the Buildkite agent token and every worker credential, the
+node pool is one block you never revisit, and a warm floor of system nodes
+keeps Agent Stack from paying cold-start latency on the first job of the day.
+
+Autopilot is a legitimate alternative — the manager runs no TPU workload, and
+because MultiKueue keeps the manager Job suspended the *test* Pod never runs
+there either, so there is little node-level decision left. The ClusterProfile
+auth plugin is delivered by an initContainer, which Autopilot permits. Choose it
+if you would rather not own node upgrades at all. It is a rewrite of the
+`google_container_cluster.manager` block (`enable_autopilot = true`, drop
+`manager_system`), not a variable — GKE cannot convert an existing cluster
+either way.
+
+**b. Worker cluster mode is not a choice.** It must be Standard and zonal. TPU
+reservation consumption becomes an explicit `reservation_affinity` on the node
+pool, verifiable before you spend a TPU hour. On Autopilot it is a ComputeClass
+behaviour you can only confirm by watching a reservation counter during a live
+run. Zonal also removes any ambiguity about where the TPU Pod and its zonal PD
+land.
+
+**c. The TPU reservation name.**
+
+```bash
+gcloud compute reservations list --project cloud-tpu-inference-test \
+  --filter="zone:southamerica-west1-a" \
+  --format="table(name,specificReservationRequired,specificReservation.count,specificReservation.inUseCount)"
+```
+
+Record `specificReservation.count` per machine type — it sets both `max_nodes`
+and, later, Kueue quota.
+
+**d. Network.** Subnets, secondary Pod/Service ranges, Cloud NAT, and Private
+Google Access in both projects. This Terraform consumes them; it does not
+create them.
+
+**e. State and secrets**, once, by hand:
+
+```bash
+gcloud storage buckets create gs://REPLACE_TF_STATE \
+  --project cloud-ullm-inference-ci-cd --location us-central1
+gcloud storage buckets update gs://REPLACE_TF_STATE --versioning
+```
+
+The Buildkite agent token is added as a Secret Manager *version* outside
+Terraform, in step 3. Terraform creates the empty container only — a token in
+state is a token in every plan output and every state backup.
+
+**Gate:** reservation name and chip counts recorded; network ranges exist in
+both projects; state bucket versioned.
+
+---
+
+## 1. Apply the foundation
+
+```bash
+cd .buildkite/kubernetes/production/terraform
+cp backend.tf.example backend.tf          # set the state bucket
+cp terraform.tfvars.example prod.tfvars   # then edit
+terraform init
+terraform fmt -check -recursive
+terraform validate
+terraform plan -var-file=prod.tfvars -out=production.tfplan
+terraform show production.tfplan
+```
+
+The values that matter for the split-project layout:
+
+```hcl
+project_id     = "cloud-ullm-inference-ci-cd"   # fleet host + manager + registry
+worker_project = "cloud-tpu-inference-test"     # worker clusters + TPU reservation
+```
+
+`worker_project` exists because a reservation is only consumable from the
+project that owns it, so the worker cluster has to live beside it. Leave it
+`null` for a single-project deployment. The worker still joins the **manager's**
+fleet: a cluster can belong to only one fleet, and MultiKueue needs both sides
+in the same one.
+
+Apply through the protected infrastructure pipeline using workload identity or
+service-account impersonation — never a downloaded key.
+
+**Gate:** apply succeeds; `terraform plan` is then empty.
+
+---
+
+## 2. Verify the node labels and the reservation
+
+Kueue's ResourceFlavors select `tpu-ci.google.com/profile`. GKE applies the TPU
+accelerator and topology labels itself. Verify rather than assume — a mismatch
+surfaces much later as a Workload admitted on the manager that never runs
+anywhere.
+
+```bash
+gcloud container clusters get-credentials tpu-ci-southamerica-west1-a \
+  --zone southamerica-west1-a --project cloud-tpu-inference-test
+
+gcloud container clusters resize tpu-ci-southamerica-west1-a \
+  --node-pool v6e-1 --num-nodes 1 --zone southamerica-west1-a \
+  --project cloud-tpu-inference-test --quiet
+
+kubectl get nodes -L tpu-ci.google.com/profile,\
+cloud.google.com/gke-tpu-accelerator,cloud.google.com/gke-tpu-topology,topology.kubernetes.io/zone
+```
+
+While that node is up:
+
+```bash
+gcloud compute reservations describe RESERVATION \
+  --project cloud-tpu-inference-test --zone southamerica-west1-a \
+  --format="value(specificReservation.inUseCount)"
+```
+
+**Gate:** the node reports `profile=v6e-1`, `tpu-v6e-slice`, `1x1`,
+`southamerica-west1-a`, **and** `inUseCount` increased. If the node came up but
+the count did not, the pool is running on-demand capacity and
+`reservation_affinity` is wrong — fix it before anything else. Scale back to 0.
+
+---
+
+## 3. Secrets and the platform stack
+
+1. Add the Buildkite agent token as a Secret Manager version.
+2. Install secret synchronization (GKE native sync or External Secrets) so
+   `agent-stack-k8s-secret` materializes in the manager **and every worker**.
+   MultiKueue copies the PodSpec and nothing else; a Secret that exists only on
+   the manager is why a copied Job's init container fails with no useful
+   Buildkite-side error.
+3. Install the pinned Kueue release on the manager and every worker — same
+   version on both.
+4. Apply the manager patch in [`kueue/manager-auth-plugin-patch.yaml`](kueue/manager-auth-plugin-patch.yaml)
+   with a reviewed, signed digest. The placeholder image must not be deployed.
+5. Apply the queue objects in [`kueue/`](kueue).
+6. Install Agent Stack on the **manager only**. A second controller on a worker
+   would let either one claim a Buildkite job before Kueue is involved.
+
+**Gate:** both Kueue controllers Available; `ClusterQueue` Active on both sides.
+
+---
+
+## 4. Connect manager to worker
+
+The connection model is Fleet `ClusterProfile` + Connect Gateway, not a stored
+kubeconfig. Verify the inventory exists before creating `MultiKueueCluster`
+objects:
+
+```bash
+kubectl --context MANAGER api-resources | grep -i clusterprofile
+kubectl --context MANAGER -n kueue-system get clusterprofile
+```
+
+If ClusterProfile is not served by your pinned Kueue and GKE versions, stop and
+decide deliberately: the fallback is a Secret-based kubeconfig, which is a
+bootstrap mechanism, not a production one. If you must use it temporarily,
+scope the worker identity to a namespaced Role, give the token a bounded
+lifetime, and rotate it automatically. `PRODUCTION_READINESS.md` treats a
+static token as a release blocker.
+
+**Gate:** `MultiKueueCluster` and `AdmissionCheck multikueue-dispatch` both
+report Active, with no Secret holding a bearer token.
+
+---
+
+## 5. Cache
+
+Read [`cache/`](cache). Two halves, both required:
+
+- **golden PVC → job.** [`cache/golden-cache-pvc.yaml`](cache/golden-cache-pvc.yaml)
+  is the warm base each job's ephemeral volume clones. Per-cluster and zonal:
+  MultiKueue does not move a PersistentVolume, so every worker needs its own
+  under the same name.
+- **job → GCS → golden.** [`cache/serviceaccounts.yaml`](cache/serviceaccounts.yaml)
+  plus [`cache/golden-refresh-cronjob.yaml`](cache/golden-refresh-cronjob.yaml).
+
+The write-back is the part the POC does not have, and it is not optional at
+production scale. A golden holds usable keys but never the full shape matrix:
+POC build 35 measured adjacent `num_reqs=16` and `num_reqs=20` shapes at ~115s
+of compilation each, on every build, forever, because nothing carried them
+back.
+
+Enable it by setting `KUBE_JAX_CACHE_WRITE=1` in the production Agent Stack
+environment and adding two commands around each TPU step:
+
+```yaml
+commands:
+  - bash .buildkite/scripts/kube_jax_cache.sh snapshot
+  - <the test command>
+  - bash .buildkite/scripts/kube_jax_cache.sh publish
+```
+
+`snapshot` records what the golden already had; `publish` uploads only the
+difference. Publish is last on purpose: Buildkite aborts the script on the first
+failure, so a failed test never reaches it and cannot poison the shared cache —
+the same guard `run_in_docker.sh` gets from the container exit code. Uploads use
+`if_generation_match=0`, so concurrent publishers of the same content-addressed
+entry are idempotent rather than racing.
+
+Both commands are inert unless `KUBE_JAX_CACHE_WRITE=1`, so they are safe to
+carry in a shared pipeline.
+
+Set `JAX_CACHE_NAMESPACE` in the refresh CronJob to match the image's JAX
+version. `kube_jax_cache.sh` prints the namespace it resolved on every run, so
+a JAX bump that misses the CronJob shows up in build logs rather than only as a
+gradual slowdown.
+
+Grants are created by [`terraform/cache.tf`](terraform/cache.tf) as direct
+Workload Identity Federation principals — no service account, no key —
+conditioned to the cache prefix so a test cannot reach the rest of the bucket.
+
+**Gate:** first build logs a non-zero `uploaded`; after a golden refresh, the
+next build logs a large baseline and a visibly shorter compile phase. Add a GCS
+lifecycle rule on the prefix before the first month of traffic — every build
+adds entries and nothing removes them.
+
+---
+
+## 6. Attach the Buildkite queue
+
+Only one Agent Stack controller may consume a queue. Either point the new
+controller at a fresh queue and cut over after validation, or stop the existing
+controller and confirm no queued or running jobs on that queue first.
+
+**Gate:** one Buildkite job produces exactly one command result and one log
+stream; cancelling it, while queued and while running, removes the Job,
+Workload, Pod, and ephemeral PVC on **both** clusters.
+
+---
+
+## 7. Before calling it production
+
+Work [`PRODUCTION_READINESS.md`](PRODUCTION_READINESS.md). The items most likely
+to be skipped:
+
+- Kueue quota must equal capacity the worker can actually autoscale into. Zero
+  means no Pod is ever created and the autoscaler never reacts; too much means
+  Kueue admits work whose Pod stays Pending indefinitely.
+- Any Buildkite concurrency limit must agree with that quota. A pipeline that
+  allows more concurrent jobs than there are chips just moves the queue.
+- `pendingTimeout` must be a measured bound, not `0`. Pair it with Kueue's
+  PodsReady/requeue policy so unavailable cloud capacity fails within a bound.
+- Every performance comparison must state cold or warm cache. A cold Kubernetes
+  run against warm bare metal is not a scheduler regression.

--- a/.buildkite/kubernetes/production/cache/golden-cache-pvc.yaml
+++ b/.buildkite/kubernetes/production/cache/golden-cache-pvc.yaml
@@ -1,0 +1,25 @@
+# Warm read-only base every TPU job clones from.
+#
+# Each test Job's ephemeral volume sets this PVC as its dataSource, so a job
+# starts with a populated compilation cache instead of an empty disk and pays a
+# CSI clone rather than a download of tens of thousands of small objects.
+#
+# The disk is zonal and per-cluster. MultiKueue does not move a
+# PersistentVolume between clusters, so every worker needs its own copy under
+# this same name; that is what makes the pipeline's volume definition portable
+# across workers without naming a region.
+#
+# Sizing must exceed the largest expected cache generation with headroom, and
+# must match the storage request of the cloning ephemeral volumes.
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: golden-jax-cache-pvc
+  namespace: buildkite
+spec:
+  accessModes:
+    - ReadWriteOnce
+  storageClassName: premium-rwo
+  resources:
+    requests:
+      storage: 500Gi

--- a/.buildkite/kubernetes/production/cache/golden-refresh-cronjob.yaml
+++ b/.buildkite/kubernetes/production/cache/golden-refresh-cronjob.yaml
@@ -1,0 +1,86 @@
+# Periodic promotion of published cache entries into the golden PVC.
+#
+# This is the other half of the loop. Test Pods publish new entries to GCS;
+# without this, those entries are never seen again, because every job clones
+# the golden PVC rather than reading GCS. The POC's one-shot
+# populate-golden-cache-job.yaml does the same copy manually and has to be
+# re-run by a human.
+#
+# Two deliberate differences from that one-shot Job:
+#
+#   * It is a CronJob, so the golden tracks published entries on its own.
+#   * The GCS namespace is configuration rather than a literal, and it is
+#     asserted below. The one-shot Job hardcodes jax0.11.0_tputpu6e; when JAX
+#     is bumped that silently refreshes a prefix nobody writes to any more, and
+#     the golden quietly goes stale while every job still looks warm.
+#
+# The golden PVC is ReadWriteOnce. This CronJob must not run while a test Pod
+# holds a clone in progress on another node; concurrencyPolicy: Forbid covers
+# overlap with itself, and the schedule should sit in a quiet window.
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: golden-jax-cache-refresh
+  namespace: buildkite
+spec:
+  schedule: "0 */6 * * *"
+  concurrencyPolicy: Forbid
+  successfulJobsHistoryLimit: 3
+  failedJobsHistoryLimit: 5
+  jobTemplate:
+    spec:
+      backoffLimit: 2
+      activeDeadlineSeconds: 3600
+      template:
+        spec:
+          serviceAccountName: buildkite-cache-refresh
+          restartPolicy: Never
+          containers:
+            - name: refresh
+              image: google/cloud-sdk:slim
+              env:
+                # Must track the JAX version in the test image. kube_jax_cache.sh
+                # prints the namespace it resolved at runtime on every job, so a
+                # mismatch is visible in build logs rather than only in a
+                # slowdown.
+                - name: JAX_CACHE_NAMESPACE
+                  value: "REPLACE_WITH_IMAGE_JAX_NAMESPACE"
+                - name: CACHE_BASE
+                  value: "gs://ullm-ci-cache/jax_cache"
+              resources:
+                requests:
+                  cpu: "2"
+                  memory: 4Gi
+                limits:
+                  memory: 8Gi
+              command:
+                - /bin/sh
+                - -ceu
+                - |
+                  target=/cache/tpu_jax_cache
+                  mkdir -p "$target"
+
+                  # Refuse to refresh into a tree that already has an extra
+                  # namespace directory: JAX would ignore every entry under it
+                  # and the golden would look populated while missing entirely.
+                  if ls -d "$target"/jax*_tpu* >/dev/null 2>&1; then
+                    echo "golden has a nested namespace directory; refusing" >&2
+                    exit 1
+                  fi
+
+                  echo "refreshing $target from $CACHE_BASE/$JAX_CACHE_NAMESPACE"
+                  # --no-clobber only: entries are content-addressed, so an
+                  # existing local file is already correct. Never pass
+                  # --delete-unmatched-destination-objects here; that would
+                  # erase entries published since the last refresh.
+                  gcloud storage rsync -r --no-clobber \
+                    "$CACHE_BASE/$JAX_CACHE_NAMESPACE" "$target"
+
+                  echo "golden entries: $(find "$target" -type f | wc -l)"
+              volumeMounts:
+                - name: golden-cache-vol
+                  mountPath: /cache/tpu_jax_cache
+          volumes:
+            - name: golden-cache-vol
+              persistentVolumeClaim:
+                claimName: golden-jax-cache-pvc

--- a/.buildkite/kubernetes/production/cache/serviceaccounts.yaml
+++ b/.buildkite/kubernetes/production/cache/serviceaccounts.yaml
@@ -1,0 +1,29 @@
+# Pod identities for the production compilation-cache loop.
+#
+# MultiKueue copies the PodSpec verbatim and replicates nothing else, so both
+# ServiceAccounts must exist under these exact names in EVERY worker cluster.
+# The POC learned this the hard way with agent-stack-k8s-secret, which had to
+# be copied by hand; provision these from the platform stack instead.
+#
+# Authorization is a direct Workload Identity Federation principal -- no Google
+# service account, no exported key. Terraform grants them in
+# ../terraform/cache.tf, scoped by IAM condition to the cache prefix only.
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: buildkite-cache
+  namespace: buildkite
+  annotations:
+    # Read + write. Used by TPU test Pods to publish newly compiled entries.
+    tpu-ci.google.com/gcs-access: "objectUser on gs://<bucket>/jax_cache/"
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: buildkite-cache-refresh
+  namespace: buildkite
+  annotations:
+    # Read only. Used by the golden-refresh CronJob, which writes to the PVC
+    # but never to GCS. Kept separate so a compromised refresh job cannot
+    # rewrite the shared cache.
+    tpu-ci.google.com/gcs-access: "objectViewer on gs://<bucket>/jax_cache/"

--- a/.buildkite/kubernetes/production/kueue/manager-auth-plugin-patch.yaml
+++ b/.buildkite/kubernetes/production/kueue/manager-auth-plugin-patch.yaml
@@ -1,0 +1,39 @@
+# Apply as a Helm post-render/Kustomize patch to the manager release only.
+# Replace the image with a reviewed, signed digest; never deploy this placeholder.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: multikueue-fleet-controller-manager
+  namespace: kueue-system
+spec:
+  template:
+    spec:
+      volumes:
+        - name: clusterprofile-plugins
+          emptyDir: {}
+      initContainers:
+        - name: add-gcp-auth-plugin
+          image: REGION-docker.pkg.dev/PROJECT/tpu-ci-images/gcp-auth-plugin@sha256:REPLACE
+          command:
+            - cp
+          args:
+            - /gcp-auth-plugin
+            - /plugins/gcp-auth-plugin
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            readOnlyRootFilesystem: true
+            runAsNonRoot: true
+            seccompProfile:
+              type: RuntimeDefault
+          volumeMounts:
+            - name: clusterprofile-plugins
+              mountPath: /plugins
+      containers:
+        - name: manager
+          volumeMounts:
+            - name: clusterprofile-plugins
+              mountPath: /plugins
+              readOnly: true

--- a/.buildkite/kubernetes/production/kueue/manager-config.yaml
+++ b/.buildkite/kubernetes/production/kueue/manager-config.yaml
@@ -1,0 +1,30 @@
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+manageJobsWithoutQueueName: false
+health:
+  healthProbeBindAddress: :8081
+metrics:
+  bindAddress: :8443
+webhook:
+  port: 9443
+leaderElection:
+  leaderElect: true
+  resourceName: c1f6bfd2.kueue.x-k8s.io
+integrations:
+  frameworks:
+    - batch/job
+featureGates:
+  MultiKueueClusterProfile: true
+multiKueue:
+  clusterProfile:
+    accessProviders:
+      - name: google
+        execConfig:
+          apiVersion: client.authentication.k8s.io/v1beta1
+          command: /plugins/gcp-auth-plugin
+          interactiveMode: Never
+# Agent Stack 0.46.2 models checkout as a regular container. Once it exits,
+# the running Pod remains Ready=False. Retain this POC workaround only until
+# the Agent Stack/Kueue readiness integration is corrected and tested.
+waitForPodsReady:
+  timeout: 10800s

--- a/.buildkite/kubernetes/production/kueue/manager-southamerica-west1.yaml
+++ b/.buildkite/kubernetes/production/kueue/manager-southamerica-west1.yaml
@@ -1,0 +1,110 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: buildkite
+  labels:
+    # Move enforcement to restricted after Agent Stack's generated checkout,
+    # agent, and command containers have compatible security contexts.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: MultiKueueCluster
+metadata:
+  name: tpu-ci-southamerica-west1-a
+spec:
+  clusterSource:
+    clusterProfileRef:
+      name: tpu-ci-southamerica-west1-a
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: MultiKueueConfig
+metadata:
+  name: v6e-workers
+spec:
+  clusters:
+    - tpu-ci-southamerica-west1-a
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: AdmissionCheck
+metadata:
+  name: multikueue-dispatch
+spec:
+  controllerName: kueue.x-k8s.io/multikueue
+  parameters:
+    apiGroup: kueue.x-k8s.io
+    kind: MultiKueueConfig
+    name: v6e-workers
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: v6e-1
+spec:
+  nodeLabels:
+    tpu-ci.google.com/profile: v6e-1
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: v6e-8
+spec:
+  nodeLabels:
+    tpu-ci.google.com/profile: v6e-8
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: v6e-1
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: buildkite
+  admissionChecksStrategy:
+    admissionChecks:
+      - name: multikueue-dispatch
+  resourceGroups:
+    - coveredResources:
+        - google.com/tpu
+      flavors:
+        - name: v6e-1
+          resources:
+            - name: google.com/tpu
+              nominalQuota: 7
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: v6e-8
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: buildkite
+  admissionChecksStrategy:
+    admissionChecks:
+      - name: multikueue-dispatch
+  resourceGroups:
+    - coveredResources:
+        - google.com/tpu
+      flavors:
+        - name: v6e-8
+          resources:
+            - name: google.com/tpu
+              nominalQuota: 8
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: v6e-1
+  namespace: buildkite
+spec:
+  clusterQueue: v6e-1
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: v6e-8
+  namespace: buildkite
+spec:
+  clusterQueue: v6e-8

--- a/.buildkite/kubernetes/production/kueue/worker-config.yaml
+++ b/.buildkite/kubernetes/production/kueue/worker-config.yaml
@@ -1,0 +1,18 @@
+apiVersion: config.kueue.x-k8s.io/v1beta2
+kind: Configuration
+manageJobsWithoutQueueName: false
+health:
+  healthProbeBindAddress: :8081
+metrics:
+  bindAddress: :8443
+webhook:
+  port: 9443
+leaderElection:
+  leaderElect: true
+  resourceName: c1f6bfd2.kueue.x-k8s.io
+integrations:
+  frameworks:
+    - batch/job
+# Must match the manager while the Agent Stack readiness workaround exists.
+waitForPodsReady:
+  timeout: 10800s

--- a/.buildkite/kubernetes/production/kueue/worker-southamerica-west1.yaml
+++ b/.buildkite/kubernetes/production/kueue/worker-southamerica-west1.yaml
@@ -1,0 +1,78 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: buildkite
+  labels:
+    # Move enforcement to restricted after Agent Stack's generated checkout,
+    # agent, and command containers have compatible security contexts.
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
+---
+# Standard GKE node pools own topology, reservation affinity, and the profile
+# label. ResourceFlavors no longer need Autopilot ComputeClass or zone labels.
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: v6e-1
+spec:
+  nodeLabels:
+    tpu-ci.google.com/profile: v6e-1
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ResourceFlavor
+metadata:
+  name: v6e-8
+spec:
+  nodeLabels:
+    tpu-ci.google.com/profile: v6e-8
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: v6e-1
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: buildkite
+  resourceGroups:
+    - coveredResources:
+        - google.com/tpu
+      flavors:
+        - name: v6e-1
+          resources:
+            - name: google.com/tpu
+              nominalQuota: 7
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: ClusterQueue
+metadata:
+  name: v6e-8
+spec:
+  namespaceSelector:
+    matchLabels:
+      kubernetes.io/metadata.name: buildkite
+  resourceGroups:
+    - coveredResources:
+        - google.com/tpu
+      flavors:
+        - name: v6e-8
+          resources:
+            - name: google.com/tpu
+              nominalQuota: 8
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: v6e-1
+  namespace: buildkite
+spec:
+  clusterQueue: v6e-1
+---
+apiVersion: kueue.x-k8s.io/v1beta2
+kind: LocalQueue
+metadata:
+  name: v6e-8
+  namespace: buildkite
+spec:
+  clusterQueue: v6e-8

--- a/.buildkite/kubernetes/production/terraform/.gitignore
+++ b/.buildkite/kubernetes/production/terraform/.gitignore
@@ -1,0 +1,12 @@
+.terraform/
+*.tfstate
+*.tfstate.*
+*.tfplan
+crash.log
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Keep the dependency lock file committed after the first reviewed init.
+!.terraform.lock.hcl

--- a/.buildkite/kubernetes/production/terraform/.terraform.lock.hcl
+++ b/.buildkite/kubernetes/production/terraform/.terraform.lock.hcl
@@ -1,0 +1,23 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/google" {
+  version     = "7.41.0"
+  constraints = ">= 7.0.0, < 8.0.0"
+  hashes = [
+    "h1:+wur8ZrXd5n6e4qXbiSRq9GntW/gmZ7rsWsvJPo3bB4=",
+    "h1:j7CeM9SQQvTWReE3vajyOaNrjsp72dbGVRnFjuk6LPA=",
+    "zh:162ba4a321308dc683f13faaf8d0ec98efda9245f0a07d5abb867da5963d00b2",
+    "zh:2377a2db9b5a6977fe16f75b107bc47e663630b5a7a8e7a99006cdd820e70ed7",
+    "zh:24cd310110d08d4e5c74c78da41c4f95573c39e4eaef2c92650ebb71cb91e9a1",
+    "zh:3315101a286b57ed6a742a8c7c04809f9ef79da3bfa6df5847bbaff207e80d31",
+    "zh:50f193d70277c5a8c6d8736ac2f4bf4f390b0a265e8d0044c7cb30fbef1f2ee8",
+    "zh:5a32a8565ff7084bff87ccd56e26cb31b78c98625a94fd49ec78b48f27f1ced6",
+    "zh:5ec0abe1056adb1f84dc4645583e1ca92b891d694929d849f82cee7221f72bfb",
+    "zh:99fa3a8a1d42cace4df576b1111fe2a9286c8a40e6c7fab778f13213c9fe858a",
+    "zh:b715f6779d201c80e8f83a21acd43f474da13dd329721cec6cd4450c42398c5e",
+    "zh:cc1f3acaaf68f4ff19ef5893e9cefca63e5b93c0800517dfc0a60672911c3f26",
+    "zh:f569b65999264a9416862bca5cd2a6177d94ccb0424f3a4ef424428912b9cb3c",
+    "zh:fd3a26b4d131414045af53780aae841e930ec6af432794768549760c7d364765",
+  ]
+}

--- a/.buildkite/kubernetes/production/terraform/apis.tf
+++ b/.buildkite/kubernetes/production/terraform/apis.tf
@@ -1,0 +1,54 @@
+resource "google_project_service" "required" {
+  for_each = local.required_services
+
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+resource "google_artifact_registry_repository" "ci_images" {
+  for_each = local.artifact_registry_regions
+
+  project       = var.project_id
+  location      = each.value
+  repository_id = "${var.name_prefix}-images"
+  description   = "Buildkite TPU CI images and ClusterProfile auth plugin"
+  format        = "DOCKER"
+  labels        = local.common_labels
+
+  cleanup_policies {
+    id     = "delete-untagged"
+    action = "DELETE"
+
+    condition {
+      tag_state  = "UNTAGGED"
+      older_than = "604800s"
+    }
+  }
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_secret_manager_secret" "buildkite_agent_token" {
+  project   = var.project_id
+  secret_id = var.buildkite_secret_id
+  labels    = local.common_labels
+
+  replication {
+    auto {}
+  }
+
+  deletion_protection = var.deletion_protection
+
+  depends_on = [google_project_service.required]
+}
+
+# The secret value is intentionally absent. Creating google_secret_manager_secret_version
+# would place the Buildkite token in Terraform state. Add and rotate versions through an
+# approved secret-delivery workflow, then synchronize them into each cluster.
+resource "google_secret_manager_secret_iam_member" "secret_sync" {
+  project   = var.project_id
+  secret_id = google_secret_manager_secret.buildkite_agent_token.secret_id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = local.secret_sync_principal
+}

--- a/.buildkite/kubernetes/production/terraform/apis.tf
+++ b/.buildkite/kubernetes/production/terraform/apis.tf
@@ -6,6 +6,17 @@ resource "google_project_service" "required" {
   disable_on_destroy = false
 }
 
+# The worker project needs its own compute/container/gkehub APIs before a
+# cluster, node pool, or fleet membership can be created there.
+resource "google_project_service" "worker_required" {
+  provider = google.worker
+  for_each = local.cross_project ? local.required_services : toset([])
+
+  project            = local.worker_project
+  service            = each.value
+  disable_on_destroy = false
+}
+
 resource "google_artifact_registry_repository" "ci_images" {
   for_each = local.artifact_registry_regions
 

--- a/.buildkite/kubernetes/production/terraform/backend.tf.example
+++ b/.buildkite/kubernetes/production/terraform/backend.tf.example
@@ -1,0 +1,6 @@
+terraform {
+  backend "gcs" {
+    bucket = "REPLACE_WITH_TERRAFORM_STATE_BUCKET"
+    prefix = "buildkite-tpu-ci/foundation"
+  }
+}

--- a/.buildkite/kubernetes/production/terraform/cache.tf
+++ b/.buildkite/kubernetes/production/terraform/cache.tf
@@ -1,0 +1,52 @@
+# Compilation-cache access for worker Pods.
+#
+# The golden PVC gives each job a warm read-only base. These grants add the
+# return path: a job publishes the entries it compiled, so a shape the golden
+# does not cover is compiled once for the fleet instead of once per build.
+#
+# The bucket is shared with the bare-metal pipeline (run_in_docker.sh writes the
+# same prefix) and long predates this stack, so it is referenced rather than
+# managed. Importing it would put a live bare-metal dependency at the mercy of
+# this state file.
+data "google_storage_bucket" "cache" {
+  name = var.cache_bucket
+}
+
+locals {
+  cache_prefix_condition = "resource.name.startsWith('projects/_/buckets/${var.cache_bucket}/objects/${var.cache_prefix}/')"
+
+  # Direct Workload Identity Federation principals. No Google service account
+  # and no exported key: the binding names the Kubernetes ServiceAccount itself.
+  # MultiKueue copies the PodSpec verbatim, so these KSA names must exist in
+  # every worker cluster -- see ../cache/serviceaccounts.yaml.
+  cache_writer_principal = "principal://iam.googleapis.com/projects/${data.google_project.worker.number}/locations/global/workloadIdentityPools/${local.worker_project}.svc.id.goog/subject/ns/${var.buildkite_namespace}/sa/${var.cache_writer_service_account}"
+  cache_reader_principal = "principal://iam.googleapis.com/projects/${data.google_project.worker.number}/locations/global/workloadIdentityPools/${local.worker_project}.svc.id.goog/subject/ns/${var.buildkite_namespace}/sa/${var.cache_reader_service_account}"
+}
+
+# TPU test Pods: read and write, but only under the cache prefix. A test that
+# is compromised or simply wrong cannot reach anything else in the bucket.
+resource "google_storage_bucket_iam_member" "cache_writer" {
+  bucket = data.google_storage_bucket.cache.name
+  role   = "roles/storage.objectUser"
+  member = local.cache_writer_principal
+
+  condition {
+    title       = "jax-cache-prefix-only"
+    description = "Buildkite TPU Pods may only touch the compilation cache prefix."
+    expression  = local.cache_prefix_condition
+  }
+}
+
+# Golden-refresh CronJob: read only. It writes to the PVC, never to GCS, so a
+# bug there cannot rewrite entries other jobs depend on.
+resource "google_storage_bucket_iam_member" "cache_reader" {
+  bucket = data.google_storage_bucket.cache.name
+  role   = "roles/storage.objectViewer"
+  member = local.cache_reader_principal
+
+  condition {
+    title       = "jax-cache-prefix-only"
+    description = "Golden refresh may only read the compilation cache prefix."
+    expression  = local.cache_prefix_condition
+  }
+}

--- a/.buildkite/kubernetes/production/terraform/clusters.tf
+++ b/.buildkite/kubernetes/production/terraform/clusters.tf
@@ -1,0 +1,429 @@
+resource "google_container_cluster" "manager" {
+  project  = var.project_id
+  name     = "${var.name_prefix}-manager"
+  location = var.manager_region
+
+  network    = var.network
+  subnetwork = var.manager_subnetwork
+
+  deletion_protection         = var.deletion_protection
+  remove_default_node_pool    = true
+  initial_node_count          = 1
+  node_locations              = var.manager_zones
+  networking_mode             = "VPC_NATIVE"
+  enable_shielded_nodes       = true
+  enable_intranode_visibility = true
+
+  release_channel {
+    channel = var.release_channel
+  }
+
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  fleet {
+    project = var.project_id
+  }
+
+  # These labels ask GKE Fleet to generate ClusterProfile inventory objects in
+  # kueue-system. MultiKueue can then use federated credentials instead of a
+  # stored worker kubeconfig and bearer token.
+  resource_labels = merge(local.common_labels, {
+    fleet-clusterinventory-management-cluster = "true"
+    fleet-clusterinventory-namespace          = "kueue-system"
+    role                                      = "manager"
+  })
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = var.manager_cluster_secondary_range_name
+    services_secondary_range_name = var.manager_services_secondary_range_name
+  }
+
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = var.enable_private_endpoint
+    master_ipv4_cidr_block  = var.manager_master_ipv4_cidr_block
+
+    master_global_access_config {
+      enabled = true
+    }
+  }
+
+  dynamic "master_authorized_networks_config" {
+    for_each = var.enable_private_endpoint ? [] : [1]
+    content {
+      dynamic "cidr_blocks" {
+        for_each = var.master_authorized_networks
+        content {
+          cidr_block   = cidr_blocks.value.cidr_block
+          display_name = cidr_blocks.value.display_name
+        }
+      }
+    }
+  }
+
+  addons_config {
+    gce_persistent_disk_csi_driver_config {
+      enabled = true
+    }
+  }
+
+  secret_manager_config {
+    enabled = true
+    rotation_config {
+      enabled           = true
+      rotation_interval = "300s"
+    }
+  }
+
+  secret_sync_config {
+    enabled = true
+    rotation_config {
+      enabled           = true
+      rotation_interval = "300s"
+    }
+  }
+
+  security_posture_config {
+    mode               = "BASIC"
+    vulnerability_mode = "VULNERABILITY_BASIC"
+  }
+
+  monitoring_config {
+    enable_components = [
+      "APISERVER",
+      "CONTROLLER_MANAGER",
+      "DAEMONSET",
+      "DEPLOYMENT",
+      "HPA",
+      "KUBELET",
+      "POD",
+      "SCHEDULER",
+      "STATEFULSET",
+      "STORAGE",
+      "SYSTEM_COMPONENTS",
+    ]
+    managed_prometheus {
+      enabled = true
+    }
+  }
+
+  maintenance_policy {
+    recurring_window {
+      start_time = "2026-01-04T09:00:00Z"
+      end_time   = "2026-01-04T13:00:00Z"
+      recurrence = "FREQ=WEEKLY;BYDAY=SU"
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.enable_private_endpoint || length(var.master_authorized_networks) > 0
+      error_message = "Provide master_authorized_networks or enable the private control-plane endpoint."
+    }
+  }
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_container_node_pool" "manager_system" {
+  project  = var.project_id
+  name     = "system"
+  location = google_container_cluster.manager.location
+  cluster  = google_container_cluster.manager.name
+
+  # Regional node-pool initial counts are per zone. Start with one in each
+  # configured zone, then let total autoscaling enforce the aggregate floor.
+  initial_node_count = 1
+
+  autoscaling {
+    total_min_node_count = var.manager_system_min_nodes
+    total_max_node_count = var.manager_system_max_nodes
+    location_policy      = "BALANCED"
+  }
+
+  node_config {
+    machine_type    = var.manager_system_machine_type
+    image_type      = "COS_CONTAINERD"
+    service_account = google_service_account.manager_nodes.email
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+    labels = {
+      "tpu-ci.google.com/role" = "system"
+    }
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = true
+    }
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+
+  lifecycle {
+    ignore_changes = [initial_node_count]
+
+    precondition {
+      condition     = var.manager_system_min_nodes >= length(var.manager_zones)
+      error_message = "manager_system_min_nodes must provide at least one system node per manager zone."
+    }
+  }
+}
+
+resource "google_container_cluster" "worker" {
+  for_each = var.worker_clusters
+
+  project  = var.project_id
+  name     = "${var.name_prefix}-${each.key}"
+  location = each.value.location
+
+  network    = var.network
+  subnetwork = each.value.subnetwork
+
+  deletion_protection         = var.deletion_protection
+  remove_default_node_pool    = true
+  initial_node_count          = 1
+  networking_mode             = "VPC_NATIVE"
+  enable_shielded_nodes       = true
+  enable_intranode_visibility = true
+
+  release_channel {
+    channel = var.release_channel
+  }
+
+  workload_identity_config {
+    workload_pool = "${var.project_id}.svc.id.goog"
+  }
+
+  fleet {
+    project = var.project_id
+  }
+
+  resource_labels = merge(local.common_labels, {
+    role   = "worker"
+    worker = each.key
+  })
+
+  ip_allocation_policy {
+    cluster_secondary_range_name  = each.value.cluster_secondary_range_name
+    services_secondary_range_name = each.value.services_secondary_range_name
+  }
+
+  private_cluster_config {
+    enable_private_nodes    = true
+    enable_private_endpoint = var.enable_private_endpoint
+    master_ipv4_cidr_block  = each.value.master_ipv4_cidr_block
+
+    master_global_access_config {
+      enabled = true
+    }
+  }
+
+  dynamic "master_authorized_networks_config" {
+    for_each = var.enable_private_endpoint ? [] : [1]
+    content {
+      dynamic "cidr_blocks" {
+        for_each = var.master_authorized_networks
+        content {
+          cidr_block   = cidr_blocks.value.cidr_block
+          display_name = cidr_blocks.value.display_name
+        }
+      }
+    }
+  }
+
+  addons_config {
+    gce_persistent_disk_csi_driver_config {
+      enabled = true
+    }
+  }
+
+  secret_manager_config {
+    enabled = true
+    rotation_config {
+      enabled           = true
+      rotation_interval = "300s"
+    }
+  }
+
+  secret_sync_config {
+    enabled = true
+    rotation_config {
+      enabled           = true
+      rotation_interval = "300s"
+    }
+  }
+
+  security_posture_config {
+    mode               = "BASIC"
+    vulnerability_mode = "VULNERABILITY_BASIC"
+  }
+
+  monitoring_config {
+    enable_components = [
+      "APISERVER",
+      "CONTROLLER_MANAGER",
+      "DAEMONSET",
+      "DEPLOYMENT",
+      "HPA",
+      "KUBELET",
+      "POD",
+      "SCHEDULER",
+      "STATEFULSET",
+      "STORAGE",
+      "SYSTEM_COMPONENTS",
+    ]
+    managed_prometheus {
+      enabled = true
+    }
+  }
+
+  maintenance_policy {
+    recurring_window {
+      start_time = "2026-01-04T09:00:00Z"
+      end_time   = "2026-01-04T13:00:00Z"
+      recurrence = "FREQ=WEEKLY;BYDAY=SU"
+    }
+  }
+
+  lifecycle {
+    precondition {
+      condition     = var.enable_private_endpoint || length(var.master_authorized_networks) > 0
+      error_message = "Provide master_authorized_networks or enable the private control-plane endpoint."
+    }
+  }
+
+  depends_on = [google_project_service.required]
+}
+
+resource "google_container_node_pool" "worker_system" {
+  for_each = var.worker_clusters
+
+  project  = var.project_id
+  name     = "system"
+  location = google_container_cluster.worker[each.key].location
+  cluster  = google_container_cluster.worker[each.key].name
+
+  initial_node_count = each.value.system_min_nodes
+
+  autoscaling {
+    min_node_count = each.value.system_min_nodes
+    max_node_count = each.value.system_max_nodes
+  }
+
+  node_config {
+    machine_type    = each.value.system_machine_type
+    image_type      = "COS_CONTAINERD"
+    service_account = google_service_account.worker_nodes[each.key].email
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+    labels = {
+      "tpu-ci.google.com/role" = "system"
+    }
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = true
+    }
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  upgrade_settings {
+    max_surge       = 1
+    max_unavailable = 0
+  }
+
+  lifecycle {
+    ignore_changes = [initial_node_count]
+  }
+}
+
+resource "google_container_node_pool" "worker_tpu" {
+  for_each = local.tpu_node_pools
+
+  project  = var.project_id
+  name     = each.value.profile_name
+  location = google_container_cluster.worker[each.value.worker_name].location
+  cluster  = google_container_cluster.worker[each.value.worker_name].name
+
+  initial_node_count = each.value.min_nodes
+
+  autoscaling {
+    min_node_count  = each.value.min_nodes
+    max_node_count  = each.value.max_nodes
+    location_policy = each.value.reservation_name == null ? "BALANCED" : "ANY"
+  }
+
+  placement_policy {
+    type         = "COMPACT"
+    tpu_topology = each.value.topology
+  }
+
+  node_config {
+    machine_type    = each.value.machine_type
+    image_type      = "COS_CONTAINERD"
+    service_account = google_service_account.worker_nodes[each.value.worker_name].email
+    oauth_scopes    = ["https://www.googleapis.com/auth/cloud-platform"]
+    labels = {
+      "tpu-ci.google.com/profile"        = each.value.profile_name
+      "tpu-ci.google.com/chips-per-node" = tostring(each.value.chips_per_node)
+    }
+    resource_labels = merge(local.common_labels, {
+      profile = each.value.profile_name
+      worker  = each.value.worker_name
+    })
+
+    dynamic "reservation_affinity" {
+      for_each = each.value.reservation_name == null ? [] : [each.value.reservation_name]
+      content {
+        consume_reservation_type = "SPECIFIC_RESERVATION"
+        key                      = "compute.googleapis.com/reservation-name"
+        values                   = [reservation_affinity.value]
+      }
+    }
+
+    workload_metadata_config {
+      mode = "GKE_METADATA"
+    }
+
+    shielded_instance_config {
+      enable_integrity_monitoring = true
+      enable_secure_boot          = true
+    }
+  }
+
+  management {
+    auto_repair  = true
+    auto_upgrade = true
+  }
+
+  # Reserved TPU pools often cannot create a surge node. This setting accepts
+  # one unavailable node during an upgrade; schedule maintenance accordingly.
+  upgrade_settings {
+    max_surge       = 0
+    max_unavailable = 1
+  }
+
+  lifecycle {
+    ignore_changes = [initial_node_count]
+  }
+}

--- a/.buildkite/kubernetes/production/terraform/clusters.tf
+++ b/.buildkite/kubernetes/production/terraform/clusters.tf
@@ -183,9 +183,10 @@ resource "google_container_node_pool" "manager_system" {
 }
 
 resource "google_container_cluster" "worker" {
+  provider = google.worker
   for_each = var.worker_clusters
 
-  project  = var.project_id
+  project  = local.worker_project
   name     = "${var.name_prefix}-${each.key}"
   location = each.value.location
 
@@ -207,6 +208,8 @@ resource "google_container_cluster" "worker" {
     workload_pool = "${var.project_id}.svc.id.goog"
   }
 
+  # Deliberately var.project_id, not the worker's own project: a cluster can
+  # belong to only one fleet, and MultiKueue needs both sides in the same one.
   fleet {
     project = var.project_id
   }
@@ -305,13 +308,17 @@ resource "google_container_cluster" "worker" {
     }
   }
 
-  depends_on = [google_project_service.required]
+  depends_on = [
+    google_project_service.required,
+    google_project_service.worker_required,
+  ]
 }
 
 resource "google_container_node_pool" "worker_system" {
+  provider = google.worker
   for_each = var.worker_clusters
 
-  project  = var.project_id
+  project  = local.worker_project
   name     = "system"
   location = google_container_cluster.worker[each.key].location
   cluster  = google_container_cluster.worker[each.key].name
@@ -358,9 +365,10 @@ resource "google_container_node_pool" "worker_system" {
 }
 
 resource "google_container_node_pool" "worker_tpu" {
+  provider = google.worker
   for_each = local.tpu_node_pools
 
-  project  = var.project_id
+  project  = local.worker_project
   name     = each.value.profile_name
   location = google_container_cluster.worker[each.value.worker_name].location
   cluster  = google_container_cluster.worker[each.value.worker_name].name

--- a/.buildkite/kubernetes/production/terraform/iam.tf
+++ b/.buildkite/kubernetes/production/terraform/iam.tf
@@ -1,0 +1,47 @@
+resource "google_service_account" "manager_nodes" {
+  project      = var.project_id
+  account_id   = substr("${var.name_prefix}-manager-nodes", 0, 30)
+  display_name = "${var.name_prefix} manager GKE nodes"
+}
+
+resource "google_service_account" "worker_nodes" {
+  for_each = var.worker_clusters
+
+  project      = var.project_id
+  account_id   = substr(replace("${var.name_prefix}-${each.key}-nodes", "_", "-"), 0, 30)
+  display_name = "${var.name_prefix} ${each.key} GKE nodes"
+}
+
+resource "google_project_iam_member" "manager_node_roles" {
+  for_each = local.node_service_account_roles
+
+  project = var.project_id
+  role    = each.value
+  member  = "serviceAccount:${google_service_account.manager_nodes.email}"
+}
+
+resource "google_project_iam_member" "worker_node_roles" {
+  for_each = local.worker_node_role_bindings
+
+  project = var.project_id
+  role    = each.value.role
+  member  = "serviceAccount:${google_service_account.worker_nodes[each.value.worker_name].email}"
+}
+
+# This follows the GKE Fleet ClusterProfile integration. The KSA name is unique
+# to the manager cluster; using the default Kueue KSA name would grant the same
+# project roles to worker controllers because GKE workload identity subjects do
+# not include a cluster name. Review whether IAM Conditions can scope these
+# roles further once the exact membership names are stable.
+resource "google_project_iam_member" "kueue_clusterprofile_access" {
+  for_each = toset([
+    "roles/container.developer",
+    "roles/gkehub.gatewayEditor",
+  ])
+
+  project = var.project_id
+  role    = each.value
+  member  = local.kueue_manager_principal
+
+  depends_on = [google_container_cluster.manager]
+}

--- a/.buildkite/kubernetes/production/terraform/iam.tf
+++ b/.buildkite/kubernetes/production/terraform/iam.tf
@@ -5,9 +5,10 @@ resource "google_service_account" "manager_nodes" {
 }
 
 resource "google_service_account" "worker_nodes" {
+  provider = google.worker
   for_each = var.worker_clusters
 
-  project      = var.project_id
+  project      = local.worker_project
   account_id   = substr(replace("${var.name_prefix}-${each.key}-nodes", "_", "-"), 0, 30)
   display_name = "${var.name_prefix} ${each.key} GKE nodes"
 }
@@ -21,9 +22,10 @@ resource "google_project_iam_member" "manager_node_roles" {
 }
 
 resource "google_project_iam_member" "worker_node_roles" {
+  provider = google.worker
   for_each = local.worker_node_role_bindings
 
-  project = var.project_id
+  project = local.worker_project
   role    = each.value.role
   member  = "serviceAccount:${google_service_account.worker_nodes[each.value.worker_name].email}"
 }
@@ -44,4 +46,33 @@ resource "google_project_iam_member" "kueue_clusterprofile_access" {
   member  = local.kueue_manager_principal
 
   depends_on = [google_container_cluster.manager]
+}
+
+# Connect Gateway authorizes in the fleet host project, but the call still lands
+# on a cluster in the worker project, so the manager identity needs GKE access
+# there too. Only when the projects differ; otherwise the binding above already
+# covers it and a duplicate would fight itself on every plan.
+resource "google_project_iam_member" "kueue_worker_cluster_access" {
+  provider = google.worker
+  count    = local.cross_project ? 1 : 0
+
+  project = local.worker_project
+  role    = "roles/container.developer"
+  member  = local.kueue_manager_principal
+
+  depends_on = [google_container_cluster.manager]
+}
+
+# The test image is published to the manager project's Artifact Registry. Worker
+# nodes in another project cannot pull it from their own project-level
+# artifactregistry.reader grant. Without this the copied Job's Pod sits in
+# ImagePullBackOff, which Buildkite surfaces only as a job that never starts.
+resource "google_artifact_registry_repository_iam_member" "worker_node_pull" {
+  for_each = local.cross_project ? local.worker_registry_pull_bindings : {}
+
+  project    = var.project_id
+  location   = each.value.location
+  repository = google_artifact_registry_repository.ci_images[each.value.location].name
+  role       = "roles/artifactregistry.reader"
+  member     = "serviceAccount:${google_service_account.worker_nodes[each.value.worker_name].email}"
 }

--- a/.buildkite/kubernetes/production/terraform/locals.tf
+++ b/.buildkite/kubernetes/production/terraform/locals.tf
@@ -1,0 +1,65 @@
+locals {
+  common_labels = merge(var.labels, {
+    managed_by = "terraform"
+    component  = "buildkite-tpu-ci"
+  })
+
+  required_services = toset([
+    "artifactregistry.googleapis.com",
+    "cloudresourcemanager.googleapis.com",
+    "compute.googleapis.com",
+    "connectgateway.googleapis.com",
+    "container.googleapis.com",
+    "gkehub.googleapis.com",
+    "iamcredentials.googleapis.com",
+    "secretmanager.googleapis.com",
+  ])
+
+  worker_regions = toset([
+    for worker in values(var.worker_clusters) :
+    regexreplace(worker.location, "-[a-z]$", "")
+  ])
+  artifact_registry_regions = setunion(toset([var.manager_region]), local.worker_regions)
+
+  node_service_account_roles = toset([
+    "roles/artifactregistry.reader",
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/monitoring.viewer",
+    "roles/stackdriver.resourceMetadata.writer",
+  ])
+
+  worker_node_role_bindings = {
+    for item in flatten([
+      for worker_name in keys(var.worker_clusters) : [
+        for role in local.node_service_account_roles : {
+          key         = "${worker_name}/${role}"
+          worker_name = worker_name
+          role        = role
+        }
+      ]
+    ]) : item.key => item
+  }
+
+  tpu_node_pools = {
+    for item in flatten([
+      for worker_name, worker in var.worker_clusters : [
+        for profile_name, pool in worker.tpu_pools : {
+          key              = "${worker_name}/${profile_name}"
+          worker_name      = worker_name
+          location         = worker.location
+          profile_name     = profile_name
+          machine_type     = pool.machine_type
+          topology         = pool.topology
+          chips_per_node   = pool.chips_per_node
+          min_nodes        = pool.min_nodes
+          max_nodes        = pool.max_nodes
+          reservation_name = try(pool.reservation_name, null)
+        }
+      ]
+    ]) : item.key => item
+  }
+
+  secret_sync_principal   = "principal://iam.googleapis.com/projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${var.project_id}.svc.id.goog/subject/ns/${var.secret_sync_namespace}/sa/${var.secret_sync_service_account}"
+  kueue_manager_principal = "principal://iam.googleapis.com/projects/${data.google_project.current.number}/locations/global/workloadIdentityPools/${var.project_id}.svc.id.goog/subject/ns/kueue-system/sa/${var.kueue_fleet_service_account}"
+}

--- a/.buildkite/kubernetes/production/terraform/locals.tf
+++ b/.buildkite/kubernetes/production/terraform/locals.tf
@@ -1,4 +1,7 @@
 locals {
+  worker_project = coalesce(var.worker_project, var.project_id)
+  cross_project  = local.worker_project != var.project_id
+
   common_labels = merge(var.labels, {
     managed_by = "terraform"
     component  = "buildkite-tpu-ci"
@@ -36,6 +39,18 @@ locals {
           key         = "${worker_name}/${role}"
           worker_name = worker_name
           role        = role
+        }
+      ]
+    ]) : item.key => item
+  }
+
+  worker_registry_pull_bindings = {
+    for item in flatten([
+      for worker_name in keys(var.worker_clusters) : [
+        for location in local.artifact_registry_regions : {
+          key         = "${worker_name}/${location}"
+          worker_name = worker_name
+          location    = location
         }
       ]
     ]) : item.key => item

--- a/.buildkite/kubernetes/production/terraform/outputs.tf
+++ b/.buildkite/kubernetes/production/terraform/outputs.tf
@@ -1,0 +1,42 @@
+output "manager_cluster" {
+  description = "Manager cluster identity used by the platform deployment stack."
+  value = {
+    name     = google_container_cluster.manager.name
+    location = google_container_cluster.manager.location
+    endpoint = google_container_cluster.manager.endpoint
+  }
+  sensitive = true
+}
+
+output "worker_clusters" {
+  description = "Worker cluster identities and logical TPU profiles."
+  value = {
+    for name, cluster in google_container_cluster.worker : name => {
+      name         = cluster.name
+      location     = cluster.location
+      endpoint     = cluster.endpoint
+      tpu_profiles = keys(var.worker_clusters[name].tpu_pools)
+    }
+  }
+  sensitive = true
+}
+
+output "artifact_registry_repository" {
+  description = "Regional repositories. Promote one tested digest to every region; do not rebuild per region."
+  value = {
+    for region, repository in google_artifact_registry_repository.ci_images :
+    region => repository.name
+  }
+}
+
+output "buildkite_secret_id" {
+  value = google_secret_manager_secret.buildkite_agent_token.secret_id
+}
+
+output "next_steps" {
+  value = [
+    "Add the Buildkite token as a Secret Manager version outside Terraform.",
+    "Install the platform stack (Kueue, ClusterProfile auth plugin, secret sync, policies, and Agent Stack).",
+    "Verify Fleet-generated ClusterProfiles before creating MultiKueueCluster objects.",
+  ]
+}

--- a/.buildkite/kubernetes/production/terraform/terraform.tfvars.example
+++ b/.buildkite/kubernetes/production/terraform/terraform.tfvars.example
@@ -1,0 +1,55 @@
+project_id  = "cloud-tpu-inference-production"
+name_prefix = "tpu-ci"
+network     = "projects/NETWORK_PROJECT/global/networks/ci"
+
+manager_region                        = "us-central1"
+manager_zones                         = ["us-central1-a", "us-central1-b", "us-central1-c"]
+manager_subnetwork                    = "projects/NETWORK_PROJECT/regions/us-central1/subnetworks/ci-manager"
+manager_cluster_secondary_range_name  = "ci-manager-pods"
+manager_services_secondary_range_name = "ci-manager-services"
+manager_master_ipv4_cidr_block        = "172.16.0.0/28"
+
+master_authorized_networks = [
+  {
+    cidr_block   = "203.0.113.10/32"
+    display_name = "terraform-runner"
+  }
+]
+
+worker_clusters = {
+  southamerica-west1-a = {
+    location                       = "southamerica-west1-a"
+    subnetwork                     = "projects/NETWORK_PROJECT/regions/southamerica-west1/subnetworks/ci-worker"
+    cluster_secondary_range_name   = "ci-worker-saw1-pods"
+    services_secondary_range_name  = "ci-worker-saw1-services"
+    master_ipv4_cidr_block         = "172.16.0.16/28"
+    system_machine_type            = "e2-standard-4"
+    system_min_nodes               = 1
+    system_max_nodes               = 3
+
+    tpu_pools = {
+      v6e-1 = {
+        machine_type     = "ct6e-standard-1t"
+        topology         = "1x1"
+        chips_per_node   = 1
+        min_nodes        = 0
+        max_nodes        = 7
+        reservation_name = "cloudtpu-REPLACE_ME"
+      }
+      v6e-8 = {
+        machine_type     = "ct6e-standard-8t"
+        topology         = "2x4"
+        chips_per_node   = 8
+        min_nodes        = 0
+        max_nodes        = 1
+        reservation_name = "cloudtpu-REPLACE_ME"
+      }
+    }
+  }
+}
+
+labels = {
+  environment = "production"
+  workload    = "tpu-ci"
+  owner       = "tpu-inference"
+}

--- a/.buildkite/kubernetes/production/terraform/variables.tf
+++ b/.buildkite/kubernetes/production/terraform/variables.tf
@@ -1,0 +1,168 @@
+variable "project_id" {
+  description = "Google Cloud project that owns the Fleet and GKE clusters."
+  type        = string
+}
+
+variable "name_prefix" {
+  description = "Short prefix used for cluster, service-account, and registry names."
+  type        = string
+  default     = "tpu-ci"
+
+  validation {
+    condition     = can(regex("^[a-z][a-z0-9-]{1,15}$", var.name_prefix))
+    error_message = "name_prefix must be 2-16 lowercase letters, digits, or hyphens and start with a letter."
+  }
+}
+
+variable "network" {
+  description = "VPC network self-link or name. NAT and private Google access must be managed by the network stack."
+  type        = string
+}
+
+variable "manager_region" {
+  description = "Region for the highly available manager cluster."
+  type        = string
+  default     = "us-central1"
+}
+
+variable "manager_zones" {
+  description = "Zones used by the manager cluster's CPU system node pool."
+  type        = list(string)
+  default     = ["us-central1-a", "us-central1-b", "us-central1-c"]
+}
+
+variable "manager_subnetwork" {
+  description = "Subnetwork self-link or name for the manager cluster."
+  type        = string
+}
+
+variable "manager_cluster_secondary_range_name" {
+  description = "Existing secondary range for manager-cluster Pods."
+  type        = string
+}
+
+variable "manager_services_secondary_range_name" {
+  description = "Existing secondary range for manager-cluster Services."
+  type        = string
+}
+
+variable "manager_master_ipv4_cidr_block" {
+  description = "Private /28 CIDR for the manager control plane."
+  type        = string
+}
+
+variable "manager_system_machine_type" {
+  description = "Machine type for Agent Stack and platform controllers."
+  type        = string
+  default     = "e2-standard-8"
+}
+
+variable "manager_system_min_nodes" {
+  type    = number
+  default = 3
+}
+
+variable "manager_system_max_nodes" {
+  type    = number
+  default = 6
+}
+
+variable "worker_clusters" {
+  description = <<-EOT
+    Zonal Standard GKE workers. Each TPU pool maps one logical profile to a
+    machine type, physical topology, reservation, and autoscaling boundary.
+  EOT
+  type = map(object({
+    location                      = string
+    subnetwork                    = string
+    cluster_secondary_range_name  = string
+    services_secondary_range_name = string
+    master_ipv4_cidr_block        = string
+    system_machine_type           = optional(string, "e2-standard-4")
+    system_min_nodes              = optional(number, 1)
+    system_max_nodes              = optional(number, 3)
+    tpu_pools = map(object({
+      machine_type     = string
+      topology         = string
+      chips_per_node   = number
+      min_nodes        = optional(number, 0)
+      max_nodes        = number
+      reservation_name = optional(string)
+    }))
+  }))
+
+  validation {
+    condition = alltrue(flatten([
+      for worker in values(var.worker_clusters) : [
+        for pool in values(worker.tpu_pools) :
+        pool.max_nodes >= pool.min_nodes && pool.chips_per_node > 0
+      ]
+    ]))
+    error_message = "Every TPU pool must have max_nodes >= min_nodes and chips_per_node > 0."
+  }
+}
+
+variable "master_authorized_networks" {
+  description = "CIDRs allowed to reach public control-plane endpoints. Empty is rejected unless private endpoints are enabled."
+  type = list(object({
+    cidr_block   = string
+    display_name = string
+  }))
+  default = []
+}
+
+variable "enable_private_endpoint" {
+  description = "Make GKE control planes private-only. Requires private Terraform/operations connectivity."
+  type        = bool
+  default     = false
+}
+
+variable "release_channel" {
+  description = "GKE release channel."
+  type        = string
+  default     = "REGULAR"
+
+  validation {
+    condition     = contains(["RAPID", "REGULAR", "STABLE"], var.release_channel)
+    error_message = "release_channel must be RAPID, REGULAR, or STABLE."
+  }
+}
+
+variable "deletion_protection" {
+  description = "Protect clusters and secret containers from accidental Terraform deletion."
+  type        = bool
+  default     = true
+}
+
+variable "labels" {
+  description = "Additional Google Cloud resource labels."
+  type        = map(string)
+  default = {
+    environment = "production"
+    workload    = "tpu-ci"
+  }
+}
+
+variable "buildkite_secret_id" {
+  description = "Secret Manager container for the Buildkite agent token. Terraform never creates a secret version."
+  type        = string
+  default     = "buildkite-tpu-ci-agent-token"
+}
+
+variable "secret_sync_namespace" {
+  description = "Namespace of the KSA allowed to synchronize the Buildkite token from Secret Manager."
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "secret_sync_service_account" {
+  description = "KSA allowed to synchronize the Buildkite token. Install it separately through the platform stack."
+  type        = string
+  default     = "external-secrets"
+}
+
+variable "kueue_fleet_service_account" {
+  description = "Manager-only KSA created by the multikueue-fleet Helm release for Fleet/Connect Gateway access. Do not reuse it on workers."
+  type        = string
+  default     = "multikueue-fleet-controller-manager"
+}

--- a/.buildkite/kubernetes/production/terraform/variables.tf
+++ b/.buildkite/kubernetes/production/terraform/variables.tf
@@ -3,6 +3,20 @@ variable "project_id" {
   type        = string
 }
 
+variable "worker_project" {
+  description = <<-EOT
+    Project that owns the worker clusters, their TPU node pools, and the TPU
+    reservation those pools consume. Leave null when manager and workers share
+    one project.
+
+    The split exists because a reservation is only consumable from the project
+    that holds it, so the worker cluster has to live beside it. The Fleet, the
+    manager cluster, and Artifact Registry stay in project_id.
+  EOT
+  type        = string
+  default     = null
+}
+
 variable "name_prefix" {
   description = "Short prefix used for cluster, service-account, and registry names."
   type        = string
@@ -165,4 +179,38 @@ variable "kueue_fleet_service_account" {
   description = "Manager-only KSA created by the multikueue-fleet Helm release for Fleet/Connect Gateway access. Do not reuse it on workers."
   type        = string
   default     = "multikueue-fleet-controller-manager"
+}
+
+variable "cache_bucket" {
+  description = <<-EOT
+    Existing bucket holding the shared JAX/XLA compilation cache. Terraform
+    manages only its IAM; the bucket itself is shared with the bare-metal
+    pipeline and is not owned by this stack.
+  EOT
+  type        = string
+  default     = "ullm-ci-cache"
+}
+
+variable "cache_prefix" {
+  description = "Object prefix within cache_bucket. Grants are conditioned on it, so Pods cannot reach the rest of the bucket."
+  type        = string
+  default     = "jax_cache"
+}
+
+variable "buildkite_namespace" {
+  description = "Namespace holding Agent Stack Jobs and the cache ServiceAccounts on every cluster."
+  type        = string
+  default     = "buildkite"
+}
+
+variable "cache_writer_service_account" {
+  description = "KSA used by TPU test Pods to publish newly compiled cache entries. Must exist in every worker cluster under this name."
+  type        = string
+  default     = "buildkite-cache"
+}
+
+variable "cache_reader_service_account" {
+  description = "KSA used by the golden-refresh CronJob. Read-only on GCS."
+  type        = string
+  default     = "buildkite-cache-refresh"
 }

--- a/.buildkite/kubernetes/production/terraform/versions.tf
+++ b/.buildkite/kubernetes/production/terraform/versions.tf
@@ -1,0 +1,19 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = ">= 7.0, < 8.0"
+    }
+  }
+}
+
+provider "google" {
+  project = var.project_id
+  region  = var.manager_region
+}
+
+data "google_project" "current" {
+  project_id = var.project_id
+}

--- a/.buildkite/kubernetes/production/terraform/versions.tf
+++ b/.buildkite/kubernetes/production/terraform/versions.tf
@@ -9,11 +9,25 @@ terraform {
   }
 }
 
+# Fleet host and manager cluster.
 provider "google" {
   project = var.project_id
   region  = var.manager_region
 }
 
+# Worker clusters, their TPU node pools, and the reservation they consume.
+# Defaults to the same project, so a single-project deployment needs no extra
+# configuration; set worker_project to split them.
+provider "google" {
+  alias   = "worker"
+  project = local.worker_project
+}
+
 data "google_project" "current" {
   project_id = var.project_id
+}
+
+data "google_project" "worker" {
+  provider   = google.worker
+  project_id = local.worker_project
 }

--- a/.buildkite/scripts/kube_jax_cache.py
+++ b/.buildkite/scripts/kube_jax_cache.py
@@ -1,0 +1,163 @@
+#!/usr/bin/env python3
+"""Publish newly compiled JAX/XLA cache entries from a Kubernetes TPU job to GCS.
+
+The golden PVC gives every job a warm read-only base. Nothing carries the other
+way: entries compiled during a build die with the job's ephemeral PVC, so a
+shape the golden does not cover is recompiled on every single build forever.
+
+This closes that loop for the production environment:
+
+    snapshot   record what the golden clone already contained
+    publish    upload only what this job added, and only if it passed
+
+Uploads use ``if_generation_match=0``. JAX cache entries are content-addressed,
+so two jobs that compile the same shape produce the same object name; the
+precondition makes the loser a no-op instead of a racing overwrite. That is the
+same property the bare-metal ``gcloud storage rsync --no-clobber`` relies on.
+
+The Kubernetes test image is built with ``BM_INFRA=false`` and therefore has no
+gcloud CLI, so transfers use google-cloud-storage from requirements.txt.
+"""
+
+from __future__ import annotations
+
+import argparse
+from concurrent.futures import ThreadPoolExecutor
+import json
+from pathlib import Path
+import sys
+from typing import Any
+
+# Cache trees are tens of thousands of small objects; serial uploads would add
+# minutes to every job. The work is network-bound, so threads are enough.
+DEFAULT_WORKERS = 32
+
+
+def parse_gcs_uri(uri: str) -> tuple[str, str]:
+    if not uri.startswith("gs://"):
+        raise ValueError(f"GCS prefix must start with gs://: {uri!r}")
+    bucket, separator, prefix = uri[5:].partition("/")
+    if not bucket or not separator or not prefix.strip("/"):
+        raise ValueError(f"GCS prefix requires bucket and object prefix: {uri!r}")
+    return bucket, prefix.strip("/") + "/"
+
+
+def snapshot_cache_files(cache_path: Path) -> list[str]:
+    if not cache_path.exists():
+        return []
+    return sorted(
+        str(path.relative_to(cache_path)) for path in cache_path.rglob("*")
+        if path.is_file() and not path.is_symlink())
+
+
+def validate_cache_layout(cache_path: Path) -> None:
+    """Reject a golden that was restored one directory too deep.
+
+    The bare-metal cache lives under gs://.../jax<VER>_tpu<GEN>/. Copying that
+    directory itself, rather than its contents, produces
+    /cache/tpu_jax_cache/jax0.11.0_tputpu6e/... which JAX silently ignores: the
+    build looks warm, every lookup misses, and the only symptom is a slow job.
+    """
+    if not cache_path.exists():
+        return
+    nested = sorted(path.name for path in cache_path.iterdir()
+                    if path.is_dir() and path.name.startswith("jax") and "_tpu" in path.name)
+    if nested:
+        raise ValueError(
+            f"compilation cache has an extra namespace directory under {cache_path}: "
+            f"{', '.join(nested)}; copy that directory's contents directly into "
+            "the configured cache path")
+
+
+def new_cache_files(cache_path: Path, manifest: dict[str, Any]) -> list[Path]:
+    baseline = manifest.get("baseline_cache_files")
+    if not isinstance(baseline, list) or not all(isinstance(e, str) for e in baseline):
+        raise ValueError("manifest has no valid baseline_cache_files list")
+    known = set(baseline)
+    return [
+        cache_path / relative for relative in snapshot_cache_files(cache_path)
+        if relative not in known
+    ]
+
+
+def publish(
+    cache_path: Path,
+    manifest: dict[str, Any],
+    write_prefix: str | None,
+    *,
+    storage_client: Any | None = None,
+    workers: int = DEFAULT_WORKERS,
+) -> dict[str, Any]:
+    files = new_cache_files(cache_path, manifest)
+    result: dict[str, Any] = {
+        "new_files": len(files),
+        "uploaded": 0,
+        "already_exists": 0,
+        "write_prefix": write_prefix,
+    }
+    if not write_prefix:
+        result["dry_run"] = True
+        return result
+    if storage_client is None:
+        from google.cloud import storage
+        storage_client = storage.Client()
+    bucket_name, prefix = parse_gcs_uri(write_prefix)
+    bucket = storage_client.bucket(bucket_name)
+
+    def upload(path: Path) -> bool:
+        blob = bucket.blob(prefix + path.relative_to(cache_path).as_posix())
+        try:
+            blob.upload_from_filename(path, if_generation_match=0)
+            return True
+        except Exception as error:
+            # 412 means another job already published this content-addressed
+            # entry. Checked via getattr so google.api_core is not needed in
+            # dry-run or unit-test environments.
+            if getattr(error, "code", None) == 412:
+                return False
+            raise
+
+    if workers <= 1 or len(files) <= 1:
+        outcomes = [upload(path) for path in files]
+    else:
+        with ThreadPoolExecutor(max_workers=min(workers, len(files))) as pool:
+            outcomes = list(pool.map(upload, files))
+
+    result["uploaded"] = sum(1 for created in outcomes if created)
+    result["already_exists"] = sum(1 for created in outcomes if not created)
+    return result
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("mode", choices=["snapshot", "publish"])
+    parser.add_argument("--cache-path", type=Path, default=Path("/cache/tpu_jax_cache"))
+    parser.add_argument("--manifest", type=Path,
+                        default=Path("/cache/.buildkite/jax-cache-manifest.json"))
+    parser.add_argument("--write-prefix")
+    parser.add_argument("--workers", type=int, default=DEFAULT_WORKERS)
+    args = parser.parse_args()
+
+    try:
+        if args.mode == "snapshot":
+            args.cache_path.mkdir(parents=True, exist_ok=True)
+            validate_cache_layout(args.cache_path)
+            baseline = snapshot_cache_files(args.cache_path)
+            args.manifest.parent.mkdir(parents=True, exist_ok=True)
+            args.manifest.write_text(
+                json.dumps({"baseline_cache_files": baseline}, indent=2) + "\n")
+            result = {"baseline_cache_file_count": len(baseline)}
+        else:
+            manifest = json.loads(args.manifest.read_text())
+            result = publish(args.cache_path, manifest, args.write_prefix,
+                             workers=args.workers)
+    except (OSError, ValueError) as error:
+        print(f"cache {args.mode} failed: {error}", file=sys.stderr)
+        return 1
+
+    print(json.dumps(result, indent=2, sort_keys=True))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/.buildkite/scripts/kube_jax_cache.sh
+++ b/.buildkite/scripts/kube_jax_cache.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# Cache write-back for Kubernetes TPU jobs. Usage: kube_jax_cache.sh snapshot|publish
+#
+# The POC reads a golden PVC and writes nothing back, which is fine while the
+# golden covers the shapes under test. Production needs the return path: build
+# 35 showed the golden holds usable keys but not the full shape matrix, with
+# adjacent num_reqs=16 and num_reqs=20 shapes each costing ~115s to recompile
+# on every build.
+#
+# OFF BY DEFAULT. Both modes exit immediately unless KUBE_JAX_CACHE_WRITE=1, so
+# the POC environment is unchanged and production opts in through Agent Stack
+# environment configuration rather than a pipeline fork.
+#
+#   snapshot   before the test commands, records what the golden already had
+#   publish    after them; Buildkite aborts the script on the first failure, so
+#              a failed test never reaches this and cannot poison the cache --
+#              the same guard run_in_docker.sh gets from the container exit code
+set -euo pipefail
+
+MODE="${1:-}"
+case "$MODE" in
+  snapshot|publish) ;;
+  *) echo "usage: $0 snapshot|publish" >&2; exit 2 ;;
+esac
+
+if [ "${KUBE_JAX_CACHE_WRITE:-0}" != "1" ]; then
+  echo "[cache] KUBE_JAX_CACHE_WRITE!=1; skipping ${MODE}"
+  exit 0
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HELPER="${SCRIPT_DIR}/kube_jax_cache.py"
+
+CACHE_PATH="${KUBE_JAX_CACHE_PATH:-/cache/tpu_jax_cache}"
+CACHE_BASE="${KUBE_JAX_CACHE_BASE:-gs://ullm-ci-cache/jax_cache}"
+MANIFEST="${KUBE_JAX_CACHE_MANIFEST:-/cache/.buildkite/jax-cache-manifest.json}"
+WORKERS="${KUBE_JAX_CACHE_WORKERS:-32}"
+
+# Resolved from the running image, and deliberately identical to the namespace
+# run_in_docker.sh uses on bare metal, so the two fleets warm each other. It is
+# printed on every run: the golden-refresh CronJob carries this same namespace
+# as static configuration, and a JAX bump that misses it shows up here as a
+# prefix nobody is refreshing.
+JAX_VERSION="$(python3 -c 'import jax; print(jax.__version__)')"
+NAMESPACE="jax${JAX_VERSION}_tpu${TPU_VERSION:-tpu6e}"
+PREFIX="${CACHE_BASE}/${NAMESPACE}"
+
+echo "[cache] mode=${MODE} namespace=${NAMESPACE} path=${CACHE_PATH}"
+started="$(date +%s)"
+
+if [ "$MODE" = "snapshot" ]; then
+  # A missing baseline must not fail the build, but it must not silently become
+  # an empty one either: publish would then re-upload the entire golden.
+  if ! python3 "$HELPER" snapshot --cache-path "$CACHE_PATH" --manifest "$MANIFEST"; then
+    echo "[cache] WARN snapshot failed; publish will be skipped for this job" >&2
+    rm -f "$MANIFEST"
+  fi
+else
+  if [ ! -f "$MANIFEST" ]; then
+    echo "[cache] WARN no baseline manifest; nothing published" >&2
+    exit 0
+  fi
+  # A GCS failure here must not fail a green TPU test. The cost of a missed
+  # publish is one slow future build; the cost of failing is a wasted TPU hour.
+  if ! python3 "$HELPER" publish \
+      --cache-path "$CACHE_PATH" \
+      --manifest "$MANIFEST" \
+      --write-prefix "$PREFIX" \
+      --workers "$WORKERS"; then
+    echo "[cache] WARN publish failed; the test result stands" >&2
+  fi
+fi
+
+echo "[cache] ${MODE} finished in $(( $(date +%s) - started ))s"


### PR DESCRIPTION
# Description

Stands up a reviewable, prod-only path for the Buildkite TPU CI migration. Cut
from `main`, so it carries **no POC material** — the `kueue-poc` manifests,
`pipeline_kube.yaml`, and the POC handoffs stay on `test-kube`.

The first three commits are the production design and Terraform foundation
brought forward from `test-kube` unchanged (same author, same content, minus the
POC-doc hunks that have no counterpart on `main`). The last commit is new work
and covers three gaps that stood between that scaffold and someone actually
building the environment.

**An ordered runbook.** [`production/SETUP.md`](.buildkite/kubernetes/production/SETUP.md)
is what a human runs, in order, with a gate after every step. Failures in this
stack are mostly silent — a Pod that never starts, a reservation that quietly
bills on-demand, a cache that looks warm and misses every lookup — so each step
ends in a check that must pass before the next begins. It also answers the
manager-mode question directly: regional Standard as scaffolded, with the case
for Autopilot and a note that switching is a resource rewrite, not a flag, since
GKE cannot convert a cluster either way. The worker is Standard and zonal
because that makes reservation consumption an explicit `reservation_affinity`
you can verify before spending a TPU hour, rather than an Autopilot
ComputeClass behaviour you can only confirm by watching a counter during a live
run.

**Cross-project layout.** The manager belongs in `cloud-ullm-inference-ci-cd`
and the worker has to sit beside the TPU reservation in
`cloud-tpu-inference-test`, because a reservation is only consumable from the
project that owns it. The scaffold assumed one project and its README listed
the split as unimplemented. An optional `worker_project` variable and an aliased
`google.worker` provider now place worker clusters, node pools, and node service
accounts there, while the fleet, manager, and Artifact Registry stay put. A
cross-project deployment additionally enables the worker project's APIs, grants
the manager Kueue identity `roles/container.developer` there, and adds a
repository-level Artifact Registry reader binding — without which the copied
Job's Pod sits in ImagePullBackOff and Buildkite reports only a job that never
starts. The worker still joins the *manager's* fleet: a cluster can belong to
only one, and MultiKueue needs both sides in the same one. Leaving
`worker_project` null keeps the previous single-project behaviour.

**Cache write-back.** The golden PVC gives each job a warm base and nothing
carries the other way, so a shape the golden does not cover is recompiled on
every build forever — POC build 35 measured that at ~115s per shape, repeatedly.
[`production/cache/`](.buildkite/kubernetes/production/cache) plus
`kube_jax_cache.sh` close the loop: `snapshot` records what the golden already
had, `publish` uploads only what the job added, and a CronJob promotes published
entries back into the golden. Publish runs last on purpose — Buildkite aborts the
script on first failure, so a failed test never reaches it and cannot poison the
shared cache, the same guard `run_in_docker.sh` gets from the container exit
code. Uploads use `if_generation_match=0`, so concurrent publishers of the same
content-addressed entry are idempotent rather than racing.

# Tests

Nothing here is applied; it is infrastructure definition and documentation.
What was checked mechanically:

```bash
cd .buildkite/kubernetes/production/terraform
terraform init -backend=false && terraform validate   # Success
terraform fmt -check -recursive                       # clean

bash -n .buildkite/scripts/kube_jax_cache.sh          # OK
python3 -c "import ast; ast.parse(open('.buildkite/scripts/kube_jax_cache.py').read())"
```

All manifests under `production/cache/` parse as YAML, and the shell embedded in
the refresh CronJob passes `bash -n`.

The cache path is off unless `KUBE_JAX_CACHE_WRITE=1`, so it changes no existing
behaviour; `SETUP.md` step 5 gives the enable procedure and the gate (a non-zero
`uploaded` on the first build, a larger baseline and shorter compile phase on the
next one after a golden refresh).

# Reviewer notes

- `.terraform.lock.hcl` came across with the foundation commit; providers were
  not re-locked here.
- One worker *project* is assumed for all workers. Several would need a child
  module per project, because Terraform cannot select a provider alias per
  `for_each` key. Noted in the README.
- `JAX_CACHE_NAMESPACE` in the refresh CronJob must track the image's JAX
  version. `kube_jax_cache.sh` prints the namespace it resolved on every run so
  a missed bump shows up in build logs rather than as a gradual slowdown.
- A GCS lifecycle rule on the cache prefix is still owed — every build adds
  entries and nothing removes them.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)