### PR TITLE
[Multimodal] Add flash attention kernel tuner

### DIFF
--- a/tools/kernel/tuner/v1/autotune/kernel_autotune_config.py
+++ b/tools/kernel/tuner/v1/autotune/kernel_autotune_config.py
@@ -15,4 +15,6 @@
 kernel_autotune_mapping = {
     'mla_kernel_tuner':
     '/workspace/tpu_inference/tpu_inference/kernels/mla/v2/tuned_params.py',
+    'flash_attention_kernel_tuner':
+    '/workspace/tpu_inference/tpu_inference/kernels/flash_attention/tuned_params.py',
 }

--- a/tools/kernel/tuner/v1/flash_attention_kernel_tuner.py
+++ b/tools/kernel/tuner/v1/flash_attention_kernel_tuner.py
@@ -1,0 +1,181 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+import itertools
+import logging
+import time
+
+import jax
+import jax.numpy as jnp
+
+from tools.kernel.tuner.v1.common.kernel_tuner_base import (KernelTunerBase,
+                                                            RunConfig,
+                                                            TunerConfig,
+                                                            TuningCase,
+                                                            TuningStatus)
+from tpu_inference.kernels.flash_attention.kernel import (BlockSizes,
+                                                          SegmentIds,
+                                                          flash_attention)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass
+class TuningKey:
+    batch_size: int
+    num_heads: int
+    q_seq_len: int
+    kv_seq_len: int
+    head_dim: int
+
+
+@dataclasses.dataclass
+class TunableParams:
+    block_q: int
+    block_k_major: int
+    block_k: int
+    block_b: int
+
+    def __ge__(self, other) -> bool:
+        return False
+
+    def __le__(self, other) -> bool:
+        return False
+
+
+class FlashAttentionKernelTuner(KernelTunerBase):
+
+    def __init__(self, run_config: RunConfig):
+        self.tuner_config = TunerConfig(
+            tuning_key_class=TuningKey,
+            tunable_params_class=TunableParams,
+            kernel_tuner_name="flash_attention_kernel_tuner")
+        self.run_config = run_config
+        super().__init__(tuner_config=self.tuner_config,
+                         run_config=self.run_config)
+
+    def generate_cases(self) -> list[TuningCase]:
+        # Based on xprof, we have the following fixed input shapes:
+        # batch_size=8, num_heads=16, q_seq_len=2560, kv_seq_len=2560, head_dim=72
+        tuning_key = TuningKey(batch_size=8,
+                               num_heads=16,
+                               q_seq_len=2560,
+                               kv_seq_len=2560,
+                               head_dim=72)
+
+        # Expand search space for comprehensive tuning based on seqlen=2560 and batch=8
+        block_q_values = [32, 64, 128, 256, 512, 640]
+        block_k_values = [128, 256, 512, 640, 1280, 2560]
+        block_b_values = [1, 2, 4, 8]
+
+        cases = []
+        for bq, bk, bb in itertools.product(block_q_values, block_k_values,
+                                            block_b_values):
+            if bk % 128 != 0:
+                continue
+            for bkm in block_k_values:
+                if bkm < bk:
+                    continue
+                if bkm % bk != 0:
+                    continue
+                if 2560 % bkm != 0:
+                    continue
+                if bk == 2560 and bkm != 2560:
+                    continue
+                tunable_params = TunableParams(block_q=bq,
+                                               block_k_major=bkm,
+                                               block_k=bk,
+                                               block_b=bb)
+                cases.append(TuningCase(tuning_key, tunable_params))
+        return cases
+
+    def generate_inputs(self, tuning_key: TuningKey):
+        if self._tuning_key and tuning_key == self._tuning_key:
+            return self._kernel_inputs_cache
+        self._tuning_key = tuning_key
+
+        q = jnp.ones((tuning_key.batch_size, tuning_key.num_heads,
+                      tuning_key.q_seq_len, tuning_key.head_dim),
+                     dtype=jnp.bfloat16)
+        k = jnp.ones((tuning_key.batch_size, tuning_key.num_heads,
+                      tuning_key.kv_seq_len, tuning_key.head_dim),
+                     dtype=jnp.bfloat16)
+        v = jnp.ones((tuning_key.batch_size, tuning_key.num_heads,
+                      tuning_key.kv_seq_len, tuning_key.head_dim),
+                     dtype=jnp.bfloat16)
+
+        # segment_ids
+        seg_q = jnp.zeros((tuning_key.batch_size, tuning_key.q_seq_len),
+                          dtype=jnp.int32)
+        seg_kv = jnp.zeros((tuning_key.batch_size, tuning_key.kv_seq_len),
+                           dtype=jnp.int32)
+        segment_ids = SegmentIds(q=seg_q, kv=seg_kv)
+
+        self._kernel_inputs_cache = {
+            'q': q,
+            'k': k,
+            'v': v,
+            'segment_ids': segment_ids,
+            'ab': None,
+        }
+        return self._kernel_inputs_cache
+
+    def run(self,
+            tuning_key: TuningKey,
+            tunable_params: TunableParams,
+            iters: int = 1) -> tuple[TuningStatus, float, float]:
+        inputs = self.generate_inputs(tuning_key)
+
+        block_sizes = BlockSizes(block_q=tunable_params.block_q,
+                                 block_k_major=tunable_params.block_k_major,
+                                 block_k=tunable_params.block_k,
+                                 block_b=tunable_params.block_b)
+
+        try:
+            f = jax.jit(flash_attention,
+                        static_argnames=['block_sizes', 'vmem_limit_bytes'])
+            vmem_limit = 16 * 1024 * 1024
+
+            # Warm up
+            out = f(q=inputs['q'],
+                    k=inputs['k'],
+                    v=inputs['v'],
+                    ab=inputs['ab'],
+                    segment_ids=inputs['segment_ids'],
+                    block_sizes=block_sizes,
+                    vmem_limit_bytes=vmem_limit)
+            out.block_until_ready()
+
+            start_ns = time.perf_counter_ns()
+            for _ in range(iters):
+                out = f(q=inputs['q'],
+                        k=inputs['k'],
+                        v=inputs['v'],
+                        ab=inputs['ab'],
+                        segment_ids=inputs['segment_ids'],
+                        block_sizes=block_sizes,
+                        vmem_limit_bytes=vmem_limit)
+                out.block_until_ready()
+            end_ns = time.perf_counter_ns()
+
+            latency_ns = (end_ns - start_ns)
+            return TuningStatus.SUCCESS, latency_ns / iters, latency_ns
+        except Exception as e:
+            logger.warning(
+                f"Kernel failed with block_q={tunable_params.block_q}, block_k_major={tunable_params.block_k_major}, block_k={tunable_params.block_k}, block_b={tunable_params.block_b}: {e}"
+            )
+            if "out of memory" in str(e).lower() or "vmem" in str(e).lower():
+                return TuningStatus.FAILED_OOM, 0.0, 0.0
+            return TuningStatus.UNKNOWN_ERROR, 0.0, 0.0

