### PR TITLE
[Gemma4] Do not allocate K/V params for KV-shared layers

### DIFF
--- a/tests/models/jax/test_gemma4_kv_share.py
+++ b/tests/models/jax/test_gemma4_kv_share.py
@@ -35,7 +35,8 @@ from flax import nnx
 from jax.sharding import Mesh
 from transformers import Gemma4TextConfig
 
-from tpu_inference.models.common.kv_share import compute_kv_share_map
+from tpu_inference.models.common.kv_share import (compute_kv_share_map,
+                                                  drop_shared_kv_weights)
 from tpu_inference.models.jax.gemma4 import Gemma4Model
 
 
@@ -323,3 +324,171 @@ def test_double_wide_mlp_off(mesh, rng=jax.random.PRNGKey(0)):
     for layer in model.layers:
         assert layer.mlp.gate_up_proj.weight.shape == (32,
                                                        2 * intermediate_size)
+
+
+# --------------------------------------------------------------------------
+# KV-shared layers own no K/V parameters (vllm-project/tpu-inference#3225).
+#
+# Gemma 4 QAT exports omit self_attn.{k_proj,v_proj,k_norm} on KV-shared
+# layers, because those layers never use their own K/V — they read the source
+# layer's from the redirected cache slot. Allocating the parameters anyway
+# made every QAT checkpoint fail to load.
+# --------------------------------------------------------------------------
+
+
+def test_shared_layers_allocate_no_kv_params(mesh, rng=jax.random.PRNGKey(0)):
+    """Shared layers get a standalone q_proj and no K/V params at all."""
+    text_config = _make_text_config(num_hidden_layers=4,
+                                    num_kv_shared_layers=2,
+                                    layer_types=["full_attention"] * 4)
+    vllm_config = _make_vllm_config(text_config)
+    with jax.set_mesh(mesh):
+        model = Gemma4Model(vllm_config, nnx.Rngs(rng), mesh)
+
+    for idx in (0, 1):  # non-shared: fused QKV, K norm present
+        attn = model.layers[idx].self_attn
+        assert attn.qkv_proj is not None
+        assert attn.k_norm is not None
+
+    for idx in (2, 3):  # shared: q only, nothing K/V-side
+        attn = model.layers[idx].self_attn
+        assert attn.qkv_proj is None, f"layer {idx} allocated a fused QKV"
+        assert attn.q_proj is not None, f"layer {idx} needs its own q_proj"
+        assert attn.k_proj is None, f"layer {idx} allocated k_proj"
+        assert attn.v_proj is None, f"layer {idx} allocated v_proj"
+        assert attn.k_norm is None, f"layer {idx} allocated k_norm"
+
+
+def _attn_weight_names(num_layers):
+    """Checkpoint-shaped names for every text attention param, all layers."""
+    names = []
+    for i in range(num_layers):
+        p = f"model.language_model.layers.{i}.self_attn"
+        for leaf in ("q_proj", "k_proj", "v_proj", "o_proj"):
+            names.append(f"{p}.{leaf}.weight")
+        for leaf in ("q_norm", "k_norm"):
+            names.append(f"{p}.{leaf}.weight")
+    return names
+
+
+def _kept(text_config, names):
+    return [
+        n for n, _ in drop_shared_kv_weights(text_config, ((n, None)
+                                                           for n in names))
+    ]
+
+
+def _shared_config():
+    return _make_text_config(num_hidden_layers=4,
+                             num_kv_shared_layers=2,
+                             layer_types=["full_attention"] * 4)
+
+
+def test_drop_shared_kv_weights_filters_only_shared_layers():
+    """A BF16 export ships K/V weights for shared layers; they must be
+    dropped, or the loader raises "is not a valid param path". Non-shared
+    layers must keep every tensor."""
+    kept = set(_kept(_shared_config(), _attn_weight_names(4)))
+
+    for i in (0, 1):  # non-shared: untouched
+        p = f"model.language_model.layers.{i}.self_attn"
+        for leaf in ("q_proj", "k_proj", "v_proj", "o_proj", "q_norm",
+                     "k_norm"):
+            assert f"{p}.{leaf}.weight" in kept
+
+    for i in (2, 3):  # shared: K/V-side dropped, the rest kept
+        p = f"model.language_model.layers.{i}.self_attn"
+        for leaf in ("k_proj", "v_proj", "k_norm"):
+            assert f"{p}.{leaf}.weight" not in kept, f"layer {i}.{leaf} kept"
+        for leaf in ("q_proj", "o_proj", "q_norm"):
+            assert f"{p}.{leaf}.weight" in kept, f"layer {i}.{leaf} dropped"
+
+
+def test_drop_shared_kv_weights_is_noop_for_qat_checkpoint():
+    """A QAT export already omits those tensors — filtering must not disturb
+    the remaining stream (this is the #3225 checkpoint shape)."""
+    shared_kv = {
+        f"model.language_model.layers.{i}.self_attn.{leaf}.weight"
+        for i in (2, 3)
+        for leaf in ("k_proj", "v_proj", "k_norm")
+    }
+    qat_names = [n for n in _attn_weight_names(4) if n not in shared_kv]
+
+    assert _kept(_shared_config(), qat_names) == qat_names
+
+
+def test_drop_shared_kv_weights_noop_without_sharing():
+    """num_kv_shared_layers=0 (26B/31B path): nothing is filtered."""
+    text_config = _make_text_config(num_hidden_layers=4,
+                                    num_kv_shared_layers=0,
+                                    layer_types=["full_attention"] * 4)
+    names = _attn_weight_names(4)
+
+    assert _kept(text_config, names) == names
+
+
+def test_drop_shared_kv_weights_spares_the_vision_tower():
+    """The vision encoder has its own per-layer self_attn.k_proj/v_proj at
+    the same layer indices. They have nothing to do with text KV-share, and
+    `Gemma4ForConditionalGeneration` really does load them — dropping them
+    would quietly leave a partly-random encoder rather than raise."""
+    vision = [
+        f"model.vision_tower.encoder.layers.{i}.self_attn.{leaf}.linear.weight"
+        for i in range(4) for leaf in ("q_proj", "k_proj", "v_proj", "o_proj")
+    ]
+    audio = [
+        f"model.audio_tower.layers.{i}.self_attn.{leaf}.weight"
+        for i in range(4) for leaf in ("k_proj", "v_proj")
+    ]
+
+    assert _kept(_shared_config(), vision + audio) == vision + audio
+
+
+def test_drop_shared_kv_weights_matches_unprefixed_names():
+    """Applied before a WeightsMapper strips "model.", or after — the
+    pattern must anchor either way."""
+    unprefixed = [n.removeprefix("model.") for n in _attn_weight_names(4)]
+    kept = set(_kept(_shared_config(), unprefixed))
+
+    assert "language_model.layers.2.self_attn.k_proj.weight" not in kept
+    assert "language_model.layers.2.self_attn.q_proj.weight" in kept
+    assert "language_model.layers.0.self_attn.k_proj.weight" in kept
+
+
+@pytest.mark.parametrize(
+    "variant,num_hidden_layers,num_kv_shared_layers,period",
+    [
+        # Read from the released config.json + safetensors headers: both QAT
+        # exports ship K/V-side tensors for exactly the non-shared layers.
+        ("E2B", 35, 20, 5),  # layer_types = (4x sliding + full) x 7
+        ("E4B", 42, 18, 6),  # layer_types = (5x sliding + full) x 7
+    ])
+def test_drop_shared_kv_weights_on_released_geometries(variant,
+                                                       num_hidden_layers,
+                                                       num_kv_shared_layers,
+                                                       period):
+    """The two shipped Gemma 4 KV-share geometries, not just a synthetic one.
+
+    E2B drops layers 15-34, E4B drops 24-41 — matching what
+    `google/gemma-4-{E2B,E4B}-it-qat-q4_0-unquantized` actually contain.
+    """
+    layer_types = (["sliding_attention"] * (period - 1) +
+                   ["full_attention"]) * (num_hidden_layers // period)
+    assert len(layer_types) == num_hidden_layers
+    text_config = _make_text_config(num_hidden_layers=num_hidden_layers,
+                                    num_kv_shared_layers=num_kv_shared_layers,
+                                    layer_types=layer_types)
+
+    first_shared = num_hidden_layers - num_kv_shared_layers
+    assert sorted(compute_kv_share_map(text_config)) == list(
+        range(first_shared, num_hidden_layers))
+
+    kept = set(_kept(text_config, _attn_weight_names(num_hidden_layers)))
+    for i in range(num_hidden_layers):
+        p = f"model.language_model.layers.{i}.self_attn"
+        shared = i >= first_shared
+        for leaf in ("k_proj", "v_proj", "k_norm"):
+            present = f"{p}.{leaf}.weight" in kept
+            assert present is not shared, f"{variant} layer {i}.{leaf}"
+        for leaf in ("q_proj", "o_proj", "q_norm"):
+            assert f"{p}.{leaf}.weight" in kept, f"{variant} layer {i}.{leaf}"

--- a/tpu_inference/models/common/kv_share.py
+++ b/tpu_inference/models/common/kv_share.py
@@ -24,6 +24,10 @@ Gemma-4 E2B / E4B) can use this helper. New JAX models that introduce
 KV-share via the same HF convention pick it up automatically.
 """
 
+import re
+from collections.abc import Iterable
+from typing import Any
+
 
 def compute_kv_share_map(text_config) -> dict:
     """Return `{shared_layer_idx: source_layer_idx}` for KV-shared layers.
