### PR TITLE
Add load-based DP rank routing behind DP_SCHED_ROUTING

### DIFF
--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -422,6 +422,10 @@ class DPScheduler(SchedulerInterface):
         # DP state
         self.dp_size = vllm_config.sharding_config.total_dp_size
         self.assigned_dp_rank: Dict[str, int] = {}  # req_id -> dp_rank
+        # Rank routing policy, see DP_SCHED_ROUTING.
+        self._routing: str = envs.DP_SCHED_ROUTING
+        self._load_waiting_weight: int = envs.DP_SCHED_LOAD_WAITING_WEIGHT
+        self._rr_start = 0
         self.cached_schedulers_output = deque()
         self._create_per_rank_configs(kv_cache_config)
         self._schedule_step_count = 0
@@ -711,6 +715,39 @@ class DPScheduler(SchedulerInterface):
         return pending, inflight, min_remaining
 
     def _find_best_rank_for_request(self, request: Request) -> int:
+        """Route a new request to a DP rank, per DP_SCHED_ROUTING."""
+        if self._routing == "load":
+            return self._find_rank_by_load()
+        return self._find_rank_by_cache_affinity(request)
+
+    def _find_rank_by_load(self) -> int:
+        """Pick the least loaded rank, mirroring vLLM upstream's DP balancer.
+
+        Upstream (DPLBAsyncMPClient.get_core_engine_for_request) scores each
+        engine as ``waiting * 4 + running`` and does not consult prefix cache
+        locality at all. Cache affinity is deliberately not an input here: the
+        attention-DP ranks advance in lockstep, so a rank made hot by cache
+        affinity gates every other rank's step.
+
+        The scan start rotates so ties do not systematically favour rank 0,
+        which also matches upstream.
+        """
+        for rank in range(self.dp_size):
+            self._send_command(rank, SchedulerCommand.GET_REQUEST_COUNTS)
+
+        scores: Dict[int, int] = {}
+        for rank in range(self.dp_size):
+            running, waiting = self._get_result(
+                rank, SchedulerCommand.GET_REQUEST_COUNTS)
+            scores[rank] = waiting * self._load_waiting_weight + running
+
+        order = [(self._rr_start + i) % self.dp_size
+                 for i in range(self.dp_size)]
+        rank = min(order, key=lambda r: scores[r])
+        self._rr_start = (self._rr_start + 1) % self.dp_size
+        return rank
+
+    def _find_rank_by_cache_affinity(self, request: Request) -> int:
         """Find the best DP rank for a new request based on load balancing.
 
         Two-tier strategy:

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -69,6 +69,8 @@ if TYPE_CHECKING:
     NUM_PRECOMPILE_WORKERS: int = 1
     DP_SCHED_BATCH_PREFILL: bool = False
     DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS: int = 10000
+    DP_SCHED_ROUTING: str = "cache"
+    DP_SCHED_LOAD_WAITING_WEIGHT: int = 4
     VLLM_MOE_CHUNK_SIZE: int = 0
     ONEHOT_MOE_PERMUTE_THRESHOLD: int = 0
     PROFILE_SINGLE_DEVICE: bool = False
@@ -415,6 +417,15 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # DP scheduler: timeout (ms) to force flush pending requests.
     "DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS":
     lambda: int(os.getenv("DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS", "30000")),
+    # DP scheduler: how a new request picks its DP rank.
+    #   "cache" - prefer any rank reporting a prefix cache hit (default).
+    #   "load"  - ignore cache locality, pick the least loaded rank using
+    #             vLLM upstream's score: waiting * weight + running.
+    "DP_SCHED_ROUTING":
+    env_with_choices("DP_SCHED_ROUTING", "cache", ["cache", "load"]),
+    # DP scheduler: weight applied to waiting requests by "load" routing.
+    "DP_SCHED_LOAD_WAITING_WEIGHT":
+    lambda: int(os.getenv("DP_SCHED_LOAD_WAITING_WEIGHT", "4")),
     "MLA_XPOSE_N_TILE_SIZE":
     lambda: int(os.getenv("MLA_XPOSE_N_TILE_SIZE", "160")),
     "VLLM_MOE_CHUNK_SIZE":


### PR DESCRIPTION
## Problem

`DPScheduler._find_best_rank_for_request` gives prefix cache affinity **absolute priority**: it probes every rank, returns the first one reporting *any* nonzero cache hit, and never consults load.

```python
if best_cache_tokens > 0:
    return best_cache_rank          # load is never considered
pending, inflight, min_remaining = self._get_rank_routing_state()
```

Under attention-DP the ranks advance in **lockstep**, so a rank made hot by cache affinity gates every other rank's step. A single cached 256-token block is enough to pin a request onto the busiest rank.

This is pathological for GRPO-shaped workloads. All `G` streams of a group share one initial prompt, so once the first stream populates a rank, the remaining `G-1` all probe-hit there and **the entire group pins to a single rank**. Instrumenting the router on a 2-group / 8-stream run:

```
conv=be79a3: 24 reqs, ranks=['0']  sticky=True
conv=129bab: 24 reqs, ranks=['1']  sticky=True
probe=[3584, 0, 0, 0] rank=0        # history exists on exactly one rank
```

Ranks 2 and 3 received no work at all.

## Fix

Add `DP_SCHED_ROUTING`:

- `cache` (**default, unchanged behaviour**) — existing cache-affinity routing, now `_find_rank_by_cache_affinity`.
- `load` — ignore cache locality, pick the least loaded rank using vLLM upstream's score from `DPLBAsyncMPClient.get_core_engine_for_request`:

```python
scores[rank] = waiting * DP_SCHED_LOAD_WAITING_WEIGHT + running   # weight default 4
```

with a rotating scan start so ties do not systematically favour rank 0 — also matching upstream. Upstream does no cache-aware routing at all in its DP balancer; cache locality lives in the external router layer.

The change is purely additive (+48/-0); the existing path is renamed, not modified.

## Measured

`Qwen/Qwen3.5-397B-A17B-FP8`, TPU v7x-8, TP8 + attn-DP4, 65536 context, `max_num_seqs=256`, 256 streams (16 GRPO groups x 16), prefix caching on. Turn counts within 0.2% across all three runs, so turns/sec and wall time are directly comparable.

| routing | prefix cache | turns/sec | wall | output tok/s | success |
|---|---|---:|---:|---:|---:|
| `cache` | off | 1.0016 | 6658 s | 545.77 | 99.97% |
| `cache` | on | 0.8581 | 7791 s | 515.52 | 100% |
| **`load`** | **on** | **1.8286** | **3656 s** | **1092.22** | **100%** |

**2.13x** over cache-first routing and **1.83x** over the caching-off baseline, at 100% request success with **zero preemptions**.

Supporting evidence:
- Per-rank request counts went from two idle ranks to **1649 / 1670 / 1706 / 1660** across 6685 requests (3.4% spread).
- The prefix cache hit rate **improves** rather than degrades. With cache-first routing it decayed 84% -> 30% over a run as ranks contended for one working set; with load routing it settles at 59-65%. Balanced ranks each hold a quarter of the working set, so there is less eviction — the load-based router gets *better* cache reuse than the cache-aware one.
- Peak KV 86.7% with no preemption, versus 37.2% before: the cache is being used productively rather than sitting behind an unbalanced queue.

## Notes for review

Default is left at `cache` so nothing changes unless opted in, but the data argues for flipping the default to `load`. I have deliberately not done that here.

Only measured on one workload shape (GRPO groups with a shared prompt, `dp_size=4`). Group-shared prefixes are what make cache-first routing degenerate, so workloads without them will show a smaller gap.

`DP_SCHED_LOAD_WAITING_WEIGHT` is exposed because upstream's weight of 4 was tuned for independent engine processes, whereas attention-DP ranks step in lockstep — imbalance is strictly more costly here, so a higher weight may prove better. Not yet swept.