--- a/tools/kernel/tuner/v1/flash_attention_kernel_tuner.py
+++ b/tools/kernel/tuner/v1/flash_attention_kernel_tuner.py
@@ -45,15 +45,12 @@ class FlashAttentionKernelTuner(KernelTunerBase):
                          run_config=self.run_config)
 
     def generate_cases(self) -> list[TuningCase]:
-        # Based on xprof, we have the following fixed input shapes:
-        # batch_size=8, num_heads=16, q_seq_len=2560, kv_seq_len=2560, head_dim=72
         tuning_key = TuningKey(batch_size=8,
                                num_heads=16,
                                q_seq_len=2560,
                                kv_seq_len=2560,
                                head_dim=72)
 
-        # Expand search space for comprehensive tuning based on seqlen=2560 and batch=8
         block_q_values = [32, 64, 128, 256, 512, 640]
         block_k_values = [128, 256, 512, 640, 1280, 2560]
         block_b_values = [1, 2, 4, 8]

--- a/tools/kernel/tuner/v1/flash_attention_kernel_tuner.py
+++ b/tools/kernel/tuner/v1/flash_attention_kernel_tuner.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import dataclasses
 import itertools
 import logging
 import time
@@ -28,31 +27,10 @@ from tools.kernel.tuner.v1.common.kernel_tuner_base import (KernelTunerBase,
 from tpu_inference.kernels.flash_attention.kernel import (BlockSizes,
                                                           SegmentIds,
                                                           flash_attention)
+from tpu_inference.kernels.flash_attention.tuned_params import (TunableParams,
+                                                                TuningKey)
 
 logger = logging.getLogger(__name__)
-
-
-@dataclasses.dataclass
-class TuningKey:
-    batch_size: int
-    num_heads: int
-    q_seq_len: int
-    kv_seq_len: int
-    head_dim: int
-
-
-@dataclasses.dataclass
-class TunableParams:
-    block_q: int
-    block_k_major: int
-    block_k: int
-    block_b: int
-
-    def __ge__(self, other) -> bool:
-        return False
-
-    def __le__(self, other) -> bool:
-        return False
 
 
 class FlashAttentionKernelTuner(KernelTunerBase):

--- a/tools/kernel/tuner/v1/kernel_tuner_runner.py
+++ b/tools/kernel/tuner/v1/kernel_tuner_runner.py
@@ -21,6 +21,8 @@ from tools.kernel.tuner.v1.batched_rpa_kernel_tuner import \
     BatchedRpaKernelTuner
 from tools.kernel.tuner.v1.common.kernel_tuner_base import RunConfig
 from tools.kernel.tuner.v1.example_kernel_tuner import ExampleKernelTuner
+from tools.kernel.tuner.v1.flash_attention_kernel_tuner import \
+    FlashAttentionKernelTuner
 from tools.kernel.tuner.v1.mla_kernel_tuner import MlaKernelTuner
 from tools.kernel.tuner.v1.rpa_v3_kernel_tuner import RpaV3KernelTuner
 from tools.kernel.tuner.v1.utils import get_tpu_queue_by_version_and_cores
@@ -110,6 +112,7 @@ KERNEL_TUNER_REGISTRY = {
     'rpa_v3_kernel_tuner': RpaV3KernelTuner,
     'mla_kernel_tuner': MlaKernelTuner,
     'batched_rpa_kernel_tuner': BatchedRpaKernelTuner,
+    'flash_attention_kernel_tuner': FlashAttentionKernelTuner,
 }
 
 

--- a/tools/kernel/tuner/v1/tests/test_kernel_tuner_runner.py
+++ b/tools/kernel/tuner/v1/tests/test_kernel_tuner_runner.py
@@ -163,6 +163,9 @@ class KernelTunerRunnerSmokeTest(absltest.TestCase):
     def test_batched_rpa_kernel_tuner(self):
         self._run_tuner_smoke_test("batched_rpa_kernel_tuner")
 
+    def test_flash_attention_kernel_tuner(self):
+        self._run_tuner_smoke_test("flash_attention_kernel_tuner")
+
 
 class TuningCaseSerializationTest(absltest.TestCase):
     """Tests for TuningCase serialization and deserialization."""

--- a/tpu_inference/kernels/flash_attention/kernel.py
+++ b/tpu_inference/kernels/flash_attention/kernel.py
@@ -13,6 +13,8 @@ from jax import lax
 from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
+from tpu_inference.kernels.flash_attention.tuned_params import (
+    TuningKey, get_tuned_params)
 from tpu_inference.utils import align_to
 
 DEFAULT_MASK_VALUE = -0.7 * float(jnp.finfo(jnp.dtype("float32")).max)
@@ -244,15 +246,32 @@ def flash_attention(
                 f"KV segment ids shape mismatch: expected ({batch_size=},"
                 f" {kv_seq_len=},), got {segment_ids.kv.shape}")
     if block_sizes is None:
-        block_sizes = BlockSizes.get_default(batch_size, num_heads, q_seq_len,
-                                             kv_seq_len, d_model)
-        # TODO (KWang1998 & hfan): tune the block sizes properly.
-        if kv_seq_len <= 92800:
-            # Override block_k/block_k_major to use `_flash_attention_kernel_single_batch_single_step`.
-            block_sizes = BlockSizes(block_q=block_sizes.block_q,
-                                     block_b=block_sizes.block_b,
-                                     block_k_major=kv_seq_len,
-                                     block_k=kv_seq_len)
+        tuned_params = get_tuned_params(
+            TuningKey(
+                batch_size=batch_size,
+                num_heads=num_heads,
+                q_seq_len=q_seq_len,
+                kv_seq_len=kv_seq_len,
+                head_dim=d_model,
+                q_dtype=q.dtype.name,
+                kv_dtype=k.dtype.name,
+            ))
+        if tuned_params is not None:
+            block_sizes = BlockSizes(block_q=tuned_params.block_q,
+                                     block_k_major=tuned_params.block_k_major,
+                                     block_k=tuned_params.block_k,
+                                     block_b=tuned_params.block_b)
+        else:
+            block_sizes = BlockSizes.get_default(batch_size, num_heads,
+                                                 q_seq_len, kv_seq_len,
+                                                 d_model)
+            # TODO (KWang1998 & hfan): tune the block sizes properly.
+            if kv_seq_len <= 92800:
+                # Override block_k/block_k_major to use `_flash_attention_kernel_single_batch_single_step`.
+                block_sizes = BlockSizes(block_q=block_sizes.block_q,
+                                         block_b=block_sizes.block_b,
+                                         block_k_major=kv_seq_len,
+                                         block_k=kv_seq_len)
     return _flash_attention(q, k, v, ab, segment_ids, False, causal, sm_scale,
                             block_sizes, vmem_limit_bytes, debug)
 

--- a/tpu_inference/kernels/flash_attention/tuned_params.py
+++ b/tpu_inference/kernels/flash_attention/tuned_params.py
@@ -1,0 +1,74 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+@dataclass(frozen=True)
+class TuningKey:
+    batch_size: int
+    num_heads: int
+    q_seq_len: int  # Assumes q_seq_len == kv_seq_len (self-attention).
+    kv_seq_len: int
+    head_dim: int
+    q_dtype: str = "bfloat16"
+    kv_dtype: str = "bfloat16"
+
+
+@dataclass
+class TunableParams:
+    block_q: int
+    block_k_major: int
+    block_k: int
+    block_b: int
+
+    def __ge__(self, other) -> bool:
+        return False
+
+    def __le__(self, other) -> bool:
+        return False
+
+
+tuned_params_mapping: dict[TuningKey, TunableParams] = {
+    TuningKey(
+        batch_size=8,
+        num_heads=16,
+        q_seq_len=2560,
+        kv_seq_len=2560,
+        head_dim=72,
+    ):
+    TunableParams(
+        block_q=640,
+        block_k_major=2560,
+        block_k=512,
+        block_b=1,
+    ),
+}
+
+
+def get_tuned_params(tuning_key: TuningKey) -> TunableParams | None:
+    """Looks up tuned flash attention block sizes for the given shape.
+
+    Returns None on a miss to fall back to the default.
+    """
+    tuned_params = tuned_params_mapping.get(tuning_key)
+    if tuned_params is None:
+        logger.warning_once(
+            f"No tuned block sizes found for flash attention with tuning key: {tuning_key}, falling back to the default block size heuristic."
+        )
+    return tuned_params

--- a/tpu_inference/kernels/flash_attention/tuned_params.py
+++ b/tpu_inference/kernels/flash_attention/tuned_params.py
@@ -30,7 +30,7 @@ class TuningKey:
     kv_dtype: str = "bfloat16"
 
 
-@dataclass
+@dataclass(frozen=True)
 class TunableParams:
     block_q: int
     block_k_major: int


### PR DESCRIPTION
# Description

Create a flash attention kernel tuner based on https://github.com/vllm-project/tpu-inference/blob/4629f242a74d9f388543eddd37389f2c85fe8194/tools/kernel/tuner/v1/README.md.
Add logic for loading tuned block sizes of flash attention kernel.

# Tests

 Tested locally with:
```
python -m tools.kernel.tuner.v1.kernel_tuner_runner \
  --kernel_tuner_name=flash_attention_kernel_tuner \
  --run_locally=True \
  --case_set_id=fa_local_test \
  --run_id=001 \
  --case_set_desc="Flash attention local test" \
  --tpu_version=tpu7x \
  --tpu_cores=2 \
  --debug=True
```

Block sizes are tuned through buildkite. 
Validated e2e on gemma4_mm with tuned block sizes: flash attention kernel time reduces from `2.8 ms` to `1.7 ms`.


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