@@ -64,6 +68,49 @@ def compute_kv_share_map(text_config) -> dict:
         src = len(prev_types) - 1 - prev_types[::-1].index(ctype)
         mapping[i] = src
     return mapping
+
+
+# K/V-side params of a *text* decoder layer, as named in an HF checkpoint.
+# Anchored on "language_model.layers." rather than matched loosely, because a
+# multimodal checkpoint also contains
+# "model.vision_tower.encoder.layers.{i}.self_attn.k_proj.linear.weight" — the
+# vision tower has its own per-layer K/V projections, they are unrelated to
+# text KV-share, and dropping them would silently load a partly-random encoder.
+_SHARED_KV_WEIGHT_RE = re.compile(
+    r"(?:^|\.)language_model\.layers\.(\d+)\.self_attn\."
+    r"(?:k_proj|v_proj|k_norm)\.")
+
+
+def drop_shared_kv_weights(
+    text_config,
+    weights: Iterable[tuple[str, Any]],
+) -> Iterable[tuple[str, Any]]:
+    """Drop the K/V weights of KV-shared text layers from a weight stream.
+
+    KV-shared layers read their K/V from the source layer's cache slot and so
+    allocate no `k_proj`/`v_proj`/`k_norm` at all. Gemma-4 QAT exports omit
+    those tensors to match; BF16 exports still ship them, and feeding them to
+    the loader raises "is not a valid param path". Filtering here lets one
+    model definition load both (vllm-project/tpu-inference#3225).
+
+    Apply to the raw checkpoint stream, before any `WeightsMapper` prefix
+    rewriting: the pattern accepts the name with or without a leading
+    "model." but assumes the `language_model.layers.{i}.self_attn.*` layout.
+
+    Returns `weights` unchanged when the config declares no KV-share.
+    """
+    shared = set(compute_kv_share_map(text_config))
+    if not shared:
+        return weights
+
+    def _filtered():
+        for name, weight in weights:
+            m = _SHARED_KV_WEIGHT_RE.search(name)
+            if m and int(m.group(1)) in shared:
+                continue
+            yield name, weight
+
+    return _filtered()
 
 
 def compute_mtp_kv_share_map(draft_config, target_config) -> dict[str, str]:

