### PR TITLE
Fix duplicate repos key in .pre-commit-config.yaml

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -26,7 +26,6 @@ repos:
         exclude: ^mkdocs\.yml$ # Exclude mkdocs.yml from this check
     -   id: end-of-file-fixer
     -   id: trailing-whitespace
-repos:
 - repo: https://github.com/google/addlicense
   rev: v1.2.0
   hooks:


### PR DESCRIPTION
## Summary

The file has two top-level `repos:` keys. YAML last-key-wins semantics silently drops the first block containing pre-commit-hooks (check-yaml, end-of-file-fixer, trailing-whitespace). This merges both blocks under a single `repos:` key.

## Changes

- Removed duplicate `repos:` key on line 29
- Merged all hooks under a single `repos:` key starting at line 21
- Preserved all hooks from both blocks

## Testing

Validated YAML syntax with `python3 -c 'import yaml; yaml.safe_load(open(".pre-commit-config.yaml"))'`