### PR TITLE
Fix nightly failures against new vLLM LKG (is_stale kwarg + MM test fault_tolerance_config)

### DIFF
--- a/tests/core/test_sched_utils.py
+++ b/tests/core/test_sched_utils.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+from unittest import mock
+
+from tpu_inference.core.sched.utils import \
+    patch_vllm_scheduler_for_continue_decode
+
+
+def _make_request(num_computed_tokens=10, num_output_placeholders=1):
+    request = mock.MagicMock()
+    request.num_computed_tokens = num_computed_tokens
+    request.num_output_placeholders = num_output_placeholders
+    return request
+
+
+class TestContinueDecodeSchedulerPatch:
+
+    def test_patched_signatures_accept_is_stale(self):
+        """vLLM passes is_stale=... as a kwarg from update_from_output; the
+        patched wrappers must accept it or the EngineCore dies with a
+        TypeError."""
+        patch_vllm_scheduler_for_continue_decode()
+        from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+        from vllm.v1.core.sched.scheduler import Scheduler
+
+        for cls in (Scheduler, AsyncScheduler):
+            params = inspect.signature(
+                cls._update_request_with_output).parameters
+            assert "is_stale" in params, (
+                f"{cls.__name__}._update_request_with_output must accept "
+                f"is_stale (got {list(params)})")
+
+    def test_sync_patch_advances_num_computed_tokens_unless_stale(self):
+        patch_vllm_scheduler_for_continue_decode()
+        from vllm.v1.core.sched.scheduler import Scheduler
+
+        scheduler = mock.MagicMock()
+        with mock.patch("vllm.v1.core.sched.scheduler.check_stop",
+                        return_value=False):
+            # Fresh output: 3 tokens returned for 1 scheduled step -> advance
+            # num_computed_tokens by the extra 2 on-device tokens.
+            request = _make_request(num_computed_tokens=10)
+            Scheduler._update_request_with_output(scheduler,
+                                                  request, [1, 2, 3],
+                                                  is_stale=False)
+            assert request.num_computed_tokens == 12
+
+            # Stale output predates the preemption rollback -> no advance.
+            request = _make_request(num_computed_tokens=10)
+            Scheduler._update_request_with_output(scheduler,
+                                                  request, [1, 2, 3],
+                                                  is_stale=True)
+            assert request.num_computed_tokens == 10
+
+    def test_async_patch_placeholder_compensation_respects_is_stale(self):
+        patch_vllm_scheduler_for_continue_decode()
+        from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+
+        # spec= so the zero-arg super() in the wrapped original resolves
+        # (isinstance check); instance attributes read by the base
+        # implementation must be set explicitly.
+        scheduler = mock.MagicMock(spec=AsyncScheduler)
+        scheduler.max_model_len = 1024
+        with mock.patch("vllm.v1.core.sched.scheduler.check_stop",
+                        return_value=False):
+            # Fresh output: pre-compensate placeholders by (N - 1) so the
+            # original's -= N lands back at 0 without underflowing.
+            request = _make_request(num_output_placeholders=1)
+            AsyncScheduler._update_request_with_output(scheduler,
+                                                       request, [1, 2, 3],
+                                                       is_stale=False)
+            assert request.num_output_placeholders == 0
+
+            # Stale output: placeholders were zeroed at preemption; neither the
+            # pre-compensation nor the original's decrement may touch them.
+            request = _make_request(num_output_placeholders=1)
+            AsyncScheduler._update_request_with_output(scheduler,
+                                                       request, [1, 2, 3],
+                                                       is_stale=True)
+            assert request.num_output_placeholders == 1

--- a/tests/core/test_sched_utils.py
+++ b/tests/core/test_sched_utils.py
@@ -15,8 +15,29 @@
 import inspect
 from unittest import mock
 
+import pytest
+
 from tpu_inference.core.sched.utils import \
     patch_vllm_scheduler_for_continue_decode
+
+
+@pytest.fixture(autouse=True)
+def restore_scheduler_patch():
+    """The continue_decode patch is a process-global, irreversible monkeypatch
+    (including Scheduler.__init__, which forces num_lookahead_tokens >= 9).
+    CI runs all of tests/ in one pytest process, so restore the originals after
+    each test to avoid leaking the patch into unrelated tests."""
+    from vllm.v1.core.sched.async_scheduler import AsyncScheduler
+    from vllm.v1.core.sched.scheduler import Scheduler
+
+    originals = (Scheduler._update_request_with_output, Scheduler.__init__,
+                 AsyncScheduler._update_request_with_output)
+    yield
+    (Scheduler._update_request_with_output, Scheduler.__init__,
+     AsyncScheduler._update_request_with_output) = originals
+    for cls in (Scheduler, AsyncScheduler):
+        if "_continue_decode_patched" in cls.__dict__:
+            del cls._continue_decode_patched
 
 
 def _make_request(num_computed_tokens=10, num_output_placeholders=1):
