### PR TITLE
[releases/v0.26.0] Cherry-pick #3268: fix Mistral-Small-4 record step failing on tpu6e skip

### DIFF
--- a/.buildkite/models/mistralai_Mistral-Small-4-119B-2603_text-only.yml
+++ b/.buildkite/models/mistralai_Mistral-Small-4-119B-2603_text-only.yml
@@ -26,7 +26,7 @@ steps:
     commands:
       - |
         if [ "${TPU_VERSION:-tpu6e}" != "tpu7x" ]; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Correctness" "skipped (only for tpu7x)"
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_mistralai_Mistral-Small-4-119B-2603_text-only_Correctness" "skipped"
         else
           # 1. Run the fast correctness test
           .buildkite/scripts/run_in_docker.sh \


### PR DESCRIPTION
Cherry-pick of #3268 (merged to main as `6954de7e8`) onto `releases/v0.26.0`.

Fixes the hard-failing `tpu6e Record correctness result for mistralai/Mistral-Small-4-119B-2603` job on the release nightly [#23216](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/23216) — the tpu6e self-skip wrote `"skipped (only for tpu7x)"` which `record_step_result.sh` doesn't recognize; the exact `skipped` token renders as Untested instead of Failing.