### PR TITLE
[releases/v0.26.0] Cherry-pick #3267: DSv4 KV cache creation for vLLM packed byte-offset overlay groups

### DIFF
--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -28,7 +28,9 @@ from vllm.v1.attention.backend import AttentionType
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheGroupSpec, KVCacheTensor,
                                         MambaSpec, MLAAttentionSpec,
-                                        SlidingWindowSpec)
+                                        SlidingWindowMLASpec,
+                                        SlidingWindowSpec,
+                                        UniformTypeKVCacheSpecs)
 from vllm.v1.request import Request
 
 from tpu_inference import utils as common_utils
@@ -1447,3 +1449,226 @@ class TestKVCacheManager:
                 assert cache.shape[0] == num_blocks, (
                     f"layer {name} attn cache has {cache.shape[0]} blocks "
                     f"but vLLM pool has {num_blocks}")
+
+    # --- DeepseekV4 packed KV cache (vLLM #48993 byte-offset overlay groups)
+
+    def _ds_v4_groups(self):
+        """DSv4-Flash-style cache groups: 2 CSA layers (0-1), each with a
+        main latent, an indexer k_cache and two compressor state caches,
+        plus 3 SWA-only layers (2-4); every layer has a swa_cache. Specs
+        mirror what the TPU DSv4 classes register (block_size 256,
+        fp8-packed-uint8 latents, f32 compressor state)."""
+        main_spec = MLAAttentionSpec(block_size=256,
+                                     num_kv_heads=1,
+                                     head_size=640,
+                                     dtype=torch.uint8,
+                                     compress_ratio=4)
+        idx_spec = MLAAttentionSpec(block_size=256,
+                                    num_kv_heads=1,
+                                    head_size=256,
+                                    dtype=torch.uint8,
+                                    compress_ratio=4)
+        swa_spec = SlidingWindowMLASpec(block_size=64,
+                                        num_kv_heads=1,
+                                        head_size=640,
+                                        dtype=torch.uint8,
+                                        sliding_window=4096)
+        main_state_spec = SlidingWindowMLASpec(block_size=4,
+                                               num_kv_heads=1,
+                                               head_size=2048,
+                                               dtype=torch.float32,
+                                               sliding_window=8)
+        idx_state_spec = SlidingWindowMLASpec(block_size=4,
+                                              num_kv_heads=1,
+                                              head_size=512,
+                                              dtype=torch.float32,
+                                              sliding_window=8)
+
+        mla_specs, state_specs = {}, {}
+        for i in range(2):
+            mla_specs[f"model.layers.{i}.attn"] = main_spec
+            mla_specs[f"model.layers.{i}.attn.indexer.k_cache"] = idx_spec
+            state_specs[
+                f"model.layers.{i}.attn.compressor.state_cache"] = main_state_spec
+            state_specs[f"model.layers.{i}.attn.indexer.compressor."
+                        "state_cache"] = idx_state_spec
+        swa_names = [f"model.layers.{i}.attn.swa_cache" for i in range(5)]
+        # vLLM splits the swa layers into two cache groups (layers[i::2]),
+        # like DSv4-Flash's 43 swa layers over 21 CSA layers.
+        swa_specs_0 = {name: swa_spec for name in swa_names[0::2]}
+        swa_specs_1 = {name: swa_spec for name in swa_names[1::2]}
+
+        groups = []
+        for block_size, specs in ((256, mla_specs), (4, state_specs),
+                                  (64, swa_specs_0), (64, swa_specs_1)):
+            groups.append(
+                KVCacheGroupSpec(layer_names=list(specs),
+                                 kv_cache_spec=UniformTypeKVCacheSpecs(
+                                     block_size=block_size,
+                                     kv_cache_specs=specs)))
+        return groups
+
+    @staticmethod
+    def _ds_v4_page_bytes(groups):
+        return {
+            name: group.kv_cache_spec.kv_cache_specs[name].page_size_bytes
+            for group in groups
+            for name in group.layer_names
+        }
+
+    def _ds_v4_packed_tensors(self, groups, num_blocks):
+        """Mirror vLLM's `_get_packed_kv_cache_layout` (#48993): lay each
+        cache group out densely in one shared block slab and emit one
+        KVCacheTensor per distinct byte offset, shared by all layers (from
+        different groups) at that offset."""
+        page_bytes = self._ds_v4_page_bytes(groups)
+        layers_by_offset = {}
+        block_stride = 0
+        for group in groups:
+            offset = 0
+            for name in group.layer_names:
+                layers_by_offset.setdefault(offset, []).append(name)
+                offset += page_bytes[name]
+            block_stride = max(block_stride, offset)
+        return [
+            KVCacheTensor(size=block_stride * num_blocks,
+                          shared_by=layers_by_offset[offset],
+                          offset=offset,
+                          block_stride=block_stride)
+            for offset in sorted(layers_by_offset)
+        ]
+
+    def _init_ds_v4(self, kv_cache_config):
+        self.runner.kv_cache_manager.use_mla = True
+        with patch('tpu_inference.runner.kv_cache_manager.is_ds_v4',
+                   return_value=True):
+            self.runner.initialize_kv_cache(kv_cache_config)
+
+    def _assert_ds_v4_overlays(self, num_blocks):
+        idx_map = self.runner.layer_name_to_kvcache_index
+        caches = self.runner.kv_caches
+
+        # 4 MLA arrays + 1 standalone for the 3rd layer of the 3-layer swa
+        # group (only 2 CSA latent arrays can host it).
+        assert len(caches) == 5
+        for cache in caches:
+            assert cache.shape[0] == num_blocks
+
+        # Every MLA layer owns its own array with its own spec's geometry.
+        assert idx_map['model.layers.0.attn'] == 0
+        assert idx_map['model.layers.0.attn.indexer.k_cache'] == 1
+        assert idx_map['model.layers.1.attn'] == 2
+        assert idx_map['model.layers.1.attn.indexer.k_cache'] == 3
+        assert caches[0].shape == (num_blocks, 16, 4, 640)
+        assert caches[1].shape == (num_blocks, 16, 4, 256)
+
+        # Compressor state caches share their compressed-KV layer's array
+        # (the compressor kernel writes state + compressed KV through one
+        # buffer and asserts index equality at runtime).
+        for i in range(2):
+            assert (idx_map[f'model.layers.{i}.attn.compressor.state_cache'] ==
+                    idx_map[f'model.layers.{i}.attn'])
+            assert (idx_map[f'model.layers.{i}.attn.indexer.compressor.'
+                            'state_cache'] ==
+                    idx_map[f'model.layers.{i}.attn.indexer.k_cache'])
+
+        # swa_caches overlay latent arrays: distinct arrays within one cache
+        # group (shared block table), and only arrays wide enough for the
+        # 640B SWA entries (never the 256B-wide indexer arrays).
+        swa_groups = [[f'model.layers.{i}.attn.swa_cache' for i in (0, 2, 4)],
+                      [f'model.layers.{i}.attn.swa_cache' for i in (1, 3)]]
+        for group_layers in swa_groups:
+            indices = [idx_map[name] for name in group_layers]
+            assert len(set(indices)) == len(indices)
+            for index in indices:
+                assert caches[index].shape[-1] == 640
+        # The overflow swa layer got the standalone array.
+        assert idx_map['model.layers.4.attn.swa_cache'] == 4
+        assert caches[4].shape == (num_blocks, 16, 4, 640)
+
+    def test_initialize_kv_cache_ds_v4_packed_overlay(self):
+        # New (post-#48993) packed layout: shared_by groups layers from
+        # different cache groups at the same byte offset.
+        num_blocks = 32
+        groups = self._ds_v4_groups()
+        tensors = self._ds_v4_packed_tensors(groups, num_blocks)
+
+        # The layout must produce the mixed offset group shape that crashed
+        # the old slot-based logic (indexer k_cache + swa_cache +
+        # compressor state_cache in one shared_by).
+        mixed = [
+            tensor for tensor in tensors
+            if any('indexer.k_cache' in name
+                   for name in tensor.shared_by) and any(
+                       'swa_cache' in name
+                       for name in tensor.shared_by) and any(
+                           'state_cache' in name for name in tensor.shared_by)
+        ]
+        assert mixed, "test setup should produce a mixed offset group"
+
+        kv_cache_config = KVCacheConfig(num_blocks=num_blocks,
+                                        kv_cache_tensors=tensors,
+                                        kv_cache_groups=groups)
+        self._init_ds_v4(kv_cache_config)
+        self._assert_ds_v4_overlays(num_blocks)
+
+    def test_initialize_kv_cache_ds_v4_legacy_slot_grouping(self):
+        # Pre-#48993 slot-based grouping (one page-size slot per tensor,
+        # main latents grouped with swa caches, indexer caches alone) must
+        # produce the same overlay plan.
+        num_blocks = 32
+        groups = self._ds_v4_groups()
+        page_bytes = self._ds_v4_page_bytes(groups)
+
+        buckets = {}
+        for group in groups:
+            slot_count = {}
+            for name in group.layer_names:
+                page_size = page_bytes[name]
+                slot = slot_count.get(page_size, 0)
+                slot_count[page_size] = slot + 1
+                bucket = buckets.setdefault(page_size, [])
+                if slot == len(bucket):
+                    bucket.append([])
+                bucket[slot].append(name)
+        block_stride = sum(page_size * len(slots)
+                           for page_size, slots in buckets.items())
+        tensors = [
+            KVCacheTensor(size=block_stride * num_blocks,
+                          shared_by=slot,
+                          block_stride=block_stride)
+            for slots in buckets.values() for slot in slots
+        ]
+
+        kv_cache_config = KVCacheConfig(num_blocks=num_blocks,
+                                        kv_cache_tensors=tensors,
+                                        kv_cache_groups=groups)
+        self._init_ds_v4(kv_cache_config)
+        self._assert_ds_v4_overlays(num_blocks)
+
+    def test_initialize_kv_cache_ds_v4_missing_k_cache_raises(self):
+        # A compressor state cache without its compressed-KV layer must fail
+        # with a self-contained error, not a bare assert.
+        num_blocks = 32
+        groups = self._ds_v4_groups()
+        kept_groups = []
+        for group in groups:
+            specs = {
+                name: spec
+                for name, spec in group.kv_cache_spec.kv_cache_specs.items()
+                if 'indexer.k_cache' not in name
+            }
+            if not specs:
+                continue
+            kept_groups.append(
+                KVCacheGroupSpec(layer_names=list(specs),
+                                 kv_cache_spec=UniformTypeKVCacheSpecs(
+                                     block_size=group.kv_cache_spec.block_size,
+                                     kv_cache_specs=specs)))
+        tensors = self._ds_v4_packed_tensors(kept_groups, num_blocks)
+        kv_cache_config = KVCacheConfig(num_blocks=num_blocks,
+                                        kv_cache_tensors=tensors,
+                                        kv_cache_groups=kept_groups)
+
+        with pytest.raises(ValueError, match=r"\[kv-cache\].*state_cache"):
+            self._init_ds_v4(kv_cache_config)

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -754,6 +754,20 @@ class KVCacheManager:
             "mamba": KVCacheMetadata(),
             "regular_attn": KVCacheMetadata()
         }
