### PR TITLE
Route DP requests by minimising the resulting maximum rank load

### DIFF
--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -246,10 +246,12 @@ class TestDPScheduler:
         scheduler._get_result = MagicMock(side_effect=[
             10,
             0,
-            (0, 0),  # rank 0: 10 cached, idle -> load 90
+            (0, 0),
+            1000,  # rank 0: 10 cached, idle -> load 90
             25,
             0,
-            (0, 0),  # rank 1: 25 cached, idle -> load 75
+            (0, 0),
+            1000,  # rank 1: 25 cached, idle -> load 75
         ])
 
         assert scheduler._find_best_rank_for_request(mock_request) == 1
@@ -273,10 +275,12 @@ class TestDPScheduler:
         scheduler._get_result = MagicMock(side_effect=[
             500,
             800,
-            (0, 0),  # rank 0: 500 cached but 800 queued -> load 1300
+            (0, 0),
+            1000,  # rank 0: 500 cached but 800 queued -> load 1300
             0,
             0,
-            (0, 0),  # rank 1: nothing cached, idle      -> load 1000
+            (0, 0),
+            1000,  # rank 1: nothing cached, idle      -> load 1000
         ])
 
         assert scheduler._find_best_rank_for_request(mock_request) == 1
@@ -298,9 +302,11 @@ class TestDPScheduler:
         # No cache probe is issued; pending_prefill and counts are collected.
         scheduler._get_result = MagicMock(side_effect=[
             100,
-            (0, 0),  # rank 0
+            (0, 0),
+            1000,  # rank 0
             50,
-            (0, 0),  # rank 1
+            (0, 0),
+            1000,  # rank 1
         ])
 
         assert scheduler._find_best_rank_for_request(mock_request) == 1
@@ -324,9 +330,36 @@ class TestDPScheduler:
         scheduler._send_command = MagicMock()
         scheduler._get_result = MagicMock(side_effect=[
             0,
-            (7, 0),  # rank 0: idle prefill queue, 7 in flight
+            (7, 0),
+            1000,  # rank 0: idle prefill queue, 7 in flight
             0,
-            (3, 0),  # rank 1: idle prefill queue, 3 in flight
+            (3, 0),
+            1000,  # rank 1: idle prefill queue, 3 in flight
+        ])
+
+        assert scheduler._find_best_rank_for_request(mock_request) == 1
+
+    def test_find_best_rank_breaks_remaining_ties_by_min_output(
+            self, mock_vllm_config, mock_kv_cache_config,
+            mock_structured_output_manager):
+        """Load and in-flight tied: prefer the rank whose running request is
+        closest to its max_tokens, so most likely to free a slot soonest."""
+        mock_vllm_config.cache_config.enable_prefix_caching = False
+        scheduler = self._create_scheduler(mock_vllm_config,
+                                           mock_kv_cache_config,
+                                           mock_structured_output_manager)
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.num_tokens = 100
+
+        scheduler._send_command = MagicMock()
+        scheduler._get_result = MagicMock(side_effect=[
+            0,
+            (4, 0),
+            900,  # rank 0: 900 output tokens still to go
+            0,
+            (4, 0),
+            100,  # rank 1: only 100 left, frees a slot sooner
         ])
 
         assert scheduler._find_best_rank_for_request(mock_request) == 1

--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -229,92 +229,71 @@ class TestDPScheduler:
         assert rank_tokens[0] == 30
         assert rank_tokens[1] == 15
 
-    def test_find_best_rank_with_cache_hit(self, mock_vllm_config,
-                                           mock_kv_cache_config,
-                                           mock_structured_output_manager):
-        """Test _find_best_rank_for_request prefers cache hits."""
-        # Enable prefix caching to exercise the cache-hit path
+    def test_find_best_rank_prefers_cache_when_idle(
+            self, mock_vllm_config, mock_kv_cache_config,
+            mock_structured_output_manager):
+        """Cache locality wins when it lowers the resulting load."""
         mock_vllm_config.cache_config.enable_prefix_caching = True
         scheduler = self._create_scheduler(mock_vllm_config,
                                            mock_kv_cache_config,
                                            mock_structured_output_manager)
 
         mock_request = MagicMock(spec=Request)
+        mock_request.num_tokens = 100
 
-        # Mock _send_command and _get_result for PROBE_COMPUTED_BLOCKS (2 ranks)
         scheduler._send_command = MagicMock()
+        # Per rank the scheduler collects (cached_tokens, pending_prefill).
         scheduler._get_result = MagicMock(side_effect=[
             10,
-            25,  # PROBE_COMPUTED_BLOCKS: rank 0=10, rank 1=25
+            0,  # rank 0: 10 cached, idle -> load 90
+            25,
+            0,  # rank 1: 25 cached, idle -> load 75
         ])
 
