### PR TITLE
[DSv4] Fix SMEM overflow in compress_norm_rope_store: prefetch per-token window pages, not the full block table

### DIFF
--- a/tests/kernels/deepseek_v4/compress_store_test.py
+++ b/tests/kernels/deepseek_v4/compress_store_test.py
@@ -465,6 +465,39 @@ class CompressStoreTest(jtu.JaxTestCase):
             self.skipTest("skip csa_decode_batch_large on TPUv6e")
         self.run_compress_store_correctness(**cfg)
 
+    def test_compress_store_production_scale_block_table(self):
+        """Regression test for b/541619368 (SMEM overflow).
+
+        A [64, 4608] int32 block table — the nightly DeepSeek-V4-Flash MMLU
+        engine shape (max_num_seqs=64, max_model_len=9216,
+        state_block_size=2) — is 1.125 MiB, over the 1 MiB scoped-SMEM
+        budget. A kernel that prefetches the full table (as before the
+        per-token window-page gather) fails to compile here with
+        RESOURCE_EXHAUSTED; the gathered form must stay bounded by the
+        token count. The case also pins the request axis of the gather:
+        all tokens map to request row 37 and every other row points at
+        page 0, so indexing the wrong row breaks output parity.
+        """
+        num_reqs, max_blocks, req_idx = 64, 4608, 37
+        num_tokens = 8
+        block_table = np.zeros((num_reqs, max_blocks), dtype=np.int32)
+        # Identity mapping on the real row; entries past the pages the test
+        # actually allocates are never dereferenced by valid positions.
+        block_table[req_idx, :] = np.arange(max_blocks, dtype=np.int32)
+        self.run_compress_store_correctness(
+            num_tokens=num_tokens,
+            head_dim=512,
+            rope_head_dim=64,
+            compress_ratio=4,
+            overlap=True,
+            physical_page_size=256,
+            hidden_size=4096,
+            token_to_req_indices=np.full((num_tokens, ),
+                                         req_idx,
+                                         dtype=np.int32),
+            block_table=block_table,
+        )
+
     def test_derive_aliases(self):
         # HCA: has_rope=True, has_rope_cache=False, num_scalar_prefetch=5
         self.assertEqual(

--- a/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/buffered_ref.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/buffered_ref.py
@@ -115,7 +115,10 @@ class PageBufferRef(_BufferedRef):
         def loop_body(idx):
             n = idx // pages_to_buffer_per_token
             p = idx % pages_to_buffer_per_token
-            idx_n = global_idx + n
+            # Clamp for the final partial tile (same convention as
+            # gather_from_page_buffer); bounds checks are disabled, so an
+            # unclamped read would fetch a garbage page number.
+            idx_n = jnp.minimum(global_idx + n, self.cfgs.dims.size_n - 1)
 
             # Page numbers for each token's window are gathered outside the
             # kernel (see compress_norm_rope_store) so only the
@@ -408,7 +411,6 @@ def create_allocs_and_specs(
     cos_sin_cache_ref,
     positions_ref,
     token_window_pages_ref,
-    token_to_req_indices_ref,
     kv_slot_mapping_ref,
     is_first_mask_ref,
     is_first_mask_rope_ref,

--- a/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/buffered_ref.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/buffered_ref.py
@@ -102,14 +102,11 @@ class PageBufferRef(_BufferedRef):
 
         (
             state_cache_ref,
-            positions_ref,
-            block_table_ref,
-            token_to_req_indices_ref,
+            token_window_pages_ref,
         ) = src_ref
 
         tile_n = self.cfgs.tile_sizes.tile_n
         pages_to_buffer_per_token = self.cfgs.pages_to_buffer_per_token
-        block_size = self.cfgs.state_block_size
 
         page_buffer_ref = self.window_ref.at[slot]
         global_idx = pid * tile_n
@@ -120,13 +117,11 @@ class PageBufferRef(_BufferedRef):
             p = idx % pages_to_buffer_per_token
             idx_n = global_idx + n
 
-            position = positions_ref[idx_n]
-            req_idx = token_to_req_indices_ref[idx_n]
-
-            block_idx = position // block_size - (pages_to_buffer_per_token -
-                                                  1) + p
-            safe_block_idx = jnp.maximum(block_idx, 0)
-            page = block_table_ref[req_idx, safe_block_idx]
+            # Page numbers for each token's window are gathered outside the
+            # kernel (see compress_norm_rope_store) so only the
+            # [num_tokens, pages_to_buffer_per_token] slice is prefetched
+            # into SMEM instead of the full block table (b/541619368).
+            page = token_window_pages_ref[idx_n, p]
 
             src = state_cache_ref.at[page, :, :, :]
             dest = page_buffer_ref.at[n, p, :, :, :]
@@ -412,7 +407,7 @@ def create_allocs_and_specs(
     rope_cache_ref,
     cos_sin_cache_ref,
     positions_ref,
-    block_table_ref,
+    token_window_pages_ref,
     token_to_req_indices_ref,
     kv_slot_mapping_ref,
     is_first_mask_ref,
@@ -487,9 +482,7 @@ def create_allocs_and_specs(
     )
     page_buffer_args = (
         cache_ref,
-        positions_ref,
-        block_table_ref,
-        token_to_req_indices_ref,
+        token_window_pages_ref,
     )
 
     # rope

--- a/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/kernel.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/kernel.py
@@ -182,7 +182,6 @@ def kernel_fn(
     # prefetched inputs (scalar)
     token_window_pages_ref,
     positions_ref,
-    token_to_req_indices_ref,
     kv_slot_mapping_ref,
     is_first_mask_ref,
     is_first_mask_rope_ref,
@@ -208,7 +207,6 @@ def kernel_fn(
         cos_sin_cache_ref=cos_sin_cache_ref,
         positions_ref=positions_ref,
         token_window_pages_ref=token_window_pages_ref,
-        token_to_req_indices_ref=token_to_req_indices_ref,
         kv_slot_mapping_ref=kv_slot_mapping_ref,
         is_first_mask_ref=is_first_mask_ref,
         is_first_mask_rope_ref=is_first_mask_rope_ref,
@@ -370,6 +368,9 @@ def compress_norm_rope_store(
     # num_reqs * max_model_len / state_block_size and overflows the 1 MiB
     # scoped-SMEM budget at production shapes (b/541619368: 64 reqs x 4608
     # blocks = 1.125 MiB at max_model_len=9216, state_block_size=2).
+    # The gathered form still has a ceiling: at ~(P + 4) int32s per token the
+    # 1 MiB budget is reached again around ~13K scheduled tokens for CSA
+    # (P=5) - revisit before raising max_num_batched_tokens that far.
     pages_per_token = cfgs.pages_to_buffer_per_token
     base_block = positions // cfgs.state_block_size
     block_offsets = jnp.arange(pages_per_token) - (pages_per_token - 1)
@@ -381,10 +382,11 @@ def compress_norm_rope_store(
     # Outer pallas_call operands, in call order. Optional operands are passed as
     # None to keep kernel_fn's argument positions fixed; pallas drops the Nones
     # when indexing, so alias indices count only the operands actually present.
+    # token_to_req_indices is consumed by the gather above and is not needed
+    # inside the kernel.
     scalar_prefetch = (
         token_window_pages,
         positions,
-        token_to_req_indices,
         kv_slot_mapping,
         is_first_mask,
         is_first_mask_rope,

--- a/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/kernel.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/kernel.py
@@ -180,7 +180,7 @@ def inner_kernel(
 
 def kernel_fn(
     # prefetched inputs (scalar)
-    block_table_ref,
+    token_window_pages_ref,
     positions_ref,
     token_to_req_indices_ref,
     kv_slot_mapping_ref,
@@ -207,7 +207,7 @@ def kernel_fn(
         rope_cache_ref=rope_cache_ref,
         cos_sin_cache_ref=cos_sin_cache_ref,
         positions_ref=positions_ref,
-        block_table_ref=block_table_ref,
+        token_window_pages_ref=token_window_pages_ref,
         token_to_req_indices_ref=token_to_req_indices_ref,
         kv_slot_mapping_ref=kv_slot_mapping_ref,
         is_first_mask_ref=is_first_mask_ref,
@@ -362,11 +362,27 @@ def compress_norm_rope_store(
         # TODO: this is confusing, should probably find a better name for it
         pack_factor=cfgs.hbm_pack,
     )
+    # Per token, gather the page numbers covering its compression window
+    # (the exact lookups PageBufferRef.copy_in used to do against the full
+    # block table). Prefetching this [num_tokens, pages_to_buffer_per_token]
+    # gather keeps the SMEM operand bounded by the scheduled-token count;
+    # prefetching the whole [num_reqs, max_blocks] block table scales with
+    # num_reqs * max_model_len / state_block_size and overflows the 1 MiB
+    # scoped-SMEM budget at production shapes (b/541619368: 64 reqs x 4608
+    # blocks = 1.125 MiB at max_model_len=9216, state_block_size=2).
+    pages_per_token = cfgs.pages_to_buffer_per_token
+    base_block = positions // cfgs.state_block_size
+    block_offsets = jnp.arange(pages_per_token) - (pages_per_token - 1)
+    block_indices = jnp.maximum(base_block[:, None] + block_offsets[None, :],
+                                0)
+    token_window_pages = block_table[token_to_req_indices[:, None],
+                                     block_indices]
+
     # Outer pallas_call operands, in call order. Optional operands are passed as
     # None to keep kernel_fn's argument positions fixed; pallas drops the Nones
     # when indexing, so alias indices count only the operands actually present.
     scalar_prefetch = (
-        block_table,
+        token_window_pages,
         positions,
         token_to_req_indices,
         kv_slot_mapping,


### PR DESCRIPTION
## Problem

Since #3310, `compress_norm_rope_store` prefetches the entire `[num_reqs, max_blocks]` state-cache block table into scoped SMEM as a scalar-prefetch operand. With the state cache's 2-token pages this scales as `num_reqs * max_model_len / 2`, and the nightly `tpu7x E2E MMLU for DeepSeek-V4-Flash torchax backend` config (`max_num_seqs=64`, `max_model_len=9216`) needs a 64x4608 int32 table = 1.125 MiB — over the 1 MiB scoped-SMEM budget. Engine init dies at compile:

```
jax.errors.JaxRuntimeError: RESOURCE_EXHAUSTED: Allocation (size=1179648) would exceed memory (size=1048576)
:: [shape = 'u8[1179648]{0}', space=smem, scoped, tag = 'prefetched SMEM operand 0'] :: compress_norm_rope_store...
```

Nightly red since build [23643](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/23643); root cause proven by commit-vs-parent A/B on the dev pipeline (build [737](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/737) @ `8ead48e6e` FAIL vs [738](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/738) @ parent PASS, same vLLM pin). The job is nightly-gated so #3310's PR CI could not catch it.

## Fix

The kernel only ever reads `pages_to_buffer_per_token` consecutive block-table entries per token (`PageBufferRef.copy_in`). Gather exactly those page numbers outside the kernel — the same host-side gather `derive_metadata` already does for `slot_mapping_slots` — and prefetch the resulting `[num_tokens, pages_to_buffer_per_token]` array instead of the full table:

- `kernel.py` (`compress_norm_rope_store`): build `token_window_pages[t, p] = block_table[req[t], max(pos[t]//state_block_size - (P-1) + p, 0)]` and pass it as scalar-prefetch operand 0. Public signature unchanged (still takes `block_table`).
- `buffered_ref.py` (`PageBufferRef.copy_in`): read `token_window_pages_ref[idx_n, p]` directly; `page_buffer_args` shrinks to `(cache_ref, token_window_pages_ref)`.

The SMEM operand now scales with the scheduled-token count (~20 KB at the failing config) instead of `num_reqs * max_model_len`. The per-token lookups are bit-identical to what the kernel computed in-SMEM before, including the `max(idx, 0)` clamp for window prefixes.

## Verification

| Check | Result |
|---|---|
| `tests/kernels/deepseek_v4/compress_store_test.py` (pallas-vs-reference parity), local tpu7x-8 | **14/14 passed** |
| Dev build [749](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/749) = this fix: kernel tests + exact nightly test_37 MMLU config | **PASSED** — MMLU accuracy **0.8715** (>= 0.86), throughput >= 1500 PASSED |
| Dev build [750](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/750) = control (unfixed main + identical pipeline) | **FAILED** with the byte-identical RESOURCE_EXHAUSTED |

The 749-vs-750 pair is a controlled before/after on the same harness: only the two-file fix differs.
