### PR TITLE
[releases/v0.26.0] Cherry-pick #3269: fix Mistral-Small-4 tpu7x correctness recompile

### DIFF
--- a/tests/e2e/mistral_small_4_correctness.py
+++ b/tests/e2e/mistral_small_4_correctness.py
@@ -26,6 +26,11 @@ def set_env_vars():
     os.environ['MODEL_IMPL_TYPE'] = 'vllm'
     os.environ[
         'SKIP_JAX_PRECOMPILE'] = '1'  # Set to '1' to skip expensive multi-shape precompilation in unit tests
+    # SKIP_JAX_PRECOMPILE means the first real step compiles during
+    # execute_model, so the CI recompilation guard
+    # (VLLM_XLA_CHECK_RECOMPILATION=1 in run_in_docker.sh) must be off here,
+    # like the other e2e tests that skip precompile.
+    os.environ['VLLM_XLA_CHECK_RECOMPILATION'] = '0'
     os.environ['VLLM_TPU_PATCH_MM_EMBEDDINGS'] = '1'
     os.environ['VLLM_DISABLE_SHARED_EXPERTS_STREAM'] = '0'
     os.environ['MOE_REQUANTIZE_BLOCK_SIZE'] = '512'


### PR DESCRIPTION
Cherry-pick of #3269 (merged to main as `812ff44a3`) onto `releases/v0.26.0` — the last of the four fixes for the release nightly [#23216](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/23216) failures.

Fixes `tpu7x Correctness for mistralai/Mistral-Small-4-119B-2603` (deterministic `JAX compilation occurred but was forbidden`: the test sets `SKIP_JAX_PRECOMPILE=1` without disabling the CI recompilation guard). Validated on [dev 699](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/699) (exact CI job green over the release base); original PR CI [#23281](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/23281) passed 48/48.