### PR TITLE
[JAX] Add int8 W8A8 compressed-tensors support to the JAX path

### DIFF
--- a/tests/layers/jax/quantization/test_int8.py
+++ b/tests/layers/jax/quantization/test_int8.py
@@ -1,0 +1,163 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the JAX-native int8 W8A8 compressed-tensors linear method."""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+from jax.sharding import Mesh
+
+from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
+from tpu_inference.layers.jax.linear import JaxLinear
+from tpu_inference.layers.jax.quantization.compressed_tensors import \
+    CompressedTensorsConfig
+from tpu_inference.layers.jax.quantization.int8 import \
+    Int8ChannelwiseLinearMethod
+from tpu_inference.layers.jax.quantization.unquantized import \
+    UnquantizedLinearMethod
+
+
+# A compressed-tensors `quantization_config` modeled on llm-compressor
+# int8 W8A8 output (e.g. RedHatAI *-quantized.w8a8 checkpoints): int8
+# channelwise static symmetric weights + dynamic per-token int8 activations.
+def _int8_channel_config(ignore=None):
+    return {
+        "quant_method": "compressed-tensors",
+        "format": "int-quantized",
+        "config_groups": {
+            "group_0": {
+                "targets": ["Linear"],
+                "weights": {
+                    "num_bits": 8,
+                    "type": "int",
+                    "symmetric": True,
+                    "strategy": "channel",
+                    "dynamic": False,
+                },
+                "input_activations": {
+                    "num_bits": 8,
+                    "type": "int",
+                    "symmetric": True,
+                    "strategy": "token",
+                    "dynamic": True,
+                },
+            }
+        },
+        "ignore": ignore or [],
+    }
+
+
+# Static (non-dynamic) activations are not supported by the JAX int8 method;
+# the dispatch must not silently mis-route this scheme.
+def _int8_static_act_config():
+    cfg = _int8_channel_config()
+    cfg["config_groups"]["group_0"]["input_activations"] = {
+        "num_bits": 8,
+        "type": "int",
+        "symmetric": True,
+        "strategy": "tensor",
+        "dynamic": False,
+    }
+    return cfg
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    if not jax.devices():
+        pytest.skip("No JAX devices available for mesh creation.")
+    devices = np.array(jax.local_devices()[:1])
+    device_mesh = devices.reshape((1, ) * len(MESH_AXIS_NAMES))
+    with Mesh(device_mesh, axis_names=MESH_AXIS_NAMES) as m:
+        yield m
+
+
+@pytest.fixture
+def rngs():
+    return nnx.Rngs(42)
+
+
+def _make_linear(rngs, quant_config, in_features=64, out_features=32):
+    return JaxLinear(in_features,
+                     out_features,
+                     rngs=rngs,
+                     quant_config=quant_config,
+                     kernel_init=nnx.initializers.uniform(),
+                     prefix="mlp.proj1")
+
+
+class TestInt8ChannelwiseDispatch:
+
+    def test_int8_routes_to_channelwise_method(self, rngs, mesh):
+        """int8 channel weights + dynamic token acts -> Int8 method."""
+        config = CompressedTensorsConfig(_int8_channel_config())
+        with jax.set_mesh(mesh):
+            layer = _make_linear(rngs, config)
+        assert isinstance(layer.quant_method, Int8ChannelwiseLinearMethod)
+
+    def test_ignored_layer_is_skipped(self, rngs, mesh):
+        """A layer matched by the ignore regex -> UnquantizedLinearMethod."""
+        config = CompressedTensorsConfig(
+            _int8_channel_config(ignore=["re:.*proj1"]))
+        with jax.set_mesh(mesh):
+            layer = _make_linear(rngs, config)
+        assert isinstance(layer.quant_method, UnquantizedLinearMethod)
+
+    def test_static_act_scheme_is_rejected(self, rngs, mesh):
+        """Static-tensor int8 activations are unsupported -> loud failure."""
+        config = CompressedTensorsConfig(_int8_static_act_config())
+        with jax.set_mesh(mesh):
+            with pytest.raises(NotImplementedError):
+                _make_linear(rngs, config)
+
+    def test_int8_weight_params(self, rngs, mesh):
+        """Weight is int8 [in, out]; scale is fp32 [out] named weight_scale."""
+        config = CompressedTensorsConfig(_int8_channel_config())
+        with jax.set_mesh(mesh):
+            layer = _make_linear(rngs, config, 64, 32)
+        assert layer.weight.get_value().dtype == jnp.int8
+        assert layer.weight.get_value().shape == (64, 32)
+        assert hasattr(layer, "weight_scale")
+        assert layer.weight_scale.get_value().shape == (32, )
+        assert layer.weight_scale.get_value().dtype == jnp.float32
+
+
+class TestInt8ChannelwiseNumerics:
+
+    def test_apply_matches_dequant_reference(self, rngs, mesh):
+        """int8 W8A8 forward tracks the fp32 dequantized reference."""
+        in_features, out_features, tokens = 64, 32, 8
+        config = CompressedTensorsConfig(_int8_channel_config())
+        with jax.set_mesh(mesh):
+            layer = _make_linear(rngs, config, in_features, out_features)
+
+            rng = np.random.default_rng(0)
+            w_f = rng.standard_normal(
+                (in_features, out_features)).astype(np.float32) * 0.05
+            w_scale = np.abs(w_f).max(axis=0) / 127.0
+            w_q = np.round(w_f / w_scale).astype(np.int8)
+            layer.weight.set_value(jnp.asarray(w_q))
+            layer.weight_scale.set_value(jnp.asarray(w_scale, jnp.float32))
+
+            x = (rng.standard_normal(
+                (tokens, in_features)) * 0.5).astype(np.float32)
+            ref = x @ (w_q.astype(np.float32) * w_scale)
+            out = np.asarray(layer(jnp.asarray(x, jnp.bfloat16)))
+
+        rel_err = np.abs(out.astype(np.float32) -
+                         ref).max() / np.abs(ref).max()
+        # Error budget: dynamic int8 activation quantization (~1/127)
+        # plus the bf16 input cast.
+        assert rel_err < 0.03, rel_err

--- a/tests/models/jax/test_qwen3_int8.py
+++ b/tests/models/jax/test_qwen3_int8.py
@@ -1,0 +1,169 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end load + forward test for compressed-tensors int8 W8A8.
+
+Exercises the JAX path added in this PR (``Int8ChannelwiseLinearMethod``)
+against a real, public ``int-quantized`` checkpoint whose scheme is:
+  - weights     : int8, symmetric, per-channel, static (``weight_scale``)
+  - activations : int8, symmetric, per-token, dynamic
+
+We use a Qwen3 (dense ``Qwen3ForCausalLM``) checkpoint because that
+architecture runs on the native flax_nnx path where this method lives.
+(The Qwen3.5 VLM suggested in review is routed to the vLLM/torchax path
+via ``_VLLM_PREFERRED_ARCHITECTURES``, so it would not exercise this code.)
+"""
+from unittest.mock import MagicMock, patch
+
+import jax
+import jax.numpy as jnp
+import pytest
+from flax import nnx
+
+from tpu_inference.distributed.jax_parallel_state import \
+    init_pp_distributed_environment
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.jax.quantization import get_tpu_quantization_config
+from tpu_inference.layers.jax.quantization.int8 import \
+    Int8ChannelwiseLinearMethod
+from tpu_inference.models.jax.qwen3 import Qwen3ForCausalLM
+from tpu_inference.runner.kv_cache import create_kv_caches
+
+# A real, public compressed-tensors ``int-quantized`` W8A8 checkpoint
+# (per-channel static int8 weights + per-token dynamic int8 activations),
+# i.e. the exact scheme this PR dispatches to Int8ChannelwiseLinearMethod.
+INT8_W8A8_MODEL = "RedHatAI/Qwen3-4B-Instruct-2507-quantized.w8a8"
+# Loading a couple of decoder layers is enough to prove the int8 path;
+# keeps device memory / compile time bounded for the full 4B checkpoint.
+NUM_LAYERS = 2
+
+
+@pytest.fixture(autouse=True)
+def mock_get_pp_group():
+    with patch("tpu_inference.models.jax.qwen3.get_pp_group",
+               return_value=MagicMock(is_first_rank=True,
+                                      is_last_rank=True,
+                                      rank_in_group=0,
+                                      world_size=1)):
+        yield
+
+
+class TestQwen3Int8W8A8:
+
+    def test_int8_w8a8_load_and_forward(self, rng, mesh, mock_vllm_config):
+        """Load a real int8 W8A8 checkpoint and run a forward pass.
+
+        Asserts that (1) the checkpoint is recognized and routed to
+        ``Int8ChannelwiseLinearMethod``, (2) linear weights materialize as
+        int8 with a channelwise (1-D) float ``weight_scale``, and (3) a
+        forward pass through the int8 matmul path yields finite outputs.
+        """
+        init_pp_distributed_environment(
+            ip="",
+            rank=0,
+            world_size=1,
+            device=jax.devices()[0],
+            need_pp=False,
+        )
+
+        cfg = mock_vllm_config(INT8_W8A8_MODEL, "auto")
+        # Only build/load a few layers -- weight loading of the first layers
+        # is representative, and it bounds memory for the 4B checkpoint.
+        cfg.model_config.hf_config.num_hidden_layers = NUM_LAYERS
+        cfg.load_config.load_format = "skip_layers_model_loader_for_test"
+        cfg.load_config.num_layers_to_load_for_test = NUM_LAYERS
+        cfg.parallel_config = None
+        cfg.quant_config = get_tpu_quantization_config(cfg)
+
+        # The checkpoint's compressed-tensors config must be picked up; if the
+        # int8 scheme were unsupported, model construction below would raise
+        # NotImplementedError from get_quant_method.
+        assert cfg.quant_config is not None
+
+        from vllm.config import set_current_vllm_config
+        from vllm.model_executor.model_loader import get_model_loader
+
+        with jax.set_mesh(mesh):
+            model = Qwen3ForCausalLM(cfg, rng, mesh)
+            loader = get_model_loader(cfg.load_config)
+            with set_current_vllm_config(cfg):
+                loader.load_weights(model, cfg.model_config)
+
+        # A quantized linear must own an Int8ChannelwiseLinearMethod and have
+        # materialized int8 weights + a channelwise (float) dequant scale.
+        # (The param is declared fp32 but the loader keeps the checkpoint's
+        # own scale dtype -- bf16 here -- same as the fp8 path.)
+        layer0 = model.model.layers[model.model.start_layer]
+        quantized_linears = {
+            "q_proj": layer0.self_attn.q_proj,
+            "o_proj": layer0.self_attn.o_proj,
+            "gate_proj": layer0.mlp.gate_proj,
+            "down_proj": layer0.mlp.down_proj,
+        }
+        for name, lin in quantized_linears.items():
+            assert isinstance(lin.quant_method, Int8ChannelwiseLinearMethod), (
+                f"{name} did not route to Int8ChannelwiseLinearMethod")
+            assert lin.weight[...].dtype == jnp.int8, (
+                f"{name}.weight is {lin.weight[...].dtype}, expected int8")
+            scale = lin.weight_scale[...]
+            assert jnp.issubdtype(scale.dtype, jnp.floating), (
+                f"{name}.weight_scale is {scale.dtype}, expected a float scale"
+            )
+            # channelwise dequant scale is a 1-D per-output-feature vector
+            assert scale.ndim == 1, (
+                f"{name}.weight_scale shape {scale.shape} is not channelwise")
+
+        # Forward pass exercises the int8 (dynamic per-token) matmul kernel.
+        hf_config = cfg.model_config.hf_config
+        hidden_size = hf_config.hidden_size
+        num_kv_heads = hf_config.num_key_value_heads
+        head_dim = 128
+
+        kv_caches = create_kv_caches(
+            num_blocks=4,
+            block_size=32,
+            num_kv_heads=num_kv_heads,
+            head_size=head_dim,
+            mesh=mesh,
+            layer_names=["layer"] * NUM_LAYERS,
+            cache_dtype=jnp.bfloat16,
+        )
+
+        num_tokens = 8
+        num_reqs = 1
+        max_num_blocks_per_req = 4
+        input_ids = jnp.ones((num_tokens, ), dtype=jnp.int32)
+        attention_metadata = AttentionMetadata(
+            input_positions=jnp.arange(num_tokens, dtype=jnp.int32),
+            block_tables=jnp.zeros((num_reqs, max_num_blocks_per_req),
+                                   dtype=jnp.int32).reshape(-1),
+            seq_lens=jnp.array([num_tokens], dtype=jnp.int32),
+            query_start_loc=jnp.array([0, num_tokens], dtype=jnp.int32),
+            request_distribution=jnp.array([0, 0, 1], dtype=jnp.int32),
+        )
+
+        # The int8 matmul lowers to jax.shard_map under an (abstract) mesh, so
+        # the forward must run inside jit -- eager execution leaves the
+        # embedded activations on a SingleDeviceSharding that the sharding
+        # constraint rejects. This mirrors how the runner invokes the model.
+        @nnx.jit
+        def _forward(m, kv_caches, input_ids, attention_metadata):
+            return m(kv_caches, input_ids, attention_metadata)
+
+        with jax.set_mesh(mesh):
+            _, hidden_states, aux_hidden_states, _ = _forward(
+                model, kv_caches, input_ids, attention_metadata)
+
+        assert hidden_states.shape == (num_tokens, hidden_size)
+        assert jnp.all(jnp.isfinite(hidden_states)), \
+            "int8 forward produced non-finite hidden states"