-        rank = scheduler._find_best_rank_for_request(mock_request)
+        assert scheduler._find_best_rank_for_request(mock_request) == 1
 
-        # Should prefer rank with better cache hit (rank 1 has 25 cached tokens)
-        assert rank == 1
+    def test_find_best_rank_abandons_cache_when_rank_busy(
+            self, mock_vllm_config, mock_kv_cache_config,
+            mock_structured_output_manager):
+        """A cache hit loses once the rank holding it is loaded enough.
 
-    def test_find_best_rank_without_cache_hit(self, mock_vllm_config,
-                                              mock_kv_cache_config,
-                                              mock_structured_output_manager):
-        """_find_best_rank_for_request sorts by
-        (pending_prefill, inflight, min_remaining_output)."""
+        This is the decision pure cache affinity cannot make.
+        """
+        mock_vllm_config.cache_config.enable_prefix_caching = True
         scheduler = self._create_scheduler(mock_vllm_config,
                                            mock_kv_cache_config,
                                            mock_structured_output_manager)
 
         mock_request = MagicMock(spec=Request)
+        mock_request.num_tokens = 1000
 
-        # Primary key wins: rank 1 has fewer pending prefill tokens.
-        scheduler._get_rank_routing_state = MagicMock(return_value=(
-            {
-                0: 100,
-                1: 50
-            },  # pending
-            {
-                0: 5,
-                1: 5
-            },  # inflight
-            {
-                0: 1000,
-                1: 1000
-            }  # min_remaining
-        ))
+        scheduler._send_command = MagicMock()
+        scheduler._get_result = MagicMock(side_effect=[
+            500,
+            800,  # rank 0: 500 cached but 800 queued -> load 1300
+            0,
+            0,  # rank 1: nothing cached, idle       -> load 1000
+        ])
+
         assert scheduler._find_best_rank_for_request(mock_request) == 1
 
-        # Primary ties; secondary key wins: rank 0 has fewer inflight.
-        scheduler._get_rank_routing_state = MagicMock(return_value=(
-            {
-                0: 50,
-                1: 50
-            },
-            {
-                0: 3,
-                1: 7
-            },
-            {
-                0: 1000,
-                1: 1000
-            },
-        ))
-        assert scheduler._find_best_rank_for_request(mock_request) == 0
+    def test_find_best_rank_without_prefix_caching(
+            self, mock_vllm_config, mock_kv_cache_config,
+            mock_structured_output_manager):
+        """With caching off no rank reports cached tokens, so the rank with
+        the least queued prefill wins."""
+        mock_vllm_config.cache_config.enable_prefix_caching = False
+        scheduler = self._create_scheduler(mock_vllm_config,
+                                           mock_kv_cache_config,
+                                           mock_structured_output_manager)
 
