### PR TITLE
[DSv4] Overlay HCA compressor state onto CSA's NOPE cache

### DIFF
--- a/tests/kernels/deepseek_v4/compress_store_test.py
+++ b/tests/kernels/deepseek_v4/compress_store_test.py
@@ -72,6 +72,7 @@ class CompressStoreTest(jtu.JaxTestCase):
         compress_ratio,
         overlap,
         physical_page_size,
+        state_physical_page_size=None,
         quant_block=64,
         rms_eps=1e-6,
         positions=None,
@@ -92,6 +93,7 @@ class CompressStoreTest(jtu.JaxTestCase):
             mode,
             size_n=num_tokens,
             physical_page_size=physical_page_size,
+            state_physical_page_size=state_physical_page_size,
             rms_eps=rms_eps,
             head_dim=head_dim,
             rope_head_dim=rope_head_dim,
@@ -100,6 +102,10 @@ class CompressStoreTest(jtu.JaxTestCase):
         )
 
         state_block_size = cfgs.state_block_size
+        if mode is config.Mode.HCA:
+            separate_state = True
+        else:
+            separate_state = False
 
         state_width = cfgs.state_width
         state_dim = 2 * state_width
@@ -136,28 +142,37 @@ class CompressStoreTest(jtu.JaxTestCase):
         ape = jax.random.normal(k3, (compress_ratio, state_width))
         run_1_positions = jnp.arange(run_1_tokens, dtype=jnp.int32)
 
-        slots_per_token = physical_page_size // state_block_size
+        slots_per_token = cfgs.state_rows_per_token
         run_1_slot_mapping = np.arange(run_1_tokens) * slots_per_token
         run_1_slot_mapping = jnp.array(run_1_slot_mapping, dtype=jnp.int32)
 
         init_cache = jnp.zeros(cfgs.cache_shape(num_pages), dtype=jnp.uint8)
+        init_state_cache = jnp.zeros(cfgs.state_cache_shape(num_pages),
+                                     dtype=jnp.uint8)
 
         ref_wkv_proj_and_save_state_jit = jax.jit(
             proj_and_save_state_ref.ref_wkv_proj_and_save_state,
             static_argnums=(6, 7, 8, 9),
         )
-        populated_cache = ref_wkv_proj_and_save_state_jit(
+        # The state scatter targets the state array, which is `init_cache`
+        # itself in the shared-buffer layout.
+        populated_state_cache = ref_wkv_proj_and_save_state_jit(
             hidden_states=hidden_states,
             wkv_wgate=wkv_wgate,
             ape=ape,
             positions=run_1_positions,
             slot_mapping=run_1_slot_mapping,
-            cache=init_cache,
+            cache=init_state_cache if separate_state else init_cache,
             state_block_size=state_block_size,
             head_dim=head_dim,
             compress_ratio=compress_ratio,
             overlap=overlap,
         )
+        if separate_state:
+            populated_cache = init_cache
+        else:
+            populated_cache = populated_state_cache
+            populated_state_cache = None
 
         # 3. Setup Kernel 2 inputs
         if token_to_req_indices is None:
@@ -206,6 +221,8 @@ class CompressStoreTest(jtu.JaxTestCase):
                                     dtype=jnp.int32)
         else:
             block_table = jnp.array(block_table)
+        block_table_stride = block_table.shape[1]
+        block_table = block_table.reshape(-1)
 
         rms_weight = jax.random.normal(k4, (head_dim, ))
 
@@ -229,7 +246,19 @@ class CompressStoreTest(jtu.JaxTestCase):
         # 4. Run Reference
         ref_compress_norm_rope_store_jit = jax.jit(
             compress_store_ref.ref_compress_norm_rope_store,
-            static_argnums=(9, 10, 11, 12, 13, 14, 15, 16, 17, 18),
+            static_argnames=(
+                "block_table_stride",
+                "state_block_size",
+                "head_dim",
+                "rope_head_dim",
+                "compress_ratio",
+                "overlap",
+                "rms_eps",
+                "quant_block",
+                "is_quantized",
+                "has_rope",
+                "has_rope_cache",
+            ),
         )
         ref_out = ref_compress_norm_rope_store_jit(
             cache=populated_cache,
@@ -241,6 +270,7 @@ class CompressStoreTest(jtu.JaxTestCase):
             kv_slot_mapping=kv_slot_mapping,
             rms_weight=rms_weight,
             cos_sin_cache=cos_sin_cache,
+            block_table_stride=block_table_stride,
             state_block_size=state_block_size,
             head_dim=head_dim,
             rope_head_dim=rope_head_dim,
@@ -251,6 +281,7 @@ class CompressStoreTest(jtu.JaxTestCase):
             is_quantized=is_quantized,
             has_rope=has_rope,
             has_rope_cache=cfgs.dims.has_rope_cache,
+            state_cache=populated_state_cache,
         )
         ref_cache_output, ref_rope_output = ref_out
 
@@ -263,6 +294,9 @@ class CompressStoreTest(jtu.JaxTestCase):
             token_to_req_indices,
             kv_slot_mapping,
             rms_weight,
+            block_table_stride=block_table_stride,
+            state_cache=(jnp.copy(populated_state_cache)
+                         if separate_state else None),
             rope_cache=jnp.copy(init_rope_cache),
             cos_sin_cache=cos_sin_cache,
             compress_ratio=cfgs.dims.compress_ratio,
@@ -324,7 +358,8 @@ class CompressStoreTest(jtu.JaxTestCase):
                 rope_head_dim=64,
                 compress_ratio=128,
                 overlap=False,
-                physical_page_size=128,
+                physical_page_size=16,
+                state_physical_page_size=256,
             ),
         ),
         (
@@ -335,7 +370,8 @@ class CompressStoreTest(jtu.JaxTestCase):
                 rope_head_dim=64,
                 compress_ratio=128,
                 overlap=False,
-                physical_page_size=128,
+                physical_page_size=16,
+                state_physical_page_size=256,
             ),
         ),
         (
@@ -372,7 +408,8 @@ class CompressStoreTest(jtu.JaxTestCase):
                 rope_head_dim=64,
                 compress_ratio=128,
                 overlap=False,
-                physical_page_size=128,
+                physical_page_size=16,
+                state_physical_page_size=256,
                 positions=np.array([127, 255, 383, 511], dtype=np.int32),
                 prefill_len=512,
             ),
@@ -398,7 +435,8 @@ class CompressStoreTest(jtu.JaxTestCase):
                 rope_head_dim=64,
                 compress_ratio=128,
                 overlap=False,
-                physical_page_size=128,
+                physical_page_size=16,
+                state_physical_page_size=256,
                 positions=np.array([383, 127, 511, 255], dtype=np.int32),
                 prefill_len=512,
             ),
@@ -424,7 +462,8 @@ class CompressStoreTest(jtu.JaxTestCase):
                 rope_head_dim=64,
                 compress_ratio=128,
                 overlap=False,
-                physical_page_size=128,
+                physical_page_size=16,
+                state_physical_page_size=256,
                 positions=np.array([127, 126, 255, 254, 383, 382],
                                    dtype=np.int32),
                 prefill_len=384,

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -1489,13 +1489,16 @@ class TestKVCacheManager:
                                               head_size=512,
                                               dtype=torch.float32,
                                               sliding_window=8)