--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -42,7 +42,8 @@ from tpu_inference.layers.jax.rope_interface import (apply_rope,
                                                      normalize_rope_scaling)
 from tpu_inference.layers.vllm.quantization.configs import VllmQuantConfig
 from tpu_inference.logger import init_logger
-from tpu_inference.models.common.kv_share import compute_kv_share_map
+from tpu_inference.models.common.kv_share import (compute_kv_share_map,
+                                                  drop_shared_kv_weights)
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
 from tpu_inference.models.jax.utils.weight_utils import (
@@ -314,7 +315,50 @@ class Gemma4Attention(JaxModule):
                            None) if _shard_kv_on_k else (None, None, "model")
         _kv_bias_spec = ("model", None) if _shard_kv_on_k else (None, "model")
 
-        if use_k_eq_v:  # TODO: Add QKV fusion logic for k == v case.
+        # KV-cache sharing (mirrors vllm-pytorch `Gemma4Attention.__init__`
+        # KV-share derivation). Layers in the last `num_kv_shared_layers`
+        # reuse K/V from earlier layers of matching attention type. The
+        # runner side populates the redirect mapping; this layer just needs
+        # to set is_kv_shared_layer + kv_sharing_target_layer_name.
+        # Derived before the projections are built because shared layers do
+        # not own K/V parameters at all (see below).
+        kv_share_map = compute_kv_share_map(config)
+        self.is_kv_shared_layer = layer_idx in kv_share_map
+        self.kv_sharing_target_layer_name: Optional[str] = None
+        if self.is_kv_shared_layer:
+            # The runner uses unprefixed "layer.{i}" keys; this string must
+            # match the keys produced by KVCacheManager's spec-creation loop
+            # and Gemma4Model's layer-name iteration.
+            self.kv_sharing_target_layer_name = (
+                f"layer.{kv_share_map[layer_idx]}")
+
+        if self.is_kv_shared_layer:
+            # Shared layers never use their own K/V: `__call__` reads the
+            # source layer's already-normed-and-roped K/V straight from the
+            # redirected cache slot, so k_proj/v_proj/k_norm are dead weight
+            # and dead compute. Gemma 4 QAT exports omit them entirely for
+            # these layers, so allocating them makes those checkpoints fail
+            # to load (vllm-project/tpu-inference#3225). BF16 exports do ship
+            # them; every `load_weights` that builds this module drops them on
+            # the way in via `drop_shared_kv_weights`.
+            self.qkv_proj = None
+            self.q_proj = JaxEinsum(
+                "TD,DNH->TNH",
+                (self.hidden_size, self.num_heads, self.head_dim),
+                bias_shape=(self.num_heads,
+                            self.head_dim) if config.attention_bias else None,
+                param_dtype=dtype,
+                kernel_init=nnx.with_partitioning(init_fn,
+                                                  (None, "model", None)),
+                bias_init=nnx.with_partitioning(init_fn, ("model", None))
+                if config.attention_bias else None,
+                rngs=rng,
+                quant_config=quant_config,
+                prefix=prefix + ".q_proj",
+            )
+            self.k_proj = None
+            self.v_proj = None
+        elif use_k_eq_v:  # TODO: Add QKV fusion logic for k == v case.
             self.qkv_proj = None
             self.q_proj = JaxEinsum(
                 "TD,DNH->TNH",
@@ -370,15 +414,21 @@ class Gemma4Attention(JaxModule):
             prefix=prefix + ".q_norm",
         )
 