-        # Primary and secondary tie; tertiary wins: rank 1 has the running
-        # req with the fewest remaining output tokens (closest to its
-        # max_tokens), so it is most likely to free a slot soonest.
-        scheduler._get_rank_routing_state = MagicMock(return_value=(
-            {
-                0: 0,
-                1: 0
-            },
-            {
-                0: 4,
-                1: 4
-            },
-            {
-                0: 9100,
-                1: 500
-            },
-        ))
+        mock_request = MagicMock(spec=Request)
+        mock_request.num_tokens = 100
+
+        scheduler._send_command = MagicMock()
+        # No cache probe is issued, so only pending_prefill is collected.
+        scheduler._get_result = MagicMock(side_effect=[100, 50])
+
         assert scheduler._find_best_rank_for_request(mock_request) == 1
 
     def test_add_request_assigns_to_best_rank(self, mock_vllm_config,

--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -245,9 +245,11 @@ class TestDPScheduler:
         # Per rank the scheduler collects (cached_tokens, pending_prefill).
         scheduler._get_result = MagicMock(side_effect=[
             10,
-            0,  # rank 0: 10 cached, idle -> load 90
+            0,
+            (0, 0),  # rank 0: 10 cached, idle -> load 90
             25,
-            0,  # rank 1: 25 cached, idle -> load 75
+            0,
+            (0, 0),  # rank 1: 25 cached, idle -> load 75
         ])
 
         assert scheduler._find_best_rank_for_request(mock_request) == 1
@@ -270,9 +272,11 @@ class TestDPScheduler:
         scheduler._send_command = MagicMock()
         scheduler._get_result = MagicMock(side_effect=[
             500,
-            800,  # rank 0: 500 cached but 800 queued -> load 1300
+            800,
+            (0, 0),  # rank 0: 500 cached but 800 queued -> load 1300
             0,
-            0,  # rank 1: nothing cached, idle       -> load 1000
+            0,
+            (0, 0),  # rank 1: nothing cached, idle      -> load 1000
         ])
 
         assert scheduler._find_best_rank_for_request(mock_request) == 1
@@ -291,8 +295,39 @@ class TestDPScheduler:
         mock_request.num_tokens = 100
 
         scheduler._send_command = MagicMock()
-        # No cache probe is issued, so only pending_prefill is collected.
-        scheduler._get_result = MagicMock(side_effect=[100, 50])
+        # No cache probe is issued; pending_prefill and counts are collected.
+        scheduler._get_result = MagicMock(side_effect=[
+            100,
+            (0, 0),  # rank 0
+            50,
+            (0, 0),  # rank 1
+        ])
+
+        assert scheduler._find_best_rank_for_request(mock_request) == 1
+
+    def test_find_best_rank_breaks_load_ties_by_inflight(
+            self, mock_vllm_config, mock_kv_cache_config,
+            mock_structured_output_manager):
+        """Equal load falls back to fewest in-flight requests.
+
+        Queued prefill does not reflect decode load, and ranks tie at zero
+        queued prefill for much of a decode-heavy phase.
+        """
+        mock_vllm_config.cache_config.enable_prefix_caching = False
+        scheduler = self._create_scheduler(mock_vllm_config,
+                                           mock_kv_cache_config,
+                                           mock_structured_output_manager)
+
+        mock_request = MagicMock(spec=Request)
+        mock_request.num_tokens = 100
+
+        scheduler._send_command = MagicMock()
+        scheduler._get_result = MagicMock(side_effect=[
+            0,
+            (7, 0),  # rank 0: idle prefill queue, 7 in flight
+            0,
+            (3, 0),  # rank 1: idle prefill queue, 3 in flight
+        ])
 
         assert scheduler._find_best_rank_for_request(mock_request) == 1
 

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -422,10 +422,7 @@ class DPScheduler(SchedulerInterface):
         # DP state
         self.dp_size = vllm_config.sharding_config.total_dp_size
         self.assigned_dp_rank: Dict[str, int] = {}  # req_id -> dp_rank
-        # Rank routing policy, see DP_SCHED_ROUTING.
-        self._routing: str = envs.DP_SCHED_ROUTING
-        self._makespan_decode_weight: int = (
-            envs.DP_SCHED_MAKESPAN_DECODE_WEIGHT)
+        # Rotates the tie-break in _find_best_rank_for_request.
         self._rr_start = 0
         self.cached_schedulers_output = deque()
         self._create_per_rank_configs(kv_cache_config)
@@ -689,39 +686,7 @@ class DPScheduler(SchedulerInterface):
                 rank, SchedulerCommand.GET_MIN_REMAINING_OUTPUT)
         return result
 
-    def _get_rank_routing_state(
-            self) -> Tuple[Dict[int, int], Dict[int, int], Dict[int, int]]:
-        """Per-rank (pending_prefill_tokens, inflight_reqs,
-        min_remaining_output) collected in a single round-trip.
-
-        Send all comments first and collect all results after to
-        allow pipelinening across ranks, minimizing the overhead."""
-        for rank in range(self.dp_size):
-            self._send_command(rank,
-                               SchedulerCommand.GET_PENDING_PREFILL_TOKENS)
-            self._send_command(rank, SchedulerCommand.GET_REQUEST_COUNTS)
-            self._send_command(rank, SchedulerCommand.GET_MIN_REMAINING_OUTPUT)
-
-        pending: Dict[int, int] = {}
-        inflight: Dict[int, int] = {}
-        min_remaining: Dict[int, int] = {}
-        for rank in range(self.dp_size):
-            pending[rank] = self._get_result(
-                rank, SchedulerCommand.GET_PENDING_PREFILL_TOKENS)
-            running, waiting = self._get_result(
-                rank, SchedulerCommand.GET_REQUEST_COUNTS)
-            inflight[rank] = running + waiting
-            min_remaining[rank] = self._get_result(
-                rank, SchedulerCommand.GET_MIN_REMAINING_OUTPUT)
-        return pending, inflight, min_remaining
-
     def _find_best_rank_for_request(self, request: Request) -> int:
