### PR TITLE
[CI] Pass explicit block size 256 to batched-RPA perf jobs

### DIFF
--- a/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
@@ -78,7 +78,7 @@ steps:
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark" "not enough HBM"
         else
-          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1226 --total_token_tput_limit 1378 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0
+          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1226 --total_token_tput_limit 1378 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --block_size 256
         fi
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
     key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"

--- a/.buildkite/models/google_gemma-4-26B-A4B-it.yml
+++ b/.buildkite/models/google_gemma-4-26B-A4B-it.yml
@@ -97,7 +97,7 @@ steps:
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_Benchmark" "not enough HBM"
           exit 0
         fi
-        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
+        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 BLOCK_SIZE=256 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-26B-A4B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-26B-A4B-it_Benchmark"

--- a/.buildkite/models/google_gemma-4-31B-it.yml
+++ b/.buildkite/models/google_gemma-4-31B-it.yml
@@ -87,7 +87,7 @@ steps:
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_Benchmark" "not enough HBM"
           exit 0
         fi
-        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
+        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 BLOCK_SIZE=256 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-31B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-31B-it_Benchmark"

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -372,7 +372,7 @@ steps:
         if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
-            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.15  --output_token_tput_limit 1170 --total_token_tput_limit 1314 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 1
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.15  --output_token_tput_limit 1170 --total_token_tput_limit 1314 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 1 --block_size 256
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 8k 1k with fused moe kernel."
         key: ${TPU_VERSION:-tpu6e}_test_21
@@ -385,7 +385,7 @@ steps:
         if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
-            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.4  --output_token_tput_limit 381 --total_token_tput_limit 3421 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 1
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.4  --output_token_tput_limit 381 --total_token_tput_limit 3421 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 1 --block_size 256
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 1k 8k with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_22
@@ -397,7 +397,7 @@ steps:
         if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
-            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1673 --total_token_tput_limit 1881 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1673 --total_token_tput_limit 1881 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --block_size 256
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 8k 1k with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_23
@@ -410,7 +410,7 @@ steps:
         if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
-            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.63  --output_token_tput_limit 645 --total_token_tput_limit 5781 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.63  --output_token_tput_limit 645 --total_token_tput_limit 5781 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0 --block_size 256
 
       - label: "${TPU_VERSION:-tpu6e} Test EP recompilation."
         key: ${TPU_VERSION:-tpu6e}_test_24


### PR DESCRIPTION
## Problem

Seven tpu7x nightly perf jobs crash at engine init — red on every `main` nightly since Jul 21 (first red: build 22832):

- `Perf regression test for qwen3 coder {1k8k, 8k1k} x {fused moe, gmm}` + `Performance benchmarks for Qwen/Qwen3-Coder-480B`: `Ran out of memory in memory space smem. Used 1.06M of 1.00M`
- `Performance benchmarks for google/gemma-4-26B-A4B-it`: `Used 1.20M of 1.00M`
- `Performance benchmarks for google/gemma-4-31B-it`: `RuntimeUnexpectedCoreHalt` BoundsCheck `dma.smem_to_vmem`

Root cause (proven by single-commit A/B on the dev pipeline: [#698](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/698) @ `eb204cdb4` = parent PASS vs [#700](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/700) @ `0cbe535e5` = #3223 FAIL, byte-identical smem OOM): #3223 removed the `USE_BATCHED_RPA_KERNEL && block_size < 256 → 256` floor, on the premise that configs pass `--block-size` explicitly — but these CI jobs never did. They fall to a small default block size → more pages → per-page batched-RPA metadata exceeds the 1MB smem budget.

## Fix (per #3223's intent, as suggested by @lkchen)

Make the job configs explicit instead of restoring the implicit override:
- `--block_size 256` on the five `bm_qwen3_coder.sh` Coder-480B invocations
- `BLOCK_SIZE=256` on the two gemma `mm_bench_recipe.sh` perf jobs

The Qwen3.5-397B invocations of the same script are currently green and left unchanged. The release branch `releases/v0.26.0` took the conservative revert instead (#3270); this is the forward fix for `main`. Longer-term smem bounding is tracked in #3007.

## Why the flag/env reaches the engine (code-verified)

- `bm_qwen3_coder.sh` parses `--block_size` and appends `--block-size $block_size` to the `vllm serve` args (lines 88-89, 151).
- `mm_bench_recipe.sh` reads `block_size="${BLOCK_SIZE:-}"` (line 25) and appends `--block-size "$block_size"` to `vllm_cmd` (lines 122-123). `BLOCK_SIZE=256` is set **inline inside the `bash -c` command** — the same mechanism as the adjacent `USE_BATCHED_RPA_KERNEL=1` — so it does not depend on `run_in_docker.sh` env forwarding.
- A user-specified block size sets `cache_config.user_specified_block_size`, and the whole page-size adjustment block in `tpu_platform.py` (`check_and_update_config`) is guarded by `if not cache_config.user_specified_block_size:` — so the platform logic cannot override the CLI value. The engine runs with `block_size=256`, exactly the value the release-branch revert validation already proved green for all seven jobs ([dev 701](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/701), [dev 704](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/704)).

## Test results — all 7 changed configs PASS on this branch (current main incl. jax 0.11)

| # | Changed config | Dev build | Result |
|---|---|---|---|
| 1 | qwen3-coder 1k8k gmm (`--block_size 256`) | [dev 705](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/705) | PASSED |
| 2 | gemma-4-26B perf (`BLOCK_SIZE=256`) | [dev 705](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/705) | PASSED (req tput 3.30 >= 2) |
| 3 | gemma-4-31B perf (`BLOCK_SIZE=256`) | [dev 705](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/705) | PASSED |
| 4 | qwen3-coder 1k8k fused (`--block_size 256`) | [dev 706](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/706) | PASSED |
| 5 | qwen3-coder 8k1k fused (`--block_size 256`) | [dev 706](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/706) | PASSED |
| 6 | qwen3-coder 8k1k gmm (`--block_size 256`) | [dev 706](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/706) | PASSED |
| 7 | Qwen3-Coder-480B perf-benchmark thresholds (`--block_size 256`) | [dev 706](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/706) | PASSED |

All seven previously-red jobs go green with the explicit block size, throughput thresholds met.

Direct engine-log confirmation that the value lands (gemma-26B job, dev 705):
```
(EngineCore pid=551) INFO 07-28 04:30:50 [tpu_platform.py:393] Using cache_config.block_size: 256 instead of overriding with _align_hybrid_block_size() since we set mamba_page_size_padded in kv_cache_manager.py
...
Request throughput comparison (>= 2): PASSED
```