+
+        if is_ds_v4(self.runner.vllm_config):
+            # DSv4's packed KV cache layout needs its own array/index plan;
+            # see `_initialize_ds_v4_kv_cache` for the invariants.
+            self._initialize_ds_v4_kv_cache(kv_cache_config,
+                                            layer_name_to_spec, kv_caches,
+                                            num_blocks_list, metadata)
+            self._log_kv_cache_init(kv_cache_config,
+                                    kv_caches,
+                                    num_blocks_list,
+                                    metadata,
+                                    duplicate_shared_layers=False)
+            return
+
         # If this is true, then we'll initialize a new KV cache for each layer in "shared_by"
         # instead of the default behavior of initializing a single KV cache for each of the
         # shared layers
@@ -904,49 +918,6 @@ class KVCacheManager:
                         # NOTE: we'll multiply the num_kv_heads by 2 in the function
                         block_size = layer_spec.storage_block_size
 
-                        if is_ds_v4(self.runner.vllm_config):
-                            os.environ["MLA_TRANSPOSE_KV_CACHE"] = "False"
-                            # DSV4 FP8 format is packed as unit8
-                            os.environ["MLA_KV_PACKING_SIZE"] = "4"
-
-                            contains_indexer_cache = any(
-                                "indexer" in layer
-                                for layer in kv_cache_tensor.shared_by)
-                            if contains_indexer_cache:
-                                # Indexer's compressor state cache kv cache must be overlay on
-                                # Indexer's compressed kv cache.
-                                # Main attn's compressor state cache kv cache and sliding window
-                                # cache must overlay on main attn's compressed kv cache.
-                                assert all(
-                                    "indexer" in layer
-                                    for layer in kv_cache_tensor.shared_by
-                                ), " kv_cache_tensor.shared_by: " + str(
-                                    kv_cache_tensor.shared_by)
-
-                            mla_spec = None
-                            for layer in kv_cache_tensor.shared_by:
-                                if isinstance(layer_name_to_spec[layer],
-                                              MLAAttentionSpec):
-                                    mla_spec = layer_name_to_spec[layer]
-                                    break
-                            # In DSV4, compressor-state-cache and sliding-window-cache
-                            # overlay on the same tensor as the main kv cache.
-                            # The created kv cache will based on the shape of the
-                            # main kv cache's spec.
-                            if mla_spec is not None:
-                                layer_spec = mla_spec
-                                block_size = layer_spec.storage_block_size
-                            if mla_spec is None:
-                                # Edge case handling: for DSV4 Flash,
-                                # There are 21 CSA layers, 43 SWA caches,
-                                # since 43 % 21 !=0, there is one SWA cache
-                                # not sharing a KV tensor with other caches.
-                                assert "swa_cache" in kv_cache_tensor.shared_by[
-                                    0]
-                                assert len(kv_cache_tensor.shared_by) == 1
-                                block_size = (kv_caches[-1].shape[1] *
-                                              kv_caches[-1].shape[2])
-
                         kv_cache = create_kv_caches(
                             num_blocks=num_blocks,
                             block_size=block_size,
@@ -982,6 +953,14 @@ class KVCacheManager:
                     layer_name] = self.runner.layer_name_to_kvcache_index[
                         target_layer_name]
 