-        """Route a new request to a DP rank, per DP_SCHED_ROUTING."""
-        if self._routing == "makespan":
-            return self._find_rank_by_makespan(request)
-        return self._find_rank_by_cache_affinity(request)
-
-    def _find_rank_by_makespan(self, request: Request) -> int:
         """Pick the rank minimising the resulting maximum load.
 
         The DP ranks advance in lockstep, so a step costs whatever the most
@@ -729,21 +694,20 @@ class DPScheduler(SchedulerInterface):
         maximum, not this request's own prefill. For each rank estimate the
         prefill work it would hold after taking the request::
 
-            load(r) = pending_prefill[r]
-                      + (num_tokens - cached_on_rank[r])
-                      + running[r] * DP_SCHED_MAKESPAN_DECODE_WEIGHT
+            load(r) = pending_prefill[r] + (num_tokens - cached_on_rank[r])
 
-        and take the argmin. The two leading terms are token counts on the
-        same rank, so they add directly with no relative weight to tune.
+        and take the argmin. Both terms are token counts on the same rank, so
+        they add directly with no relative weight to tune.
 
         Cache locality lowers a rank's score because it removes work, not
         because it is privileged. A rank holding this conversation's history
         wins while it is idle, and loses once it is busy enough that the
-        saved prefill no longer compensates -- the decision that pure cache
-        affinity cannot make.
+        saved prefill no longer compensates.
+
+        With prefix caching disabled every rank reports zero cached tokens,
+        so this reduces to picking the rank with the least queued prefill.
         """
         enable_cache = self.vllm_config.cache_config.enable_prefix_caching
-        decode_weight = self._makespan_decode_weight
 
         # Send every query first, then collect, so ranks answer in parallel.
         for rank in range(self.dp_size):
@@ -753,8 +717,6 @@ class DPScheduler(SchedulerInterface):
                                    request)
             self._send_command(rank,
                                SchedulerCommand.GET_PENDING_PREFILL_TOKENS)
-            if decode_weight:
-                self._send_command(rank, SchedulerCommand.GET_REQUEST_COUNTS)
 
         num_tokens = request.num_tokens
         loads: Dict[int, int] = {}
@@ -765,12 +727,7 @@ class DPScheduler(SchedulerInterface):
                     rank, SchedulerCommand.PROBE_COMPUTED_BLOCKS)
             pending = self._get_result(
                 rank, SchedulerCommand.GET_PENDING_PREFILL_TOKENS)
-            running = 0
-            if decode_weight:
-                running, _ = self._get_result(
-                    rank, SchedulerCommand.GET_REQUEST_COUNTS)
-            loads[rank] = (pending + max(0, num_tokens - cached) +
-                           running * decode_weight)
+            loads[rank] = pending + max(0, num_tokens - cached)
 
         # Rotate the scan start so ties do not always favour rank 0.
         order = [(self._rr_start + i) % self.dp_size
@@ -778,42 +735,6 @@ class DPScheduler(SchedulerInterface):
         rank = min(order, key=lambda r: loads[r])
         self._rr_start = (self._rr_start + 1) % self.dp_size
         return rank
-
-    def _find_rank_by_cache_affinity(self, request: Request) -> int:
-        """Find the best DP rank for a new request based on load balancing.
-
-        Two-tier strategy:
-        1. Prefix cache hit: assign to rank with best cache hit.
-        2. Otherwise:
-           - Primary key: fewest pending prefill tokens (keeps prefill
-             balanced across ranks).
-           - Secondary key: fewest in-flight reqs (balances decode load
-             across ranks under DP lockstep once prefills finish).
-           - Tertiary key: rank whose running req is closest to its
-             max_tokens (smallest remaining output tokens), which is
-             most likely to free a slot soon.
-        """
-        # First, try to find a rank with prefix cache hit.
-        if self.vllm_config.cache_config.enable_prefix_caching:
-            for rank in range(self.dp_size):
-                self._send_command(rank,
-                                   SchedulerCommand.PROBE_COMPUTED_BLOCKS,
-                                   request)
-
-            best_cache_rank = None
-            best_cache_tokens = 0
-            for rank in range(self.dp_size):
-                cached_tokens = self._get_result(
-                    rank, SchedulerCommand.PROBE_COMPUTED_BLOCKS)
-                if cached_tokens > best_cache_tokens:
-                    best_cache_tokens = cached_tokens
-                    best_cache_rank = rank
-            if best_cache_tokens > 0:
-                return best_cache_rank
-
-        pending, inflight, min_remaining = self._get_rank_routing_state()
-        return min(range(self.dp_size),
-                   key=lambda r: (pending[r], inflight[r], min_remaining[r]))
 
     def add_request(self, request: Request) -> None:
         """

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -704,14 +704,17 @@ class DPScheduler(SchedulerInterface):
         wins while it is idle, and loses once it is busy enough that the
         saved prefill no longer compensates.
 
-        Ties on load are broken by in-flight requests, which is the only
-        signal here that reflects decode load: queued prefill says nothing
-        about a rank already running many long-lived decodes, and ranks tie
-        at zero queued prefill for much of a decode-heavy phase.
+        Ties on load fall back to the order the previous cache-affinity
+        fallback used: fewest in-flight requests, then the rank whose running
+        request is closest to its max_tokens (so most likely to free a slot
+        soonest). In-flight is the only signal here reflecting decode load --
+        queued prefill says nothing about a rank already running many
+        long-lived decodes, and ranks tie at zero queued prefill for much of
+        a decode-heavy phase.
 
         With prefix caching disabled every rank reports zero cached tokens,
-        so this reduces to (least queued prefill, fewest in-flight) -- the
-        same order the previous cache-affinity fallback used.
+        so this reduces to (least queued prefill, fewest in-flight, smallest
+        remaining output), matching the previous behaviour exactly.
         """
         enable_cache = self.vllm_config.cache_config.enable_prefix_caching
 
@@ -724,10 +727,12 @@ class DPScheduler(SchedulerInterface):
             self._send_command(rank,
                                SchedulerCommand.GET_PENDING_PREFILL_TOKENS)
             self._send_command(rank, SchedulerCommand.GET_REQUEST_COUNTS)
+            self._send_command(rank, SchedulerCommand.GET_MIN_REMAINING_OUTPUT)
 
         num_tokens = request.num_tokens
         loads: Dict[int, int] = {}
         inflight: Dict[int, int] = {}
+        min_remaining: Dict[int, int] = {}
         for rank in range(self.dp_size):
             cached = 0
             if enable_cache:
@@ -739,11 +744,14 @@ class DPScheduler(SchedulerInterface):
                 rank, SchedulerCommand.GET_REQUEST_COUNTS)
             loads[rank] = pending + max(0, num_tokens - cached)
             inflight[rank] = running + waiting
