### PR TITLE
[CI] Fix Mistral-Small-4 tpu7x correctness: allow compile when precompile is skipped

### DIFF
--- a/tests/e2e/mistral_small_4_correctness.py
+++ b/tests/e2e/mistral_small_4_correctness.py
@@ -26,6 +26,11 @@ def set_env_vars():
     os.environ['MODEL_IMPL_TYPE'] = 'vllm'
     os.environ[
         'SKIP_JAX_PRECOMPILE'] = '1'  # Set to '1' to skip expensive multi-shape precompilation in unit tests
+    # SKIP_JAX_PRECOMPILE means the first real step compiles during
+    # execute_model, so the CI recompilation guard
+    # (VLLM_XLA_CHECK_RECOMPILATION=1 in run_in_docker.sh) must be off here,
+    # like the other e2e tests that skip precompile.
+    os.environ['VLLM_XLA_CHECK_RECOMPILATION'] = '0'
     os.environ['VLLM_TPU_PATCH_MM_EMBEDDINGS'] = '1'
     os.environ['VLLM_DISABLE_SHARED_EXPERTS_STREAM'] = '0'
     os.environ['MOE_REQUANTIZE_BLOCK_SIZE'] = '512'


### PR DESCRIPTION
## Problem

`tpu7x Correctness for mistralai/Mistral-Small-4-119B-2603/text-only` has failed every nightly since the test landed (#2991) — on `main` (e.g. builds 23189, 23204, 23225) and inherited by the `releases/v0.26.0` nightly (build 23216):

```
File "tpu_inference/runner/tpu_runner.py", line 1630, in _execute_model
RuntimeError: JAX compilation occurred but was forbidden in this context.
```

Root cause: the test sets `SKIP_JAX_PRECOMPILE=1`, so the first executed step necessarily compiles inside `execute_model`. CI's `run_in_docker.sh` hardcodes `VLLM_XLA_CHECK_RECOMPILATION=1`, whose `ForbidCompile` guard turns that first compile into the RuntimeError — deterministically.

## Fix

Set `VLLM_XLA_CHECK_RECOMPILATION=0` inside the test's `set_env_vars()`, matching the established pattern in the other e2e tests that skip precompile (`test_multi_modal_inference.py`, `test_hybrid_kvcache.py`, `test_data_parallel.py`, `test_pipeline_parallel.py`).

## Test evidence

Validated on [dev build 699](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/699) (job `tpu7x Correctness for mistralai/Mistral-Small-4-119B-2603/text-only`, tpu7x-8, this branch): the dev job runs the **identical CI command** — `.buildkite/scripts/run_in_docker.sh bash -c 'python3 /workspace/tpu_inference/tests/e2e/mistral_small_4_correctness.py'` — via `run_in_docker.sh`, which hardcodes `VLLM_XLA_CHECK_RECOMPILATION=1` exactly like the nightly.

Without this fix the run dies at the first generate step with the RuntimeError above (it has never passed in any nightly). With the fix, the engine initializes, all 3 prompts generate, and the test's assertions pass (non-empty outputs + the `"Paris"` correctness check):

```
Initializing LLM with model mistralai/Mistral-Small-4-119B-2603...
Processed prompts: 100%|██████████| 3/3 [00:44<00:00, 14.68s/it, ...]
--- Prompt: Hello, my name is ---
Generated:  Brenda and I am a student at the University of North Carolina at Chapel Hill. ...
--- Prompt: The capital of France is ---
Generated:  Paris. Paris is the largest city in France and serves as its political, economic, and cultural center. ...
--- Prompt: Write a short poem about artificial intelligence on TPUs. ---
Generated:  (Tensor Processing Units) ...
```

Job exit 0, build green.

## Note

This PR now targets `main` (the bug exists identically on both branches); after merge it can be cherry-picked to `releases/v0.26.0`.
