### PR TITLE
[releases/v0.26.0] Switch smem fix to fix-forward: revert #3270, cherry-pick #3280

### DIFF
--- a/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen3-Coder-480B-A35B-Instruct.yml
@@ -78,7 +78,7 @@ steps:
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark" "not enough HBM"
         else
-          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1226 --total_token_tput_limit 1378 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0
+          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1226 --total_token_tput_limit 1378 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --block_size 256
         fi
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen3-Coder-480B-A35B-Instruct"
     key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen3-Coder-480B-A35B-Instruct_Benchmark"

--- a/.buildkite/models/google_gemma-4-26B-A4B-it.yml
+++ b/.buildkite/models/google_gemma-4-26B-A4B-it.yml
@@ -97,7 +97,7 @@ steps:
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_Benchmark" "not enough HBM"
           exit 0
         fi
-        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
+        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 BLOCK_SIZE=256 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-26B-A4B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-26B-A4B-it_Benchmark"

--- a/.buildkite/models/google_gemma-4-31B-it.yml
+++ b/.buildkite/models/google_gemma-4-31B-it.yml
@@ -87,7 +87,7 @@ steps:
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_Benchmark" "not enough HBM"
           exit 0
         fi
-        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
+        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 BLOCK_SIZE=256 USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-31B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-31B-it_Benchmark"

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -372,7 +372,7 @@ steps:
         if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
-            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.15  --output_token_tput_limit 1170 --total_token_tput_limit 1314 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 1
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.15  --output_token_tput_limit 1170 --total_token_tput_limit 1314 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 1 --block_size 256
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 8k 1k with fused moe kernel."
         key: ${TPU_VERSION:-tpu6e}_test_21
@@ -385,7 +385,7 @@ steps:
         if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
-            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.4  --output_token_tput_limit 381 --total_token_tput_limit 3421 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 1
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.4  --output_token_tput_limit 381 --total_token_tput_limit 3421 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 1 --block_size 256
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 1k 8k with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_22
@@ -397,7 +397,7 @@ steps:
         if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
-            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1673 --total_token_tput_limit 1881 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.16  --output_token_tput_limit 1673 --total_token_tput_limit 1881 --input_len 1024 --output_len 8192 --use_moe_ep_kernel 0 --block_size 256
 
       - label: "${TPU_VERSION:-tpu6e} Perf regression test for qwen3 coder 8k 1k with gmm kernel."
         key: ${TPU_VERSION:-tpu6e}_test_23
@@ -410,7 +410,7 @@ steps:
         if: build.env("NIGHTLY") == "1" && "${TPU_VERSION:-tpu6e}" == "tpu7x"
         commands:
           - |
-            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.63  --output_token_tput_limit 645 --total_token_tput_limit 5781 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0
+            .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/bm_qwen3_coder.sh --model Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8 --tp 8 --req_tput_limit 0.63  --output_token_tput_limit 645 --total_token_tput_limit 5781 --input_len 8192 --output_len 1024 --use_moe_ep_kernel 0 --block_size 256
 
       - label: "${TPU_VERSION:-tpu6e} Test EP recompilation."
         key: ${TPU_VERSION:-tpu6e}_test_24

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -306,8 +306,6 @@ class TpuPlatform(Platform):
                             min_page_size,
                         )
                         cache_config.block_size = min_page_size  # type: ignore[assignment]
-            if envs.USE_BATCHED_RPA_KERNEL and cache_config.block_size < 256:
-                cache_config.block_size = 256
 
         parallel_config = vllm_config.parallel_config
         scheduler_config = vllm_config.scheduler_config


### PR DESCRIPTION
Aligns the release branch with `main`'s resolution of the batched-RPA smem OOM group, replacing the temporary revert with the config-level fix-forward. Two commits that must land together:

1. **Revert of #3270** — re-applies #3223 (no implicit `USE_BATCHED_RPA_KERNEL` block-size floor). Alone this would re-break the 7 perf jobs, hence:
2. **Cherry-pick of #3280** (main `6f54e68ac`) — explicit `--block_size 256` on the five `bm_qwen3_coder.sh` Coder-480B jobs and `BLOCK_SIZE=256` on the two gemma `mm_bench_recipe.sh` perf jobs.

## Why safe

The resulting state is exactly what `main` runs today, which the Jul-28 main nightly [#23298](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/23298) proved green across all seven previously-red jobs (qwen3-coder perf regression x4, Qwen3-Coder-480B benchmark, gemma-4-26B/31B perf — plus the same jobs green on tpu6e). #3280 itself was validated exhaustively on dev [705](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/705)/[706](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/706) (all 7 configs, engine log confirms `block_size: 256` reaches the engine).

Release nightly baseline with the revert: [#23291](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/23291) (all real jobs green) — this PR swaps the mechanism, not the effective block size.