+            min_remaining[rank] = self._get_result(
+                rank, SchedulerCommand.GET_MIN_REMAINING_OUTPUT)
 
         # Rotate the scan start so remaining ties do not always favour rank 0.
         order = [(self._rr_start + i) % self.dp_size
                  for i in range(self.dp_size)]
-        rank = min(order, key=lambda r: (loads[r], inflight[r]))
+        rank = min(order,
+                   key=lambda r: (loads[r], inflight[r], min_remaining[r]))
         self._rr_start = (self._rr_start + 1) % self.dp_size
         return rank
 

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -422,8 +422,6 @@ class DPScheduler(SchedulerInterface):
         # DP state
         self.dp_size = vllm_config.sharding_config.total_dp_size
         self.assigned_dp_rank: Dict[str, int] = {}  # req_id -> dp_rank
-        # Rotates the tie-break in _find_best_rank_for_request.
-        self._rr_start = 0
         self.cached_schedulers_output = deque()
         self._create_per_rank_configs(kv_cache_config)
         self._schedule_step_count = 0
@@ -715,6 +713,11 @@ class DPScheduler(SchedulerInterface):
         With prefix caching disabled every rank reports zero cached tokens,
         so this reduces to (least queued prefill, fewest in-flight, smallest
         remaining output), matching the previous behaviour exactly.
+
+        No rotation is needed for fully tied ranks. ADD_REQUEST is issued
+        synchronously after routing, so a rank's queued prefill already
+        reflects the request just placed on it by the time the next one is
+        routed, and the tie is broken by load from then on.
         """
         enable_cache = self.vllm_config.cache_config.enable_prefix_caching
 
@@ -747,13 +750,8 @@ class DPScheduler(SchedulerInterface):
             min_remaining[rank] = self._get_result(
                 rank, SchedulerCommand.GET_MIN_REMAINING_OUTPUT)
 
-        # Rotate the scan start so remaining ties do not always favour rank 0.
-        order = [(self._rr_start + i) % self.dp_size
-                 for i in range(self.dp_size)]
-        rank = min(order,
+        return min(range(self.dp_size),
                    key=lambda r: (loads[r], inflight[r], min_remaining[r]))
-        self._rr_start = (self._rr_start + 1) % self.dp_size
-        return rank
 
     def add_request(self, request: Request) -> None:
         """

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -422,6 +422,11 @@ class DPScheduler(SchedulerInterface):
         # DP state
         self.dp_size = vllm_config.sharding_config.total_dp_size
         self.assigned_dp_rank: Dict[str, int] = {}  # req_id -> dp_rank
