### PR TITLE
Add JAX-native JinaBert (jina-embeddings-v2) encoder-only embedding m…

### DIFF
--- a/tests/e2e/test_jina_embeddings.py
+++ b/tests/e2e/test_jina_embeddings.py
@@ -1,0 +1,101 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""E2E test: jina-embeddings-v2-small-en under the pooling runner.
+
+Mirrors test_step_pooling.py, but with real weights, and — when
+sentence-transformers is available — validates the embeddings numerically
+against the reference implementation (cosine similarity > 0.99).
+"""
+
+import multiprocessing as mp
+
+try:
+    if mp.get_start_method(allow_none=True) != 'spawn':
+        mp.set_start_method('spawn', force=True)
+except RuntimeError:
+    pass
+
+import numpy as np
+import pytest
+
+MODEL_ID = "jinaai/jina-embeddings-v2-small-en"
+
+
+def test_jina_embeddings_e2e():
+    from vllm import LLM
+
+    max_model_len = 1024
+    sentences = [
+        "How is the weather today?",
+        "What is the current weather like today?",
+        "Jina embeddings now run on TPU v6e with vLLM.",
+    ]
+
+    try:
+        llm = LLM(
+            model=MODEL_ID,
+            runner="pooling",
+            max_num_seqs=4,
+            max_model_len=max_model_len,
+            dtype="float32",
+            trust_remote_code=True,
+            override_pooler_config={"pooling_type": "MEAN"},
+            tensor_parallel_size=1,
+        )
+    except Exception as e:
+        pytest.skip(f"Skipping test: {e}")
+
+    try:
+        results = llm.embed(sentences)
+
+        assert len(results) == len(sentences)
+        embeddings = []
+        for result in results:
+            emb = result.outputs.embedding
+            assert emb is not None
+            assert len(emb) == 512  # hidden_size of the small-en variant
+            embeddings.append(np.asarray(emb, dtype=np.float32))
+
+        # The two weather questions must be closer to each other than either
+        # is to the unrelated TPU sentence.
+        def cos(a, b):
+            return float(
+                np.dot(a, b) / (np.linalg.norm(a) * np.linalg.norm(b)))
+
+        sim_related = cos(embeddings[0], embeddings[1])
+        sim_unrelated = cos(embeddings[0], embeddings[2])
+        assert sim_related > sim_unrelated, (
+            f"similarity sanity check failed: {sim_related} <= {sim_unrelated}"
+        )
+
+        # Numerical parity vs sentence-transformers, when available.
+        try:
+            from sentence_transformers import SentenceTransformer
+        except ImportError:
+            SentenceTransformer = None
+        if SentenceTransformer is not None:
+            try:
+                st_model = SentenceTransformer(MODEL_ID,
+                                               trust_remote_code=True)
+                ref = st_model.encode(sentences)
+            except Exception:
+                ref = None
+            if ref is not None:
+                for got, expected in zip(embeddings, ref):
+                    similarity = cos(got, np.asarray(expected,
+                                                     dtype=np.float32))
+                    assert similarity > 0.99, (
+                        f"embedding does not match reference: {similarity}")
+    finally:
+        llm.llm_engine.engine_core.shutdown()

--- a/tests/models/jax/test_jina_bert.py
+++ b/tests/models/jax/test_jina_bert.py
@@ -1,0 +1,194 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for the JAX-native JinaBert embedding model.
+
+Includes a numerical parity test against the HF `transformers` reference
+implementation (trust_remote_code) — cosine similarity of per-token hidden
+states and mean-pooled embeddings must exceed 0.999 in float32.
+"""
+
+from unittest.mock import MagicMock
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax.typing import PRNGKey
+from jax.sharding import Mesh
+from vllm.config import ModelConfig, set_current_vllm_config
+from vllm.model_executor.model_loader import LoadConfig, get_model_loader
+
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.models.jax.jina_bert import (JinaBertForMaskedLM,
+                                                get_alibi_slopes)
+
+MODEL_ID = "jinaai/jina-embeddings-v2-small-en"
+
+
+class MockVllmConfig:
+    """A mock VllmConfig sufficient for testing the JinaBert model."""
+
+    def __init__(self, model: str):
+        self.model_config = ModelConfig(model,
+                                        runner="pooling",
+                                        trust_remote_code=True)
+        self.model_config.dtype = jnp.float32
+        self.load_config = MagicMock()
+        self.load_config.download_dir = None
+        self.cache_config = MagicMock(cache_dtype="auto")
+        self.quant_config = None
+        self.parallel_config = None
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    if not jax.devices():
+        pytest.skip("No JAX devices available for mesh creation.")
+    devices = np.array(jax.local_devices()[:1])
+    device_mesh = devices.reshape((1, 1, 1, 1))
+    with Mesh(device_mesh,
+              axis_names=('data', 'attn_dp', 'expert', 'model')) as m:
+        yield m
+
+
+@pytest.fixture
+def rng() -> PRNGKey:
+    return jax.random.PRNGKey(42)
+
+
+@pytest.fixture(scope="module")
+def mock_vllm_config():
+    # Register the arch with vLLM's registry first (normally done by the
+    # vllm.general_plugins entrypoint).
+    from tpu_inference.models.vllm.experimental import register_models
+    register_models()
+    try:
+        return MockVllmConfig(MODEL_ID)
+    except Exception as e:  # e.g. no network to fetch the HF config
+        pytest.skip(f"Could not build ModelConfig for {MODEL_ID}: {e}")
+
+
+def _make_attention_metadata(seq_lens_list):
+    total = int(sum(seq_lens_list))
+    positions = jnp.concatenate(
+        [jnp.arange(n, dtype=jnp.int32) for n in seq_lens_list])
+    seq_lens = jnp.array(seq_lens_list, dtype=jnp.int32)
+    query_start_loc = jnp.array(np.cumsum([0] + list(seq_lens_list)),
+                                dtype=jnp.int32)
+    return AttentionMetadata(
+        input_positions=positions,
+        block_tables=jnp.zeros((len(seq_lens_list), ), dtype=jnp.int32),
+        seq_lens=seq_lens,
+        query_start_loc=query_start_loc,
+        request_distribution=jnp.array([0, 0, len(seq_lens_list)],
+                                       dtype=jnp.int32),
+    ), total
+
+
+def test_alibi_slopes_reference():
+    """Slopes must match the reference 2^(-8i/n) geometric sequence."""
+    slopes = get_alibi_slopes(8)
+    expected = [2**(-i) for i in range(1, 9)]
+    np.testing.assert_allclose(slopes, expected, rtol=1e-12)
+    # Non-power-of-2 head counts follow the interleaving rule.
+    assert len(get_alibi_slopes(12)) == 12
+
+
+class TestJinaBert:
+
+    def test_model_init(self, mock_vllm_config, rng, mesh):
+        with jax.set_mesh(mesh):
+            model = JinaBertForMaskedLM(mock_vllm_config, rng, mesh)
+
+        hf_config = mock_vllm_config.model_config.hf_config
+        layers = model.model.encoder.layer
+        assert len(layers) == hf_config.num_hidden_layers
+
+        attn = getattr(layers[0].attention, "self")
+        assert attn.num_heads == hf_config.num_attention_heads
+        assert attn.head_dim == hf_config.hidden_size // \
+            hf_config.num_attention_heads
+        assert attn.query.weight.shape == (hf_config.hidden_size,
+                                           attn.num_heads, attn.head_dim)
+        assert attn.query.bias.shape == (attn.num_heads, attn.head_dim)
+
+        mlp = layers[0].mlp
+        assert mlp.gated_layers.weight.shape == (
+            hf_config.hidden_size, 2 * hf_config.intermediate_size)
+        assert mlp.wo.weight.shape == (hf_config.intermediate_size,
+                                       hf_config.hidden_size)
+        emb = model.model.embeddings
+        assert emb.word_embeddings.weight.shape == (hf_config.vocab_size,
+                                                    hf_config.hidden_size)
+
+    def test_forward_and_hf_parity(self, mock_vllm_config, rng, mesh):
+        torch = pytest.importorskip("torch")
+        transformers = pytest.importorskip("transformers")
+
+        # --- HF reference (CPU, float32) ---
+        try:
+            tokenizer = transformers.AutoTokenizer.from_pretrained(MODEL_ID)
+            hf_model = transformers.AutoModel.from_pretrained(
+                MODEL_ID, trust_remote_code=True,
+                torch_dtype=torch.float32).eval()
+        except Exception as e:
+            pytest.skip(f"Could not download HF reference model: {e}")
+
+        sentences = [
+            "How is the weather today?",
+            "Jina embeddings run on TPU v6e with vLLM.",
+        ]
+        encoded = [tokenizer(s, return_tensors="pt") for s in sentences]
+        with torch.no_grad():
+            hf_hidden = [
+                hf_model(**e).last_hidden_state[0].numpy() for e in encoded
+            ]
+
+        # --- JAX model, same tokens as one concatenated ragged batch ---
+        with jax.set_mesh(mesh):
+            model = JinaBertForMaskedLM(mock_vllm_config, rng, mesh)
+        with jax.set_mesh(mesh), set_current_vllm_config(mock_vllm_config):
+            loader = get_model_loader(LoadConfig(load_format="hf"))
+            loader.load_weights(model, mock_vllm_config.model_config)
+
+        seq_lens = [e.input_ids.shape[1] for e in encoded]
+        input_ids = jnp.array(
+            np.concatenate([e.input_ids[0].numpy() for e in encoded]),
+            dtype=jnp.int32)
+        metadata, total = _make_attention_metadata(seq_lens)
+
+        kv_caches, hidden, aux, _ = model(kv_caches=[],
+                                          input_ids=input_ids,
+                                          attention_metadata=metadata)
+        assert hidden.shape == (total,
+                                mock_vllm_config.model_config.hf_config.
+                                hidden_size)
+        assert kv_caches == []
+        assert aux == []
+
+        hidden = np.asarray(hidden, dtype=np.float32)
+        offset = 0
+        for ref, n in zip(hf_hidden, seq_lens):
+            got = hidden[offset:offset + n]
+            offset += n
+            # Per-token cosine similarity.
+            cos = np.sum(ref * got, axis=-1) / (
+                np.linalg.norm(ref, axis=-1) * np.linalg.norm(got, axis=-1))
+            assert cos.min() > 0.999, f"per-token cosine too low: {cos.min()}"
+            # Mean-pooled embedding cosine similarity.
+            ref_emb = ref.mean(axis=0)
+            got_emb = got.mean(axis=0)
+            emb_cos = np.dot(ref_emb, got_emb) / (np.linalg.norm(ref_emb) *
+                                                  np.linalg.norm(got_emb))
+            assert emb_cos > 0.999, f"pooled cosine too low: {emb_cos}"

