### PR TITLE
[skip ci] [CODEOWNERS] Add @RobMulla as a docs owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,9 +14,9 @@
 /.github/ @QiliangCui @yiw-wang @CienetStingLin @theminghuang
 
 # Documentation
-/docs/ @bvrockwell @vipannalla @QiliangCui
-/README.md @bvrockwell @vipannalla @QiliangCui
-/CONTRIBUTING.md @jrplatin @bvrockwell @QiliangCui
+/docs/ @bvrockwell @RobMulla @vipannalla @QiliangCui
+/README.md @bvrockwell @RobMulla @vipannalla @QiliangCui
+/CONTRIBUTING.md @jrplatin @bvrockwell @RobMulla @QiliangCui
 
 # Distributed Computing
 /tpu_inference/distributed/ @mrjunwan-lang @sixiang-google


### PR DESCRIPTION
## Purpose

@bvrockwell is currently out of office. This adds @RobMulla alongside her on
every documentation ownership rule so docs PRs still have available CODEOWNER
review coverage.

## Changes

`.github/CODEOWNERS` — the three rules that list `@bvrockwell` now also list `@RobMulla`:

- `/docs/`
- `/README.md`
- `/CONTRIBUTING.md`

No other ownership rules are touched, and no existing owner is removed.
@RobMulla has admin permission on the repo, so the entries are valid CODEOWNERS.