+        # Rank routing policy, see DP_SCHED_ROUTING.
+        self._routing: str = envs.DP_SCHED_ROUTING
+        self._makespan_decode_weight: int = (
+            envs.DP_SCHED_MAKESPAN_DECODE_WEIGHT)
+        self._rr_start = 0
         self.cached_schedulers_output = deque()
         self._create_per_rank_configs(kv_cache_config)
         self._schedule_step_count = 0
@@ -711,6 +716,70 @@ class DPScheduler(SchedulerInterface):
         return pending, inflight, min_remaining
 
     def _find_best_rank_for_request(self, request: Request) -> int:
+        """Route a new request to a DP rank, per DP_SCHED_ROUTING."""
+        if self._routing == "makespan":
+            return self._find_rank_by_makespan(request)
+        return self._find_rank_by_cache_affinity(request)
+
+    def _find_rank_by_makespan(self, request: Request) -> int:
+        """Pick the rank minimising the resulting maximum load.
+
+        The DP ranks advance in lockstep, so a step costs whatever the most
+        loaded rank costs: the quantity to minimise is the post-assignment
+        maximum, not this request's own prefill. For each rank estimate the
+        prefill work it would hold after taking the request::
+
+            load(r) = pending_prefill[r]
+                      + (num_tokens - cached_on_rank[r])
+                      + running[r] * DP_SCHED_MAKESPAN_DECODE_WEIGHT
+
+        and take the argmin. The two leading terms are token counts on the
+        same rank, so they add directly with no relative weight to tune.
+
+        Cache locality lowers a rank's score because it removes work, not
+        because it is privileged. A rank holding this conversation's history
+        wins while it is idle, and loses once it is busy enough that the
+        saved prefill no longer compensates -- the decision that pure cache
+        affinity cannot make.
+        """
+        enable_cache = self.vllm_config.cache_config.enable_prefix_caching
+        decode_weight = self._makespan_decode_weight
+
+        # Send every query first, then collect, so ranks answer in parallel.
+        for rank in range(self.dp_size):
+            if enable_cache:
+                self._send_command(rank,
+                                   SchedulerCommand.PROBE_COMPUTED_BLOCKS,
+                                   request)
+            self._send_command(rank,
+                               SchedulerCommand.GET_PENDING_PREFILL_TOKENS)
+            if decode_weight:
+                self._send_command(rank, SchedulerCommand.GET_REQUEST_COUNTS)
+
+        num_tokens = request.num_tokens
+        loads: Dict[int, int] = {}
+        for rank in range(self.dp_size):
+            cached = 0
+            if enable_cache:
+                cached = self._get_result(
+                    rank, SchedulerCommand.PROBE_COMPUTED_BLOCKS)
+            pending = self._get_result(
+                rank, SchedulerCommand.GET_PENDING_PREFILL_TOKENS)
+            running = 0
+            if decode_weight:
+                running, _ = self._get_result(
+                    rank, SchedulerCommand.GET_REQUEST_COUNTS)
+            loads[rank] = (pending + max(0, num_tokens - cached) +
+                           running * decode_weight)
+
+        # Rotate the scan start so ties do not always favour rank 0.
+        order = [(self._rr_start + i) % self.dp_size
+                 for i in range(self.dp_size)]
+        rank = min(order, key=lambda r: loads[r])
+        self._rr_start = (self._rr_start + 1) % self.dp_size
+        return rank
+
+    def _find_rank_by_cache_affinity(self, request: Request) -> int:
         """Find the best DP rank for a new request based on load balancing.
 
         Two-tier strategy:

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -687,37 +687,9 @@ class DPScheduler(SchedulerInterface):
     def _find_best_rank_for_request(self, request: Request) -> int:
         """Pick the rank minimising the resulting maximum load.
 