--- a/tpu_inference/kernels/flash_attention/kernel.py
+++ b/tpu_inference/kernels/flash_attention/kernel.py
@@ -89,6 +89,7 @@ def encoder_only_flash_attention(
     k,  # [k_len, num_kv_heads, head_size]
     v,  # [k_len, num_kv_heads, head_size]
     seq_lens,  # [batch_size]
+    alibi_slopes=None,  # [num_heads] or None
     *,
     causal: bool = False,
     sm_scale: float | None = None,
@@ -160,13 +161,29 @@ def encoder_only_flash_attention(
         )
         return segment_ids
 
-    if sliding_window is not None:
+    if sliding_window is not None or alibi_slopes is not None:
         row_ids = jnp.arange(padded_len_q)[:, None]
         col_ids = jnp.arange(padded_len_kv)[None, :]
-        mask = jnp.abs(row_ids - col_ids) <= sliding_window
+        distance = jnp.abs(row_ids - col_ids)
+    if sliding_window is not None and alibi_slopes is None:
+        mask = distance <= sliding_window
         ab = jnp.where(mask, 0.0, -1e4).astype(q_bhtd.dtype)
         ab = jnp.expand_dims(ab, axis=(0, 1))
         ab = jnp.tile(ab, (1, num_heads, 1, 1))
+    elif alibi_slopes is not None:
+        # Symmetric (encoder) ALiBi: bias[h, i, j] = -slope_h * |i - j|.
+        # Cross-sequence pairs in the concatenated ragged batch are masked by
+        # segment IDs inside the kernel, so the global |i - j| formulation is
+        # correct per sequence. NOTE: the kernel adds `ab` to the raw q·k
+        # logits BEFORE multiplying by sm_scale, while the ALiBi reference
+        # adds the bias to the already-scaled logits — so pre-divide by
+        # sm_scale here. Kept in float32 for numerical parity.
+        alibi = -alibi_slopes.astype(jnp.float32)[:, None, None] * (
+            distance.astype(jnp.float32)[None, :, :] / sm_scale)
+        ab = jnp.expand_dims(alibi, axis=0)  # [1, num_heads, Tq, Tkv]
+        if sliding_window is not None:
+            window_bias = jnp.where(distance <= sliding_window, 0.0, -1e4)
+            ab = ab + window_bias[None, None, :, :]
     else:
         ab = None
 

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -130,21 +130,26 @@ def sharded_encoder_only_attention(
     sm_scale: Optional[float] = None,
     sliding_window: Optional[int] = None,
     vmem_limit_bytes: int | None = None,
+    has_alibi: bool = False,
 ) -> Callable[..., Any]:
-    in_specs = (
+    in_specs = [
         P(None, "model", None),  # q: [q_len, num_heads, head_size]
         P(None, "model", None),  # k: [k_len, num_kv_heads, head_size]
         P(None, "model", None),  # v: [k_len, num_kv_heads, head_size]
         P(),  # seq_lens: [batch_size]
-    )
+    ]
+    if has_alibi:
+        # alibi_slopes: [num_heads], sharded with the heads.
+        in_specs.append(P("model"))
     out_specs = P(None, "model", None)
 
-    def _flash_attention(q, k, v, seq_lens):
+    def _flash_attention(q, k, v, seq_lens, alibi_slopes=None):
         return encoder_only_flash_attention(
             q,
             k,
             v,
             seq_lens,
+            alibi_slopes,
             causal=causal,
             sm_scale=sm_scale,
             sliding_window=sliding_window,
@@ -155,7 +160,7 @@ def sharded_encoder_only_attention(
         jax.shard_map(
             _flash_attention,
             mesh=mesh,
-            in_specs=in_specs,
+            in_specs=tuple(in_specs),
             out_specs=out_specs,
             check_vma=False,
         ))
@@ -717,11 +722,15 @@ def encoder_only_attention(
     mesh: Mesh,
     sm_scale: float | None = None,
     sliding_window: int | None = None,
+    alibi_slopes: jax.Array | None = None,
 ) -> jax.Array:
     kernel = sharded_encoder_only_attention(
         mesh=mesh,
         causal=False,
         sm_scale=sm_scale,
         sliding_window=sliding_window,
+        has_alibi=alibi_slopes is not None,
     )
+    if alibi_slopes is not None:
+        return kernel(q, k, v, attention_metadata.seq_lens, alibi_slopes)
     return kernel(q, k, v, attention_metadata.seq_lens)

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -85,6 +85,7 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     from tpu_inference.models.jax.llama4 import Llama4ForCausalLM
     from tpu_inference.models.jax.llama_eagle3 import EagleLlama3ForCausalLM
     from tpu_inference.models.jax.llama_guard_4 import LlamaGuard4ForCausalLM
+    from tpu_inference.models.jax.jina_bert import JinaBertForMaskedLM
     from tpu_inference.models.jax.qwen2 import Qwen2ForCausalLM
     from tpu_inference.models.jax.qwen2_5_vl import \
         Qwen2_5_VLForConditionalGeneration
@@ -105,6 +106,10 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     _MODEL_REGISTRY["Gemma4MTPModel"] = Gemma4MTPForCausalLM
     _MODEL_REGISTRY["DFlashForCausalLM"] = DFlashForCausalLM
     _MODEL_REGISTRY["DFlashDraftModel"] = DFlashForCausalLM
+    # Encoder-only embedding model (runner="pooling"); "JinaBertModel" is the
+    # arch string when the checkpoint is exported without the MLM head.
+    _MODEL_REGISTRY["JinaBertForMaskedLM"] = JinaBertForMaskedLM
+    _MODEL_REGISTRY["JinaBertModel"] = JinaBertForMaskedLM
 
     architectures = getattr(config, "architectures", [])
     for arch in architectures:

--- a/tpu_inference/models/jax/jina_bert.py
+++ b/tpu_inference/models/jax/jina_bert.py
@@ -1,0 +1,418 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""JAX-native JinaBert (jina-embeddings-v2) encoder-only embedding model.
+
+Implements the "JinaBert" architecture (`jinaai/jina-bert-implementation`):
+a BERT variant with symmetric encoder ALiBi (no position embeddings),
+GEGLU feed-forward, and post-LayerNorm — e.g.
+`jinaai/jina-embeddings-v2-small-en`.
+
+Runs prefill-only under `--runner pooling`; the mean pooler executes on CPU
+via vLLM's DispatchPooler (see model_loader). No KV cache is used.
+
+Module attribute names deliberately mirror the HF checkpoint tensor names
+(`embeddings.word_embeddings.weight`,
+`encoder.layer.N.attention.self.query.weight`, `...mlp.gated_layers.weight`,
+etc.) so that `JaxAutoWeightsLoader` matches them without a rename table.
+"""
+
+import functools
+import math
+from typing import List, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from flax import nnx
+from jax.sharding import Mesh
+from vllm.config import VllmConfig
+
+from tpu_inference import utils
+from tpu_inference.layers.common.attention_interface import \
+    encoder_only_attention
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.jax import JaxModule
+from tpu_inference.layers.jax.embed import JaxEmbed
+from tpu_inference.layers.jax.linear import JaxEinsum, JaxLinear
+from tpu_inference.layers.jax.norm import JaxLayerNorm
+from tpu_inference.logger import init_logger
+from tpu_inference.models.jax.jax_intermediate_tensor import \
+    JaxIntermediateTensors
+from tpu_inference.models.jax.utils.weight_utils import (
+    LoadableWithIterator, load_nnx_param_from_reshaped_torch)
+
+logger = init_logger(__name__)
+
+init_fn = nnx.initializers.uniform()
+
+
+def get_alibi_slopes(n_heads: int) -> List[float]:
+    """Standard ALiBi head slopes (geometric sequence), incl. non-power-of-2.
+
+    Matches `_get_alibi_head_slopes` in the JinaBert reference implementation.
+    """
+
+    def slopes_power_of_2(n):
+        start = 2**(-(2**-(math.log2(n) - 3)))
+        ratio = start
+        return [start * ratio**i for i in range(n)]
+
+    if math.log2(n_heads).is_integer():
+        return slopes_power_of_2(n_heads)
+    closest_power_of_2 = 2**math.floor(math.log2(n_heads))
+    return (slopes_power_of_2(closest_power_of_2) +
+            get_alibi_slopes(2 * closest_power_of_2)[0::2][:n_heads -
+                                                           closest_power_of_2])
+
+
+def _set_weight_loader(param: nnx.Param,
+                       param_name: str,
+                       reshape_dims: Optional[Tuple[int, ...]] = None,
+                       permute_dims: Optional[Tuple[int, ...]] = None) -> None:
+    """Attach an explicit HF->JAX weight loader to a param.
+
+    Needed where the auto-loader's name-based heuristics (q_proj/o_proj/
+    embed_tokens) don't match the HF BERT-style names used here.
+    """
+    param.set_metadata(
+        "weight_loader",
+        functools.partial(load_nnx_param_from_reshaped_torch,
+                          reshape_dims=reshape_dims,
+                          permute_dims=permute_dims,
+                          param_name=param_name))
+
+
+class JinaBertEmbeddings(JaxModule):
+    """word + token_type embeddings -> LayerNorm. No position embeddings."""
+
+    def __init__(self, config, dtype: jnp.dtype, rng: nnx.Rngs):
+        self.word_embeddings = JaxEmbed(
+            num_embeddings=config.vocab_size,
+            features=config.hidden_size,
+            dtype=dtype,
+            embedding_init=nnx.with_partitioning(init_fn, ("model", None)),
+            rngs=rng,
+        )
+        self.token_type_embeddings = JaxEmbed(
+            num_embeddings=config.type_vocab_size,
+            features=config.hidden_size,
+            dtype=dtype,
+            embedding_init=nnx.with_partitioning(init_fn, (None, None)),
+            rngs=rng,
+        )
+        self.LayerNorm = JaxLayerNorm(
+            num_features=config.hidden_size,
+            epsilon=config.layer_norm_eps,
+            dtype=dtype,
+            rngs=rng,
+        )
+        # Embedding tables must be loaded as-is (no 2D transpose).
+        _set_weight_loader(self.word_embeddings.weight,
+                           "embeddings.word_embeddings.weight",
+                           permute_dims=(0, 1))
+        _set_weight_loader(self.token_type_embeddings.weight,
+                           "embeddings.token_type_embeddings.weight",
+                           permute_dims=(0, 1))
+
+    def __call__(self, input_ids: jax.Array) -> jax.Array:
+        x = self.word_embeddings(input_ids)
+        # Embedding use: token_type_ids are all zeros -> row 0 broadcast.
+        x = x + self.token_type_embeddings.weight.value[0]
+        return self.LayerNorm(x)
+
+
+class JinaBertSelfAttention(JaxModule):
+    """QKV projections + encoder-only flash attention with ALiBi bias."""
+
+    def __init__(self, config, dtype: jnp.dtype, rng: nnx.Rngs, mesh: Mesh,
+                 prefix: str):
+        self.hidden_size = config.hidden_size
+        self.num_heads = config.num_attention_heads
+        self.head_dim_original = self.hidden_size // self.num_heads
+        self.head_dim = utils.get_padded_head_dim(self.head_dim_original)
+        sharding_size = mesh.shape["model"]
+        self.num_heads = utils.get_padded_num_heads(self.num_heads,
+                                                    sharding_size)
+        self.mesh = mesh
+
+        def qkv(name):
+            proj = JaxEinsum(
+                "TD,DNH->TNH",
+                (self.hidden_size, self.num_heads, self.head_dim),
+                bias_shape=(self.num_heads, self.head_dim),
+                dtype=dtype,
+                kernel_init=nnx.with_partitioning(init_fn,
+                                                  (None, "model", None)),
+                bias_init=nnx.with_partitioning(init_fn, ("model", None)),
+                rngs=rng,
+                prefix=f"{prefix}.{name}",
+            )
+            # HF: [N*H, D] -> reshape (N, H, D) -> permute to (D, N, H).
+            _set_weight_loader(proj.weight,
+                               f"{prefix}.{name}.weight",
+                               reshape_dims=(self.num_heads, self.head_dim,
+                                             self.hidden_size),
+                               permute_dims=(2, 0, 1))
+            _set_weight_loader(proj.bias,
+                               f"{prefix}.{name}.bias",
+                               reshape_dims=(self.num_heads, self.head_dim),
+                               permute_dims=(0, 1))
+            return proj
+
+        self.query = qkv("query")
+        self.key = qkv("key")
+        self.value = qkv("value")
+
+        # Constant per-head ALiBi slopes; numpy so it stays out of nnx state.
+        self.alibi_slopes = np.asarray(get_alibi_slopes(self.num_heads),
+                                       dtype=np.float32)
+
+    def __call__(self, x: jax.Array,
+                 attention_metadata: AttentionMetadata) -> jax.Array:
+        q = self.query(x)  # [T, N, H]
+        k = self.key(x)
+        v = self.value(x)
+        return encoder_only_attention(
+            q,
+            k,
+            v,
+            attention_metadata,
+            self.mesh,
+            sm_scale=self.head_dim_original**-0.5,
+            alibi_slopes=jnp.asarray(self.alibi_slopes),
+        )
+
+
+class JinaBertSelfOutput(JaxModule):
+    """attention output dense + residual + post-LayerNorm."""
+
+    def __init__(self, config, dtype: jnp.dtype, rng: nnx.Rngs,
+                 num_heads: int, head_dim: int, prefix: str):
+        hidden_size = config.hidden_size
+        self.dense = JaxEinsum(
+            "TNH,NHD->TD",
+            (num_heads, head_dim, hidden_size),
+            bias_shape=(hidden_size, ),
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, ("model", None, None)),
+            bias_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            prefix=prefix + ".dense",
+        )
+        # HF: [D_out, N*H] -> reshape (D, N, H) -> permute to (N, H, D).
+        _set_weight_loader(self.dense.weight,
+                           f"{prefix}.dense.weight",
+                           reshape_dims=(hidden_size, num_heads, head_dim),
+                           permute_dims=(1, 2, 0))
+        self.LayerNorm = JaxLayerNorm(
+            num_features=hidden_size,
+            epsilon=config.layer_norm_eps,
+            dtype=dtype,
+            rngs=rng,
+        )
+
+    def __call__(self, x: jax.Array, residual: jax.Array) -> jax.Array:
+        return self.LayerNorm(self.dense(x) + residual)
+
+
+class JinaBertAttention(JaxModule):
+
+    def __init__(self, config, dtype: jnp.dtype, rng: nnx.Rngs, mesh: Mesh,
+                 prefix: str):
+        self_attention = JinaBertSelfAttention(config,
+                                               dtype,
+                                               rng,
+                                               mesh,
+                                               prefix=prefix + ".self")
+        # HF checkpoint path is `attention.self.*`; `self` is a valid
+        # attribute name in Python.
+        setattr(self, "self", self_attention)
+        self.output = JinaBertSelfOutput(
+            config,
+            dtype,
+            rng,
+            num_heads=self_attention.num_heads,
+            head_dim=self_attention.head_dim,
+            prefix=prefix + ".output",
+        )
+
+    def __call__(self, x: jax.Array,
+                 attention_metadata: AttentionMetadata) -> jax.Array:
+        attn = getattr(self, "self")(x, attention_metadata)
+        return self.output(attn, x)
+
+
+class JinaBertGLUMLP(JaxModule):
+    """GEGLU MLP with internal residual + post-LayerNorm.
+
+    forward: x -> gated_layers -> gelu(first half) * second half -> wo
+             -> LayerNorm(out + x)
+    """
+
+    def __init__(self, config, dtype: jnp.dtype, rng: nnx.Rngs, prefix: str):
+        hidden_size = config.hidden_size
+        self.intermediate_size = config.intermediate_size
+        assert getattr(config, "feed_forward_type", "geglu") == "geglu", (
+            "Only feed_forward_type='geglu' is supported")
+        self.gated_layers = JaxLinear(
+            hidden_size,
+            2 * self.intermediate_size,
+            use_bias=False,
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, (None, "model")),
+            rngs=rng,
+            prefix=prefix + ".gated_layers",
+        )
+        self.wo = JaxLinear(
+            self.intermediate_size,
+            hidden_size,
+            use_bias=True,
+            dtype=dtype,
+            kernel_init=nnx.with_partitioning(init_fn, ("model", None)),
+            bias_init=nnx.with_partitioning(init_fn, (None, )),
+            rngs=rng,
+            prefix=prefix + ".wo",
+        )
+        self.layernorm = JaxLayerNorm(
+            num_features=hidden_size,
+            epsilon=config.layer_norm_eps,
+            dtype=dtype,
+            rngs=rng,
+        )
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        residual = x
+        h = self.gated_layers(x)
+        gated = h[..., :self.intermediate_size]
+        non_gated = h[..., self.intermediate_size:]
+        # HF reference uses torch.nn.GELU() (exact erf form).
+        h = jax.nn.gelu(gated, approximate=False) * non_gated
+        h = self.wo(h)
+        return self.layernorm(h + residual)
+
+
+class JinaBertLayer(JaxModule):
+
+    def __init__(self, config, dtype: jnp.dtype, rng: nnx.Rngs, mesh: Mesh,
+                 prefix: str):
+        self.attention = JinaBertAttention(config,
+                                           dtype,
+                                           rng,
+                                           mesh,
+                                           prefix=prefix + ".attention")
+        self.mlp = JinaBertGLUMLP(config, dtype, rng, prefix=prefix + ".mlp")
+
+    def __call__(self, x: jax.Array,
+                 attention_metadata: AttentionMetadata) -> jax.Array:
+        x = self.attention(x, attention_metadata)
+        return self.mlp(x)
+
+
+class JinaBertEncoder(JaxModule):
+
+    def __init__(self, config, dtype: jnp.dtype, rng: nnx.Rngs, mesh: Mesh,
+                 prefix: str):
+        self.layer = [
+            JinaBertLayer(config,
+                          dtype,
+                          rng,
+                          mesh,
+                          prefix=f"{prefix}.layer.{i}")
+            for i in range(config.num_hidden_layers)
+        ]
+
+    def __call__(self, x: jax.Array,
+                 attention_metadata: AttentionMetadata) -> jax.Array:
+        for layer in self.layer:
+            x = layer(x, attention_metadata)
+        return x
+
+
+class JinaBertModel(JaxModule):
+
+    def __init__(self, vllm_config: VllmConfig, rng: nnx.Rngs, mesh: Mesh):
+        config = vllm_config.model_config.hf_config
+        dtype = vllm_config.model_config.dtype
+        self.embeddings = JinaBertEmbeddings(config, dtype, rng)
+        self.encoder = JinaBertEncoder(config,
+                                       dtype,
+                                       rng,
+                                       mesh,
+                                       prefix="encoder")
+
+    def __call__(self, input_ids: jax.Array,
+                 attention_metadata: AttentionMetadata) -> jax.Array:
+        x = self.embeddings(input_ids)
+        return self.encoder(x, attention_metadata)
+
+
+class JinaBertForMaskedLM(JaxModule, LoadableWithIterator):
+    """Embedding-only JinaBert ("JinaBertForMaskedLM" arch string).
+
+    The MLM head (`cls.*`) and the (unused) BERT tanh pooler are not
+    instantiated; mean pooling runs in vLLM's CPU pooler.
+    """
+
+    # vLLM registry inspection: this model only supports the pooling runner.
+    is_pooling_model = True
+
+    def __init__(self, vllm_config: VllmConfig, rng_key: jax.Array,
+                 mesh: Mesh) -> None:
+        self.vllm_config = vllm_config
+        self.mesh = mesh
+        rng = nnx.Rngs(rng_key)
+        self.model = JinaBertModel(vllm_config, rng, mesh)
+
+    def __call__(
+        self,
+        kv_caches: List[jax.Array],
+        input_ids: jax.Array,
+        attention_metadata: AttentionMetadata,
+        inputs_embeds: Optional[jax.Array] = None,
+        _input_positions=None,
+        _layer_name_to_kv_cache=None,
+        _lora_metadata=None,
+        intermediate_tensors: Optional[JaxIntermediateTensors] = None,
+        is_first_rank: bool = True,
+        is_last_rank: bool = True,
+        *args,
+    ) -> Tuple[List[jax.Array], jax.Array, List[jax.Array],
+               Optional[jax.Array]]:
+        assert inputs_embeds is None, (
+            "JinaBert does not support external input embeddings")
+        hidden_states = self.model(input_ids, attention_metadata)
+        # Encoder-only: kv_caches pass through untouched.
+        return kv_caches, hidden_states, [], None
+
+    def load_weights(self, weights):
+        """Strip optional 'bert.' prefixes and drop MLM-head/pooler weights,
+        then delegate to the standard JAX auto-loader."""
+        from tpu_inference.models.jax.utils.weight_utils import \
+            JaxAutoWeightsLoader
+        from tpu_inference.utils import to_torch_dtype
+
+        # The published jina-embeddings-v2 safetensors are float16 while the
+        # model params follow --dtype (float32/bfloat16); cast on load.
+        torch_dtype = to_torch_dtype(self.vllm_config.model_config.dtype)
+
+        def _filtered(weights_iter):
+            for name, weight in weights_iter:
+                if name.startswith("bert."):
+                    name = name[len("bert."):]
+                if name.startswith("cls.") or name.startswith("pooler."):
+                    continue
+                yield name, weight.to(torch_dtype)
+
+        loader = JaxAutoWeightsLoader(self, skip_prefixes=None)
+        return loader.load_weights(_filtered(weights))

--- a/tpu_inference/models/vllm/experimental/__init__.py
+++ b/tpu_inference/models/vllm/experimental/__init__.py
@@ -19,6 +19,12 @@
 _TPU_VLLM_MODELS = {
     "DeepseekV4ForCausalLM":
     "tpu_inference.models.vllm.experimental.deepseek_v4:DeepseekV4ForCausalLM",
+    # JAX-native encoder-only embedding model; the vLLM-side class is only a
+    # registry-compatibility shim (see jina_bert_compat.py).
+    "JinaBertForMaskedLM":
+    "tpu_inference.models.vllm.jina_bert_compat:JinaBertForMaskedLM",
+    "JinaBertModel":
+    "tpu_inference.models.vllm.jina_bert_compat:JinaBertForMaskedLM",
 }
 
 

--- a/tpu_inference/models/vllm/jina_bert_compat.py
+++ b/tpu_inference/models/vllm/jina_bert_compat.py
@@ -1,0 +1,63 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""vLLM-registry compatibility wrapper for the JAX-native JinaBert model.
+
+vLLM resolves architectures like "JinaBertForMaskedLM" through its own
+ModelRegistry at config time (to determine, among other things, that this is
+a pooling model). vLLM upstream has no JinaBert implementation, so we
+register this wrapper — it is never instantiated or executed by vLLM's
+PyTorch backend; the real model is the JAX implementation in
+`tpu_inference.models.jax.jina_bert`, dispatched via tpu-inference's own
+registry. This mirrors what `model_loader.register_model` builds dynamically
+for out-of-tree models.
+"""
+
+from typing import Any, Optional
+
+import torch
+
+from tpu_inference.models.jax.jina_bert import \
+    JinaBertForMaskedLM as _JaxJinaBertForMaskedLM
+
+
+class JinaBertForMaskedLM(_JaxJinaBertForMaskedLM, torch.nn.Module):
+    is_pooling_model = True
+
+    def __init__(self, *args, **kwargs):
+        # Only torch.nn.Module init: this class exists purely to satisfy
+        # vLLM's registry inspection and must not trigger JAX logic.
+        torch.nn.Module.__init__(self)
+
+    def forward(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        intermediate_tensors: Optional[Any] = None,
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> None:
+        raise NotImplementedError(
+            "This is a JAX model and does not implement the PyTorch forward.")
+
+    def embed_input_ids(
+        self,
+        input_ids: torch.Tensor,
+        positions: torch.Tensor,
+        inputs_embeds: Optional[torch.Tensor] = None,
+    ) -> torch.Tensor:
+        raise NotImplementedError(
+            "This is a JAX model and does not implement embed_input_ids.")
+
+    def load_weights(self, *args, **kwargs):
+        # Prevent vLLM from trying to load weights into this dummy class.
+        return None


### PR DESCRIPTION
…odel

- ALiBi bias support in encoder_only_attention -> encoder_only_flash_attention: symmetric -slope*|i-j| additive bias built alongside the existing sliding-window bias (pre-divided by sm_scale to match reference scaling)
- New flax/nnx JinaBert model: no position embeddings, GEGLU MLP with internal post-LN residual, BERT post-LN attention block; module names mirror HF checkpoint keys for the auto weight loader
- Register JinaBertForMaskedLM/JinaBertModel in the JAX registry and, via a torch-compat shim, in vLLM's ModelRegistry (pooling model)
- Unit parity test vs HF transformers reference and e2e pooling test

# Description

Start with a short description of what the PR does and how this is a change from
the past.

The rest of the description includes relevant details and context, examples:
- why is this change being made,
- the problem being solved and any relevant context,
- why this is a good solution,
- some information about the specific implementation,
- shortcomings of the solution and possible future improvements.

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