+        self._log_kv_cache_init(kv_cache_config, kv_caches, num_blocks_list,
+                                metadata, duplicate_shared_layers)
+
+    def _log_kv_cache_init(self, kv_cache_config: KVCacheConfig,
+                           kv_caches: List[jax.Array],
+                           num_blocks_list: List[int],
+                           metadata: dict[str, KVCacheMetadata],
+                           duplicate_shared_layers: bool) -> None:
         logger.info(
             "Hybrid KV cache layout: num_kv_cache_groups=%d, "
             "num_kv_cache_tensors=%d, kv_cache_config.num_blocks=%d, "
@@ -1011,6 +990,239 @@ class KVCacheManager:
             f"hbm={utils.hbm_usage_gb(self.runner.mesh.devices.flatten())}Gb")
 
         logger.info(" | ".join(log_parts))
+
+    _DS_V4_STATE_CACHE_SUFFIX = ".compressor.state_cache"
+
+    @staticmethod
+    def _ds_v4_compressed_kv_layer_name(state_cache_name: str) -> str:
+        """The layer whose compressed-KV buffer a DSv4 state cache overlays.
+
+        Mirrors how vLLM wires ``DeepseekCompressor.k_cache_prefix`` (the
+        attention layer itself for the main compressor, the indexer's
+        ``k_cache`` for the indexer compressor):
+
+          ``<...>.attn.compressor.state_cache``          -> ``<...>.attn``
+          ``<...>.attn.indexer.compressor.state_cache``  ->
+              ``<...>.attn.indexer.k_cache``
+        """
+        base = state_cache_name[:-len(KVCacheManager._DS_V4_STATE_CACHE_SUFFIX
+                                      )]
+        if base.endswith(".indexer"):
+            return base + ".k_cache"
+        return base
+
+    def _initialize_ds_v4_kv_cache(
+            self, kv_cache_config: KVCacheConfig,
+            layer_name_to_spec: dict[str, KVCacheSpec],
+            kv_caches: List[jax.Array], num_blocks_list: List[int],
+            metadata: dict[str, KVCacheMetadata]) -> None:
+        """Create the JAX KV cache arrays for DeepseekV4.
+
+        Since vLLM #48993 (``_get_packed_kv_cache_layout``), DSv4's cache
+        groups are laid out densely in one shared block slab: every
+        ``KVCacheTensor`` spans the whole slab (``size == block_stride *
+        num_blocks``) and its ``shared_by`` lists the layers -- from
+        *different* cache groups -- that start at the same byte ``offset``.
+        A block ID is owned by one cache group at a time, so same-offset
+        layers may alias memory, and mixed groups (e.g. an indexer k_cache
+        with swa_caches and compressor state_caches) are normal. The
+        pre-#48993 layout instead grouped one page-size slot per tensor
+        (a main latent with its own overlay caches; indexer caches only with
+        indexer caches).
+
+        JAX arrays cannot be byte views into one slab, so the TPU port
+        ignores vLLM's byte offsets and rebuilds the overlay plan from the
+        specs, which also makes it independent of either vLLM grouping:
+
+        - Every ``MLAAttentionSpec`` layer (CSA main latent ``*.attn`` and
+          indexer ``*.attn.indexer.k_cache``) gets its own array shaped by
+          its own spec, so the MLA/indexer kernels see exactly the page
+          geometry the spec promised.
+        - Every compressor state cache maps to the array of its
+          compressed-KV layer: the compressor kernel writes the f32 state
+          rows and the compressed KV through one buffer, and
+          ``VllmDeepseekCompressor.forward`` asserts both layer names
+          resolve to the same array index. State and full-attention groups
+          never own the same block ID, so the rows never collide.
+        - Every ``swa_cache`` maps to a distinct CSA main-latent array
+          (their entry layouts match by construction); distinct because
+          layers of one cache group share a block table. SWA groups with
+          more layers than there are latent arrays (DSv4-Flash: 43 SWA vs
+          21 CSA layers) get standalone arrays for the overflow.
+        """
+        os.environ["MLA_TRANSPOSE_KV_CACHE"] = "False"
+        # DSV4 FP8 format is packed as uint8
+        os.environ["MLA_KV_PACKING_SIZE"] = "4"
+
+        # All packed tensors describe the same slab, so they must agree on
+        # the block count.
+        num_blocks_candidates = set()
+        for tensor in kv_cache_config.kv_cache_tensors:
+            if tensor.block_stride:
+                if tensor.size % tensor.block_stride:
+                    raise ValueError(
+                        "[kv-cache] DSv4 KVCacheTensor size is not a multiple "
+                        f"of block_stride: size={tensor.size}, "
+                        f"block_stride={tensor.block_stride}, "
+                        f"offset={tensor.offset}, "
+                        f"shared_by={tensor.shared_by}")
+                num_blocks_candidates.add(tensor.size // tensor.block_stride)
+            else:
+                # Legacy layout without a packed slab: the tensor is sized
+                # for its own layers' page size.
+                page_size = layer_name_to_spec[
+                    tensor.shared_by[0]].page_size_bytes
+                num_blocks_candidates.add(tensor.size // page_size)
+        if len(num_blocks_candidates) != 1:
+            raise ValueError(
+                "[kv-cache] DSv4 KVCacheTensors disagree on num_blocks: "
+                f"{sorted(num_blocks_candidates)}; expected one shared block "
+                "count across the packed slab. tensors="
+                f"{kv_cache_config.kv_cache_tensors}")
+        num_blocks = num_blocks_candidates.pop()
+
+        # Default KV cache is sharded over (BATCH=(dp, attn_dp)); num_blocks
+        # must be a multiple of the sharding divisor.
+        divisor = common_utils.get_mesh_shape_product(self.runner.mesh,
+                                                      ShardingAxisName.BATCH)
+        num_blocks = (num_blocks // divisor) * divisor
+        if self.runner.cache_config.num_gpu_blocks_override is not None:
+            num_blocks = min(num_blocks,
+                             self.runner.cache_config.num_gpu_blocks_override)
+
+        def _page_bytes(cache: jax.Array) -> int:
+            page_elems = 1
+            for dim in cache.shape[1:]:
+                page_elems *= dim
+            return page_elems * cache.dtype.itemsize
+
+        def _create_cache(spec: KVCacheSpec, tag: str) -> jax.Array:
+            cache = create_kv_caches(
+                num_blocks=num_blocks,
+                block_size=spec.storage_block_size,
+                num_kv_heads=spec.num_kv_heads,
+                head_size=spec.head_size,
+                mesh=self.runner.mesh,
+                layer_names=[tag],
+                cache_dtype=t2j_dtype(spec.dtype),
+                use_mla=self.use_mla,
+            )[0]
+            kv_caches.append(cache)
+            num_blocks_list.append(num_blocks)
+            metadata["regular_attn"].count += 1
+            if metadata["regular_attn"].shape is None:
+                metadata["regular_attn"].shape = cache.shape
+                metadata["regular_attn"].dtype = cache.dtype
+                metadata["regular_attn"].sharding = cache.sharding
+            return cache
+
+        # Classify every layer by the consumer that reads it. Iteration is in
+        # group order so array creation and overlay assignment are
+        # deterministic.
+        mla_layer_names: list[str] = []
+        swa_layer_groups: list[list[str]] = []
+        state_layer_names: list[str] = []
+        for group in kv_cache_config.kv_cache_groups:
+            swa_layers_in_group: list[str] = []
+            for layer_name in group.layer_names:
+                spec = layer_name_to_spec[layer_name]
+                if isinstance(spec, MLAAttentionSpec):
+                    mla_layer_names.append(layer_name)
+                elif layer_name.endswith(self._DS_V4_STATE_CACHE_SUFFIX):
+                    state_layer_names.append(layer_name)
+                elif "swa_cache" in layer_name:
+                    swa_layers_in_group.append(layer_name)
+                else:
+                    raise ValueError(
+                        "[kv-cache] DSv4 layer has no known role (expected an "
+                        "MLAAttentionSpec cache, a `*.compressor.state_cache` "
+                        f"or a `*swa_cache*` layer): layer={layer_name}, "
+                        f"spec={spec}")
+            if swa_layers_in_group:
+                swa_layer_groups.append(swa_layers_in_group)
+        if not mla_layer_names:
+            raise ValueError(
+                "[kv-cache] DSv4 model has no MLAAttentionSpec layers to "
+                "anchor the KV cache overlays. groups="
+                f"{[group.layer_names for group in kv_cache_config.kv_cache_groups]}"
+            )
+
+        layer_to_index: dict[str, int] = {}
+        for layer_name in mla_layer_names:
+            _create_cache(layer_name_to_spec[layer_name], layer_name)
+            layer_to_index[layer_name] = len(kv_caches) - 1
+
+        # Overlay swa_caches onto compatible latent arrays: same dtype, entry
+        # width (last dim) covering the SWA entry, and enough entries per
+        # physical page for the SWA logical page. This selects the CSA main
+        # latent arrays and rejects the narrower indexer k_cache arrays.
+        for group_swa_layers in swa_layer_groups:
+            swa_spec = layer_name_to_spec[group_swa_layers[0]]
+            swa_dtype = t2j_dtype(swa_spec.dtype)
+            swa_entry_bytes = (swa_spec.num_kv_heads * swa_spec.head_size *
+                               jnp.dtype(swa_dtype).itemsize)
+            hosts = []
+            for mla_layer_name in mla_layer_names:
+                cache = kv_caches[layer_to_index[mla_layer_name]]
+                entry_width_bytes = cache.shape[-1] * cache.dtype.itemsize
+                physical_page_entries = cache.shape[1] * cache.shape[2]
+                if (cache.dtype == jnp.dtype(swa_dtype)
+                        and entry_width_bytes >= swa_entry_bytes and
+                        physical_page_entries >= swa_spec.storage_block_size):
+                    hosts.append(layer_to_index[mla_layer_name])
+            for position, layer_name in enumerate(group_swa_layers):
+                if position < len(hosts):
+                    layer_to_index[layer_name] = hosts[position]
+                else:
+                    _create_cache(layer_name_to_spec[layer_name], layer_name)
+                    layer_to_index[layer_name] = len(kv_caches) - 1
+
+        # Compressor state caches overlay the compressed-KV array of their
+        # own (sub)layer.
+        for layer_name in state_layer_names:
+            spec = layer_name_to_spec[layer_name]
+            kv_layer_name = self._ds_v4_compressed_kv_layer_name(layer_name)
+            if kv_layer_name not in layer_to_index:
+                raise ValueError(
+                    "[kv-cache] DSv4 compressor state cache has no "
+                    "compressed-KV layer to overlay (the compressor kernel "
+                    "writes the f32 state and the compressed KV through one "
+                    f"buffer): state_cache={layer_name}, expected KV layer "
+                    f"{kv_layer_name}, known MLA layers={mla_layer_names}")
+            host_index = layer_to_index[kv_layer_name]
+            host_cache = kv_caches[host_index]
+            # The kernel byte-packs `block_size` state rows of `head_size`
+            # values into each page of the host array (see
+            # `pack_state_cache`); validate the fit here so a layout
+            # regression fails at startup with context instead of inside the
+            # kernel.
+            state_page_bytes = (spec.block_size * spec.num_kv_heads *
+                                spec.head_size *
+                                jnp.dtype(t2j_dtype(spec.dtype)).itemsize)
+            host_page_entries = host_cache.shape[1] * host_cache.shape[2]
+            if (state_page_bytes > _page_bytes(host_cache)
+                    or host_page_entries % spec.block_size != 0):
+                raise ValueError(
+                    "[kv-cache] DSv4 compressor state cache does not fit its "
+                    f"compressed-KV array: state_cache={layer_name} needs "
+                    f"{state_page_bytes}B per page ({spec.block_size} state "
+                    f"rows x {spec.num_kv_heads}x{spec.head_size} "
+                    f"{spec.dtype}), but KV layer {kv_layer_name} array has "
+                    f"shape {host_cache.shape} ({_page_bytes(host_cache)}B "
+                    f"and {host_page_entries} entries per page; entries must "
+                    f"also divide evenly by the {spec.block_size}-row state "
+                    "page).")
+            layer_to_index[layer_name] = host_index
+
+        for layer_name, index in layer_to_index.items():
+            self.runner.layer_name_to_kvcache_index[layer_name] = index
+
+        logger.info(
+            "[kv-cache] DSv4 KV cache: %d arrays for %d layers (mla=%d, "
+            "swa=%d, state=%d), num_blocks=%d", len(kv_caches),
+            len(layer_to_index), len(mla_layer_names),
+            sum(len(group) for group in swa_layer_groups),
+            len(state_layer_names), num_blocks)
 
     def delete_kv_cache(self) -> None:
         """Delete KV cache JAX arrays to free HBM.


### PR DESCRIPTION
Cherry-pick of #3267 (merged to main as `d1145f15f`) onto `releases/v0.26.0`.

Fixes the `tpu7x E2E MMLU for DeepSeek-V4-Flash torchax backend` startup crash (`AssertionError: kv_cache_tensor.shared_by` at `kv_cache_manager.py:920`) seen on the release nightly [#23216](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/23216).

Validation: [dev 696](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/696) ran the new unit tests + the exact failing E2E MMLU job on this code over the release base — both green. Original PR's pre-commit CI [#23265](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/23265) passed 48/48.