-        self.k_norm = JaxRmsNorm(
-            self.head_dim,
-            epsilon=self.rms_norm_eps,
-            param_dtype=dtype,
-            scale_init=nnx.with_partitioning(init_fn, (None, )),
-            rngs=rng,
-            quant_config=quant_config,
-            prefix=prefix + ".k_norm",
-        )
+        # Only non-shared layers norm their own K (see `__call__`); shared
+        # layers read K/V that the source layer already normed. Assigned once
+        # per branch: nnx rejects re-binding a static None to a Module.
+        if self.is_kv_shared_layer:
+            self.k_norm = None
+        else:
+            self.k_norm = JaxRmsNorm(
+                self.head_dim,
+                epsilon=self.rms_norm_eps,
+                param_dtype=dtype,
+                scale_init=nnx.with_partitioning(init_fn, (None, )),
+                rngs=rng,
+                quant_config=quant_config,
+                prefix=prefix + ".k_norm",
+            )
         # V norm: no learnable scale (pure normalization only)
         self.v_norm = JaxRmsNorm(
             self.head_dim,
@@ -411,21 +461,6 @@ class Gemma4Attention(JaxModule):
             self.kv_cache_quantized_dtype = utils.get_jax_dtype_from_str_dtype(
                 kv_cache_dtype)
 
-        # KV-cache sharing (mirrors vllm-pytorch `Gemma4Attention.__init__`
-        # KV-share derivation). Layers in the last `num_kv_shared_layers`
-        # reuse K/V from earlier layers of matching attention type. The
-        # runner side populates the redirect mapping; this layer just needs
-        # to set is_kv_shared_layer + kv_sharing_target_layer_name.
-        kv_share_map = compute_kv_share_map(config)
-        self.is_kv_shared_layer = layer_idx in kv_share_map
-        self.kv_sharing_target_layer_name: Optional[str] = None
-        if self.is_kv_shared_layer:
-            # The runner uses unprefixed "layer.{i}" keys; this string must
-            # match the keys produced by KVCacheManager's spec-creation loop
-            # and Gemma4Model's layer-name iteration.
-            self.kv_sharing_target_layer_name = (
-                f"layer.{kv_share_map[layer_idx]}")
-
     def __call__(
         self,
         kv_cache: Optional[jax.Array],
@@ -433,7 +468,16 @@ class Gemma4Attention(JaxModule):
         attention_metadata: AttentionMetadata,
     ) -> Tuple[jax.Array, jax.Array]:
         md = attention_metadata
-        if self.qkv_proj is not None:
+        if self.is_kv_shared_layer:
+            # q: (T, N, H). No K/V projection: the attention call below runs
+            # with update_kv_cache=False and reads the source layer's K/V from
+            # the redirected cache slot, so this layer's own k/v were never
+            # used for attention math. They are passed only to satisfy the
+            # `attention()` signature.
+            q = self.q_proj(x)
+            k = v = jnp.zeros((x.shape[0], self.num_kv_heads, self.head_dim),
+                              dtype=q.dtype)
+        elif self.qkv_proj is not None:
             q, k, v = self.qkv_proj(x)
         else:
             k = self.k_proj(x)
@@ -471,8 +515,8 @@ class Gemma4Attention(JaxModule):
             # not overwrite the source slot with our raw k,v and (b) reads
             # everything from cache rather than mixing in the layer's own
             # input k,v. Shared's input k,v is therefore unused for attention
-            # math; we still allocate q_proj/k_proj/v_proj because gemma-4's
-            # checkpoint stores full Q/K/V weights for shared layers.
+            # math, which is why these layers allocate no k_proj/v_proj/k_norm
+            # at all — see `__init__`.
             q = apply_rope(q,
                            md.input_positions,
                            self.head_dim_original,
@@ -1070,6 +1114,9 @@ class Gemma4ForCausalLM(JaxModule, LoadableWithIterator):
                            if not hasattr(self, 'lm_head') else []),
             skip_substrs=["vision", "audio", "multi_modal"],
         )
