### PR TITLE
Fix spurious client-side failures in agentic benchmark

### DIFF
--- a/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
+++ b/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
@@ -17,10 +17,38 @@ import os
 import random
 import sys
 import time
+from collections import Counter
 from typing import Any, Dict, List
 
 import aiohttp
 from transformers import AutoTokenizer
+
+
+def make_client_session() -> aiohttp.ClientSession:
+    """Creates an aiohttp session suited to long-running benchmark requests.
+
+    Two defaults of aiohttp are unsuitable here and cause spurious failures
+    that look like server errors even though every response is HTTP 200:
+
+    - The default ``ClientTimeout(total=5*60)`` aborts a turn that legitimately
+      takes longer than 5 minutes, which happens at high concurrency with large
+      ``--output-len-max``. It surfaces as ``asyncio.TimeoutError``, whose
+      ``str()`` is empty, so the recorded error message is blank.
+    - Pooled keep-alive connections may be reused after the server has already
+      closed them during an idle gap between turns, raising
+      ``ServerDisconnectedError``. ``force_close`` opens a fresh connection per
+      request instead.
+
+    Returns:
+        aiohttp.ClientSession: Session with no total timeout and no connection
+        reuse.
+    """
+    return aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=None,
+                                      sock_read=None,
+                                      sock_connect=30),
+        connector=aiohttp.TCPConnector(force_close=True, limit=0),
+    )
 
 
 def get_percentile(data: List[float], percentile: float) -> float:
@@ -197,6 +225,11 @@ async def run_grpo_stream(
 
         except Exception as e:
             total_time_ms = (time.perf_counter() - start_time) * 1000.0
+            # Include the type: some exceptions (notably asyncio.TimeoutError)
+            # have an empty str(), which would otherwise record the failure
+            # with no reason at all.
+            error_msg = f"{type(e).__name__}: {e}" if str(e) else \
+                type(e).__name__
             stats.append({
                 "group_idx": group_idx,
                 "stream_idx": stream_idx,
@@ -208,7 +241,7 @@ async def run_grpo_stream(
                 "output_tokens": 0,
                 "input_history_tokens": 0,
                 "success": False,
-                "error": str(e),
+                "error": error_msg,
             })
             # End conversation on error
             break
@@ -301,6 +334,11 @@ def print_report(
     print(f"Total Conversational Turns:{total_turns} (Success: "
           f"{successful_turns}, Failed: {failed_turns}, "
           f"Rate: {success_rate:.2f}%)")
+    if failed_turns:
+        reasons = Counter(s["error"] for s in all_stats if not s["success"])
+        print("Failure Breakdown:")
+        for reason, count in reasons.most_common():
+            print(f"  {count:6d} x {reason}")
     print(f"Total Input Tokens (Pref): {total_input_tokens:,}")
     print(f"Total Output Tokens (Dec): {total_output_tokens:,}")
     print(f"Total Tokens Processed:    {total_tokens:,}")
@@ -407,7 +445,7 @@ async def main_async(args: argparse.Namespace):
     url = f"http://{args.host}:{args.port}/v1/chat/completions"
     print(f"Connecting to vLLM server at {url}...")
 
-    async with aiohttp.ClientSession() as session:
+    async with make_client_session() as session:
         try:
             async with session.get(
                     f"http://{args.host}:{args.port}/health") as resp:
@@ -431,7 +469,7 @@ async def main_async(args: argparse.Namespace):
 
     start_time = time.perf_counter()
 
-    async with aiohttp.ClientSession() as session:
+    async with make_client_session() as session:
         group_tasks = [
             worker(i, session) for i in range(1, args.num_groups + 1)
         ]

--- a/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
+++ b/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
@@ -25,24 +25,6 @@ from transformers import AutoTokenizer
 
 
 def make_client_session() -> aiohttp.ClientSession:
-    """Creates an aiohttp session suited to long-running benchmark requests.
-
-    Two defaults of aiohttp are unsuitable here and cause spurious failures
-    that look like server errors even though every response is HTTP 200:
-
-    - The default ``ClientTimeout(total=5*60)`` aborts a turn that legitimately
-      takes longer than 5 minutes, which happens at high concurrency with large
-      ``--output-len-max``. It surfaces as ``asyncio.TimeoutError``, whose
-      ``str()`` is empty, so the recorded error message is blank.
-    - Pooled keep-alive connections may be reused after the server has already
-      closed them during an idle gap between turns, raising
-      ``ServerDisconnectedError``. ``force_close`` opens a fresh connection per
-      request instead.
-
-    Returns:
-        aiohttp.ClientSession: Session with no total timeout and no connection
-        reuse.
-    """
     return aiohttp.ClientSession(
         timeout=aiohttp.ClientTimeout(total=None,
                                       sock_read=None,


### PR DESCRIPTION
## Problem

Running `scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py` against a long-context model reports a small but persistent turn failure rate (0.05-0.5% in my runs) even though **the server returns HTTP 200 for every single request**. Both causes are aiohttp client defaults, not server behaviour:

1. **Default 5-minute timeout.** `aiohttp.ClientSession()` applies `ClientTimeout(total=5*60)`. Turns that legitimately take longer -- high concurrency with a large `--output-len-max` -- are aborted client-side. It surfaces as `asyncio.TimeoutError`, whose `str()` is the empty string, so `"error": str(e)` recorded the failure with **no reason at all**, making it undiagnosable from the report.
2. **Stale keep-alive connection reuse.** The connection pool reuses a keep-alive connection that the server has already closed during an idle gap between turns, raising `ServerDisconnectedError`. This was the only residual failure mode once the timeout was fixed.

## Fix

- Add `make_client_session()` -- `total=None` (no cap on a single turn; `sock_connect=30` retained) and `TCPConnector(force_close=True)` so a fresh connection is used per request. Used for both the health check and the benchmark session.
- Record the exception type alongside its message, so an empty `str(e)` can never produce a blank reason.
- Print a `Failure Breakdown` after the success-rate line, tallied by reason, so any future failure is self-identifying.

## Result

On `Qwen/Qwen3.5-397B-A17B-FP8` (TPU v7x-8, TP8 + attention-DP4, 65536 context), a concurrency sweep at 2/4/6/8/12/16 showed 99.79-99.97% success in every run, with every failure attributable to the two causes above. With this change the full run -- **50 groups at concurrency 16, 800 rollouts, 21,490 turns over 4.6 hours** -- completed at **100.00% success, 0 failed**.

Report excerpt showing the new breakdown format (synthetic failures):

```
Total Conversational Turns:4 (Success: 1, Failed: 3, Rate: 25.00%)
Failure Breakdown:
       2 x TimeoutError
       1 x ServerDisconnectedError: Server disconnected
```

## Testing

- `yapf --diff` clean on the changed file.
- End-to-end run against a live vLLM server: health check OK, 4/4 turns, 100%.
- `print_report()` exercised directly with synthetic failing stats to verify the breakdown renders and sorts by frequency.
- Session config asserted at runtime (`timeout.total is None`, `connector._force_close is True`).
- No change to any measured metric or to the request payload -- this only affects connection handling and error reporting.

## Note on token counts

An earlier revision of this description quoted a total-tokens-processed figure for the validation run. That number came from the script's client-side token estimates, which are inaccurate in both directions -- the prompt count tokenizes the Python repr of the message list, and the completion count re-encodes detokenized text. #3298 fixes that by using the server-reported `usage`. The counts quoted above (rollouts, turns, success rate, duration) are unaffected by that issue, so they stand as-is.

#3298 touches the same function in this file, so whichever lands first will need a trivial rebase of the other.
