### PR TITLE
Use server-reported token counts in agentic benchmark

### DIFF
--- a/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
+++ b/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
@@ -124,10 +124,14 @@ async def run_grpo_stream(
         }
         if args.ignore_eos:
             payload["ignore_eos"] = True
+        # Ask the server to report the token counts it actually processed.
+        # Sent as a final chunk with an empty "choices" list.
+        payload["stream_options"] = {"include_usage": True}
 
         headers = {"Authorization": f"Bearer {os.getenv('HF_TOKEN', '')}"}
         start_time = time.perf_counter()
         ttft = None
+        usage = None
         full_response_text = []
 
         try:
@@ -151,6 +155,9 @@ async def run_grpo_stream(
                                 ttft = ((time.perf_counter() - start_time) *
                                         1000.0)
 
+                            if data.get("usage"):
+                                usage = data["usage"]
+
                             if "choices" in data and len(data["choices"]) > 0:
                                 delta = data["choices"][0].get("delta", {})
                                 content = delta.get("content", "")
@@ -163,7 +170,19 @@ async def run_grpo_stream(
             total_time_ms = (end_time - start_time) * 1000.0
 
             assistant_response = "".join(full_response_text)
-            assistant_tokens = len(tokenizer.encode(assistant_response))
+
+            # Prefer the server-reported counts: they are what the engine
+            # actually processed. The tokenizer fallbacks are approximations --
+            # the prompt one in particular tokenizes the Python repr of the
+            # message list, so dict punctuation is counted as prompt tokens.
+            reported = usage or {}
+            prompt_tokens = reported.get("prompt_tokens")
+            completion_tokens = reported.get("completion_tokens")
+
+            if completion_tokens is None:
+                assistant_tokens = len(tokenizer.encode(assistant_response))
+            else:
+                assistant_tokens = completion_tokens
 
             if ttft is None:
                 ttft = total_time_ms
@@ -178,6 +197,9 @@ async def run_grpo_stream(
                 "content": assistant_response
             })
 
+            if prompt_tokens is None:
+                prompt_tokens = len(tokenizer.encode(str(messages[:-1])))
+
             turn_stat = {
                 "group_idx": group_idx,
                 "stream_idx": stream_idx,
@@ -187,8 +209,7 @@ async def run_grpo_stream(
                 "tpot_ms": tpot,
                 "total_time_ms": total_time_ms,
                 "output_tokens": assistant_tokens,
-                "input_history_tokens":
-                len(tokenizer.encode(str(messages[:-1]))),
+                "input_history_tokens": prompt_tokens,
                 "success": True,
             }
 

--- a/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
+++ b/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
@@ -171,17 +171,18 @@ async def run_grpo_stream(
 
             assistant_response = "".join(full_response_text)
 
-            # Prefer the server-reported counts: they are what the engine
-            # actually processed. The fallbacks below reproduce them closely,
-            # but rely on the local tokenizer matching the server's template.
-            reported = usage or {}
-            prompt_tokens = reported.get("prompt_tokens")
-            completion_tokens = reported.get("completion_tokens")
+            # Token counts come from the server: they are what the engine
+            # actually processed. Counting client-side instead is inaccurate
+            # in both directions -- re-encoding detokenized text is not
+            # round-trip identity, and any tokens the server reports outside
+            # "content" are invisible here.
+            if not usage:
+                raise RuntimeError(
+                    "server did not report usage; it must support "
+                    "stream_options.include_usage")
 
-            if completion_tokens is None:
-                assistant_tokens = len(tokenizer.encode(assistant_response))
-            else:
-                assistant_tokens = completion_tokens
+            prompt_tokens = usage["prompt_tokens"]
+            assistant_tokens = usage["completion_tokens"]
 
             if ttft is None:
                 ttft = total_time_ms
@@ -195,13 +196,6 @@ async def run_grpo_stream(
                 "role": "assistant",
                 "content": assistant_response
             })
-
-            if prompt_tokens is None:
-                prompt_tokens = len(
-                    tokenizer.apply_chat_template(messages[:-1],
-                                                  add_generation_prompt=True,
-                                                  tokenize=True,
-                                                  return_dict=False))
 
             turn_stat = {
                 "group_idx": group_idx,

--- a/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
+++ b/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
@@ -172,9 +172,8 @@ async def run_grpo_stream(
             assistant_response = "".join(full_response_text)
 
             # Prefer the server-reported counts: they are what the engine
-            # actually processed. The tokenizer fallbacks are approximations --
-            # the prompt one in particular tokenizes the Python repr of the
-            # message list, so dict punctuation is counted as prompt tokens.
+            # actually processed. The fallbacks below reproduce them closely,
+            # but rely on the local tokenizer matching the server's template.
             reported = usage or {}
             prompt_tokens = reported.get("prompt_tokens")
             completion_tokens = reported.get("completion_tokens")
@@ -198,7 +197,11 @@ async def run_grpo_stream(
             })
 
             if prompt_tokens is None:
-                prompt_tokens = len(tokenizer.encode(str(messages[:-1])))
+                prompt_tokens = len(
+                    tokenizer.apply_chat_template(messages[:-1],
+                                                  add_generation_prompt=True,
+                                                  tokenize=True,
+                                                  return_dict=False))
 
             turn_stat = {
                 "group_idx": group_idx,


### PR DESCRIPTION
## Problem

The throughput this benchmark reports was derived from client-side tokenizer estimates rather than the token counts the engine actually processed. 

**Prompt.** The count was:

```python
"input_history_tokens": len(tokenizer.encode(str(messages[:-1]))),
```

`str(messages[:-1])` is the **Python repr** of a list of dicts, so every `{`, `'role':`, `'content':`, quote and comma is tokenized as a prompt token, while the chat template's own control tokens and generation prompt are absent.  

| messages | server (truth) | `str(messages)` |
|---:|---:|---:|
| 2 | 824 | 831 (+0.8%) |
| 22 | 3,444 | 3,591 (+4.3%) |
| 52 | 7,374 | 7,731 (+4.8%) |
| 100 | 13,662 | 14,355 (+5.1%) |

## Fix

Request usage explicitly:

```python
payload["stream_options"] = {"include_usage": True}
```

vLLM then emits a final chunk with an empty `choices` list carrying `usage`; take `prompt_tokens` and `completion_tokens` from it. 

A server that does not report usage is a **hard error** .

