### PR TITLE
Pin pypa/gh-action-pypi-publish to exact version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
       run: python3 -m build
 
     - name: Publish package distributions to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
+      uses: pypa/gh-action-pypi-publish@2834a314042ef964da07689278dd1e9d773e8afd # v1.14.1
 
     - name: Publish completed message
       run: echo "---Build and publish completed successfully.---"


### PR DESCRIPTION
## Summary

The release workflow uses `pypa/gh-action-pypi-publish@release/v1` (a branch ref) instead of a pinned SHA or exact tag. For a PyPI publish step, supply-chain security is critical.

## Changes

- Pin `pypa/gh-action-pypi-publish` to SHA `2834a314042ef964da07689278dd1e9d773e8afd` (v1.14.1)
- Add inline comment with tag version for reference

## Testing

N/A — verified by grep / visual inspection.