--- a/tpu_inference/layers/jax/base.py
+++ b/tpu_inference/layers/jax/base.py
@@ -31,7 +31,16 @@ logger = init_logger(__name__)
 # Define singleton initializers to avoid re-compilation.
 scale_initializer = nnx.initializers.ones
 sharded_initializer = nnx.initializers.xavier_normal()
-_init_fn = nnx.initializers.uniform()
+_uniform_init_fn = nnx.initializers.uniform()
+
+
+def _init_fn(key, shape, dtype=jnp.float32):
+    # jax.random.uniform only supports floating dtypes; integer params
+    # (e.g. int8 quantized weights, overwritten by the weight loader)
+    # are zero-initialized instead.
+    if jnp.issubdtype(jnp.dtype(dtype), jnp.integer):
+        return jnp.zeros(shape, dtype)
+    return _uniform_init_fn(key, shape, dtype)
 
 
 @dataclass

--- a/tpu_inference/layers/jax/quantization/compressed_tensors.py
+++ b/tpu_inference/layers/jax/quantization/compressed_tensors.py
@@ -36,6 +36,8 @@ from tpu_inference.layers.jax.quantization.configs import (QuantizationConfig,
 from tpu_inference.layers.jax.quantization.fp8 import (
     Fp8BlockwiseLinearMethod, Fp8FusedMoEMethod, Fp8TensorwiseLinearMethod,
     Fp8TensorwiseMergedLinearMethod)
+from tpu_inference.layers.jax.quantization.int8 import \
+    Int8ChannelwiseLinearMethod
 from tpu_inference.layers.jax.quantization.unquantized import (
     UnquantizedFusedMoEMethod, UnquantizedLinearMethod)
 
@@ -141,6 +143,18 @@ class CompressedTensorsConfig(QuantizationConfig):
             if isinstance(layer, JaxMergedColumnParallelLinear):
                 return Fp8TensorwiseMergedLinearMethod(layer, linear_config)
             return Fp8TensorwiseLinearMethod(layer, linear_config)
+
+        # int8 W8A8 (int-quantized): channelwise/tensorwise symmetric int8
+        # weights + dynamic per-token int8 activations (llm-compressor style).
+        # QuantizationType is a str enum, so a plain string compare is safe.
+        if (weight_quant is not None and input_quant is not None
+                and getattr(weight_quant, "type", None) == "int" and
+                self._ct._is_dynamic_token_w8a8(weight_quant, input_quant)):
+            if isinstance(layer, JaxMergedColumnParallelLinear):
+                raise NotImplementedError(
+                    "compressed-tensors int8 W8A8 is not yet supported for "
+                    "JaxMergedColumnParallelLinear layers in the JAX path.")
+            return Int8ChannelwiseLinearMethod(layer, linear_config)
 
         # TODO: w4a8 / wNa16 schemes need their own JAX methods (not yet ported).
         raise NotImplementedError(

--- a/tpu_inference/layers/jax/quantization/int8.py
+++ b/tpu_inference/layers/jax/quantization/int8.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""JAX-native int8 W8A8 (compressed-tensors ``int-quantized``) linear method.
+
+Supports the llm-compressor / RedHatAI-style scheme:
+  - weights: int8, symmetric, static, per-channel scale (``weight_scale``)
+  - activations: int8, symmetric, dynamic per-token (quantized at runtime)
+
+The numeric path reuses ``sharded_quantized_matmul`` ->
+``xla_quantized_matmul``, which already handles integer weight dtypes
+(int32 accumulation + per-token activation quantization).
+
+NOTE: this class intentionally mirrors ``Fp8TensorwiseLinearMethod``
+(layers/jax/quantization/fp8.py) with the weight dtype swapped to int8.
+Kept as a standalone copy for now to leave the fp8 path untouched; when
+upstreaming, extract a shared channelwise base class (fp8-tensorwise /
+int8 family) instead of inheriting across dtypes. fp4/mx formats are a
+different family (packed storage + block scales) and should not share
+this base.
+"""
+import math
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import PartitionSpec as P
+
+from tpu_inference.layers.common.linear import sharded_quantized_batched_matmul
+from tpu_inference.layers.common.quantization import fp8 as common_fp8
+from tpu_inference.layers.jax import JaxModule
+from tpu_inference.layers.jax.base import create_param
+from tpu_inference.layers.jax.linear import JaxEinsum
+from tpu_inference.layers.jax.quantization import QuantizeMethodBase
+from tpu_inference.layers.jax.quantization.configs import QuantLinearConfig
+from tpu_inference.logger import init_logger
+from tpu_inference.models.jax.utils.weight_utils import \
+    load_nnx_param_from_reshaped_torch
+
+logger = init_logger(__name__)
+
+
+class Int8ChannelwiseLinearMethod(QuantizeMethodBase,
+                                  common_fp8.Fp8LinearMethod):
+    """int8 W8A8 (channelwise weight scale, dynamic per-token acts)."""
+
+    weight_dtype = jnp.int8
+
+    def __init__(self, layer: JaxEinsum, linear_config: QuantLinearConfig):
+        common_fp8.Fp8LinearMethod.__init__(self, linear_config)
+
+        self.einsum_str = layer.einsum_str
+
+        self.output_shape = linear_config.out_features
+        self.batch_features = linear_config.batch_features
+        self.batch_sharding = linear_config.batch_sharding
+        out_features = math.prod(self.output_shape)
+        in_features = math.prod(linear_config.in_features)
+        self.weight_sharding = linear_config.weight_sharding
+        if self.batch_features:
+            # Batched case: keep original weight sharding for the full
+            # 3D weight (matches kernel_shape).
+            self.kernel_shape = layer.kernel_shape
+        else:
+            self.kernel_shape = (in_features, out_features)
+
+        self.in_features = in_features
+
+    def create_weights_jax(self, layer: JaxEinsum, *weight_args, rngs,
+                           **extra_weight_attrs):
+        assert isinstance(layer, JaxEinsum)
+
+        out_features = sum(self.linear_config.output_sizes)
+
+        layer.weight = create_param(rngs,
+                                    shape=self.kernel_shape,
+                                    dtype=self.weight_dtype,
+                                    sharding=self.weight_sharding)
+
+        layer.weight.set_metadata(
+            'weight_loader',
+            partial(load_nnx_param_from_reshaped_torch,
+                    permute_dims=(1, 0),
+                    param_name=layer.prefix + ".weight"))
+
+        # compressed-tensors serializes the channelwise dequant scale as
+        # "weight_scale" with shape [out, 1]; reshape to 1D on load.
+        scale_sharding = None
+        if self.batch_features:
+            if self.batch_sharding:
+                scale_sharding = None  # replicated scale for simplicity
+        elif isinstance(self.weight_sharding, P) and len(
+                self.weight_sharding) > 0:
+            scale_sharding = P(self.weight_sharding[0])
+        elif isinstance(self.weight_sharding,
+                        (tuple, list)) and len(self.weight_sharding) > 0:
+            scale_sharding = (self.weight_sharding[0], )
+
+        layer.weight_scale = create_param(rngs,
+                                          shape=(out_features, ),
+                                          dtype=jnp.float32,
+                                          sharding=scale_sharding)
+        layer.weight_scale.set_metadata(
+            'weight_loader',
+            partial(load_nnx_param_from_reshaped_torch,
+                    reshape_dims=(out_features, ),
+                    permute_dims=None,
+                    param_name=layer.prefix + ".weight_scale"))
+
+    def apply_jax(self, layer: JaxModule, x: jax.Array) -> jax.Array:
+        bias = layer.bias[...] if layer.bias is not None else None
+
+        if self.batch_features:
+            out = sharded_quantized_batched_matmul(
+                x,
+                layer.weight[...],
+                layer.weight_scale[...],
+                einsum_str=self.einsum_str,
+                weight_sharding=self.weight_sharding,
+                mesh=self.linear_config.mesh)
+            if bias is not None:
+                out += bias
+            return out
+
+        if len(x.shape) > 2:
+            x = x.reshape(-1, self.in_features)
+        out = self._apply_fused(x,
+                                layer.weight[...],
+                                layer.weight_scale[...],
+                                bias=bias)
+        out = out.reshape(out.shape[:-1] + self.output_shape)
+        return out


### PR DESCRIPTION
# Description

The JAX path only supported fp8 compressed-tensors schemes; int8 W8A8
(`int-quantized`) checkpoints hit `NotImplementedError` in
`CompressedTensorsConfig.get_quant_method`.

This adds `Int8ChannelwiseLinearMethod` for the llm-compressor style scheme
(int8 per-channel static weights + dynamic per-token int8 activations). It
reuses the existing `xla_quantized_matmul`, which already handles integer
weight dtypes, so only the int8 weight dtype and channelwise `weight_scale`
are new.

Fused `JaxMergedColumnParallelLinear` int8 raises `NotImplementedError` for
now, matching the fp8 blockwise branch.

# Tests

New `test_int8.py` (5 tests: dispatch, ignore-regex, static-act rejection,
param shapes, forward vs fp32 dequant reference).

```
JAX_PLATFORMS=cpu python -m pytest tests/layers/jax/quantization/test_int8.py -v
```

All 5 pass; also validated on TPU v6e-1 with a real int8 W8A8 checkpoint
(parity with the torchax int8 path).

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
