### PR TITLE
PCP: add a ring-KV cache phase alongside gather-KV

### DIFF
--- a/tests/layers/common/test_pcp_attention_interface.py
+++ b/tests/layers/common/test_pcp_attention_interface.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
+from unittest import mock
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -19,6 +22,7 @@ from absl.testing import absltest, parameterized
 from jax._src import test_util as jtu
 from jax.sharding import Mesh
 
+from tpu_inference import envs
 from tpu_inference.kernels.ragged_paged_attention.v3.kernel import (
     merge_kv, ref_ragged_paged_attention)
 from tpu_inference.kernels.ragged_paged_attention.v3.util import (
@@ -170,11 +174,12 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
         return Mesh(
             np.array(jax.devices()[:pcp]).reshape(shape), MESH_AXIS_NAMES)
 
-    def _run(self, pcp, L, num_current, padded_s):
+    def _run(self, pcp, L, num_current, padded_s, cache_phase=None):
         """Drive the wrapper; return (out_rank_order, kv_cache, exp_token_order).
 
         L = num_computed (already in the strided cache), num_current = the real
         current tokens, padded_s = 2*pcp*C (what the token buffers are sized to).
+        `cache_phase` selects the cache-phase strategy (None = auto-dispatch).
         """
         C = padded_s // (2 * pcp)
         kv_total = L + num_current  # the REAL kv length
@@ -245,7 +250,8 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                                                     sm_scale=SM_SCALE,
                                                     cache_pages=cache_pages,
                                                     update_kv_cache=True,
-                                                    use_causal_mask=True)
+                                                    use_causal_mask=True,
+                                                    cache_phase=cache_phase)
         return np.asarray(out), np.asarray(new_cache), exp, C
 
     def _assert_matches(self, out, exp, pcp, C, num_current):
@@ -319,8 +325,10 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
             got = cache[page, r * PAGE + off]
             self.assertAllClose(got, ref[i], atol=2e-2, rtol=2e-2)
 
