### PR TITLE
[NOT READY FOR REVIEW] [Platform] Honor an explicit enable_dp_attention: false opt-out for MLA models

### DIFF
--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -372,6 +372,18 @@ class TestTpuPlatform:
             with pytest.raises(ValueError, match=expected_msg):
                 TpuPlatform.check_and_update_config(vllm_config)
 
+            # NEW_MODEL_DESIGN is required even with an explicit dp-attention
+            # opt-out.
+            vllm_config.additional_config = {
+                "sharding": {
+                    "sharding_strategy": {
+                        "enable_dp_attention": False
+                    }
+                }
+            }
+            with pytest.raises(ValueError, match=expected_msg):
+                TpuPlatform.check_and_update_config(vllm_config)
+
         # Next, test set NEW_MODEL_DESIGN and unset additional_config to ensure it is required
         with patch("tpu_inference.envs.NEW_MODEL_DESIGN", True):
             vllm_config.additional_config = {}
@@ -383,17 +395,6 @@ class TestTpuPlatform:
                 "sharding": {
                     "sharding_strategy": {
                         "debug_key": True
-                    }
-                }
-            }
-            with pytest.raises(ValueError, match=expected_msg):
-                TpuPlatform.check_and_update_config(vllm_config)
-
-            # Test where `enable_dp_attention` exists but is explicitly set to False
-            vllm_config.additional_config = {
-                "sharding": {
-                    "sharding_strategy": {
-                        "enable_dp_attention": False
                     }
                 }
             }
@@ -420,6 +421,38 @@ class TestTpuPlatform:
                             pytest.fail(
                                 f"MLA check failed even when config was correct: {e}"
                             )
+
+    def test_check_and_update_config_mla_explicit_dp_attention_opt_out(self):
+        # An EXPLICIT `enable_dp_attention: False` (key present) is honored as
+        # a user opt-out: no raise, and a self-contained warning is logged.
+        vllm_config = MagicMock()
+        vllm_config.model_config.use_mla = True
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.additional_config = {
+            "sharding": {
+                "sharding_strategy": {
+                    "enable_dp_attention": False
+                }
+            }
+        }
+
+        with patch("tpu_inference.envs.NEW_MODEL_DESIGN", True), \
+             patch.object(TpuPlatform, "_initialize_sharding_config"), \
+             patch("vllm.config.CompilationMode"), \
+             patch("tpu_inference.platforms.tpu_platform.logger") as mock_logger:
+            try:
+                TpuPlatform.check_and_update_config(vllm_config)
+            except Exception as e:
+                if isinstance(e,
+                              ValueError) and "MLA models require" in str(e):
+                    pytest.fail(
+                        f"MLA check raised despite explicit dp-attention opt-out: {e}"
+                    )
+            assert any(
+                "WITHOUT DP attention" in str(call.args[0])
+                for call in mock_logger.warning.call_args_list), (
+                    "expected a warning stating MLA is served without DP "
+                    "attention at the user's explicit request")
 
     def test_check_and_update_config_mla_disabled_via_env(self, vllm_config):
         vllm_config.additional_config = {}

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -274,13 +274,29 @@ class TpuPlatform(Platform):
             )
 
         if vllm_config.model_config and vllm_config.model_config.use_mla:
-            if not envs.NEW_MODEL_DESIGN or not vllm_config.additional_config.get(
-                    "sharding", {}).get("sharding_strategy", {}).get(
-                        "enable_dp_attention", False):
+            sharding_strategy = vllm_config.additional_config.get(
+                "sharding", {}).get("sharding_strategy", {})
+            # DP attention is the validated default for MLA models, but very
+            # large MoE+MLA models may not fit it: every device spent on an
+            # attention-DP shard holds no expert weights, so the
+            # expert-parallel x tensor-parallel weight capacity shrinks and
+            # can exceed per-device HBM in every dp-attention layout. An
+            # EXPLICIT `enable_dp_attention: false` in the user's config is
+            # therefore honored as an opt-out; an absent key still raises so
+            # default behavior is unchanged.
+            if (not envs.NEW_MODEL_DESIGN
+                    or "enable_dp_attention" not in sharding_strategy):
                 raise ValueError(
                     "MLA models require both the NEW_MODEL_DESIGN=1 environment "
                     "variable to be set and DP attention set via: --additional_config \'{\"sharding\": {\"sharding_strategy\": {\"enable_dp_attention\": true}}}\'"
                 )
+            if not sharding_strategy["enable_dp_attention"]:
+                logger.warning(
+                    "[platform] Serving an MLA model WITHOUT DP attention "
+                    "because additional_config sharding.sharding_strategy."
+                    "enable_dp_attention is explicitly set to false. This is "
+                    "an explicit user opt-out from the recommended MLA "
+                    "configuration; attention will not be data-parallel.")
         cls._initialize_sharding_config(vllm_config)
 
         cache_config = vllm_config.cache_config


### PR DESCRIPTION
### Problem

`check_and_update_config` rejects every MLA model unless dp-attention is enabled (`--additional_config '{"sharding": {"sharding_strategy": {"enable_dp_attention": true}}}'` plus `NEW_MODEL_DESIGN=1`). Because the check reads the flag with `.get("enable_dp_attention", False)`, it cannot distinguish "user never set it" from "user deliberately set it to false" — so there is no way to serve an MLA model without dp-attention even when the user knowingly wants that.

For very large MoE+MLA models, no dp-attention configuration fits: with k attention-DP shards, the devices serving each shard hold no expert weights, so the expert-parallel × tensor-parallel weight capacity drops from N devices to N/k — and at these model sizes every choice of k exceeds per-device HBM. The only viable layout dedicates all N devices to expert×tensor sharding, i.e. runs MLA without attention DP.

### Change

- An **explicit** `"enable_dp_attention": false` in `additional_config.sharding.sharding_strategy` is now accepted. A self-contained `[platform]` warning is logged stating that MLA is being served without DP attention at the user's explicit request.
- An **absent** key still raises the exact same error as before — nobody who hasn't opted out sees any behavior change.
- `NEW_MODEL_DESIGN=1` remains required in all cases.

### Correctness evidence

MLA without dp-attention has been validated on real hardware: greedy completions are byte-identical to the dp-attention-enabled baseline on the same checkpoint, with clean concurrent-request isolation and reproducible outputs across runs (multi-host tpu7x, expert×tensor mesh).

### Tests

`tests/platforms/test_tpu_platform.py`: absent key raises (with and without `NEW_MODEL_DESIGN`), explicit false with `NEW_MODEL_DESIGN` unset raises, explicit true passes, and a new test asserts explicit false passes and emits the opt-out warning. All 39 tests in the file pass (CPU-only).

Note for reviewers: the pre-existing `test_check_and_update_config_mla_checks` asserted that explicit-false raises; that assertion was the old behavior under test and is necessarily updated by this change.