-        hca_state_spec = SlidingWindowMLASpec(block_size=1,
+        # HCA states are hosted on a CSA NoPE array (131072B page), so they are
+        # paged at 32 states/block -- a different (block_size, sliding_window)
+        # family than the CSA/indexer states, hence their own cache group.
+        hca_state_spec = SlidingWindowMLASpec(block_size=32,
                                               num_kv_heads=1,
                                               head_size=1024,
                                               dtype=torch.float32,
-                                              sliding_window=8)
+                                              sliding_window=128)
 
-        mla_specs, state_specs = {}, {}
+        mla_specs, state_specs, hca_state_specs = {}, {}, {}
         for i in range(2):
             mla_specs[f"model.layers.{i}.attn"] = main_spec
             mla_specs[f"model.layers.{i}.attn.indexer.k_cache"] = idx_spec
@@ -1504,7 +1507,7 @@ class TestKVCacheManager:
             state_specs[f"model.layers.{i}.attn.indexer.compressor."
                         "state_cache"] = idx_state_spec
         mla_specs["model.layers.2.attn"] = hca_spec
-        state_specs[
+        hca_state_specs[
             "model.layers.2.attn.compressor.state_cache"] = hca_state_spec
         swa_names = [
             f"model.layers.{i}.attn.swa_cache" for i in range(num_swa_layers)
@@ -1516,7 +1519,8 @@ class TestKVCacheManager:
 
         groups = []
         for block_size, specs in ((1024, mla_specs), (16, state_specs),
-                                  (128, swa_specs_0), (128, swa_specs_1)):
+                                  (32, hca_state_specs), (128, swa_specs_0),
+                                  (128, swa_specs_1)):
             groups.append(
                 KVCacheGroupSpec(layer_names=list(specs),
                                  kv_cache_spec=UniformTypeKVCacheSpecs(
@@ -1587,17 +1591,23 @@ class TestKVCacheManager:
         assert caches[2].shape == (num_blocks, 64, 4, 256)
         assert caches[6].shape == (num_blocks, 16, 4, 128)
 
-        # Compressor state caches share their compressed-KV layer's array
-        # (the compressor kernel writes state + compressed KV through one
-        # buffer and asserts index equality at runtime).
+        # CSA / indexer compressor state caches share their own compressed-KV
+        # layer's array (the compressor kernel writes state + compressed KV
+        # through one buffer there).
         for i in range(2):
             assert (idx_map[f'model.layers.{i}.attn.compressor.state_cache'] ==
                     idx_map[f'model.layers.{i}.attn'])
             assert (idx_map[f'model.layers.{i}.attn.indexer.compressor.'
                             'state_cache'] ==
                     idx_map[f'model.layers.{i}.attn.indexer.k_cache'])
+        # The HCA state cache goes on a CSA NoPE array instead of its own HCA
+        # array, whose page holds only 2 token states (vs 32) and would make
+        # the state block table 16x longer than SMEM can hold. Its cache group
+        # holds nothing else, so the first CSA NoPE array is free.
         assert (idx_map['model.layers.2.attn.compressor.state_cache'] ==
-                idx_map['model.layers.2.attn'])
+                idx_map['model.layers.0.attn'])
+        assert (idx_map['model.layers.2.attn.compressor.state_cache']
+                != idx_map['model.layers.2.attn'])
 
         # swa_caches overlay the CSA NoPE arrays (never the indexer or HCA
         # arrays), by position: distinct within one cache group (shared block
@@ -1718,6 +1728,107 @@ class TestKVCacheManager:
             assert len(set(indices)) == len(indices)
         assert ([idx_map[name] for name in swa_groups[0]
                  ] == [idx_map[name] for name in swa_groups[1]])
+
+    def _ds_v4_hca_state_group(self, groups):
+        for group in groups:
+            names = group.layer_names
+            if any(
+                    name.endswith('.compressor.state_cache')
+                    and 'indexer' not in name and 'layers.2' in name
+                    for name in names):
+                return group
+        raise AssertionError('no HCA state group')
+
+    def test_initialize_kv_cache_ds_v4_hca_state_overflows_csa_arrays(self):
+        # 3 HCA state caches but only 2 CSA NoPE arrays to host them: the
+        # third falls through to the overflow pool, never to a CSA array a
+        # sibling state cache already took.
+        num_blocks = 32
+        groups = self._ds_v4_groups()
+        hca_group = self._ds_v4_hca_state_group(groups)
+        base_spec = hca_group.kv_cache_spec.kv_cache_specs[
+            'model.layers.2.attn.compressor.state_cache']
+        hca_specs = dict(hca_group.kv_cache_spec.kv_cache_specs)
+        mla_group = next(group for group in groups
+                         if 'model.layers.2.attn' in group.layer_names)
+        mla_specs = dict(mla_group.kv_cache_spec.kv_cache_specs)
+        hca_layer_spec = mla_specs['model.layers.2.attn']
+        for i in (3, 4):
+            mla_specs[f'model.layers.{i}.attn'] = hca_layer_spec
+            hca_specs[
+                f'model.layers.{i}.attn.compressor.state_cache'] = base_spec
+
+        rebuilt = []
+        for group in groups:
+            specs = group.kv_cache_spec.kv_cache_specs
+            if group is hca_group:
+                specs = hca_specs
+            elif group is mla_group:
+                specs = mla_specs
+            rebuilt.append(
+                KVCacheGroupSpec(layer_names=list(specs),
+                                 kv_cache_spec=UniformTypeKVCacheSpecs(
+                                     block_size=group.kv_cache_spec.block_size,
+                                     kv_cache_specs=specs)))
+
+        tensors = self._ds_v4_packed_tensors(rebuilt, num_blocks)
+        self._init_ds_v4(
+            KVCacheConfig(num_blocks=num_blocks,
+                          kv_cache_tensors=tensors,
+                          kv_cache_groups=rebuilt))
+
+        idx_map = self.runner.layer_name_to_kvcache_index
+        caches = self.runner.kv_caches
+        csa_nope = [
+            idx_map['model.layers.0.attn'], idx_map['model.layers.1.attn']
+        ]
+        state_indices = [
+            idx_map[f'model.layers.{i}.attn.compressor.state_cache']
+            for i in (2, 3, 4)
+        ]
+        # Distinct within the group (they share a block table), first two on
+        # the CSA NoPE arrays, the third on an array of the same shape from
+        # the overflow pool.
+        assert len(set(state_indices)) == 3
+        assert state_indices[:2] == csa_nope
+        assert state_indices[2] not in csa_nope
+        assert caches[state_indices[2]].shape == caches[csa_nope[0]].shape
+
+    def test_initialize_kv_cache_ds_v4_same_group_collision_raises(self):
+        # Layers of one cache group share a block table, so two of them on one
+        # array would write the same rows. The overlay maps the i-th HCA state
+        # onto the i-th CSA NoPE array, which is only safe because the HCA
+        # states are always their own cache group; if vLLM ever merges them
+        # with the CSA states (already on those arrays), fail loudly at
+        # startup rather than silently corrupt the cache.
+        num_blocks = 32
+        groups = self._ds_v4_groups()
+        hca_group = self._ds_v4_hca_state_group(groups)
+        state_group = next(group for group in groups
+                           if 'model.layers.0.attn.compressor.state_cache' in
+                           group.layer_names)
+        merged_specs = dict(state_group.kv_cache_spec.kv_cache_specs)
+        merged_specs.update(hca_group.kv_cache_spec.kv_cache_specs)
+
+        rebuilt = []
+        for group in groups:
+            if group is hca_group:
+                continue
+            specs = (merged_specs if group is state_group else
+                     group.kv_cache_spec.kv_cache_specs)
+            rebuilt.append(
+                KVCacheGroupSpec(layer_names=list(specs),
+                                 kv_cache_spec=UniformTypeKVCacheSpecs(
+                                     block_size=group.kv_cache_spec.block_size,
+                                     kv_cache_specs=specs)))
+
+        tensors = self._ds_v4_packed_tensors(rebuilt, num_blocks)
+        kv_cache_config = KVCacheConfig(num_blocks=num_blocks,
+                                        kv_cache_tensors=tensors,
+                                        kv_cache_groups=rebuilt)
+
+        with pytest.raises(ValueError, match=r"\[kv-cache\].*same array"):
+            self._init_ds_v4(kv_cache_config)
 
     def test_initialize_kv_cache_ds_v4_missing_k_cache_raises(self):
         # A compressor state cache without its compressed-KV layer must fail

--- a/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/buffered_ref.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/buffered_ref.py
@@ -104,6 +104,7 @@ class PageBufferRef(_BufferedRef):
             state_cache_ref,
             positions_ref,
             block_table_ref,
+            block_table_stride,
             token_to_req_indices_ref,
         ) = src_ref
 
@@ -126,7 +127,8 @@ class PageBufferRef(_BufferedRef):
             block_idx = position // block_size - (pages_to_buffer_per_token -
                                                   1) + p
             safe_block_idx = jnp.maximum(block_idx, 0)
-            page = block_table_ref[req_idx, safe_block_idx]
+            page = block_table_ref[req_idx * block_table_stride +
+                                   safe_block_idx]
 
             src = state_cache_ref.at[page, :, :, :]
             dest = page_buffer_ref.at[n, p, :, :, :]
@@ -410,9 +412,11 @@ def create_allocs_and_specs(
     *,
     cache_ref,
     rope_cache_ref,
+    state_cache_ref,
     cos_sin_cache_ref,
     positions_ref,
     block_table_ref,
+    block_table_stride,
     token_to_req_indices_ref,
     kv_slot_mapping_ref,
     is_first_mask_ref,
@@ -486,9 +490,10 @@ def create_allocs_and_specs(
         cfgs=cfgs,
     )
     page_buffer_args = (
-        cache_ref,
+        cache_ref if state_cache_ref is None else state_cache_ref,
         positions_ref,
         block_table_ref,
+        block_table_stride,
         token_to_req_indices_ref,
     )
 

--- a/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/compress_store_ref.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/compress_store_ref.py
@@ -69,7 +69,8 @@ def interleaved_rope(
 def gather_state_windows(
     state_cache: jax.Array,
     positions: jax.Array,
-    block_table: jax.Array,
+    block_table: jax.Array,  # [num_reqs * block_table_stride]
+    block_table_stride: int,
     token_to_req_indices: jax.Array,
     block_size: int,
     head_dim: int,
@@ -88,7 +89,8 @@ def gather_state_windows(
 
     safe_pos = jnp.maximum(pos, 0)
     req = token_to_req_indices[:, None]
-    block_numbers = block_table[req, safe_pos // block_size]
+    block_numbers = block_table[req * block_table_stride +
+                                safe_pos // block_size]
     block_offsets = safe_pos % block_size
 
     head_offset = (w_idx >= compress_ratio).astype(jnp.int32) * head_dim
@@ -154,11 +156,12 @@ def ref_compress_norm_rope_store(
     rope_cache: jax.Array,  # [num_pages, rope_page_size, 4, 128] uint8
     positions: jax.Array,  # [num_tokens] int
     slot_mapping: jax.Array,  # [num_tokens] int (state-cache slots)
-    block_table: jax.Array,  # [num_reqs, max_blocks] int (state pages)
+    block_table: jax.Array,  # [num_reqs * stride] int (state pages)
     token_to_req_indices: jax.Array,  # [num_tokens] int
     kv_slot_mapping: jax.Array,  # [num_tokens] int (compressed-KV slots)
     rms_weight: jax.Array,  # [head_dim] fp32
     cos_sin_cache: jax.Array,  # [max_pos, rope_head_dim] fp32
+    block_table_stride: int,
     state_block_size: int,
     head_dim: int,
     rope_head_dim: int,
@@ -169,8 +172,13 @@ def ref_compress_norm_rope_store(
     is_quantized: bool = True,
     has_rope: bool = True,
     has_rope_cache: bool | None = None,
+    state_cache: jax.Array | None = None,
 ) -> tuple[jax.Array, jax.Array]:
-    """Golden JAX reference for Kernel 2 (compress + store)."""
+    """Golden JAX reference for Kernel 2 (compress + store).
+
+    ``state_cache`` is the array holding the f32 states; ``None`` means it
+    shares ``cache``'s buffer (CSA / indexer).
+    """
     coff = 1 + int(overlap)
     state_width = coff * head_dim
     state_dim = 2 * state_width
@@ -210,7 +218,9 @@ def ref_compress_norm_rope_store(
         assert d2 == 128
         slot_bytes = slots_per_part_hbm * d2
 
-    slots_per_token = page_size // state_block_size
+    state_source = cache if state_cache is None else state_cache
+    state_page_size = page_size if state_cache is None else state_cache.shape[1]
+    slots_per_token = state_page_size // state_block_size
     f32_per_slot = state_dim // slots_per_token
     bytes_per_slot = f32_per_slot * 4
     assert bytes_per_slot == slot_bytes
@@ -226,12 +236,13 @@ def ref_compress_norm_rope_store(
     # within a row the ``hbm_pack`` sub-slots hold the four bytes of an f32, so a
     # single byte-transpose inverts the packing for every mode. This is the exact
     # inverse of the pack in ``ref_wkv_proj_and_save_state``.
-    phys_pages, phys_page_size, hbm_pack, last_dim = cache.shape
+    phys_pages, phys_page_size, hbm_pack, last_dim = state_source.shape
     assert hbm_pack == 4, f"expected 4 bytes per f32 in a slot row, got {hbm_pack}"
     state_rows = phys_page_size // state_block_size
     assert state_rows * hbm_pack * last_dim == state_dim * 4
-    state_bytes_t = cache.reshape(phys_pages, state_block_size, state_rows,
-                                  hbm_pack, last_dim).transpose(0, 1, 2, 4, 3)
+    state_bytes_t = state_source.reshape(phys_pages, state_block_size,
+                                         state_rows, hbm_pack,
+                                         last_dim).transpose(0, 1, 2, 4, 3)
     state_view = jax.lax.bitcast_convert_type(state_bytes_t,
                                               jnp.float32).reshape(
                                                   phys_pages, state_block_size,
@@ -242,6 +253,7 @@ def ref_compress_norm_rope_store(
         state_cache=state_view,
         positions=positions,
         block_table=block_table,
+        block_table_stride=block_table_stride,
         token_to_req_indices=token_to_req_indices,
         block_size=state_block_size,
         head_dim=head_dim,

--- a/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/compressor_v1.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/compressor_v1.py
@@ -21,6 +21,13 @@ import tpu_inference.kernels.experimental.deepseek_v4.compress_and_store.kernel 
 import tpu_inference.kernels.experimental.deepseek_v4.compress_and_store.proj_and_save_state as proj_kernel
 
 
+def block_table_row_stride(block_table: jax.Array, num_reqs: int) -> int:
+    """Per-request row stride of a flattened [num_reqs * max_blocks] table."""
+    assert block_table.ndim == 1
+    assert block_table.shape[0] % num_reqs == 0
+    return block_table.shape[0] // num_reqs
+
+
 def derive_metadata(
     positions: jax.Array,
     block_table: jax.Array,
@@ -32,30 +39,35 @@ def derive_metadata(
     head_dim: int,
     overlap: bool,
     cos_sin_cache: jax.Array | None,
+    state_cache: jax.Array | None = None,
 ) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Derives token_to_req_indices, slot_mapping_slots, and kv_slot_mapping.
 
   The page geometry is taken from ``config.Configs`` keyed on
-  ``cache.shape[1]``, which is the same derivation ``compress_norm_rope_store``
-  and ``proj_and_save_state`` use. It must not be recomputed from a separate
-  model here: the three only agree for CSA, and diverge by 2x (HCA) and 4x
-  (indexer) otherwise, which silently scatters state and compressed-KV writes
-  across the wrong pages.
+  ``cache.shape[1]`` (compressed KV) and ``state_cache.shape[1]`` (state),
+  which is the same derivation ``compress_norm_rope_store`` and
+  ``proj_and_save_state`` use. It must not be recomputed from a separate model
+  here: the three only agree for CSA, and diverge by 2x (HCA) and 4x (indexer)
+  otherwise, which silently scatters state and compressed-KV writes across the
+  wrong pages.
 
   Args:
     positions: [num_tokens]. Logical position of each token in its request.
-    block_table: [num_reqs, max_blocks]. Page table for the state cache.
+    block_table: [num_reqs * max_blocks]. Flattened row-major page table for the
+      state cache.
     query_start_loc: [num_reqs + 1]. Cumulative sum of query lengths.
-    kv_block_table: [num_reqs, max_kv_blocks]. Page table for the compressed KV
-      cache.
-    cache: [num_pages, physical_page_size, 4, lanes] uint8. The shared
-      state + compressed-KV buffer; only its shape is read here.
+    kv_block_table: [num_reqs * max_kv_blocks]. Flattened row-major page table
+      for the compressed KV cache.
+    cache: [num_pages, physical_page_size, 4, lanes] uint8. The compressed-KV
+      buffer; only its shape is read here.
     compress_ratio: Compression ratio (e.g. 4 for CSA, 128 for HCA).
     state_block_size: Block size vLLM used to build ``block_table``. Must match
-      the geometry of ``cache``; asserted below.
+      the geometry of ``state_cache``; asserted below.
     head_dim: Dimensionality of attention heads.
     overlap: Whether to use overlap (CSA path).
     cos_sin_cache: [max_pos, rope_head_dim] or None. RoPE cos/sin cache.
+    state_cache: [num_pages, state_page_size, 4, lanes] uint8, or None when the
+      state shares ``cache``'s buffer. Only its shape is read here.
   Returns:
     token_to_req_indices: [num_tokens]. Request index for each token.
     slot_mapping_slots: [num_tokens]. Physical row index in the state cache.
@@ -64,17 +76,19 @@ def derive_metadata(
   """
     num_tokens = positions.shape[0]
     rope_head_dim = cos_sin_cache.shape[1] if cos_sin_cache is not None else 0
+    state_source = cache if state_cache is None else state_cache
 
     cfgs = config.Configs.make(
         config.select_mode(head_dim, overlap),
         size_n=num_tokens,
         physical_page_size=cache.shape[1],
+        state_physical_page_size=state_source.shape[1],
         head_dim=head_dim,
         rope_head_dim=rope_head_dim,
         compress_ratio=compress_ratio,
     )
     # Rows per page, rows per token's state, and the KV sub-slot packing.
-    page_size = cfgs.physical_page_size
+    page_size = cfgs.state_physical_page_size
     state_rows_per_token = cfgs.state_rows_per_token
     kv_block_size = cfgs.kv_block_size
     kv_stride = cfgs.kv_stride
@@ -84,8 +98,8 @@ def derive_metadata(
     # be the number of token states that actually fit in one physical page.
     assert state_block_size == cfgs.state_block_size, (
         f"state cache block_size {state_block_size} does not match the "
-        f"{cfgs.dims.mode.value} cache geometry {cache.shape}, which holds "
-        f"{cfgs.state_block_size} token states per page ")
+        f"{cfgs.dims.mode.value} state cache geometry {state_source.shape}, "
+        f"which holds {cfgs.state_block_size} token states per page ")
 
     # 2. Map tokens to request indices (Handles Ragged Batch)
     query_lens = jnp.diff(query_start_loc)
@@ -95,10 +109,13 @@ def derive_metadata(
                                       total_repeat_length=num_tokens)
     req = token_to_req_indices
 
+    block_table_stride = block_table_row_stride(block_table, batch_size)
+    kv_block_table_stride = block_table_row_stride(kv_block_table, batch_size)
+
     # 3. State Cache Slot Mapping (Virtual -> Physical)
     state_page_idx = positions // state_block_size
     state_page_offset = positions % state_block_size
-    state_page_numbers = block_table[req, state_page_idx]
+    state_page_numbers = block_table[req * block_table_stride + state_page_idx]
     slot_mapping_slots = (state_page_numbers * page_size +
                           state_page_offset * state_rows_per_token)
 
@@ -107,7 +124,7 @@ def derive_metadata(
     kv_page_idx = kv_idx // kv_block_size
     kv_page_offset = kv_idx % kv_block_size
 
-    kv_page_number = kv_block_table[req, kv_page_idx]
+    kv_page_number = kv_block_table[req * kv_block_table_stride + kv_page_idx]
 
     kv_slot_mapping = (kv_page_number * kv_page_stride +
                        kv_page_offset * kv_stride)
@@ -203,9 +220,9 @@ def compressor_forward(
     norm_weight: jax.Array,  # [head_dim] fp32
     cos_sin_cache: jax.Array,  # [max_pos, rope_head_dim] fp32
     positions: jax.Array,  # [num_tokens] int
-    block_table: jax.Array,  # [num_reqs, max_blocks] int
+    block_table: jax.Array,  # [num_reqs * max_blocks] int
     query_start_loc: jax.Array,  # [num_reqs + 1] int
-    kv_block_table: jax.Array,  # [num_reqs, max_kv_blocks] int
+    kv_block_table: jax.Array,  # [num_reqs * max_kv_blocks] int
     cache: jax.Array,  # [num_pages, page_size, 4, 128] uint8
     rope_cache: jax.Array,  # [num_pages, page_size // 4, 4, 128] uint8
     distribution: jax.Array,  # i32[3]
@@ -215,10 +232,14 @@ def compressor_forward(
     overlap: bool,
     rms_eps: float,
     quant_block: int,
-) -> tuple[jax.Array, jax.Array]:
-    """Projects, saves state, then compresses and stores the boundary records."""
+    state_cache: jax.Array
+    | None = None,  # [num_pages, state_page_size, 4, 128] uint8
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Projects, saves state, then compresses and stores the boundary records.
+    """
     num_tokens = positions.shape[0]
     num_reqs = query_start_loc.shape[0] - 1
+    shares_buffer = state_cache is None
 
     token_to_req_indices, slot_mapping_slots, kv_slot_mapping = derive_metadata(
         positions=positions,
@@ -231,21 +252,26 @@ def compressor_forward(
         head_dim=head_dim,
         overlap=overlap,
         cos_sin_cache=cos_sin_cache,
+        state_cache=state_cache,
     )
 
     token_index = jnp.arange(num_tokens)
     is_real_token = token_index < query_start_loc[distribution[2]]
     slot_mapping_slots = jnp.where(is_real_token, slot_mapping_slots, -1)
 
-    cache = proj_kernel.proj_and_save_state(
+    updated_state = proj_kernel.proj_and_save_state(
         hidden_states=hidden_states,
         wkv_wgate=wkv_wgate,
         ape=ape,
         positions=positions,
         slot_mapping=slot_mapping_slots,
-        cache=cache,
+        cache=cache if shares_buffer else state_cache,
         compress_ratio=compress_ratio,
     )
+    if shares_buffer:
+        cache = updated_state
+    else:
+        state_cache = updated_state
 
     is_decode_token = token_index < query_start_loc[distribution[0]]
     is_boundary = (kv_slot_mapping >= 0) & is_real_token
@@ -267,6 +293,8 @@ def compressor_forward(
         boundary_req,
         boundary_kv_slot,
         norm_weight,
+        block_table_stride=block_table_row_stride(block_table, num_reqs),
+        state_cache=state_cache,
         rope_cache=rope_cache,
         cos_sin_cache=cos_sin_cache,
         compress_ratio=compress_ratio,
@@ -275,4 +303,4 @@ def compressor_forward(
         rms_eps=rms_eps,
     )
 
-    return cache, rope_cache
+    return cache, rope_cache, (cache if shares_buffer else state_cache)

--- a/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/config.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/config.py
@@ -45,6 +45,7 @@ LANE = 128  # bytes per sub-slot / TPU lane width
 SLOT_PACK = 4  # sub-slots packed into one physical HBM slot row
 N_FIELDS = 2  # values stored per token: kv + score
 FP32_BYTES = 4
+CSA_COMPRESS_RATIO = 4  # the compress ratio that selects Mode.CSA
 
 
 class Mode(enum.Enum):
@@ -113,6 +114,16 @@ def physical_page_size(mode: Mode, kv_cache_block_size: int,
     return storage_block_size * 2
 
 
+def state_host_page_size(mode: Mode, kv_cache_block_size: int,
+                         compress_ratio: int) -> int:
+    """Rows per page of the array that *hosts* ``mode``'s f32 compressor state.
+    """
+    if mode is Mode.HCA:
+        return physical_page_size(Mode.CSA, kv_cache_block_size,
+                                  CSA_COMPRESS_RATIO)
+    return physical_page_size(mode, kv_cache_block_size, compress_ratio)
+
+
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
 class TileSizes:
@@ -131,6 +142,7 @@ class Dimensions:
     rope_head_dim: int
     compress_ratio: int
     physical_page_size: int
+    state_physical_page_size: int
     quant_block: int
     overlap: bool
     has_rope_cache: bool
@@ -171,11 +183,16 @@ class Configs:
         *,
         size_n,
         physical_page_size,
+        state_physical_page_size=None,
         rms_eps=1e-6,
         tile_n=4,
         **overrides,
     ) -> "Configs":
-        """Build a config for `mode`; `overrides` replace per-mode defaults."""
+        """Build a config for `mode`; `overrides` replace per-mode defaults.
+
+        `state_physical_page_size` defaults to `physical_page_size`, i.e. the
+        state and the compressed KV share one buffer.
+        """
         actual_overrides = {**_MODE_DEFAULTS[mode], **overrides}
         if mode == Mode.HCA:
             actual_overrides["quant_block"] = 0
@@ -184,6 +201,9 @@ class Configs:
             mode=mode,
             size_n=size_n,
             physical_page_size=physical_page_size,
+            state_physical_page_size=(physical_page_size
+                                      if state_physical_page_size is None else
+                                      state_physical_page_size),
             rms_eps=rms_eps,
             **actual_overrides,
         )
@@ -285,8 +305,13 @@ class Configs:
     # --- block sizes and physical page size ------------------------------------
     @property
     def physical_page_size(self) -> int:
-        """Number of physical HBM rows per page."""
+        """Number of physical HBM rows per page of the compressed-KV array."""
         return self.dims.physical_page_size
+
+    @property
+    def state_physical_page_size(self) -> int:
+        """Number of physical HBM rows per page of the *state* array."""
+        return self.dims.state_physical_page_size
 
     @property
     def state_rows_per_token(self) -> int:
@@ -302,8 +327,8 @@ class Configs:
 
     @property
     def state_block_size(self) -> int:
-        """Number of state tokens per page."""
-        return self.physical_page_size // self.state_rows_per_token
+        """Number of state tokens per page of the state array."""
+        return self.state_physical_page_size // self.state_rows_per_token
 
     @property
     def kv_block_size(self) -> int:
@@ -353,11 +378,15 @@ class Configs:
         return (self._tile_n, self.record_rows) + self.cache_last_dims
 
     def page_buffer_shape(self) -> tuple[int, ...]:
-        """Page-buffer VMEM block: (tile, pages, physical_page_size) + cache_last_dims."""
+        """Page-buffer VMEM block: (tile, pages, state page rows) + cache_last_dims.
+
+        Pages are DMA'd whole out of the *state* array, so this is sized by
+        `state_physical_page_size`, not by the compressed-KV page.
+        """
         return (
             self._tile_n,
             self.pages_to_buffer_per_token,
-            self.physical_page_size,
+            self.state_physical_page_size,
         ) + self.cache_last_dims
 
     def rope_output_shape(self) -> tuple[int, ...]:
@@ -372,6 +401,11 @@ class Configs:
     def cache_shape(self, num_pages: int) -> tuple[int, ...]:
         """Shape of the global HBM KV cache."""
         return (num_pages, self.physical_page_size) + self.cache_last_dims
+
+    def state_cache_shape(self, num_pages: int) -> tuple[int, ...]:
+        """Shape of the global HBM array hosting the f32 compressor state."""
+        return (num_pages,
+                self.state_physical_page_size) + self.cache_last_dims
 
     def rope_cache_shape(self, num_pages: int) -> tuple[int, ...]:
         """Shape of the global HBM RoPE cache."""

--- a/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/kernel.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/kernel.py
@@ -192,12 +192,14 @@ def kernel_fn(
     cos_sin_cache_ref,
     cache_ref,
     rope_cache_ref,
+    state_cache_ref,
     # outputs (aliased)
     _out_cache_ref,
     _out_rope_cache_ref,
     window_scratch_ref,
     *,
     cfgs: config.Configs,
+    block_table_stride: int,
 ):
     """Pallas kernel entry point."""
     grid_size = grid_size_ref[...]
@@ -205,9 +207,11 @@ def kernel_fn(
         cfgs=cfgs,
         cache_ref=cache_ref,
         rope_cache_ref=rope_cache_ref,
+        state_cache_ref=state_cache_ref,
         cos_sin_cache_ref=cos_sin_cache_ref,
         positions_ref=positions_ref,
         block_table_ref=block_table_ref,
+        block_table_stride=block_table_stride,
         token_to_req_indices_ref=token_to_req_indices_ref,
         kv_slot_mapping_ref=kv_slot_mapping_ref,
         is_first_mask_ref=is_first_mask_ref,
@@ -287,6 +291,7 @@ def compute_is_first_mask(kv_slot_mapping, tile_n, pack_factor=4):
 @functools.partial(
     jax.jit,
     static_argnames=(
+        "block_table_stride",
         "compress_ratio",
         "overlap",
         "quant_block",
@@ -299,11 +304,13 @@ def compute_is_first_mask(kv_slot_mapping, tile_n, pack_factor=4):
 def compress_norm_rope_store(
     cache: jax.Array,
     positions: jax.Array,
-    block_table: jax.Array,
+    block_table: jax.Array,  # [num_reqs * block_table_stride] int
     token_to_req_indices: jax.Array,
     kv_slot_mapping: jax.Array,
     rms_weight: jax.Array,
     *,
+    block_table_stride: int,
+    state_cache: jax.Array | None = None,
     rope_cache: jax.Array | None = None,
     cos_sin_cache: jax.Array | None = None,
     compress_ratio: int,
@@ -313,18 +320,24 @@ def compress_norm_rope_store(
     interpret: bool = False,
     name: str = "compress_norm_rope_store",
 ) -> tuple[jax.Array, jax.Array | None]:
-    """Compresses, normalizes, applies RoPE and stores to cache."""
-    # TODO(alynie): In HCA, we want to overlay HCA's compressor state cache
-    # onto CSA's compressed KV cache (instead of HCA's compressed KV cache)
-    # to save memory.
+    """Compresses, normalizes, applies RoPE and stores to cache.
+    """
+    assert block_table.ndim == 1
+    assert block_table.shape[0] % block_table_stride == 0
+
     num_tokens = positions.shape[0]
     head_dim = rms_weight.shape[0]
     rope_head_dim = cos_sin_cache.shape[1] if cos_sin_cache is not None else 0
+
+    state_operand = (None if state_cache is None or state_cache is cache else
+                     state_cache)
+    state_source = cache if state_operand is None else state_operand
 
     cfgs = config.Configs.make(
         _select_mode(head_dim, overlap),
         size_n=num_tokens,
         physical_page_size=cache.shape[1],
+        state_physical_page_size=state_source.shape[1],
         rms_eps=rms_eps,
         tile_n=4,
         head_dim=head_dim,
@@ -384,6 +397,8 @@ def compress_norm_rope_store(
         pl.BlockSpec(memory_space=pltpu.HBM),  # cache
         (pl.BlockSpec(memory_space=pltpu.HBM)
          if cfgs.dims.has_rope_cache else None),  # rope_cache
+        (pl.BlockSpec(memory_space=pltpu.HBM)
+         if state_operand is not None else None),  # state_cache
     )
     out_specs = (
         pl.BlockSpec(memory_space=pltpu.HBM),  # cache
@@ -407,7 +422,9 @@ def compress_norm_rope_store(
     )
 
     out_cache, out_rope_cache = pl.pallas_call(
-        functools.partial(kernel_fn, cfgs=cfgs),
+        functools.partial(kernel_fn,
+                          cfgs=cfgs,
+                          block_table_stride=block_table_stride),
         out_shape=out_shapes,
         grid_spec=grid_spec,
         input_output_aliases=aliases,
@@ -420,6 +437,7 @@ def compress_norm_rope_store(
         cos_sin_operand,
         cache,
         rope_operand,
+        state_operand,
     )
 
     return out_cache, out_rope_cache

--- a/tpu_inference/kernels/experimental/deepseek_v4/core_attention/mla.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/core_attention/mla.py
@@ -364,17 +364,6 @@ def _mla_ragged_paged_attention_kernel(
         bkv_bf16 = pltpu.bitcast(bkv_u8, jnp.bfloat16)
         bkv = bkv_bf16.reshape(-1, head_dim)
         assert bkv.shape == (bkv_sz, head_dim)
-
-        # In vLLM, multiple caches may overlay on the same KV Tensor. For example,
-        # compressor state cache write data in bfloat16 / float32 format, certain
-        # byte pattern are interpreted as NaN in FP8, e.g. float8_e8m0fnu byte 0xFF
-        # decodes to NaN.
-        # We need to mask out the data by the actual kv_len to avoid NaN propagting
-        # to the downstream computation.
-        k_span = bkv_idx * bkv_sz + lax.broadcasted_iota(
-            jnp.int32, bkv.shape, 0)
-        bkv = jnp.where(k_span < kv_len, bkv, 0)
-
         return bkv
 
     def broadcast_minor(src, shape):
@@ -516,7 +505,13 @@ def _mla_ragged_paged_attention_kernel(
     def prologue():
         start_fetch_bq(start_seq_idx, 0, 0)
         start_fetch_swa(start_seq_idx, 0, 0)
+
+        # Initialize bkv_x2_ref to avoid NaN issues from accessing uninitialized
+        # memory
+        bkv_zeros = jnp.zeros(bkv_x2_ref.shape[1:], bkv_x2_ref.dtype)
+        bkv_x2_ref[0] = bkv_zeros
         start_fetch_bkv(start_seq_idx, 0, 0)
+        bkv_x2_ref[1] = bkv_zeros
 
     process()
 

--- a/tpu_inference/kernels/experimental/deepseek_v4/core_attention/mla_swa.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/core_attention/mla_swa.py
@@ -571,16 +571,6 @@ def _mla_sliding_window_ragged_paged_attention_kernel(
         # hi byte). `pltpu.bitcast` fuses consecutive sublanes little-endian, so the
         # reconstruction is a plain bitcast + reshape.
         bkv = pltpu.bitcast(bkv_u8, jnp.bfloat16).reshape(bkv_sz, head_dim)
-
-        # In vLLM, multiple caches may overlay on the same KV Tensor. For example,
-        # compressor state cache write data in bfloat16 / float32 format, certain
-        # byte pattern are interpreted as NaN in FP8, e.g. float8_e8m0fnu byte 0xFF
-        # decodes to NaN.
-        # We need to mask out the data by the actual kv_len to avoid NaN propagting
-        # to the downstream computation.
-        k_span = (start_offset + bkv_idx * bkv_sz +
-                  lax.broadcasted_iota(jnp.int32, bkv.shape, 0))
-        bkv = jnp.where(k_span < kv_len, bkv, 0)
         return bkv
 
     def broadcast_minor(src, shape):
@@ -764,8 +754,14 @@ def _mla_sliding_window_ragged_paged_attention_kernel(
     @pl.when(seq_idx == start_seq_idx)
     def prologue():
         start_fetch_bq(start_seq_idx, 0, 0)
+
+        # Initialize bkv_x2_ref to avoid NaN issues from accessing uninitialized
+        # memory
+        bkv_zeros = jnp.zeros(bkv_x2_ref.shape[1:], bkv_x2_ref.dtype)
+        bkv_x2_ref[0] = bkv_zeros
         # bq_idx=0, relative bkv_idx=0 (page-aligned base via _start_offset).
         start_fetch_bkv(start_seq_idx, 0, 0, _start_offset(start_seq_idx, 0))
+        bkv_x2_ref[1] = bkv_zeros
 
     process()
 
@@ -1116,8 +1112,16 @@ def mla_sliding_window_ragged_paged_attention(
 
     # Decode-only
     num_l_heads = align_to(num_q_heads, 128)
-    l_sum = jnp.zeros((q.shape[0], num_l_heads), dtype=jnp.float32)
-    m = jnp.zeros((q.shape[0], num_l_heads), dtype=jnp.float32)
+    if unnormalized_output:
+        # output of swa attn is consumed by csa, hca attn, padding tokens'
+        # data won't be used downstream at all, so un-initialized buffer is fine.
+        l_sum = jnp.empty((q.shape[0], num_l_heads), dtype=jnp.float32)
+        m = jnp.empty((q.shape[0], num_l_heads), dtype=jnp.float32)
+        in_output = jnp.empty_like(q)
+    else:
+        l_sum = jnp.zeros((q.shape[0], num_l_heads), dtype=jnp.float32)
+        m = jnp.zeros((q.shape[0], num_l_heads), dtype=jnp.float32)
+        in_output = jnp.zeros_like(q)
     output, updated_kv, out_l, out_m = run_mla_kernel(
         q,
         new_kv,
@@ -1129,9 +1133,7 @@ def mla_sliding_window_ragged_paged_attention(
         num_queries_per_block=num_queries_per_blocks[0],
         start_seq_idx=jnp.array(0),
         end_seq_idx=distribution[0],
-        # TODO: the jnp.zeros_like is quite expensive, optimize while not have
-        # the NaN output issue of jnp.empty_like.
-        in_output=jnp.zeros_like(q),
+        in_output=in_output,
         in_l=l_sum,
         in_m=m,
         attention_sinks=attention_sinks,

--- a/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_compressor.py
+++ b/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_compressor.py
@@ -60,17 +60,8 @@ class VllmCompressorStateCache(CompressorStateCache):
         )
         coff = 1 + (compress_ratio == 4)
         self.head_dim = state_dim // 2 // coff
-        # We let HCA's state cache overlay with HCA's compressed cache;
-        # CSA's state cache overlay with CSA's compressed cache for now.
-        # TODO: we may better let HCA's state cache overlay on CSA's compressed cache,
-        # whose page size is bigger, for better performance.
-        #
-        # This block_size is the granularity of the block table the compressor
-        # kernel indexes with, so it must be the number of token states that
-        # physically fit in one page of the array `KVCacheManager` allocates --
-        # which is *not* the same across modes: HCA stores raw bf16 (two rows
-        # per record) and the indexer array is 256 lanes wide. Derive it from
-        # the kernel's own layout model instead of a closed-form guess.
+        # CSA's and the indexer's state caches overlay their own compressed-KV
+        # array; HCA's overlays a *CSA NoPE* array.
         kv_cache_block_size = get_current_vllm_config().cache_config.block_size
         assert kv_cache_block_size // compress_ratio > 0
         mode = compressor_config.select_mode(self.head_dim,
@@ -79,6 +70,8 @@ class VllmCompressorStateCache(CompressorStateCache):
             mode,
             size_n=0,
             physical_page_size=compressor_config.physical_page_size(
+                mode, kv_cache_block_size, compress_ratio),
+            state_physical_page_size=compressor_config.state_host_page_size(
                 mode, kv_cache_block_size, compress_ratio),
             head_dim=self.head_dim,
             compress_ratio=compress_ratio,
@@ -158,15 +151,15 @@ class VllmDeepseekCompressor(DeepseekCompressor):
         state_cache_index = wrapper_ctx.layer_name_to_kvcache_index[
             self.state_cache.prefix]
 
-        # code under
-        # `tpu_inference.kernels.experimental.deepseek_v4.compress_and_store`
-        # assume state cache and the compressed kv cache of the *same layer* overlay
-        # on the same tensor. That is, layer-i's HCA state cache share the same
-        # Tensor with layer-i's HCA compressed kv cache.
-        # This assumption is too strict.
-        # TODO: we may better let HCA's state cache overlay on CSA's main kv cache,
-        # whose page size is bigger, for better performance.
-        assert state_cache_index == cache_index
+        separate_state = state_cache_index != cache_index
+        if self.overlap:
+            # CSA
+            assert separate_state is False
+        else:
+            # HCA
+            assert separate_state is True
+        state_cache = (wrapper_ctx.kv_caches[state_cache_index]
+                       if separate_state else None)
 
         data_spec = P(ShardingAxisName.ATTN_DATA)
         cache_spec = P(ShardingAxisName.BATCH)
@@ -184,35 +177,37 @@ class VllmDeepseekCompressor(DeepseekCompressor):
             cache_spec,  # cache
         )
         has_rope_cache = rope_cache is not None
+        out_spec_list = [cache_spec]
         if has_rope_cache:
             in_specs += (cache_spec, )  # rope_cache
-            out_specs = (cache_spec, cache_spec)
-        else:
-            out_specs = cache_spec
+            out_spec_list.append(cache_spec)
+        if separate_state:
+            in_specs += (cache_spec, )  # state_cache
+            out_spec_list.append(cache_spec)
+        out_specs = (tuple(out_spec_list)
+                     if len(out_spec_list) > 1 else out_spec_list[0])
 
         def _compress(hidden_states, wkv_wgate, ape, norm_weight,
                       cos_sin_cache, positions, state_block_tables,
                       query_start_loc, k_block_tables, request_distribution,
-                      cache, *rope_cache_operand):
-            rope_c = rope_cache_operand[0] if rope_cache_operand else None
-            num_reqs = query_start_loc.shape[0] - 1
-            assert state_block_tables.shape[0] % num_reqs == 0
-            assert k_block_tables.shape[0] % num_reqs == 0
-            block_table = state_block_tables.reshape(num_reqs, -1)
-            kv_block_table = k_block_tables.reshape(num_reqs, -1)
+                      cache, *optional_caches):
+            optional_caches = list(optional_caches)
+            rope_c = optional_caches.pop(0) if has_rope_cache else None
+            state_c = optional_caches.pop(0) if separate_state else None
 
-            new_cache, new_rope_cache = compressor_forward(
+            new_cache, new_rope_cache, new_state_cache = compressor_forward(
                 hidden_states=hidden_states,
                 wkv_wgate=wkv_wgate,
                 ape=ape,
                 norm_weight=norm_weight,
                 cos_sin_cache=cos_sin_cache,
                 positions=positions,
-                block_table=block_table,
+                block_table=state_block_tables,
                 query_start_loc=query_start_loc,
-                kv_block_table=kv_block_table,
+                kv_block_table=k_block_tables,
                 cache=cache,
                 rope_cache=rope_c,
+                state_cache=state_c,
                 distribution=request_distribution,
                 state_block_size=self.state_cache.block_size,
                 head_dim=self.head_dim,
@@ -221,9 +216,12 @@ class VllmDeepseekCompressor(DeepseekCompressor):
                 rms_eps=self.rms_norm_eps,
                 quant_block=self._quant_block,
             )
+            outs = [new_cache]
             if has_rope_cache:
-                return new_cache, new_rope_cache
-            return new_cache
+                outs.append(new_rope_cache)
+            if separate_state:
+                outs.append(new_state_cache)
+            return tuple(outs) if len(outs) > 1 else outs[0]
 
         operands = (
             jax_view(hidden_states),
@@ -240,6 +238,8 @@ class VllmDeepseekCompressor(DeepseekCompressor):
         )
         if has_rope_cache:
             operands += (rope_cache, )
+        if separate_state:
+            operands += (state_cache, )
 
         outs = jax.shard_map(
             _compress,
@@ -249,9 +249,9 @@ class VllmDeepseekCompressor(DeepseekCompressor):
             check_vma=False,
         )(*operands)
 
+        outs = list(outs) if isinstance(outs, tuple) else [outs]
+        wrapper_ctx.kv_caches[cache_index] = outs.pop(0)
         if has_rope_cache:
-            new_cache, new_rope_cache = outs
-            wrapper_ctx.kv_caches[rope_cache_index] = new_rope_cache
-        else:
-            new_cache = outs
-        wrapper_ctx.kv_caches[state_cache_index] = new_cache
+            wrapper_ctx.kv_caches[rope_cache_index] = outs.pop(0)
+        if separate_state:
+            wrapper_ctx.kv_caches[state_cache_index] = outs.pop(0)

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -1053,12 +1053,12 @@ class KVCacheManager:
             HCA ``*.attn``        ``(N, T*2, 4, 128)``     1024B/token (raw
                                                             bf16)
 
-        - Every compressor state cache maps to the array of its
-          compressed-KV layer: the compressor kernel writes the f32 state
-          rows and the compressed KV through one buffer, and
-          ``VllmDeepseekCompressor.forward`` asserts both layer names
-          resolve to the same array index. State and full-attention groups
-          never own the same block ID, so the rows never collide.
+        - Every CSA / indexer compressor state cache maps to the array of its
+          own compressed-KV layer; the compressor kernel writes the f32 state
+          rows and the compressed KV through one buffer there. State and
+          full-attention groups never own the same block ID, so the rows never
+          collide.
+        - The i-th *HCA* compressor state cache maps to the i-th CSA NoPE array.
         - Every ``swa_cache`` maps to a CSA NoPE array by its position in its
           cache group.
         """
@@ -1101,12 +1101,6 @@ class KVCacheManager:
         if self.runner.cache_config.num_gpu_blocks_override is not None:
             num_blocks = min(num_blocks,
                              self.runner.cache_config.num_gpu_blocks_override)
-
-        def _page_bytes(cache: jax.Array) -> int:
-            page_elems = 1
-            for dim in cache.shape[1:]:
-                page_elems *= dim
-            return page_elems * cache.dtype.itemsize
 
         def _create_cache(shape: tuple, tag: str) -> jax.Array:
             """Allocate one uint8 DSv4 array and register it as a new index."""
@@ -1156,8 +1150,12 @@ class KVCacheManager:
             )
 
         layer_to_index: dict[str, int] = {}
-        # CSA NoPE arrays, in layer order; the SWA caches overlay these.
+        # CSA NoPE arrays, in layer order; the SWA caches and the HCA
+        # compressor states overlay these.
         csa_nope_indices: list[int] = []
+        # HCA compressed-KV layers, whose own page (two token states) is far
+        # too small to host their state cache.
+        hca_layer_names: set[str] = set()
         for layer_name in mla_layer_names:
             spec = layer_name_to_spec[layer_name]
             page_size = spec.storage_block_size * common_utils.get_mesh_shape_product(
@@ -1187,6 +1185,7 @@ class KVCacheManager:
                          128)
                 _create_cache(shape, layer_name)
                 layer_to_index[layer_name] = len(kv_caches) - 1
+                hca_layer_names.add(layer_name)
 
         # Overlay swa_caches onto the CSA NoPE arrays.
         if not csa_nope_indices:
@@ -1206,42 +1205,50 @@ class KVCacheManager:
                     swa_host_indices.append(len(kv_caches) - 1)
                 layer_to_index[layer_name] = swa_host_indices[position]
 
-        # Compressor state caches overlay the compressed-KV array of their
-        # own (sub)layer.
+        # CSA and indexer compressor state caches overlay onto the compressed kv
+        # array of their own (sub)layer;
+        # HCA compressor state caches overlay onto CSA NoPE arrays.
+        hca_state_layers: list[str] = []
         for layer_name in state_layer_names:
-            spec = layer_name_to_spec[layer_name]
             kv_layer_name = self._ds_v4_compressed_kv_layer_name(layer_name)
             if kv_layer_name not in layer_to_index:
                 raise ValueError(
                     "[kv-cache] DSv4 compressor state cache has no "
-                    "compressed-KV layer to overlay (the compressor kernel "
-                    "writes the f32 state and the compressed KV through one "
-                    f"buffer): state_cache={layer_name}, expected KV layer "
+                    "compressed-KV layer (its compressed records are written "
+                    f"there): state_cache={layer_name}, expected KV layer "
                     f"{kv_layer_name}, known MLA layers={mla_layer_names}")
-            host_index = layer_to_index[kv_layer_name]
-            host_cache = kv_caches[host_index]
-            # The kernel byte-packs `block_size` state rows of `head_size`
-            # values into each page of the host array (see
-            # `pack_state_cache`); validate the fit here so a layout
-            # regression fails at startup with context instead of inside the
-            # kernel.
-            state_page_bytes = (spec.block_size * spec.num_kv_heads *
-                                spec.head_size *
-                                jnp.dtype(t2j_dtype(spec.dtype)).itemsize)
-            host_page_entries = host_cache.shape[1] * host_cache.shape[2]
-            if (state_page_bytes > _page_bytes(host_cache)
-                    or host_page_entries % spec.block_size != 0):
-                raise ValueError(
-                    "[kv-cache] DSv4 compressor state cache does not fit its "
-                    f"compressed-KV array: state_cache={layer_name} needs "
-                    f"{state_page_bytes}B per page ({spec.block_size} state "
-                    f"rows x {spec.num_kv_heads}x{spec.head_size} "
-                    f"{spec.dtype}), but KV layer {kv_layer_name} array has "
-                    f"shape {host_cache.shape} ({_page_bytes(host_cache)}B "
-                    f"and {host_page_entries} entries per page; entries must "
-                    f"also divide evenly by the {spec.block_size}-row state "
-                    "page).")
+            if kv_layer_name in hca_layer_names:
+                hca_state_layers.append(layer_name)
+            else:
+                layer_to_index[layer_name] = layer_to_index[kv_layer_name]
+
+        # `swa_host_indices` is CSA's NOPE + potential overflow
+        hca_state_host = swa_host_indices
+        for position, layer_name in enumerate(hca_state_layers):
+            if position < len(hca_state_host):
+                host_index = hca_state_host[position]
+            else:
+                # Overflow: more HCA layers than CSA layers, so add a
+                # standalone array of the same shape (mirrors the swa path).
+                _create_cache(kv_caches[csa_nope_indices[0]].shape,
+                              f"hca_state_overflow.{len(kv_caches)}")
+                host_index = len(kv_caches) - 1
             layer_to_index[layer_name] = host_index
+
+        # Sanity check.
+        for group in kv_cache_config.kv_cache_groups:
+            hosts: dict[int, str] = {}
+            for layer_name in group.layer_names:
+                index = layer_to_index[layer_name]
+                if index in hosts:
+                    raise ValueError(
+                        "[kv-cache] DSv4 KV cache overlay put two layers of "
+                        "one cache group on the same array; they share a "
+                        "block table, so they would corrupt each other: "
+                        f"{layer_name} and {hosts[index]} both map to array "
+                        f"{index} (shape {kv_caches[index].shape}). Group "
+                        f"layers={group.layer_names}")
+                hosts[index] = layer_name
 
         for layer_name, index in layer_to_index.items():
             self.runner.layer_name_to_kvcache_index[layer_name] = index


### PR DESCRIPTION
[DSv4] Overlay HCA compressor state onto CSA's NOPE cache (instead of HCA's kv cache)
fix the TODO in https://screenshot-v2.corp.google.com/7wzqnyBVfpsjHfp

With this change, HCA compressor state's block_size change from 2 -> 32; so that the block_table for HCA compressor state become 16x smaller, avoid the SMEM OOM in https://b.corp.google.com/issues/541619368.

Verified with MMLU & MMLU Pro for V4Flash:
https://paste.googleplex.com/6250520430903296
https://paste.googleplex.com/4908257251557376

also piggyback 2 additional small changes:
* let compressor_forward take 1D block_table instead of 2D, so that caller don't need to reshape (tpu-runner's attn-metadata contains 1D block table)
* small perf improvement in mla_swa.py + mla.py