-    @parameterized.parameters((2, False), (4, False), (2, True), (4, True))
-    def test_noncontiguous_block_table(self, pcp, tight_hint):
+    @parameterized.product(pcp=[2, 4],
+                           tight_hint=[False, True],
+                           cache_phase=["gather_kv", "ring_kv"])
+    def test_noncontiguous_block_table(self, pcp, tight_hint, cache_phase):
         """The cache phase must be correct when the request's pages are an
         arbitrary, non-contiguous subset of a cache that is bigger than the
         request -- i.e. what a real server looks like, where one KV cache holds
@@ -408,7 +416,7 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                                             qpos,
                                             SM_SCALE,
                                             cache_pages=hint,
-                                            cache_phase="gather_kv")
+                                            cache_phase=cache_phase)
 
         inv = _inv_row(pcp)
         got = np.asarray(out).reshape(2 * pcp, C, NQ,
@@ -416,6 +424,71 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
         self.assertTrue(np.all(np.isfinite(got)))
         self.assertGreater(float(np.abs(got).max()), 0.0)
         self.assertAllClose(got, np.asarray(exp), atol=2e-2, rtol=2e-2)
+
+    @parameterized.product(pcp=[2, 4])
+    def test_ring_kv_chunked_prefill(self, pcp):
+        """Ring cache phase: instead of all-gathering the cache, each rank
+        rotates its own shard around the pcp ring and LSE-merges the pcp
+        partials. The result must still equal the full-causal reference."""
+        if jax.device_count() < pcp:
+            self.skipTest(f"needs >= {pcp} devices")
+        L, S = 128, 128
+        out, _, exp, C = self._run(pcp, L, S, S, cache_phase="ring_kv")
+        self._assert_matches(out, exp, pcp, C, S)
+
+    @parameterized.product(pcp=[2, 4])
+    def test_ring_kv_partial_tail(self, pcp):
+        """Ring cache phase with a partly-padded tail: the per-rank `tail_real`
+        skew lives in the current phase, but the ring's local-Q layout must not
+        disturb it."""
+        if jax.device_count() < pcp:
+            self.skipTest(f"needs >= {pcp} devices")
+        L, S, padded_s = 128, 100, 128
+        out, _, exp, C = self._run(pcp, L, S, padded_s, cache_phase="ring_kv")
+        self._assert_matches(out, exp, pcp, C, S)
+
+    @parameterized.product(pcp=[2, 4], other=["ring_kv", "gather_q"])
+    def test_cache_phases_agree(self, pcp, other):
+        """The three cache-phase strategies are communication schedules for the
+        same math, so each must agree with gather-KV far more tightly than any
+        of them agrees with the reference -- on the attention output AND on the
+        cache the current phase writes (the cache phase must not touch it)."""
+        if jax.device_count() < pcp:
+            self.skipTest(f"needs >= {pcp} devices")
+        L, S = 128, 128
+        out, cache, _, _ = self._run(pcp, L, S, S, cache_phase=other)
+        ag_out, ag_cache, _, _ = self._run(pcp,
+                                           L,
+                                           S,
+                                           S,
+                                           cache_phase="gather_kv")
+        self.assertTrue(np.all(np.isfinite(out)))
+        # The ring splits the same softmax into pcp partials and merges them,
+        # so it differs from gather-KV only by accumulation order (~1e-4 here,
+        # vs the 2e-2 the reference comparisons allow). A real divergence --
+        # e.g. a shard mapped to the wrong cp_rank -- is O(1).
+        self.assertAllClose(out, ag_out, atol=2e-3, rtol=2e-3)
+        # Unwritten cache slots stay NaN in both; compare the live ones.
+        live = np.isfinite(ag_cache)
+        np.testing.assert_array_equal(np.isfinite(cache), live)
+        self.assertAllClose(cache[live], ag_cache[live])
+
+    def test_cache_phase_env_var(self):
+        """`PCP_CACHE_PHASE` is the only way a deployment opts into the ring
+        (auto-dispatch never picks it), so the env name must be spelled right
+        all the way through to the wrapper -- and must reject typos rather than
+        silently falling back."""
+        pcp = 2
+        if jax.device_count() < pcp:
+            self.skipTest(f"needs >= {pcp} devices")
+        with mock.patch.dict(os.environ, {"PCP_CACHE_PHASE": "ring_kv"}):
+            self.assertEqual(envs.PCP_CACHE_PHASE, "ring_kv")
+            L, S = 128, 128
+            out, _, exp, C = self._run(pcp, L, S, S)  # cache_phase unset
+        self._assert_matches(out, exp, pcp, C, S)
+        with mock.patch.dict(os.environ, {"PCP_CACHE_PHASE": "ring"}):
+            with self.assertRaises(ValueError):
+                _ = envs.PCP_CACHE_PHASE
 
     @parameterized.parameters(2, 4)
     def test_first_chunk_skips_cache_phase(self, pcp):

--- a/tests/layers/common/test_pcp_attention_interface.py
+++ b/tests/layers/common/test_pcp_attention_interface.py
@@ -144,6 +144,27 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
         out[pps:2 * pps] = pi
         return jnp.asarray(out)
 
+    def _cache_at_pages(self, k, v, ntok, pcp, pps, npages, phys):
+        """Build an `npages`-page global pcp cache in which the request's
+        logical page i is stored at physical page `phys[i]` (so the block
+        table is non-contiguous), leaving the other pages unused."""
+        dims = self._cache_dims(1)
+        shards = []
+        for r in range(pcp):
+            idx = np.arange(r, ntok, pcp)
+            kv = np.asarray(merge_kv(k[idx], v[idx])) if len(idx) else None
+            shard = np.full((npages, PAGE, *dims), np.nan, np.float32)
+            if kv is not None:
+                n = kv.shape[0]
+                kv = np.pad(kv, ((0, cdiv(n, PAGE) * PAGE - n), (0, 0), (0, 0),
+                                 (0, 0)),
+                            constant_values=np.nan)
+                kv = kv.reshape(-1, PAGE, *dims)
+                for i in range(kv.shape[0]):
+                    shard[phys[i]] = kv[i]
+            shards.append(shard)
+        return jnp.asarray(np.concatenate(shards, axis=1), DTYPE)
+
     def _mesh(self, pcp):
         shape = tuple(pcp if a == "pcp" else 1 for a in MESH_AXIS_NAMES)
         return Mesh(
@@ -209,6 +230,7 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
         cu_q_lens, q_pos_offsets = _pcp_meta(pcp, C, num_current)
         distribution = jnp.array([0, 0, 2], jnp.int32)  # head + tail
 
+        cache_pages = cdiv(L, PAGE * pcp)
         out, new_cache = pcp_ragged_paged_attention(self._mesh(pcp),
                                                     q,
                                                     k,
@@ -221,6 +243,7 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                                                     kv_cache_lens,
                                                     q_pos_offsets,
                                                     sm_scale=SM_SCALE,
+                                                    cache_pages=cache_pages,
                                                     update_kv_cache=True,
                                                     use_causal_mask=True)
         return np.asarray(out), np.asarray(new_cache), exp, C
@@ -295,6 +318,162 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
             page, off = local // PAGE, local % PAGE
             got = cache[page, r * PAGE + off]
             self.assertAllClose(got, ref[i], atol=2e-2, rtol=2e-2)
+
+    @parameterized.parameters((2, False), (4, False), (2, True), (4, True))
+    def test_noncontiguous_block_table(self, pcp, tight_hint):
+        """The cache phase must be correct when the request's pages are an
+        arbitrary, non-contiguous subset of a cache that is bigger than the
+        request -- i.e. what a real server looks like, where one KV cache holds
+        many sequences (in production num_blocks is ~9x the per-request block
+        table width).  Both conditions are needed to exercise gather-KV's page
+        compaction: it selects the request's pages via the block table before
+        the all-gather, so an indexing bug shows up as a numerical mismatch
+        against the plain-attention reference.
+
+        `tight_hint` additionally exercises the `cache_pages` bound: True
+        passes a rung strictly tighter than the block-table width, False passes
+        the full width.
+        """
+        if jax.device_count() < pcp:
+            self.skipTest(f"needs {pcp} devices")
+        rng = np.random.default_rng(0)
+        C = 32
+        num_current = 2 * pcp * C
+        L = 4 * PAGE * pcp  # cached tokens
+        kv_total = L + num_current
+
+        q = self._rand(rng, (num_current, NQ, HD))
+        k = self._rand(rng, (num_current, NKV, HD))
+        v = self._rand(rng, (num_current, NKV, HD))
+        k_prev = self._rand(rng, (L, NKV, HD))
+        v_prev = self._rand(rng, (L, NKV, HD))
+
+        # ---- reference: plain non-PCP attention over the same tokens ----
+        ref_pps = cdiv(kv_total, PAGE)
+        ref_pi = jnp.pad(jnp.arange(ref_pps, dtype=jnp.int32),
+                         (0, MAX_SEQ * ref_pps - ref_pps))
+        exp, _ = ref_ragged_paged_attention(
+            q,
+            k,
+            v,
+            self._ref_cache(k_prev, v_prev, L, ref_pps),
+            jnp.pad(jnp.array([kv_total], jnp.int32), (0, MAX_SEQ - 1)),
+            ref_pi,
+            jnp.pad(jnp.array([0, num_current], jnp.int32), (0, MAX_SEQ - 1)),
+            jnp.array([0, 0, 1], jnp.int32),
+            sm_scale=SM_SCALE)
+
+        # ---- PCP: cache is 4x the request, pages non-contiguous ----
+        pps = cdiv(cdiv(kv_total, pcp), PAGE)
+        npages = 4 * pps  # cache bigger than the request
+        # arbitrary non-identity, non-contiguous physical placement
+        phys = (np.arange(pps) * 3 + 5) % npages
+        assert len(set(phys.tolist())) == pps, "phys must be a permutation"
+        cache = self._cache_at_pages(k_prev, v_prev, L, pcp, pps, npages, phys)
+
+        pi = np.zeros(MAX_SEQ * pps, np.int32)
+        pi[:pps] = phys
+        pi[pps:2 * pps] = phys
+        pi = jnp.asarray(pi)
+
+        def pad1(xs):
+            return jnp.pad(jnp.array(xs, jnp.int32), (0, MAX_SEQ - len(xs)))
+
+        # `cache_pages` is the static bound the runner supplies: the number of
+        # pages the CACHED tokens occupy (page P of the token-ordered cache
+        # holds gpage = PAGE*pcp tokens), rounded up to a power of two.  It is
+        # strictly tighter than pages_per_seq here, so it exercises the bound.
+        gpage = PAGE * pcp
+        live = cdiv(L, gpage)
+        # tight_hint=True exercises the bound (a rung strictly tighter than the
+        # block-table width); False passes the loosest legal value, i.e. the
+        # full width, so the compaction runs without the extra bound.
+        hint = (1 << (max(live - 1, 0)).bit_length()) if tight_hint else pps
+        self.assertGreaterEqual(hint, live, "hint must cover live pages")
+        if tight_hint:
+            self.assertLess(hint, pps,
+                            "hint must be tighter than pages_per_seq")
+
+        cu, qpos = _pcp_meta(pcp, C, num_current)
+        out, _ = pcp_ragged_paged_attention(self._mesh(pcp),
+                                            _to_rank_order(q, pcp, C),
+                                            _to_rank_order(k, pcp, C),
+                                            _to_rank_order(v, pcp, C),
+                                            cache,
+                                            pad1([kv_total, kv_total]),
+                                            pi,
+                                            cu,
+                                            jnp.array([0, 0, 2], jnp.int32),
+                                            pad1([L, L]),
+                                            qpos,
+                                            SM_SCALE,
+                                            cache_pages=hint,
+                                            cache_phase="gather_kv")
+
+        inv = _inv_row(pcp)
+        got = np.asarray(out).reshape(2 * pcp, C, NQ,
+                                      HD)[inv].reshape(num_current, NQ, HD)
+        self.assertTrue(np.all(np.isfinite(got)))
+        self.assertGreater(float(np.abs(got).max()), 0.0)
+        self.assertAllClose(got, np.asarray(exp), atol=2e-2, rtol=2e-2)
+
+    @parameterized.parameters(2, 4)
+    def test_first_chunk_skips_cache_phase(self, pcp):
+        """cache_pages=0 elides the cache phase; with no cached tokens the
+        result must still match plain attention over the current chunk."""
+        if jax.device_count() < pcp:
+            self.skipTest(f"needs {pcp} devices")
+        rng = np.random.default_rng(1)
+        C = 32
+        num_current = 2 * pcp * C
+        kv_total = num_current  # L == 0 -> first chunk, empty cache
+
+        q = self._rand(rng, (num_current, NQ, HD))
+        k = self._rand(rng, (num_current, NKV, HD))
+        v = self._rand(rng, (num_current, NKV, HD))
+
+        ref_pps = cdiv(kv_total, PAGE)
+        ref_pi = jnp.pad(jnp.arange(ref_pps, dtype=jnp.int32),
+                         (0, MAX_SEQ * ref_pps - ref_pps))
+        empty = jnp.full((ref_pps, PAGE, *self._cache_dims(1)), jnp.nan, DTYPE)
+        exp, _ = ref_ragged_paged_attention(
+            q,
+            k,
+            v,
+            empty,
+            jnp.pad(jnp.array([kv_total], jnp.int32), (0, MAX_SEQ - 1)),
+            ref_pi,
+            jnp.pad(jnp.array([0, num_current], jnp.int32), (0, MAX_SEQ - 1)),
+            jnp.array([0, 0, 1], jnp.int32),
+            sm_scale=SM_SCALE)
+
+        pps = cdiv(cdiv(kv_total, pcp), PAGE)
+        npages = 4 * pps
+        cache = jnp.full((npages, PAGE * pcp, *self._cache_dims(1)), jnp.nan,
+                         DTYPE)
+        pi = np.zeros(MAX_SEQ * pps, np.int32)
+        pi[:pps] = np.arange(pps)
+        pi[pps:2 * pps] = np.arange(pps)
+        pi = jnp.asarray(pi)
+
+        def pad1(xs):
+            return jnp.pad(jnp.array(xs, jnp.int32), (0, MAX_SEQ - len(xs)))
+
+        cu, qpos = _pcp_meta(pcp, C, num_current)
+        out, _ = pcp_ragged_paged_attention(self._mesh(pcp),
+                                            _to_rank_order(q, pcp, C),
+                                            _to_rank_order(k, pcp, C),
+                                            _to_rank_order(v, pcp, C),
+                                            cache,
+                                            pad1([kv_total, kv_total]),
+                                            pi,
+                                            cu,
+                                            jnp.array([0, 0, 2], jnp.int32),
+                                            pad1([0, 0]),
+                                            qpos,
+                                            SM_SCALE,
+                                            cache_pages=0,
+                                            cache_phase="gather_kv")
 
 
 if __name__ == "__main__":

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -48,6 +48,7 @@ if TYPE_CHECKING:
     RPA_V3_DECODE_BLOCK_SIZES: list[int] = []
     RPA_V3_PREFILL_BLOCK_SIZES: list[int] = []
     RPA_V3_MIXED_BLOCK_SIZES: list[int] = []
+    PCP_CACHE_PHASE: str = "auto"
     FORCE_MOE_RANDOM_ROUTING: bool = False
     JITTED_MM_MODULE_KEYS: list[str] = []
     REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES: list[str] = []
@@ -340,6 +341,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     env_int_list("RPA_V3_PREFILL_BLOCK_SIZES"),
     "RPA_V3_MIXED_BLOCK_SIZES":
     env_int_list("RPA_V3_MIXED_BLOCK_SIZES"),
+    # How the PCP cache phase gives every rank what it needs to attend the
+    # pcp-striped KV cache:
+    #   "gather_q"  all-gather Q, attend the local shard, LSE reduce-scatter O
+    #   "gather_kv" all-gather the cache into global token order, attend locally
+    #   "ring_kv"   rotate the cache shard around the pcp ring, LSE-merge the
+    #               per-round partials (same bytes as gather_kv, but peak memory
+    #               is 2 shards instead of pcp)
+    #   "auto"      (default) pick gather_q or gather_kv per compile from their
+    #               static communication volumes; never picks ring_kv.
+    "PCP_CACHE_PHASE":
+    env_with_choices("PCP_CACHE_PHASE", "auto",
+                     ["auto", "gather_q", "gather_kv", "ring_kv"]),
     # Force random expert routing in MoE layers (for testing purposes only)
     "FORCE_MOE_RANDOM_ROUTING":
     env_bool("FORCE_MOE_RANDOM_ROUTING", default=False),

--- a/tpu_inference/kernels/megablox/gmm_v2.py
+++ b/tpu_inference/kernels/megablox/gmm_v2.py
@@ -1016,6 +1016,10 @@ def calculate_tiling(
             tile_k = align_to(dims.size_k,
                               num_k_tiles * num_lanes) // num_k_tiles
 
+    if (rhs_cfgs.has_scale and rhs_cfgs.quant_block_size is not None
+            and not _is_tile_k_quant_block_compatible(tile_k)):
+        tile_k = rhs_cfgs.quant_block_size
+
     if tile_n == 0 or tile_k == 0:
         final_estimate = _gmm_vmem_estimate(tile_m, tile_n, tile_k)
         raise ValueError(f"Could not find valid tile sizes for {dims=} and"

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -806,11 +806,13 @@ def pcp_ragged_paged_attention(
     kv_cache_lens: jax.Array,
     pcp_q_pos_offsets: jax.Array,
     sm_scale: float,
+    cache_pages: int,
     q_scale: float | None = None,
     k_scale: float | None = None,
     v_scale: float | None = None,
     update_kv_cache: bool = True,
     use_causal_mask: bool = True,
+    cache_phase: str | None = None,
 ):
     """Single-request prefill context-parallel (PCP) attention.
 