-        The DP ranks advance in lockstep, so a step costs whatever the most
-        loaded rank costs: the quantity to minimise is the post-assignment
-        maximum, not this request's own prefill. For each rank estimate the
-        prefill work it would hold after taking the request::
-
-            load(r) = pending_prefill[r] + (num_tokens - cached_on_rank[r])
-
-        and take the argmin. Both terms are token counts on the same rank, so
-        they add directly with no relative weight to tune.
-
-        Cache locality lowers a rank's score because it removes work, not
-        because it is privileged. A rank holding this conversation's history
-        wins while it is idle, and loses once it is busy enough that the
-        saved prefill no longer compensates.
-
-        Ties on load fall back to the order the previous cache-affinity
-        fallback used: fewest in-flight requests, then the rank whose running
-        request is closest to its max_tokens (so most likely to free a slot
-        soonest). In-flight is the only signal here reflecting decode load --
-        queued prefill says nothing about a rank already running many
-        long-lived decodes, and ranks tie at zero queued prefill for much of
-        a decode-heavy phase.
-
-        With prefix caching disabled every rank reports zero cached tokens,
-        so this reduces to (least queued prefill, fewest in-flight, smallest
-        remaining output), matching the previous behaviour exactly.
-
-        No rotation is needed for fully tied ranks. ADD_REQUEST is issued
-        synchronously after routing, so a rank's queued prefill already
-        reflects the request just placed on it by the time the next one is
-        routed, and the tie is broken by load from then on.
+        Ties on load with fewest in-flight requests, then the rank whose
+        running request is closest to its max_tokens (so most likely to free
+        a slot soonest).
         """
         enable_cache = self.vllm_config.cache_config.enable_prefix_caching
 

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -704,8 +704,14 @@ class DPScheduler(SchedulerInterface):
         wins while it is idle, and loses once it is busy enough that the
         saved prefill no longer compensates.
 
+        Ties on load are broken by in-flight requests, which is the only
+        signal here that reflects decode load: queued prefill says nothing
+        about a rank already running many long-lived decodes, and ranks tie
+        at zero queued prefill for much of a decode-heavy phase.
+
         With prefix caching disabled every rank reports zero cached tokens,
-        so this reduces to picking the rank with the least queued prefill.
+        so this reduces to (least queued prefill, fewest in-flight) -- the
+        same order the previous cache-affinity fallback used.
         """
         enable_cache = self.vllm_config.cache_config.enable_prefix_caching
 
@@ -717,9 +723,11 @@ class DPScheduler(SchedulerInterface):
                                    request)
             self._send_command(rank,
                                SchedulerCommand.GET_PENDING_PREFILL_TOKENS)
+            self._send_command(rank, SchedulerCommand.GET_REQUEST_COUNTS)
 
         num_tokens = request.num_tokens
         loads: Dict[int, int] = {}
+        inflight: Dict[int, int] = {}
         for rank in range(self.dp_size):
             cached = 0
             if enable_cache:
@@ -727,12 +735,15 @@ class DPScheduler(SchedulerInterface):
                     rank, SchedulerCommand.PROBE_COMPUTED_BLOCKS)
             pending = self._get_result(
                 rank, SchedulerCommand.GET_PENDING_PREFILL_TOKENS)
+            running, waiting = self._get_result(
+                rank, SchedulerCommand.GET_REQUEST_COUNTS)
             loads[rank] = pending + max(0, num_tokens - cached)
+            inflight[rank] = running + waiting
 
-        # Rotate the scan start so ties do not always favour rank 0.
+        # Rotate the scan start so remaining ties do not always favour rank 0.
         order = [(self._rr_start + i) % self.dp_size
                  for i in range(self.dp_size)]
-        rank = min(order, key=lambda r: loads[r])
+        rank = min(order, key=lambda r: (loads[r], inflight[r]))
         self._rr_start = (self._rr_start + 1) % self.dp_size
         return rank
 

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -69,6 +69,8 @@ if TYPE_CHECKING:
     NUM_PRECOMPILE_WORKERS: int = 1
     DP_SCHED_BATCH_PREFILL: bool = False
     DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS: int = 10000
+    DP_SCHED_ROUTING: str = "cache"
+    DP_SCHED_MAKESPAN_DECODE_WEIGHT: int = 0
     VLLM_MOE_CHUNK_SIZE: int = 0
     ONEHOT_MOE_PERMUTE_THRESHOLD: int = 0
     PROFILE_SINGLE_DEVICE: bool = False
@@ -415,6 +417,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # DP scheduler: timeout (ms) to force flush pending requests.
     "DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS":
     lambda: int(os.getenv("DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS", "30000")),
+    # DP scheduler: how a new request picks its DP rank.
+    #   "cache"    - prefer any rank reporting a prefix cache hit (default).
+    #   "makespan" - pick the rank minimising the resulting maximum load,
+    #                pending_prefill + (prompt - cached_on_rank). Cache
+    #                locality lowers a rank's score because it removes work,
+    #                so affinity applies only while the rank is not busy.
+    "DP_SCHED_ROUTING":
+    env_with_choices("DP_SCHED_ROUTING", "cache", ["cache", "makespan"]),
+    # DP scheduler: tokens of load attributed to each running (decoding)
+    # request by "makespan" routing. 0 counts queued prefill only.
+    "DP_SCHED_MAKESPAN_DECODE_WEIGHT":
+    lambda: int(os.getenv("DP_SCHED_MAKESPAN_DECODE_WEIGHT", "0")),
     "MLA_XPOSE_N_TILE_SIZE":
     lambda: int(os.getenv("MLA_XPOSE_N_TILE_SIZE", "160")),
     "VLLM_MOE_CHUNK_SIZE":

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -69,8 +69,6 @@ if TYPE_CHECKING:
     NUM_PRECOMPILE_WORKERS: int = 1
     DP_SCHED_BATCH_PREFILL: bool = False
     DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS: int = 10000