@@ -24,6 +45,16 @@ def _make_request(num_computed_tokens=10, num_output_placeholders=1):
     request.num_computed_tokens = num_computed_tokens
     request.num_output_placeholders = num_output_placeholders
     return request
+
+
+def _make_scheduler(cls):
+    # spec= so getattr(scheduler, "_cd_stale_in_flight", False) is False (a
+    # bare MagicMock would auto-create a truthy attribute) and so the zero-arg
+    # super() in the wrapped async original resolves (isinstance check).
+    # Instance attributes read by the base implementation are set explicitly.
+    scheduler = mock.MagicMock(spec=cls)
+    scheduler.max_model_len = 1024
+    return scheduler
 
 
 class TestContinueDecodeSchedulerPatch:
@@ -42,12 +73,16 @@ class TestContinueDecodeSchedulerPatch:
             assert "is_stale" in params, (
                 f"{cls.__name__}._update_request_with_output must accept "
                 f"is_stale (got {list(params)})")
+            assert any(p.kind == inspect.Parameter.VAR_KEYWORD
+                       for p in params.values()), (
+                           f"{cls.__name__}._update_request_with_output must "
+                           f"pass through future kwargs (**kwargs)")
 
     def test_sync_patch_advances_num_computed_tokens_unless_stale(self):
         patch_vllm_scheduler_for_continue_decode()
         from vllm.v1.core.sched.scheduler import Scheduler
 
-        scheduler = mock.MagicMock()
+        scheduler = _make_scheduler(Scheduler)
         with mock.patch("vllm.v1.core.sched.scheduler.check_stop",
                         return_value=False):
             # Fresh output: 3 tokens returned for 1 scheduled step -> advance
@@ -65,29 +100,34 @@ class TestContinueDecodeSchedulerPatch:
                                                   is_stale=True)
             assert request.num_computed_tokens == 10
 
-    def test_async_patch_placeholder_compensation_respects_is_stale(self):
+    def test_async_patch_stale_handling(self):
+        """The async original calls super() WITHOUT forwarding is_stale, so
+        staleness reaches the patched base via the _cd_stale_in_flight flag.
+        Assert both counters end-to-end through the full async chain."""
         patch_vllm_scheduler_for_continue_decode()
         from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 
-        # spec= so the zero-arg super() in the wrapped original resolves
-        # (isinstance check); instance attributes read by the base
-        # implementation must be set explicitly.
-        scheduler = mock.MagicMock(spec=AsyncScheduler)
-        scheduler.max_model_len = 1024
+        scheduler = _make_scheduler(AsyncScheduler)
         with mock.patch("vllm.v1.core.sched.scheduler.check_stop",
                         return_value=False):
-            # Fresh output: pre-compensate placeholders by (N - 1) so the
-            # original's -= N lands back at 0 without underflowing.
-            request = _make_request(num_output_placeholders=1)
+            # Fresh output: placeholders pre-compensated by (N - 1) so the
+            # original's -= N lands back at 0; num_computed_tokens advances.
+            request = _make_request(num_computed_tokens=10,
+                                    num_output_placeholders=1)
             AsyncScheduler._update_request_with_output(scheduler,
                                                        request, [1, 2, 3],
                                                        is_stale=False)
             assert request.num_output_placeholders == 0
+            assert request.num_computed_tokens == 12
 
-            # Stale output: placeholders were zeroed at preemption; neither the
-            # pre-compensation nor the original's decrement may touch them.
-            request = _make_request(num_output_placeholders=1)
+            # Stale output: placeholders were zeroed at preemption and
+            # num_computed_tokens was rolled back; neither may move.
+            request = _make_request(num_computed_tokens=10,
+                                    num_output_placeholders=1)
             AsyncScheduler._update_request_with_output(scheduler,
                                                        request, [1, 2, 3],
                                                        is_stale=True)
             assert request.num_output_placeholders == 1
+            assert request.num_computed_tokens == 10
+            # The flag must not leak past the call.
+            assert scheduler._cd_stale_in_flight is False

--- a/tests/e2e/test_multi_modal_inference.py
+++ b/tests/e2e/test_multi_modal_inference.py
@@ -91,6 +91,12 @@ def test_multi_modal_inference(monkeypatch, enable_dynamic_image_sizes):
     pass_config = {k: v for k, v in pass_config.items() if v is not None}
     engine_args["compilation_config"]["pass_config"] = pass_config
 