@@ -832,6 +834,28 @@ def pcp_ragged_paged_attention(
     padded_q_len = q.shape[
         0]  # padded current tokens across all pcp ranks = 2*pcp*chunk
     pcp_chunk_size = padded_q_len // two_p  # head-tail chunk size
+
+    # --- cache-phase communication strategy ---------------------------------
+    if cache_phase is None:
+        nq_h, nkv_h = q.shape[1], k.shape[1]
+        hd = q.shape[2]
+        max_cached_tokens = cache_pages * kv_cache.shape[1]
+        # Two ways to give every rank what it needs for the cache phase:
+        #   gather-Q : all-gather(Q) + reduce-scatter(O)
+        #   gather-KV: all-gather(cache)
+        comm_q = 2 * padded_q_len * nq_h * hd
+        comm_kv = 2 * max_cached_tokens * nkv_h * hd
+        # Empirically gather-Q needs ~2x the raw
+        # volume advantage before it actually wins.
+        # TODO(wenxindong): apply more accurate heuristic for choosing Q vs KV.
+        GATHER_Q_OVERHEAD = 2.0
+        _cache_phase = ("gather_kv" if comm_kv < GATHER_Q_OVERHEAD *
+                        comm_q else "gather_q")
+    else:
+        _cache_phase = cache_phase.lower()
+
+    assert _cache_phase in ("gather_kv", "gather_q"), (
+        f"cache_phase must be 'gather_kv' or 'gather_q', got {_cache_phase!r}")
 
     _row = [c for r in range(pcp_size) for c in (r, two_p - 1 - r)]
     _inv = [0] * two_p
@@ -868,23 +892,66 @@ def pcp_ragged_paged_attention(
                       v_scale=v_scale)
 
         # ---- cache phase ----
-        ag_q = ag(q_l)  # [pcp*2*chunk]
         cu_cache = jnp.zeros_like(cu_q_lens[0]).at[1:].set(padded_q_len)
         dist_cache = jnp.array([0, 0, 1], jnp.int32)
-        o1, kvc1, l1 = rpa_v3_cp.ragged_paged_attention(ag_q,
-                                                        k_l,
-                                                        v_l,
-                                                        kvc,
-                                                        kvl,
-                                                        pi,
-                                                        cu_cache,
-                                                        dist_cache,
-                                                        kv_cache_lens=kvcl,
-                                                        skip_current_attn=True,
-                                                        use_causal_mask=False,
-                                                        update_kv_cache=False,
-                                                        **common)
-        o1, l1 = _lse_reduce_scatter(o1, l1, pcp_axis, pcp_size)
+        # First chunk of a chunked prefill has no cached tokens
+        if cache_pages == 0:
+            o1 = l1 = None
+            kvc1 = kvc
+        elif _cache_phase == "gather_kv":
+            local_q = q_l.shape[
+                0]  # = padded_q_len // pcp = 2 * pcp_chunk_size
+            cu_kv = jnp.zeros_like(cu_q_lens[0]).at[1:].set(local_q)
+
+            max_seqs = kvl.shape[0]
+            n_gather = int(cache_pages)
+            kv_src = jnp.take(kvc, pi[:n_gather], axis=0)
+
+            kv_tok = lax.all_gather(kv_src, pcp_axis, axis=2, tiled=False)
+            n_pages_tok = kv_src.shape[0] * pcp_size
+            kv_tok = kv_tok.reshape(n_pages_tok, kv_src.shape[1],
+                                    *kv_src.shape[2:])
+            pi_src = jnp.tile(jnp.arange(n_pages_tok, dtype=pi.dtype),
+                              max_seqs)
+            common_kv = {
+                k: v
+                for k, v in common.items()
+                if k not in ("cp_rank", "cp_group_size")
+            }
+            o1, _, l1 = rpa_v3_cp.ragged_paged_attention(
+                q_l,
+                k_l,
+                v_l,
+                kv_tok,
+                kvl,
+                pi_src,
+                cu_kv,
+                dist_cache,
+                kv_cache_lens=kvcl,
+                cp_rank=_rank_i32(0),
+                cp_group_size=1,
+                skip_current_attn=True,
+                use_causal_mask=False,
+                update_kv_cache=False,
+                **common_kv)
+            kvc1 = kvc  # cache unchanged in this phase; current phase writes it
+        else:
+            ag_q = ag(q_l)  # [pcp*2*chunk]
+            o1, kvc1, l1 = rpa_v3_cp.ragged_paged_attention(
+                ag_q,
+                k_l,
+                v_l,
+                kvc,
+                kvl,
+                pi,
+                cu_cache,
+                dist_cache,
+                kv_cache_lens=kvcl,
+                skip_current_attn=True,
+                use_causal_mask=False,
+                update_kv_cache=False,
+                **common)
+            o1, l1 = _lse_reduce_scatter(o1, l1, pcp_axis, pcp_size)
 
         # ---- current phase -----
         # `cu_q_lens[0]` = [0, chunk, chunk+tail_real] and `pcp_qpos` =
@@ -915,8 +982,12 @@ def pcp_ragged_paged_attention(
             write_last_seq_only=True,
             **common)
 
-        # cache term vs. current term: disjoint KV, so LSE-combine.
-        out, _ = merge_attn_states(o1, l1, o2, l2)  # [2*chunk] = [head | tail]
+        # cache term vs. current term: disjoint KV, so LSE-combine.  With no
+        # cached tokens the current phase already is the answer.
+        if o1 is None:
+            out = o2
+        else:
+            out, _ = merge_attn_states(o1, l1, o2, l2)  # [2*chunk]=[head|tail]
         return out.astype(q.dtype), kvc2
 
     return jax.shard_map(
@@ -987,6 +1058,8 @@ def attention(
             v_scale=v_scale,
         )
     if 'pcp' in mesh.shape and mesh.shape['pcp'] > 1:
+        assert md.pcp_cache_pages is not None, (
+            "pcp_cache_pages must be set whenever PCP is enabled")
         output, kv_cache = pcp_ragged_paged_attention(
             mesh,
             q,
@@ -1003,6 +1076,7 @@ def attention(
             q_scale=q_scale,
             k_scale=k_scale,
             v_scale=v_scale,
+            cache_pages=md.pcp_cache_pages,
             update_kv_cache=update_kv_cache,
             use_causal_mask=use_causal_mask,
         )

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -822,11 +822,31 @@ def pcp_ragged_paged_attention(
     `2*pcp-1-r` (tail), so its local buffer is `[head_chunk | tail_chunk]`.
 
     Two kernel launches per rank and is LSE-combined:
-      * cache phase:  all-gather Q across pcp , attend the pcp-strided 
-        cache (non-causal, no write), LSE all-reduce over pcp.
+      * cache phase:  attend the pcp-strided cache (non-causal, no write) by
+        one of three strategies -- see `cache_phase`.
       * current phase: the local Q attends the current KV (causal,
         token-order all-gathered KV, per-chunk `q_pos_offset`); the tail phase
-        writes the strided cache. 
+        writes the strided cache.
+
+    Args:
+      cache_phase: how the cache phase is communicated. One of
+
+        * `"gather_q"`  - all-gather Q, attend the local shard, LSE
+          reduce-scatter the output. Moves `~2 * S * NQ * HD`, independent of
+          context length.
+        * `"gather_kv"` - all-gather the live cache pages into global token
+          order so every rank holds the whole cache, then attend the local Q as
+          ordinary paged attention. Moves `~ctx * NKV * HD` and materialises
+          `pcp` shards.
+        * `"ring_kv"`   - keep only the local shard and rotate it around the
+          pcp ring, LSE-merging the `pcp` partials. Same bytes on the wire as
+          gather-KV, but peak memory is 2 shards instead of `pcp`, at the cost
+          of `pcp` kernel launches. A memory play, not a bandwidth play.
+        * `None` (default) - take the `PCP_CACHE_PHASE` env var, or `"auto"`,
+          which compares the two static communication estimates and picks
+          gather-KV at short/medium context and gather-Q once it is long
+          enough. Auto never picks ring-KV: it costs the same bandwidth as
+          gather-KV and only pays off under memory pressure, so it is opt-in.
     """
     pcp_axis = ShardingAxisName.PREFILL_CONTEXT
     pcp_size = get_mesh_shape_product(mesh, pcp_axis)
@@ -836,13 +856,19 @@ def pcp_ragged_paged_attention(
     pcp_chunk_size = padded_q_len // two_p  # head-tail chunk size
 
     # --- cache-phase communication strategy ---------------------------------
-    if cache_phase is None:
+    _cache_phase = (cache_phase or envs.PCP_CACHE_PHASE or "auto").lower()
+    assert _cache_phase in ("auto", "gather_kv", "gather_q", "ring_kv"), (
+        "cache_phase must be 'auto', 'gather_kv', 'gather_q' or 'ring_kv', "
+        f"got {_cache_phase!r}")
+    if _cache_phase == "auto":
         nq_h, nkv_h = q.shape[1], k.shape[1]
         hd = q.shape[2]
         max_cached_tokens = cache_pages * kv_cache.shape[1]
         # Two ways to give every rank what it needs for the cache phase:
         #   gather-Q : all-gather(Q) + reduce-scatter(O)
         #   gather-KV: all-gather(cache)
+        # (ring-KV moves the same bytes as gather-KV, so it is never chosen
+        # here -- it trades kernel launches for memory and is opt-in.)
         comm_q = 2 * padded_q_len * nq_h * hd
         comm_kv = 2 * max_cached_tokens * nkv_h * hd
         # Empirically gather-Q needs ~2x the raw
@@ -851,11 +877,6 @@ def pcp_ragged_paged_attention(
         GATHER_Q_OVERHEAD = 2.0
         _cache_phase = ("gather_kv" if comm_kv < GATHER_Q_OVERHEAD *
                         comm_q else "gather_q")
-    else:
-        _cache_phase = cache_phase.lower()
-
-    assert _cache_phase in ("gather_kv", "gather_q"), (
-        f"cache_phase must be 'gather_kv' or 'gather_q', got {_cache_phase!r}")
 
     _row = [c for r in range(pcp_size) for c in (r, two_p - 1 - r)]
     _inv = [0] * two_p
@@ -883,28 +904,29 @@ def pcp_ragged_paged_attention(
             g = ag(x).reshape(two_p, pcp_chunk_size, *x.shape[1:])
             return g[inv_row].reshape(padded_q_len, *x.shape[1:])
 
-        common = dict(cp_rank=_rank_i32(r),
-                      cp_group_size=pcp_size,
-                      return_lse=True,
+        common = dict(return_lse=True,
                       sm_scale=sm_scale,
                       q_scale=q_scale,
                       k_scale=k_scale,
                       v_scale=v_scale)
+        # The local shard's view of the strided cache: global token g lives on
+        # rank g % pcp at local slot g // pcp.
+        cp_local = dict(cp_rank=_rank_i32(r), cp_group_size=pcp_size)
 
         # ---- cache phase ----
         cu_cache = jnp.zeros_like(cu_q_lens[0]).at[1:].set(padded_q_len)
         dist_cache = jnp.array([0, 0, 1], jnp.int32)
+        # Only the request's live pages participate; the block table is sized
+        # for max_model_len.  `local_q` = padded_q_len // pcp = 2 * chunk.
+        local_q = q_l.shape[0]
+        cu_kv = jnp.zeros_like(cu_q_lens[0]).at[1:].set(local_q)
+        max_seqs = kvl.shape[0]
+        n_gather = int(cache_pages)
         # First chunk of a chunked prefill has no cached tokens
         if cache_pages == 0:
             o1 = l1 = None
             kvc1 = kvc
         elif _cache_phase == "gather_kv":
-            local_q = q_l.shape[
-                0]  # = padded_q_len // pcp = 2 * pcp_chunk_size
-            cu_kv = jnp.zeros_like(cu_q_lens[0]).at[1:].set(local_q)
-
-            max_seqs = kvl.shape[0]
-            n_gather = int(cache_pages)
             kv_src = jnp.take(kvc, pi[:n_gather], axis=0)
 
             kv_tok = lax.all_gather(kv_src, pcp_axis, axis=2, tiled=False)
@@ -913,11 +935,6 @@ def pcp_ragged_paged_attention(
                                     *kv_src.shape[2:])
             pi_src = jnp.tile(jnp.arange(n_pages_tok, dtype=pi.dtype),
                               max_seqs)
-            common_kv = {
-                k: v
-                for k, v in common.items()
-                if k not in ("cp_rank", "cp_group_size")
-            }
             o1, _, l1 = rpa_v3_cp.ragged_paged_attention(
                 q_l,
                 k_l,
@@ -933,7 +950,49 @@ def pcp_ragged_paged_attention(
                 skip_current_attn=True,
                 use_causal_mask=False,
                 update_kv_cache=False,
-                **common_kv)
+                **common)
+            kvc1 = kvc  # cache unchanged in this phase; current phase writes it
+        elif _cache_phase == "ring_kv":
+            # Ring: nobody materialises the whole cache.  Each rank keeps only
+            # its own shard and rotates it one hop per round, so over `pcp`
+            # rounds the local Q meets every rank's shard exactly once and the
+            # partials LSE-merge into the same answer gather-KV computes.
+            # Bytes on the wire match gather-KV ((pcp-1) shards per rank), but
+            # only two shards are ever live.
+            kv_shard = jnp.take(kvc, pi[:n_gather], axis=0)
+            pi_ring = jnp.tile(jnp.arange(n_gather, dtype=pi.dtype), max_seqs)
+            # Rank i hands its shard to rank i+1, so the shard rank r holds at
+            # round t started on rank (r - t) % pcp -- which is exactly the
+            # `cp_rank` the kernel needs to place those tokens globally.
+            rot = [(i, (i + 1) % pcp_size) for i in range(pcp_size)]
+            o1 = l1 = None
+            for t in range(pcp_size):
+                # Issue the rotation before attending so the collective
+                # overlaps this round's kernel.
+                kv_next = (lax.ppermute(kv_shard, pcp_axis, perm=rot)
+                           if t < pcp_size - 1 else None)
+                src_rank = lax.rem(r + pcp_size - t, pcp_size)
+                o_t, _, l_t = rpa_v3_cp.ragged_paged_attention(
+                    q_l,
+                    k_l,
+                    v_l,
+                    kv_shard,
+                    kvl,
+                    pi_ring,
+                    cu_kv,
+                    dist_cache,
+                    kv_cache_lens=kvcl,
+                    cp_rank=_rank_i32(src_rank),
+                    cp_group_size=pcp_size,
+                    skip_current_attn=True,
+                    use_causal_mask=False,
+                    update_kv_cache=False,
+                    **common)
+                # Disjoint KV per round, so the merge is exact and
+                # order-independent.
+                o1, l1 = ((o_t, l_t) if o1 is None else merge_attn_states(
+                    o1, l1, o_t, l_t))
+                kv_shard = kv_next
             kvc1 = kvc  # cache unchanged in this phase; current phase writes it
         else:
             ag_q = ag(q_l)  # [pcp*2*chunk]
@@ -950,7 +1009,8 @@ def pcp_ragged_paged_attention(
                 skip_current_attn=True,
                 use_causal_mask=False,
                 update_kv_cache=False,
-                **common)
+                **common,
+                **cp_local)
             o1, l1 = _lse_reduce_scatter(o1, l1, pcp_axis, pcp_size)
 
         # ---- current phase -----
@@ -980,7 +1040,8 @@ def pcp_ragged_paged_attention(
             use_causal_mask=use_causal_mask,
             update_kv_cache=update_kv_cache,
             write_last_seq_only=True,
-            **common)
+            **common,
+            **cp_local)
 
         # cache term vs. current term: disjoint KV, so LSE-combine.  With no
         # cached tokens the current phase already is the answer.

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -13,9 +13,11 @@
 # limitations under the License.
 
 import functools
+import math
 from dataclasses import dataclass
 
 import jax
+from vllm.utils.math_utils import cdiv
 
 
 @functools.partial(
@@ -30,7 +32,7 @@ import jax
         "pcp_q_pos_offsets",
         "pcp_kv_cache_lens",
     ],
-    meta_fields=["padded_num_reqs"],
+    meta_fields=["padded_num_reqs", "pcp_cache_pages"],
 )
 @dataclass
 class AttentionMetadata(object):
@@ -69,6 +71,9 @@ class AttentionMetadata(object):
     # Env var ATTN_CUSTOM_NUM_REQS_BUCKETS can manually override the buckets.
     padded_num_reqs: int = -1
 
+    # PCP gather-KV only. Number of kv pages occupied by the current request.
+    pcp_cache_pages: int | None = None
+
 
 @functools.partial(
     jax.tree_util.register_dataclass,
@@ -106,3 +111,32 @@ class SharedAttentionMetadata(object):
     # power of 2 between min and max requests.
     # Env var ATTN_CUSTOM_NUM_REQS_BUCKETS can manually override the buckets.
     padded_num_reqs: int = -1
+
+
+PCP_CACHE_PAGE_BUCKET_COUNT = 5
+
+
+def pcp_cache_page_buckets(max_num_blocks_per_req: int) -> list[int]:
+    """The buckets for the `pcp_cache_pages` value, including 0.
+    """
+    buckets = {0, max_num_blocks_per_req}
+    n = PCP_CACHE_PAGE_BUCKET_COUNT - len(buckets)
+    if n > 0 and max_num_blocks_per_req > 1:
+        step = math.log(max_num_blocks_per_req) / (n + 1)
+        for i in range(1, n + 1):
+            v = 1 << max(0, round(math.exp(step * i)).bit_length() - 1)
+            buckets.add(min(max(v, 1), max_num_blocks_per_req))
+    return sorted(buckets)
+
+
+def round_up_pcp_cache_pages(num_computed_tokens: int, block_size: int,
+                             max_num_blocks_per_req: int) -> int:
+    """Round a request's number of kv pages up to the nearest bucket.
+    """
+    if num_computed_tokens <= 0:
+        return 0
+    live_pages = cdiv(num_computed_tokens, block_size)
+    for b in pcp_cache_page_buckets(max_num_blocks_per_req):
+        if b >= live_pages:
+            return b
+    return max_num_blocks_per_req

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -28,7 +28,7 @@ import tpu_inference.envs as envs
 from tpu_inference.core.disagg_utils import is_disagg_enabled
 from tpu_inference.core.sched.utils import DEFAULT_MAX_DECODE_STEPS
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, SharedAttentionMetadata)
+    AttentionMetadata, SharedAttentionMetadata, pcp_cache_page_buckets)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling import (
     compute_and_gather_logprobs, compute_and_gather_prompt_logprobs, sample)
@@ -360,16 +360,24 @@ class CompilationManager:
                 num_tokens=num_tokens,
             )
 
-    def _precompile_backbone_helper(self,
-                                    name,
-                                    *,
-                                    input_ids,
-                                    positions,
-                                    inputs_embeds,
-                                    intermediate_tensors=None,
-                                    is_first_rank=True,
-                                    is_last_rank=True,
-                                    num_reqs: int) -> None:
+    def _pcp_cache_page_buckets(self) -> list[int]:
+        pcp_size = self.runner.vllm_config.sharding_config.prefill_cp_size
+        if pcp_size <= 1:
+            return [None]
+        return pcp_cache_page_buckets(self.runner.max_num_blocks_per_req)
+
+    def _precompile_backbone_helper(
+            self,
+            name,
+            *,
+            input_ids,
+            positions,
+            inputs_embeds,
+            intermediate_tensors=None,
+            is_first_rank=True,
+            is_last_rank=True,
+            num_reqs: int,
+            pcp_cache_pages: int | None = None) -> None:
         num_tokens = None
         if input_ids is not None:
             num_tokens = input_ids.shape[0]
@@ -449,6 +457,7 @@ class CompilationManager:
                 padded_num_reqs=num_reqs,
                 pcp_kv_cache_lens=pcp_kv_cache_lens,
                 pcp_q_pos_offsets=pcp_q_pos_offsets,
+                pcp_cache_pages=pcp_cache_pages,
             )
 
             return attention_metadata_gid
@@ -693,15 +702,17 @@ class CompilationManager:
                             "hidden_states": hidden_states,
                             "residual": residual
                         })
-                self._precompile_backbone_helper(
-                    f"worker{self.runner.rank} backbone",
-                    input_ids=input_ids,
-                    positions=positions,
-                    inputs_embeds=None,
-                    intermediate_tensors=intermediate_tensors,
-                    is_first_rank=is_first_rank,
-                    is_last_rank=is_last_rank,
-                    num_reqs=num_reqs)
+                for _cache_pages in self._pcp_cache_page_buckets():
+                    self._precompile_backbone_helper(
+                        f"worker{self.runner.rank} backbone",
+                        input_ids=input_ids,
+                        positions=positions,
+                        inputs_embeds=None,
+                        intermediate_tensors=intermediate_tensors,
+                        is_first_rank=is_first_rank,
+                        is_last_rank=is_last_rank,
+                        num_reqs=num_reqs,
+                        pcp_cache_pages=_cache_pages)
 
     def _precompile_backbone_with_inputs_embeds(self) -> None:
         hidden_size = self.runner.model_config.get_hidden_size()

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -53,7 +53,7 @@ import tpu_inference.envs as envs
 from tpu_inference import utils as common_utils
 from tpu_inference.core.sched.utils import DEFAULT_MAX_DECODE_STEPS
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, SharedAttentionMetadata)
+    AttentionMetadata, SharedAttentionMetadata, round_up_pcp_cache_pages)
 from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
                                                   MESH_AXIS_NAMES_2D,
                                                   ShardingAxisName,
@@ -2832,6 +2832,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # Prefill context parallelism (single request, prefill only): head-tail
         # arrange this request's current tokens into rank order
         pcp_kv_cache_lens = None
+        pcp_cache_pages = None
         pcp_query_start_loc = None
         pcp_q_pos_offsets = None
         pcp_size = self.vllm_config.sharding_config.prefill_cp_size
@@ -2896,6 +2897,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 self.mesh, PartitionSpec(ShardingAxisName.PREFILL_CONTEXT,
                                          None))
             repl = NamedSharding(self.mesh, PartitionSpec())
+            pcp_cache_pages = round_up_pcp_cache_pages(
+                num_computed, self.block_size, self.max_num_blocks_per_req)
             pcp_kv_cache_lens = device_array(self.mesh,
                                              kv_cache_lens_np,
                                              sharding=repl)
@@ -3045,6 +3048,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 padded_num_reqs=attn_padded_num_reqs,
                 pcp_kv_cache_lens=pcp_kv_cache_lens,
                 pcp_q_pos_offsets=pcp_q_pos_offsets,
+                pcp_cache_pages=pcp_cache_pages,
             )
 
             return attention_metadata_gid


### PR DESCRIPTION
Stacked on `wxd-pcp-gatherkv` (#gather-KV cache phase). Only the last commit is new.

## What

The gather-KV cache phase all-gathers the striped KV cache so every rank holds the whole thing, then attends the local Q against it. That materialises `pcp` shards per rank, which is the dominant HBM cost at long context with large chunked-prefill buckets.

Ring-KV keeps only the local shard and rotates it one hop around the pcp ring per round, attending the local Q against whatever shard is in hand and LSE-merging the `pcp` partials. Over `pcp` rounds every rank's Q meets every shard exactly once, so it computes the same thing gather-KV does.

| | bytes per rank | peak extra memory | launches |
|---|---|---|---|
| gather-KV | `(pcp-1) x shard` | `pcp x shard` | 1 |
| ring-KV | `(pcp-1) x shard` | `2 x shard` | `pcp` |

**Ring is a memory play, not a bandwidth play.**

## How

No kernel changes. The rotation is a `lax.ppermute` in the wrapper, and the shard in hand at round `t` started on rank `(r - t) % pcp` — exactly the `cp_rank` the kernel already takes to interpret an interleave-1 striped cache. The cache layout is untouched, so a ring-mode server reads and writes caches written by either of the other two paths.

This deliberately avoids the in-kernel-DMA design (forking `kernel.py`, `lax.axis_index` under Mosaic/MPMD): the wrapper-level ring gets the memory win with none of that risk.

## Selection

`cache_phase="ring_kv"`, or the new `PCP_CACHE_PHASE` env var, opts in. Auto-dispatch is unchanged and **never** picks ring-KV — same bandwidth as gather-KV, only pays off under memory pressure, so it stays a per-deployment choice.

## Testing

`tests/layers/common/test_pcp_attention_interface.py` — 27 passed on v7x-8, `pcp=2` and `pcp=4`:

- ring vs the full-causal reference (chunked prefill; partly-padded tail);
- ring vs gather-KV on both the output and the written cache — they agree to ~1e-4 (accumulation-order noise) where the reference comparisons need 2e-2, and a shard-to-`cp_rank` mix-up would be O(1);
- the non-contiguous block table / over-allocated cache case under ring;
- `PCP_CACHE_PHASE` end-to-end, including that a typo raises;
- gather-Q gained equivalence coverage it previously lacked in this file.

Lowering check: ring replaces the cache-phase all-gather with a collective-permute (remaining all-gathers are the unchanged current phase).

## Not done

No memory/latency benchmark at 4k / 64k / 262k yet — the motivating profile and the measured memory win are still open, and are what should decide whether ring ever becomes more than opt-in.