### PR TITLE
Support TPU8i in utils

### DIFF
--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,11 +12,34 @@ from jax.experimental.pallas import tpu as pltpu
 from torchax.ops.mappings import t2j as ref_t2j
 
 # Import the functions to be tested
-from tpu_inference.utils import (GBYTES, enable_megacore,
-                                 get_jax_dtype_from_str_dtype, get_megacore,
-                                 get_padded_head_dim, hbm_usage_bytes,
-                                 hbm_usage_gb)
+from tpu_inference.utils import (GBYTES, enable_megacore, get_device_hbm_limit,
+                                 get_device_name, get_jax_dtype_from_str_dtype,
+                                 get_megacore, get_padded_head_dim,
+                                 hbm_usage_bytes, hbm_usage_gb)
 from tpu_inference.utils import t2j as t2j
+
+
+@pytest.mark.parametrize(
+    "raw_kind,expected_name,expected_hbm",
+    [
+        ("TPU v5p", "TPU v5p", 95 * GBYTES),
+        ("TPU v5e", "TPU v5e", 16 * GBYTES),
+        ("TPU v6e", "TPU v6e", 32 * GBYTES),
+        ("TPU7x", "TPU v7", 96 * GBYTES),
+        ("TPU8i", "TPU v8i", 144 * GBYTES),
+        ("TPU v8i", "TPU v8i", 144 * GBYTES),
+    ],
+)
+@patch("jax.devices")
+def test_get_device_name_and_hbm_limit(mock_devices, raw_kind, expected_name,
+                                       expected_hbm):
+    """Tests get_device_name and get_device_hbm_limit functions."""
+    mock_dev = MagicMock()
+    mock_dev.device_kind = raw_kind
+    mock_devices.return_value = [mock_dev]
+
+    assert get_device_name() == expected_name
+    assert get_device_hbm_limit() == expected_hbm
 
 
 def test_enable_and_get_megacore():

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -166,8 +166,14 @@ def get_device_name(num_devices: int | None = None):
     elif kind.endswith('p'):
         kind = kind[:-1]
         suffix = 'p'
-    elif kind == 'TPU7x':
+    elif kind.endswith('i'):
+        kind = kind[:-1]
+        suffix = 'i'
+
+    if kind.startswith('TPU7'):
         kind = 'TPU v7'
+    elif kind.startswith('TPU8'):
+        kind = 'TPU v8'
     assert kind[:-1] == 'TPU v', kind
     kind += suffix
     if num_devices is not None:
@@ -188,6 +194,10 @@ def get_device_hbm_limit() -> int:
         # 192 * GBYTES / 2 because each JAX device (v7x core) has
         # 1/2 of the total chip HBM
         return 96 * GBYTES
+    elif device_kind == "TPU v8i":
+        # 288 * GBYTES / 2 because each JAX device (v8i core) has 1/2 of
+        # total chip HBM
+        return 144 * GBYTES
     else:
         raise ValueError(f"Unknown device kind: {device_kind}")
 


### PR DESCRIPTION
# Description

Adds support for TPU8i devices in `tpu_inference/utils.py`, enabling proper device name resolution (`"TPU v8i"`) and setting the correct HBM limit (144 GiB per core).

### Details
- **Why**: TPU8i was previously unhandled in `get_device_name()` and `get_device_hbm_limit()`.
- **Problem Solved**: Separated suffix parsing (`.endswith('i')`) from version prefix normalization (`.startswith('TPU8')`) in `get_device_name()` so that device kinds like `"TPU8i"` strip the suffix and normalize the prefix without short-circuiting.
- **HBM Limit**: Configured `get_device_hbm_limit()` for `"TPU v8i"` to return `144 * GBYTES` (144 GiB, half of 288 GiB total chip HBM per JAX device core).

# Tests

- Added `test_get_device_name_and_hbm_limit` unit test in `tests/test_utils.py` covering `TPU8i`, `TPU v8i`, `TPU7x`, `TPU v6e`, `TPU v5p`, and `TPU v5e`.
- Ran unit tests via `pytest`:
  ```bash
  pytest tests/test_utils.py -k test_get_device_name_and_hbm_limit
  ```
  **Result**: 6 passed.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