+    # asdict() turns the default FaultToleranceConfig into a plain dict, and
+    # EngineArgs.__post_init__ treats a dict fault_tolerance_config as an
+    # explicit opt-in, force-enabling fault tolerance — which is then rejected
+    # in internal-LB mode. Drop it so the default (disabled) config is used.
+    engine_args.pop("fault_tolerance_config", None)
+
     llm = LLM(**engine_args)
 
     try:

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -39,20 +39,27 @@ def patch_vllm_scheduler_for_continue_decode():
         def patched_update_base(scheduler_self,
                                 request,
                                 new_token_ids,
-                                is_stale=False):
+                                is_stale=False,
+                                **kwargs):
             # Original update appends new_token_ids to request output and trims on stop token.
             res_token_ids, stopped = original_update_base(scheduler_self,
                                                           request,
                                                           new_token_ids,
-                                                          is_stale=is_stale)
+                                                          is_stale=is_stale,
+                                                          **kwargs)
 
             # schedule() only incremented num_computed_tokens by 1. Advance by the remaining
             # (N - 1) tokens generated on-device so host-side num_computed_tokens is accurate.
             # A stale delivery predates the preemption rollback of
             # num_computed_tokens and must not advance it (mirrors the
             # `if not output_is_stale` guards in vLLM's update_from_output).
+            # AsyncScheduler's original calls super() WITHOUT forwarding
+            # is_stale, so the async wrapper threads staleness through
+            # _cd_stale_in_flight instead — check both.
+            stale = is_stale or getattr(scheduler_self, "_cd_stale_in_flight",
+                                        False)
             diff = len(res_token_ids) - 1
-            if diff > 0 and not is_stale:
+            if diff > 0 and not stale:
                 request.num_computed_tokens += diff
 
             return res_token_ids, stopped
@@ -82,7 +89,8 @@ def patch_vllm_scheduler_for_continue_decode():
         def patched_async_update_request_with_output(scheduler_self,
                                                      request,
                                                      new_token_ids,
-                                                     is_stale=False):
+                                                     is_stale=False,
+                                                     **kwargs):
             if len(new_token_ids) > 1 and not is_stale:
                 # In AsyncScheduler, _update_after_schedule() added 1 in-flight placeholder token.
                 # When N tokens return, original_async_update_req will subtract N from
@@ -91,10 +99,18 @@ def patch_vllm_scheduler_for_continue_decode():
                 # Placeholders are zeroed at preemption, so a stale delivery must
                 # not be pre-compensated (the original skips its decrement too).
                 request.num_output_placeholders += (len(new_token_ids) - 1)
-            return original_async_update_req(scheduler_self,
-                                             request,
-                                             new_token_ids,
-                                             is_stale=is_stale)
+            # The original's super() call does not forward is_stale, so the
+            # patched base can't see it as a parameter. Thread it through an
+            # instance flag for the duration of this call.
+            scheduler_self._cd_stale_in_flight = is_stale
+            try:
+                return original_async_update_req(scheduler_self,
+                                                 request,
+                                                 new_token_ids,
+                                                 is_stale=is_stale,
+                                                 **kwargs)
+            finally:
+                scheduler_self._cd_stale_in_flight = False
 
         AsyncScheduler._update_request_with_output = patched_async_update_request_with_output
         AsyncScheduler._continue_decode_patched = True

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -36,15 +36,23 @@ def patch_vllm_scheduler_for_continue_decode():
     if not getattr(Scheduler, "_continue_decode_patched", False):
         original_update_base = Scheduler._update_request_with_output
 
-        def patched_update_base(scheduler_self, request, new_token_ids):
+        def patched_update_base(scheduler_self,
+                                request,
+                                new_token_ids,
+                                is_stale=False):
             # Original update appends new_token_ids to request output and trims on stop token.
-            res_token_ids, stopped = original_update_base(
-                scheduler_self, request, new_token_ids)
+            res_token_ids, stopped = original_update_base(scheduler_self,
+                                                          request,
+                                                          new_token_ids,
+                                                          is_stale=is_stale)
 
             # schedule() only incremented num_computed_tokens by 1. Advance by the remaining
             # (N - 1) tokens generated on-device so host-side num_computed_tokens is accurate.
+            # A stale delivery predates the preemption rollback of
+            # num_computed_tokens and must not advance it (mirrors the
+            # `if not output_is_stale` guards in vLLM's update_from_output).
             diff = len(res_token_ids) - 1
-            if diff > 0:
+            if diff > 0 and not is_stale:
                 request.num_computed_tokens += diff
 
             return res_token_ids, stopped
@@ -71,16 +79,22 @@ def patch_vllm_scheduler_for_continue_decode():
     if not getattr(AsyncScheduler, "_continue_decode_patched", False):
         original_async_update_req = AsyncScheduler._update_request_with_output
 
