### PR TITLE
[releases/v0.26.0] Revert "[Batch RPA] remove block_size override (#3223)" — fixes smem compile OOM in 7 nightly perf jobs

### DIFF
--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -306,6 +306,8 @@ class TpuPlatform(Platform):
                             min_page_size,
                         )
                         cache_config.block_size = min_page_size  # type: ignore[assignment]
+            if envs.USE_BATCHED_RPA_KERNEL and cache_config.block_size < 256:
+                cache_config.block_size = 256
 
         parallel_config = vllm_config.parallel_config
         scheduler_config = vllm_config.scheduler_config


### PR DESCRIPTION
## Problem

Seven tpu7x nightly jobs crash at engine init with an XLA smem compile OOM — red on `main` since the Jul 21 nightly (build 22832) and inherited by the `releases/v0.26.0` nightly (build 23216):

- `Perf regression test for qwen3 coder {1k8k, 8k1k} x {fused moe, gmm}` (4 jobs): `Ran out of memory in memory space smem. Used 1.06M of 1.00M (+66.1K)`
- `Performance benchmarks for Qwen/Qwen3-Coder-480B-A35B-Instruct`
- `Performance benchmarks for google/gemma-4-26B-A4B-it`: `Used 1.20M of 1.00M (+208.1K)`
- `Performance benchmarks for google/gemma-4-31B-it`: runtime `RuntimeUnexpectedCoreHalt` BoundsCheck `dma.smem_to_vmem` (same window, smem-adjacent)

## Root cause — proven by single-commit A/B

#3223 removed the `USE_BATCHED_RPA_KERNEL && block_size < 256 → 256` floor in `tpu_platform.py`, on the rationale that users should pass `--block-size` via CLI. But the nightly jobs export `USE_BATCHED_RPA_KERNEL=1` **without** a block size (`bm_qwen3_coder.sh`, the gemma-4 model ymls), so they now fall to a small block size → more pages → the batched-RPA per-page metadata exceeds the 1MB smem budget at compile.

Dev-pipeline bisect of the Jul 20→21 window, running the exact `qwen3 coder 1k8k gmm` job per commit:

| build | commit | result |
|---|---|---|
| [dev #697](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/697) | `0a6fbff7c` (post-GMM #3219/#3161, LKG `c9be3a8aa`) | PASS |
| [dev #698](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/698) | `eb204cdb4` (LKG `bd091079c`) = **parent of #3223** | PASS |
| [dev #700](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/700) | `0cbe535e5` = **#3223** | FAIL — byte-identical smem OOM (1.06M/1.00M, +66.1K) |

Same job, same vLLM pin as the parent probe — #3223 is the only variable. GMM kernel PRs and both LKG bumps are exonerated.

## Fix

Revert #3223 on the release branch, restoring the 256 floor (v0.25 behavior). The forward-looking alternative (bounding batched-RPA smem metadata) is tracked upstream in #3007 and is not release-branch material.

## Validation

Dev-pipeline run of the qwen3-coder 1k8k gmm job AND the gemma-4-26B perf benchmark on this branch (links to follow in comments).