### PR TITLE
Unblock PCP config validation on TPU

### DIFF
--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -24,6 +24,7 @@ if hasattr(torch, "accelerator") and hasattr(torch.accelerator, "empty_cache"):
                 raise e
 
     torch.accelerator.empty_cache = _patched_empty_cache
+
 from vllm.platforms.interface import Platform, PlatformEnum
 
 from tpu_inference import envs
@@ -311,6 +312,55 @@ class TpuPlatform(Platform):
         scheduler_config = vllm_config.scheduler_config
         parallel_config.worker_cls = \
                         "tpu_inference.worker.tpu_worker.TPUWorker"
+
+        # Upstream vllm forces the V2 model runner when
+        # prefill_context_parallel_size > 1, but V2's own unsupported-feature
+        # list rejects PCP unless the model uses MLA -- the two rules
+        # contradict, so a non-MLA model with PCP > 1 cannot be configured.
+        # Neither applies on TPU: worker_cls above swaps in TPUWorker, so
+        # vllm's V1/V2 GPU model runners never execute and PCP is implemented
+        # by tpu_inference.  Drop just the PCP entry, keeping every other V2
+        # check.  Done here (not at import) because vllm.config.vllm is only
+        # partially initialised while this module is being imported, and
+        # because vllm calls this hook before _validate_v2_model_runner.
+        try:
+            from vllm.config.vllm import VllmConfig as _VllmConfig
+            _fn = "_get_v2_model_runner_unsupported_features"
+            if not getattr(getattr(_VllmConfig, _fn, None), "_tpu_pcp_patched",
+                           False):
+                _orig = getattr(_VllmConfig, _fn)
+
+                def _drop_pcp(self, _orig=_orig):
+                    return [
+                        f for f in _orig(self)
+                        if f != "prefill context parallelism"
+                    ]
+
+                _drop_pcp._tpu_pcp_patched = True
+                setattr(_VllmConfig, _fn, _drop_pcp)
+
+            # The same V2 validation also hard-requires Triton, which is
+            # disabled on TPU hosts (installed, but 0 active drivers).  TPU
+            # never runs Triton kernels, so suppress just that check for the
+            # duration of the call, leaving the rest of the validation intact.
+            _vfn = "_validate_v2_model_runner"
+            if not getattr(getattr(_VllmConfig, _vfn, None),
+                           "_tpu_pcp_patched", False):
+                _orig_validate = getattr(_VllmConfig, _vfn)
+
+                def _validate_without_triton(self, _orig=_orig_validate):
+                    import vllm.config.vllm as _vmod
+                    _saved = _vmod.HAS_TRITON
+                    _vmod.HAS_TRITON = True
+                    try:
+                        return _orig(self)
+                    finally:
+                        _vmod.HAS_TRITON = _saved
+
+                _validate_without_triton._tpu_pcp_patched = True
+                setattr(_VllmConfig, _vfn, _validate_without_triton)
+        except (ImportError, AttributeError):
+            pass
 
         multihost_backend = envs.TPU_MULTIHOST_BACKEND
         if not multihost_backend:  # Single host


### PR DESCRIPTION
## Problem

vllm cannot currently be configured with `prefill_context_parallel_size > 1`
for a non-MLA model. Two of its rules contradict each other:

- `VllmConfig.use_v2_model_runner` forces the V2 model runner whenever
  `prefill_context_parallel_size > 1` — *"PCP runtime support is implemented
  only by the V2 model runner"*
- `_get_v2_model_runner_unsupported_features()` lists `"prefill context
  parallelism"` as **unsupported by V2** unless `model_config.use_mla`

so config validation raises:

```
Model Runner V2 does not yet support: prefill context parallelism
```

There is no configuration-level escape: `VLLM_USE_V2_MODEL_RUNNER=0` is
rejected explicitly with *"Prefill context parallelism requires Model Runner
V2. Remove VLLM_USE_V2_MODEL_RUNNER=0."*

## Why this doesn't apply to TPU

`check_and_update_config` already sets
`parallel_config.worker_cls = tpu_inference.worker.tpu_worker.TPUWorker`, so
vllm's V1/V2 **GPU** model runners never execute here — PCP is implemented by
`tpu_inference`. The gate is purely a config-validation artifact on this path.

## What this does

1. Drops **only** the `"prefill context parallelism"` entry from V2's
   unsupported list; every other V2 check is left intact.
2. Suppresses the V2 Triton requirement **for the duration of that one
   validation call** (`HAS_TRITON` is restored in a `finally`). vllm disables
   Triton on TPU hosts (installed, 0 active drivers) and TPU never runs Triton
   kernels.

Both are applied from `check_and_update_config` rather than at import:
`vllm.config.vllm` is only partially initialised while this module is being
imported (circular import via `vllm.utils.torch_utils`), and vllm calls this
hook immediately before `_validate_v2_model_runner`. Both are idempotent and
are skipped on vllm versions lacking these methods.

## Testing

`Qwen/Qwen3-8B-Base`, `--tensor-parallel-size=4 --prefill-context-parallel-size 2`
via `examples/offline_inference.py`: configuration succeeds and all 35 example
prompts generate coherent text (previously: hard `ValueError` at config time).

## Caveat

This is a **workaround for an upstream contradiction, not a fix.** It patches
private (`_`-prefixed) methods, so it is brittle: if vllm renames them or
changes the feature string, the patch silently stops applying. It should be
removed once vllm either stops forcing V2 for PCP or lets platforms opt out.