+        # KV-shared layers own no K/V params; a BF16 export still ships them.
+        text_config = self.vllm_config.model_config.hf_config.text_config
+        weights = drop_shared_kv_weights(text_config, weights)
         return loader.load_weights(mapper.apply(weights))
 
     def __call__(

--- a/tpu_inference/models/jax/gemma4.py
+++ b/tpu_inference/models/jax/gemma4.py
@@ -331,16 +331,15 @@ class Gemma4Attention(JaxModule):
             # and Gemma4Model's layer-name iteration.
             self.kv_sharing_target_layer_name = (
                 f"layer.{kv_share_map[layer_idx]}")
-
-        if self.is_kv_shared_layer:
             # Shared layers never use their own K/V: `__call__` reads the
             # source layer's already-normed-and-roped K/V straight from the
-            # redirected cache slot, so k_proj/v_proj/k_norm are dead weight
-            # and dead compute. Gemma 4 QAT exports omit them entirely for
-            # these layers, so allocating them makes those checkpoints fail
-            # to load (vllm-project/tpu-inference#3225). BF16 exports do ship
-            # them; every `load_weights` that builds this module drops them on
-            # the way in via `drop_shared_kv_weights`.
+            # redirected cache slot, so nothing ever reads what k_proj/
+            # v_proj/k_norm would produce. Gemma 4 QAT exports omit them
+            # entirely for these layers, so allocating them makes those
+            # checkpoints fail to load (vllm-project/tpu-inference#3225).
+            # BF16 exports do ship them; every `load_weights` that builds
+            # this module drops them on the way in via
+            # `drop_shared_kv_weights`.
             self.qkv_proj = None
             self.q_proj = JaxEinsum(
                 "TD,DNH->TNH",

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -37,6 +37,7 @@ from tpu_inference.layers.jax.norm import JaxRmsNorm
 from tpu_inference.layers.jax.pp_utils import make_layers
 from tpu_inference.layers.vllm.quantization.configs import VllmQuantConfig
 from tpu_inference.logger import init_logger
+from tpu_inference.models.common.kv_share import drop_shared_kv_weights
 from tpu_inference.models.jax.gemma4 import Gemma4ForCausalLM, Gemma4Model
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
@@ -730,6 +731,13 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
                 ".output_min",
             ],
         )
