### PR TITLE
[CI] Fix Mistral-Small-4 record step failing on tpu6e skip

### DIFF
--- a/.buildkite/models/mistralai_Mistral-Small-4-119B-2603_text-only.yml
+++ b/.buildkite/models/mistralai_Mistral-Small-4-119B-2603_text-only.yml
@@ -26,7 +26,7 @@ steps:
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" != "tpu7x" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Correctness" "skipped (only for tpu7x)"
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Correctness" "skipped"
         else
           # 1. Run the fast correctness test
           .buildkite/scripts/run_in_docker.sh \


### PR DESCRIPTION
## Problem

Every nightly, the job `tpu6e Record correctness result for mistralai/Mistral-Small-4-119B-2603/text-only` hard-fails (`soft_fail` is not set on record steps) even though the upstream `tpu6e Correctness` step passes. Red on `main` nightlies (e.g. build 23204) and inherited by the `releases/v0.26.0` nightly build 23216.

Root cause (introduced with the model config in #2991): on tpu6e the Correctness step self-skips and writes the outcome to buildkite meta-data as `"skipped (only for tpu7x)"`. `record_step_result.sh` matches outcomes exactly — `passed` / `skipped` / `unverified` / `not enough HBM` — so this string falls through to `Failing` and `exit 1`.

## Fix

Write the exact `skipped` token the recorder expects (renders as "Untested" in the support matrix).

Log evidence from build 23216:
```
--- Checking tpu6e_mistralai_Mistral-Small-4-119B-2603_text-only_Correctness Outcome (Hardware: tpu6e)
Step tpu6e_..._Correctness outcome: skipped (only for tpu7x)
Error: The command exited with status 1
```

Nightly (release branch): https://buildkite.com/tpu-commons/tpu-inference-ci/builds/23216