-        def patched_async_update_request_with_output(scheduler_self, request,
-                                                     new_token_ids):
-            if len(new_token_ids) > 1:
+        def patched_async_update_request_with_output(scheduler_self,
+                                                     request,
+                                                     new_token_ids,
+                                                     is_stale=False):
+            if len(new_token_ids) > 1 and not is_stale:
                 # In AsyncScheduler, _update_after_schedule() added 1 in-flight placeholder token.
                 # When N tokens return, original_async_update_req will subtract N from
                 # num_output_placeholders. Pre-compensate by adding (N - 1) first so that
                 # num_output_placeholders cleanly decrements by 1 without underflowing < 0.
+                # Placeholders are zeroed at preemption, so a stale delivery must
+                # not be pre-compensated (the original skips its decrement too).
                 request.num_output_placeholders += (len(new_token_ids) - 1)
-            return original_async_update_req(scheduler_self, request,
-                                             new_token_ids)
+            return original_async_update_req(scheduler_self,
+                                             request,
+                                             new_token_ids,
+                                             is_stale=is_stale)
 
         AsyncScheduler._update_request_with_output = patched_async_update_request_with_output
         AsyncScheduler._continue_decode_patched = True


### PR DESCRIPTION
## Problem

The 07-31 nightly (build 23558) fails on both tpu6e and tpu7x with two distinct regressions introduced by the vLLM LKG advancing to `a7a204cc6`:

1. **moe_expert_ids / continue_decode scheduler patch**: vLLM added an `is_stale` kwarg to `Scheduler._update_request_with_output` and `AsyncScheduler._update_request_with_output` (the caller in `update_from_output` now passes `is_stale=output_is_stale`). The continue_decode monkeypatch wrappers in `tpu_inference/core/sched/utils.py` kept the old 2-arg signature, so any engine with the patched scheduler dies:
   `TypeError: patch_vllm_scheduler_for_continue_decode.<locals>.patched_update_base() got an unexpected keyword argument 'is_stale'` -> `EngineDeadError`.

2. **test_multi_modal_inference**: the test round-trips `asdict(EngineArgs(...))` into `LLM(...)`. `asdict` converts the default `FaultToleranceConfig` dataclass into a plain dict, and `EngineArgs.__post_init__` now treats a dict `fault_tolerance_config` as an explicit opt-in and force-enables fault tolerance, which validation then rejects:
   `ValueError: Fault tolerance requires external load balancer mode ... Internal LB mode is not supported.`

## Fix

- `tpu_inference/core/sched/utils.py`: both patched wrappers accept and forward `is_stale`. The `num_computed_tokens` advance and the `num_output_placeholders` pre-compensation are skipped for stale deliveries, mirroring the `if not output_is_stale` guards vLLM applies around its own counter adjustments (stale output predates the preemption rollback of those counters).
- `tests/e2e/test_multi_modal_inference.py`: drop `fault_tolerance_config` from the asdict dict before `LLM(...)` (same class of workaround as the existing pass_config None-stripping) so the default disabled config is used.
- New `tests/core/test_sched_utils.py` covering the wrapper signatures and both is_stale guards.

## Validation (local tpu7x, vllm at LKG a7a204cc6)

- `tests/runner/test_moe_expert_ids.py::TestMoEExpertIds::test_moe_expert_ids_sync_path_prompt_populated` (the failing nightly test): **1 passed** (was EngineDeadError).
- `tests/e2e/test_multi_modal_inference.py` both params: **2 passed** (was ValueError at engine init).
- `tests/core/test_sched_utils.py`: 3 passed.
- Verified the mechanism directly: `EngineArgs(fault_tolerance_config=<dict from asdict>)` -> `enable_fault_tolerance=True`; field omitted -> `False`.

## Dev-pipeline verification (test evidence)

Dev build [tpu-inference-dev #716](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/716) — **PASSED** — ran this branch's fixes with the exact commands of the failing nightly steps (`rl/moe_expert_ids.yml`, `features/Multimodal_Inputs.yml`) on both platforms, plus the new unit tests:

| Job | Result | Nightly 23558 (before fix) |
|---|---|---|
| tpu6e `pytest tests/core/test_sched_utils.py tests/runner/test_moe_expert_ids.py` | **7 passed** (47:19) | FAILED (`EngineDeadError`, is_stale TypeError) |
| tpu7x `pytest tests/core/test_sched_utils.py tests/runner/test_moe_expert_ids.py` | **7 passed** (31:45) | FAILED (same) |
| tpu6e `pytest tests/e2e/test_multi_modal_inference.py` | **2 passed** (5:12) | FAILED (fault-tolerance ValueError at init) |
| tpu7x `pytest tests/e2e/test_multi_modal_inference.py` | **2 passed** (3:52) | FAILED (same) |