+        # KV-shared text layers own no K/V params; a BF16 export still ships
+        # them. Unlike the text-only model this one really does load the
+        # vision tower, whose encoder layers have their own self_attn.k_proj —
+        # `drop_shared_kv_weights` is anchored on the language_model path so
+        # those are never touched.
+        text_config = self.vllm_config.model_config.hf_config.text_config
+        weights = drop_shared_kv_weights(text_config, weights)
         return loader.load_weights(mapper.apply(weights))
 
     def embed_input_ids(self,


### PR DESCRIPTION
## Summary

KV-shared layers in Gemma 4 (the last `num_kv_shared_layers`) read K/V out of the source layer's cache slot. `Gemma4Attention.__call__` already skipped `k_norm` and RoPE on them and called `attention(..., update_kv_cache=False)`, and the RPA v3 kernel sets `kv_left_frm_cache = kv_left` in that mode — so the layer's own k/v operands are never read. The layers were nevertheless allocating `k_proj`, `v_proj` and `k_norm`, and the loader then required those tensors from the checkpoint.

Gemma 4 QAT exports omit them, exactly as the config implies, so every QAT checkpoint failed to load:

```
ValueError: Following weights were not initialized from checkpoint:
{'model.language_model.layers.15.self_attn.k_norm.weight', ...
 'model.language_model.layers.34.self_attn.k_norm.weight'}
```

Layers 15–34 are the 20 KV-shared layers of E2B. Both released KV-share geometries are affected — read straight from the safetensors headers, the QAT exports carry K/V-side tensors for exactly the non-shared layers:

| checkpoint | layers | KV-shared | `k_proj`/`v_proj`/`k_norm` present |
| --- | --- | --- | --- |
| `google/gemma-4-E2B-it` | 35 | 15–34 | all 35 |
| `google/gemma-4-E2B-it-qat-q4_0-unquantized` | 35 | 15–34 | layers 0–14 only |
| `google/gemma-4-E4B-it` | 42 | 24–41 | all 42 |
| `google/gemma-4-E4B-it-qat-q4_0-unquantized` | 42 | 24–41 | layers 0–23 only |

Fixes #3225 on the JAX path.

## Changes

- **`Gemma4Attention.__init__`** — KV-shared layers build a standalone `q_proj` and no `qkv_proj`/`k_proj`/`v_proj`/`k_norm`. `__call__` passes zeros for k/v to satisfy the `attention()` signature; the kernel discards them in `update_kv_cache=False` mode.
- **`kv_share.drop_shared_kv_weights`** — filters those tensors out of the weight stream, so plain BF16 exports (which do ship them, unused) keep loading through the same model definition instead of hitting "is not a valid param path". Anchored on `language_model.layers.{i}.self_attn.`, so the vision and audio towers' own per-layer `k_proj`/`v_proj` are untouched — dropping those would have left a partly random encoder rather than raising.
- Applied in both `Gemma4ForCausalLM.load_weights` and `Gemma4ForConditionalGeneration.load_weights`.

Weight routing needs no change: `JaxAutoWeightsLoader._route` falls through when no fused `qkv_proj` param exists at that path, so the standalone `q_proj` loads normally — the same mechanism the existing `use_k_eq_v` branch relies on.

## Test plan

New cases in `tests/models/jax/test_gemma4_kv_share.py`:

- `test_shared_layers_allocate_no_kv_params` — non-shared layers keep the fused QKV and `k_norm`; shared layers have `q_proj` only.
- `test_drop_shared_kv_weights_filters_only_shared_layers` — BF16 stream: shared layers' K/V-side tensors dropped, everything else kept.
- `test_drop_shared_kv_weights_is_noop_for_qat_checkpoint` — the #3225 checkpoint shape passes through unchanged.
- `test_drop_shared_kv_weights_noop_without_sharing` — `num_kv_shared_layers=0` (26B/31B path).
- `test_drop_shared_kv_weights_spares_the_vision_tower` — vision/audio tower attention weights survive.
- `test_drop_shared_kv_weights_matches_unprefixed_names` — anchors with or without the leading `model.`.
- `test_drop_shared_kv_weights_on_released_geometries` — parametrized over the real E2B (35/20) and E4B (42/18) configs, asserting the shared range and that exactly those layers lose their K/V-side tensors.

### Verified on hardware (v6e-1, `ct6e-standard-1t`, europe-west4-a)

`vllm/vllm-tpu:nightly` (tpu-inference at `30dcf7ad0`) vs. the same image with this patch applied, `--tensor-parallel-size 1 --max-model-len 65536`:

| image | checkpoint | result |
| --- | --- | --- |
| nightly | `gemma-4-E2B-it` (BF16) | serves |
| nightly | `gemma-4-E2B-it-qat-q4_0-unquantized` | ❌ `ValueError: Following weights were not initialized from checkpoint` — `k_norm` for layers 15–34; engine exits 1 |
| **patched** | `gemma-4-E2B-it-qat-q4_0-unquantized` | ✅ weights load in 43.2 s, `Application startup complete`, generates correctly |
| **patched** | `gemma-4-E2B-it` (BF16) | ✅ weights load in 44.8 s — the path where `drop_shared_kv_weights` actually filters — generates correctly |
| nightly | `gemma-4-E4B-it-qat-q4_0-unquantized` | ❌ same failure, `k_norm` for layers 24–41 |
| **patched** | `gemma-4-E4B-it-qat-q4_0-unquantized` | ✅ weights load in 57.4 s, serves, generates correctly |

The failing layer ranges match each config's KV-share geometry exactly (E2B 35/20 → 15–34, E4B 42/18 → 24–41).

`pytest tests/models/jax/test_gemma4_kv_share.py tests/models/jax/test_gemma4_ple.py` → **28 passed on the v6e-1**.

Unaffected by construction: `gemma-4-31B-it` and `gemma-4-26B-A4B-it` both declare `num_kv_shared_layers: 0`, so `compute_kv_share_map` returns `{}`, the filter is a pass-through, and every layer takes the pre-existing `use_k_eq_v` branch.

Scope note: this fixes the JAX path only. The same checkpoint also fails on the torchax path (Failure 2 in #3225), which lives in vllm's own Gemma 4 model, and the `-qat-w4a16-ct` variant fails earlier in compressed-tensors scheme resolution (Failure 3) — both left for follow-ups.