-    DP_SCHED_ROUTING: str = "cache"
-    DP_SCHED_MAKESPAN_DECODE_WEIGHT: int = 0
     VLLM_MOE_CHUNK_SIZE: int = 0
     ONEHOT_MOE_PERMUTE_THRESHOLD: int = 0
     PROFILE_SINGLE_DEVICE: bool = False
@@ -417,18 +415,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # DP scheduler: timeout (ms) to force flush pending requests.
     "DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS":
     lambda: int(os.getenv("DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS", "30000")),
-    # DP scheduler: how a new request picks its DP rank.
-    #   "cache"    - prefer any rank reporting a prefix cache hit (default).
-    #   "makespan" - pick the rank minimising the resulting maximum load,
-    #                pending_prefill + (prompt - cached_on_rank). Cache
-    #                locality lowers a rank's score because it removes work,
-    #                so affinity applies only while the rank is not busy.
-    "DP_SCHED_ROUTING":
-    env_with_choices("DP_SCHED_ROUTING", "cache", ["cache", "makespan"]),
-    # DP scheduler: tokens of load attributed to each running (decoding)
-    # request by "makespan" routing. 0 counts queued prefill only.
-    "DP_SCHED_MAKESPAN_DECODE_WEIGHT":
-    lambda: int(os.getenv("DP_SCHED_MAKESPAN_DECODE_WEIGHT", "0")),
     "MLA_XPOSE_N_TILE_SIZE":
     lambda: int(os.getenv("MLA_XPOSE_N_TILE_SIZE", "160")),
     "VLLM_MOE_CHUNK_SIZE":


### PR DESCRIPTION
## Description

This PR improves the DP scheduler router logic. 

#### Before

`DPScheduler._find_best_rank_for_request` gave prefix cache affinity **absolute priority**: it probed every rank, returned the first reporting *any* nonzero hit, and never consulted load.

```python
if best_cache_tokens > 0:
    return best_cache_rank          # load is never examined
```

A single cached 256-token block was enough to pin a request onto the busiest rank. SPMD DP runs in lock step,  so a forward step costs whatever the *most loaded* rank costs.  

#### Now 

The new routing logic is the following

**Route each request so that the maximum load on any rank is minimised.**

```python
load(r) = pending_prefill[r] + (num_tokens - cached_on_rank[r])
rank    = argmin (load(r), inflight[r], min_remaining_output[r])
```

The load that a new request contributes is `total prompt tokens - prefix-cached tokens`

## Compatibility

**With prefix caching disabled this is identical to the previous behaviour.** The old fallback sorted by `(pending_prefill, inflight, min_remaining_output)`, and all three keys are preserved.

## Performance

`Qwen/Qwen3.5-397B-A17B-FP8`, TPU v7x-8, TP8 + attn-DP4, 65536 context, `max_num_seqs=256`, 256 streams (16 GRPO groups x 16), 6685 turns. Turn counts within 0.2% across runs, so turns/sec and wall time are directly comparable.

| routing | prefix cache | turns/sec | wall | output tok/s | peak KV | preempt | 
|---|---|---:|---:|---:|---:|---:|
| old | off | 1.0016 | 6658 s | 545.77 | 59.4% | 0 | 
| old | on | 0.8581 | 7791 s | 515.52 | 37.2% | 0 |
| **new** | **on** | **2.8222** | **2369 s** | **1679.76** | 74.1% | 0 |

**2.82x** the caching-off baseline and **3.29x** the old routing, at 100% success with zero preemptions. Wall time 1h51m -> 39min.

### Cache hit rate reaches the workload ceiling

| routing | hit rate across the run |
|---|---|
| old | 84.6% peak -> **29.7%** (decays) |
| **new** | 74 -> 88 -> 90 -> 90 -> 87 -> 85 -> 87 -> 91 -> 95 -> **97%** (rises) |

The ceiling for this workload is `1 - new_tokens_per_turn / context_per_turn` = **96.4%** (600 new tokens on a 16,801-token context), so the new routing effectively saturates it. The old routing decayed instead because pinned ranks oversubscribed their caches and evicted, destroying the affinity it optimised for.

Peak KV also fell from 86.7% to **74.1%** while doing far more work -- better affinity means less duplicated history across ranks. Requests spread across ranks **1581 / 1743 / 1658 / 1703**, versus two idle ranks before.

