### PR TITLE
[DO NOT REVIEW] Sharding config guard and loader log-spam fixes

### DIFF
--- a/tests/layers/common/test_sharding.py
+++ b/tests/layers/common/test_sharding.py
@@ -275,6 +275,137 @@ class TestShardingConfigManager(unittest.TestCase):
         self.assertIn("enable_dp_attention=True", msg)
         self.assertIn("attn_dp=1", msg)
         self.assertIn("tensor_parallelism=4", msg)
+        # attn_dp_size was set explicitly, so the advice must be about
+        # removing or adjusting attn_dp_size.
+        self.assertIn("Remove attn_dp_size", msg)
+
+    @patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", True)
+    @patch("tpu_inference.layers.common.sharding.envs.USE_BATCHED_RPA_KERNEL",
+           False)
+    @patch(
+        "tpu_inference.layers.common.sharding.envs.USE_BATCHED_RPA_SEQ_ON_LANE",
+        False)
+    def test_sharding_config_manager_dp_attention_auto_attn_dp_oversized_tp(
+            self):
+        vllm_config = MagicMock()
+        vllm_config.parallel_config.tensor_parallel_size = 4
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
+        vllm_config.parallel_config.prefill_context_parallel_size = 1
+        vllm_config.model_config.use_mla = False
+        vllm_config.model_config.get_total_num_kv_heads.return_value = 3
+        vllm_config.model_config.get_head_size.return_value = 128
+        vllm_config.speculative_config = None
+        vllm_config.lora_config = None
+        vllm_config.cache_config.cache_dtype = "bfloat16"
+
+        # No attn_dp_size key: attn_dp is auto-derived.
+        vllm_config.additional_config = {
+            "sharding": {
+                "sharding_strategy": {
+                    "enable_dp_attention": True,
+                }
+            }
+        }
+
+        # num_kv_heads = 3 (non-MLA), packing = 2 (BF16)
+        # num_kv_heads_per_device_in_kv_cache = max(1, (3 * 2) / 2) = 3.0
+        # attn_dp = max(int(4 // 3.0), 1) = 1, tensor_parallelism stays 4.
+        # shard_divisor = 3.0 // 4 = 0 -> config error. Since attn_dp_size was
+        # NOT set, the advice must be about adjusting tensor_parallelism, and
+        # the (float) capacity must be printed floored as an int.
+        with self.assertRaises(ValueError) as ctx:
+            ShardingConfigManager.from_vllm_config(vllm_config)
+        msg = str(ctx.exception)
+        self.assertIn("[sharding]", msg)
+        self.assertIn("tensor_parallelism=4", msg)
+        self.assertIn("num_kv_heads_per_device_in_kv_cache=3", msg)
+        self.assertNotIn("3.0", msg)
+        self.assertIn("does not exceed the per-device KV-head capacity (3)",
+                      msg)
+        self.assertIn("integer multiple", msg)
+        self.assertNotIn("Remove attn_dp_size", msg)
+
+    @patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", True)
+    @patch("tpu_inference.layers.common.sharding.envs.USE_BATCHED_RPA_KERNEL",
+           False)
+    @patch(
+        "tpu_inference.layers.common.sharding.envs.USE_BATCHED_RPA_SEQ_ON_LANE",
+        False)
+    def test_sharding_config_manager_dp_attention_zero_attn_dp_size_raises(
+            self):
+        vllm_config = MagicMock()
+        vllm_config.parallel_config.tensor_parallel_size = 4
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
+        vllm_config.parallel_config.prefill_context_parallel_size = 1
+        vllm_config.model_config.use_mla = True
+        vllm_config.model_config.get_total_num_kv_heads.return_value = 1
+        vllm_config.model_config.get_head_size.return_value = 128
+        vllm_config.speculative_config = None
+        vllm_config.lora_config = None
+        vllm_config.cache_config.cache_dtype = "bfloat16"
+
+        vllm_config.additional_config = {
+            "sharding": {
+                "sharding_strategy": {
+                    "enable_dp_attention": True,
+                    "attn_dp_size": 0,
+                }
+            }
+        }
+
+        # attn_dp_size=0 must surface as a config error, not a bare
+        # ZeroDivisionError from the divisibility check.
+        with self.assertRaises(ValueError) as ctx:
+            ShardingConfigManager.from_vllm_config(vllm_config)
+        msg = str(ctx.exception)
+        self.assertIn("[sharding]", msg)
+        self.assertIn("attn_dp_size=0", msg)
+        self.assertIn("positive", msg)
+
+    @patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", True)
+    @patch("tpu_inference.layers.common.sharding.envs.USE_BATCHED_RPA_KERNEL",
+           False)
+    @patch(
+        "tpu_inference.layers.common.sharding.envs.USE_BATCHED_RPA_SEQ_ON_LANE",
+        False)
+    def test_sharding_config_manager_dp_attention_non_dividing_attn_dp_size(
+            self):
+        vllm_config = MagicMock()
+        vllm_config.parallel_config.tensor_parallel_size = 8
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 2
+        vllm_config.parallel_config.prefill_context_parallel_size = 1
+        vllm_config.model_config.use_mla = True
+        vllm_config.model_config.get_total_num_kv_heads.return_value = 1
+        vllm_config.model_config.get_head_size.return_value = 128
+        vllm_config.speculative_config = None
+        vllm_config.lora_config = None
+        vllm_config.cache_config.cache_dtype = "bfloat16"
+
+        vllm_config.additional_config = {
+            "sharding": {
+                "sharding_strategy": {
+                    "enable_dp_attention": True,
+                    "attn_dp_size": 3,
+                }
+            }
+        }
+
+        # tensor_parallelism = 8 // decode_context_parallelism (2) = 4, which
+        # attn_dp_size=3 does not divide. Must surface as a config error (not
+        # a bare AssertionError) and state the DCP division so the user can
+        # trace 4 back to their configured tensor_parallel_size=8.
+        with self.assertRaises(ValueError) as ctx:
+            ShardingConfigManager.from_vllm_config(vllm_config)
+        msg = str(ctx.exception)
+        self.assertIn("[sharding]", msg)
+        self.assertIn("attn_dp_size=3", msg)
+        self.assertIn("does not evenly divide", msg)
+        self.assertIn("tensor_parallelism=4", msg)
+        self.assertIn("user-specified tensor_parallelism=8", msg)
+        self.assertIn("decode_context_parallelism=2", msg)
 
     def test_sharding_config_manager_explicit_tp(self):
         vllm_config = MagicMock()

--- a/tests/layers/common/test_sharding.py
+++ b/tests/layers/common/test_sharding.py
@@ -232,6 +232,50 @@ class TestShardingConfigManager(unittest.TestCase):
         self.assertEqual(manager.expert_size, 1)
         self.assertEqual(manager.total_dp_size, 8)  # 8 * 1 * 1
 
+    @patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", True)
+    @patch("tpu_inference.layers.common.sharding.envs.USE_BATCHED_RPA_KERNEL",
+           False)
+    @patch(
+        "tpu_inference.layers.common.sharding.envs.USE_BATCHED_RPA_SEQ_ON_LANE",
+        False)
+    def test_sharding_config_manager_dp_attention_oversized_tp_raises(self):
+        vllm_config = MagicMock()
+        vllm_config.parallel_config.tensor_parallel_size = 4
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.decode_context_parallel_size = 1
+        vllm_config.parallel_config.prefill_context_parallel_size = 1
+        vllm_config.model_config.use_mla = True
+        vllm_config.model_config.get_total_num_kv_heads.return_value = 1
+        vllm_config.model_config.get_head_size.return_value = 128
+        vllm_config.speculative_config = None
+        vllm_config.lora_config = None
+        vllm_config.cache_config.cache_dtype = "bfloat16"
+
+        # Pin attn_dp_size to 1 while TP exceeds the per-device KV-head
+        # capacity of the cache.
+        vllm_config.additional_config = {
+            "sharding": {
+                "sharding_strategy": {
+                    "enable_dp_attention": True,
+                    "attn_dp_size": 1,
+                }
+            }
+        }
+
+        # num_kv_heads = 1 (MLA), packing = 2 (BF16)
+        # num_kv_heads_per_device_in_kv_cache = max(1, (1 * 2) / 2) = 1
+        # attn_dp is pinned to 1, so tensor_parallelism stays 4, which is
+        # larger than the KV-head capacity (1): the KV-head shard divisor
+        # would be 0. This must surface as a config error, not a
+        # ZeroDivisionError.
+        with self.assertRaises(ValueError) as ctx:
+            ShardingConfigManager.from_vllm_config(vllm_config)
+        msg = str(ctx.exception)
+        self.assertIn("[sharding]", msg)
+        self.assertIn("enable_dp_attention=True", msg)
+        self.assertIn("attn_dp=1", msg)
+        self.assertIn("tensor_parallelism=4", msg)
+
     def test_sharding_config_manager_explicit_tp(self):
         vllm_config = MagicMock()
         vllm_config.parallel_config.tensor_parallel_size = 1

--- a/tests/layers/jax/test_pp_utils.py
+++ b/tests/layers/jax/test_pp_utils.py
@@ -1,0 +1,49 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock
+
+from tpu_inference.layers.jax.pp_utils import PPMissingLayer
+
+
+class TestPPMissingLayer(unittest.TestCase):
+
+    def test_load_weights_returns_set_and_consumes_iterator(self):
+        # vLLM's AutoWeightsLoader logs a per-layer warning (with the full
+        # module repr) whenever a module's load_weights returns None. The
+        # placeholder layer must return a set so a pipeline-parallel load
+        # of a many-layer model does not spam one warning per missing layer.
+        layer = PPMissingLayer()
+        weights = iter([
+            ("layers.0.mlp.gate_proj.weight", MagicMock()),
+            ("layers.0.mlp.up_proj.weight", MagicMock()),
+        ])
+
+        loaded = layer.load_weights(weights)
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded, set())
+        # The weights iterator must be fully drained.
+        self.assertEqual(list(weights), [])
+
+    def test_call_passes_through_first_arg(self):
+        layer = PPMissingLayer()
+        sentinel = object()
+        self.assertIs(layer(sentinel, "other"), sentinel)
+        self.assertIs(layer(hidden_states=sentinel), sentinel)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/models/jax/test_mla_einsum.py
+++ b/tests/models/jax/test_mla_einsum.py
@@ -12,8 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import contextlib
 import unittest
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
+
+import jax.numpy as jnp
 
 from tpu_inference.models.jax.deepseek_v3 import MLAEinsum
 
@@ -49,6 +52,62 @@ class TestMLAEinsumLoadWeights(unittest.TestCase):
 
         with self.assertRaises(ValueError):
             MLAEinsum.load_weights(fake_einsum, [("extra", MagicMock())])
+
+    @patch("tpu_inference.models.jax.deepseek_v3.shard_put")
+    @patch("tpu_inference.models.jax.deepseek_v3.JaxEinsum")
+    @patch("tpu_inference.models.jax.deepseek_v3.quantize_tensor")
+    @patch("tpu_inference.models.jax.deepseek_v3.dequantize_tensor")
+    @patch("tpu_inference.models.jax.deepseek_v3.cpu_mesh_context")
+    def test_full_load_splits_kv_and_returns_loaded_names(
+            self, mock_mesh_ctx, mock_dequantize, mock_quantize,
+            mock_jax_einsum, mock_shard_put):
+        # Once every named param has been loaded, load_weights runs the k/v
+        # split path to the end and must still return the names loaded in
+        # this call (not None), so vLLM's AutoWeightsLoader stays quiet.
+        kv_lora_rank = 2  # A
+        num_heads = 1  # N
+        qk_nope_head_dim = 2
+        v_head_dim = 1
+
+        mock_mesh_ctx.return_value = contextlib.nullcontext()
+        mock_dequantize.return_value = jnp.zeros(
+            (kv_lora_rank, num_heads * (qk_nope_head_dim + v_head_dim)),
+            dtype=jnp.float32)
+        # quantize_tensor returns (weight, scale); the scale is transposed
+        # with 3 axes, so hand back 3-D arrays.
+        mock_quantize.return_value = (jnp.zeros((1, 1, 1), dtype=jnp.float32),
+                                      jnp.zeros((1, 1, 1), dtype=jnp.float32))
+
+        mla_layer = MagicMock()
+        mla_layer.kv_lora_rank = kv_lora_rank
+        mla_layer.N = num_heads
+        mla_layer.qk_nope_head_dim = qk_nope_head_dim
+        mla_layer.v_head_dim = v_head_dim
+        mla_layer.prefix = "layers.0.self_attn.kv_b_proj"
+        mla_layer.anh_sharding = ()
+
+        fake_einsum = MagicMock()
+        fake_einsum.loaded = set()
+        fake_einsum.mla_layer = mla_layer
+        fake_einsum.quant_config = MagicMock()
+        fake_einsum.weight = MagicMock()
+        fake_einsum.weight_scale_inv = MagicMock()
+        weight_param = MagicMock()
+        # A single named param means this one call completes the load and
+        # reaches the final return.
+        fake_einsum.named_parameters.return_value = [("weight", weight_param)]
+
+        loaded = MLAEinsum.load_weights(fake_einsum, [("weight", MagicMock())])
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded, {"weight"})
+        weight_param.weight_loader.assert_called_once()
+        # The k/v split path ran: k_up_proj and v_up_proj were built and
+        # their weights/scales placed on the mesh.
+        self.assertEqual(mock_jax_einsum.call_count, 2)
+        self.assertEqual(mock_shard_put.call_count, 4)
+        self.assertIs(mla_layer.k_up_proj, mock_jax_einsum.return_value)
+        self.assertIs(mla_layer.v_up_proj, mock_jax_einsum.return_value)
 
 
 if __name__ == "__main__":

--- a/tests/models/jax/test_mla_einsum.py
+++ b/tests/models/jax/test_mla_einsum.py
@@ -1,0 +1,55 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock
+
+from tpu_inference.models.jax.deepseek_v3 import MLAEinsum
+
+
+class TestMLAEinsumLoadWeights(unittest.TestCase):
+
+    def test_partial_load_returns_loaded_names(self):
+        # vLLM's AutoWeightsLoader logs a warning (dumping the full module
+        # repr) for every module whose load_weights returns None. MLAEinsum
+        # receives its two params (weight, weight_scale_inv) in separate
+        # calls, so each call must report the names it loaded to avoid one
+        # multi-line warning per decoder layer.
+        fake_einsum = MagicMock()
+        fake_einsum.loaded = set()
+        weight_param = MagicMock()
+        scale_param = MagicMock()
+        fake_einsum.named_parameters.return_value = [
+            ("weight", weight_param),
+            ("weight_scale_inv", scale_param),
+        ]
+
+        loaded = MLAEinsum.load_weights(fake_einsum, [("weight", MagicMock())])
+
+        self.assertIsNotNone(loaded)
+        self.assertEqual(loaded, {"weight"})
+        self.assertEqual(fake_einsum.loaded, {"weight"})
+        weight_param.weight_loader.assert_called_once()
+
+    def test_load_more_than_two_params_raises(self):
+        fake_einsum = MagicMock()
+        fake_einsum.loaded = {"weight", "weight_scale_inv"}
+        fake_einsum.named_parameters.return_value = []
+
+        with self.assertRaises(ValueError):
+            MLAEinsum.load_weights(fake_einsum, [("extra", MagicMock())])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -286,6 +286,20 @@ class ShardingConfigManager:
                 # Otherwise, shard KV heads over the expert axis.
                 # Use the remaining KV heads per device as the divisor.
                 shard_divisor = num_kv_heads_per_device_in_kv_cache // tensor_parallelism
+                if shard_divisor < 1:
+                    raise ValueError(
+                        f"[sharding] invalid sharding_strategy: "
+                        f"enable_dp_attention=True with attn_dp={attn_dp} and "
+                        f"tensor_parallelism={tensor_parallelism} — "
+                        f"tensor_parallelism exceeds the per-device KV-head "
+                        f"capacity of the KV cache "
+                        f"(num_kv_heads_per_device_in_kv_cache="
+                        f"{num_kv_heads_per_device_in_kv_cache}), so TP would "
+                        f"duplicate KV heads instead of sharding them. Remove "
+                        f"attn_dp_size to derive attn_dp automatically, or "
+                        f"choose attn_dp_size so that tensor_parallelism / "
+                        f"attn_dp_size <= "
+                        f"{num_kv_heads_per_device_in_kv_cache}.")
                 attn_dp_expert = max(1,
                                      int(expert_parallelism // shard_divisor))
                 expert_parallelism //= attn_dp_expert

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -236,7 +236,17 @@ class ShardingConfigManager:
                 f"tensor_parallelism ({tensor_parallelism}) must be divisible by "
                 f"decode_context_parallelism ({decode_context_parallelism})")
         # DCP reused TP axis
+        user_tensor_parallelism = tensor_parallelism
         tensor_parallelism = tensor_parallelism // decode_context_parallelism
+        if decode_context_parallelism > 1:
+            # Used in error messages so users can trace the effective TP back
+            # to the value they configured.
+            tp_origin_note = (
+                f" (user-specified tensor_parallelism="
+                f"{user_tensor_parallelism} divided by "
+                f"decode_context_parallelism={decode_context_parallelism})")
+        else:
+            tp_origin_note = ""
 
         if enable_dp_attention:
             # Replicate attention layer when num_kv_heads < TP
@@ -270,8 +280,23 @@ class ShardingConfigManager:
                         num_kv_heads_per_device_in_kv_cache), 1)
                 tensor_parallelism = tensor_parallelism // attn_dp
             else:
+                if attn_dp_size <= 0:
+                    raise ValueError(
+                        f"[sharding] invalid sharding_strategy: "
+                        f"attn_dp_size={attn_dp_size} must be a positive "
+                        f"integer. Remove attn_dp_size to derive it "
+                        f"automatically, or set it to a positive divisor of "
+                        f"tensor_parallelism="
+                        f"{tensor_parallelism}{tp_origin_note}.")
+                if tensor_parallelism % attn_dp_size != 0:
+                    raise ValueError(
+                        f"[sharding] invalid sharding_strategy: "
+                        f"attn_dp_size={attn_dp_size} does not evenly divide "
+                        f"tensor_parallelism="
+                        f"{tensor_parallelism}{tp_origin_note}. Remove "
+                        f"attn_dp_size to derive it automatically, or set it "
+                        f"to a divisor of tensor_parallelism.")
                 attn_dp = attn_dp_size
-                assert tensor_parallelism % attn_dp_size == 0
                 tensor_parallelism = tensor_parallelism // attn_dp
 
             # If Attention DP is active or TP perfectly saturates the KV heads limit,
@@ -287,19 +312,32 @@ class ShardingConfigManager:
                 # Use the remaining KV heads per device as the divisor.
                 shard_divisor = num_kv_heads_per_device_in_kv_cache // tensor_parallelism
                 if shard_divisor < 1:
+                    kv_head_capacity = int(num_kv_heads_per_device_in_kv_cache)
+                    if attn_dp_size is not None:
+                        # attn_dp_size was set explicitly in the sharding
+                        # strategy, so the fix is to adjust or drop it.
+                        advice = (
+                            f"Remove attn_dp_size to derive attn_dp "
+                            f"automatically, or choose attn_dp_size so that "
+                            f"tensor_parallelism / attn_dp_size <= "
+                            f"{kv_head_capacity}.")
+                    else:
+                        # attn_dp was auto-derived, so the fix is to adjust
+                        # tensor parallelism itself.
+                        advice = (
+                            f"Choose a tensor_parallelism that does not "
+                            f"exceed the per-device KV-head capacity "
+                            f"({kv_head_capacity}) or is an integer multiple "
+                            f"of it.")
                     raise ValueError(
                         f"[sharding] invalid sharding_strategy: "
                         f"enable_dp_attention=True with attn_dp={attn_dp} and "
-                        f"tensor_parallelism={tensor_parallelism} — "
-                        f"tensor_parallelism exceeds the per-device KV-head "
-                        f"capacity of the KV cache "
+                        f"tensor_parallelism={tensor_parallelism}"
+                        f"{tp_origin_note} — tensor_parallelism exceeds the "
+                        f"per-device KV-head capacity of the KV cache "
                         f"(num_kv_heads_per_device_in_kv_cache="
-                        f"{num_kv_heads_per_device_in_kv_cache}), so TP would "
-                        f"duplicate KV heads instead of sharding them. Remove "
-                        f"attn_dp_size to derive attn_dp automatically, or "
-                        f"choose attn_dp_size so that tensor_parallelism / "
-                        f"attn_dp_size <= "
-                        f"{num_kv_heads_per_device_in_kv_cache}.")
+                        f"{kv_head_capacity}), so TP would duplicate KV heads "
+                        f"instead of sharding them. {advice}")
                 attn_dp_expert = max(1,
                                      int(expert_parallelism // shard_divisor))
                 expert_parallelism //= attn_dp_expert

--- a/tpu_inference/layers/jax/pp_utils.py
+++ b/tpu_inference/layers/jax/pp_utils.py
@@ -19,6 +19,9 @@ from vllm.distributed.utils import get_pp_indices
 
 from tpu_inference.distributed.jax_parallel_state import get_pp_group
 from tpu_inference.layers.jax import JaxModule
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
 
 
 class PPMissingLayer(JaxModule):
@@ -33,10 +36,19 @@ class PPMissingLayer(JaxModule):
         """Return the first arg from args or the first value from kwargs."""
         return args[0] if args else next(iter(kwargs.values()))
 
-    def load_weights(self, weights: Iterable, *args, **kwargs):
-        """No-op for loading weights."""
-        for _ in weights:
-            pass
+    def load_weights(self, weights: Iterable, *args, **kwargs) -> set[str]:
+        """Consume and drop weights owned by other pipeline stages.
+
+        Returns an empty set: nothing is loaded on this rank. Returning a
+        set (instead of None) tells vLLM's AutoWeightsLoader that the
+        weights were handled, so it does not emit a per-layer
+        "Unable to collect loaded parameters" warning during loading.
+        """
+        num_dropped = sum(1 for _ in weights)
+        logger.debug(
+            "[pp] PPMissingLayer dropped %d weights owned by another "
+            "pipeline stage", num_dropped)
+        return set()
 
 
 class LayerFn(Protocol):

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -509,19 +509,24 @@ class MLAEinsum(JaxEinsum):
         # Override, otherwise "mla_layer" will be visited, causing infinite recursion.
         yield from []
 
-    def load_weights(self, weights):
+    def load_weights(self, weights) -> set[str]:
+        # Return the loaded param names so vLLM's AutoWeightsLoader does not
+        # emit a per-layer "Unable to collect loaded parameters" warning
+        # (which dumps the full module repr for every decoder layer).
         named_params = dict(self.named_parameters())
         if len(self.loaded) >= 2:
             raise ValueError(
                 f"Expect at most 2 params to load for kv_b_proj, already got {self.loaded}, still have {[name for name, _ in weights]} coming."
             )
+        loaded_now = set()
         for name, weight in weights:
             param = named_params[name]
             weight_loader = getattr(param, "weight_loader")
             weight_loader(param, weight)
             self.loaded.add(name)
+            loaded_now.add(name)
         if len(self.loaded) != len(named_params):
-            return
+            return loaded_now
         assert self.quant_config is not None
         # After loading, split the weights into k/v
         with cpu_mesh_context():
@@ -581,6 +586,7 @@ class MLAEinsum(JaxEinsum):
         delattr(self, 'weight')
         delattr(self, 'weight_scale_inv')
         delattr(self, 'quant_method')
+        return loaded_now
 
 
 @dataclass(kw_only=True)


### PR DESCRIPTION
Two independent small fixes staged from the Kimi-K3 bring-up (not K3-specific).

1. **Sharding**: replace a bare ZeroDivisionError in ShardingConfigManager (dp-attention enabled, attn_dp=1, TP exceeding per-device KV-head capacity) with a self-contained ValueError naming the invalid combination and how to fix it. The new unit test reproduced the original crash before the fix.
2. **Loader log spam**: PPMissingLayer.load_weights and MLAEinsum.load_weights returned None, which makes vLLM's AutoWeightsLoader print a full module repr warning once per decoder layer (1000+ lines on large loads). Both now conform to the loader's return contract; no change to what gets loaded. Unit tests assert the contract.

CPU-only tests; no TPU required. Marked DO NOT REVIEW pending review-queue sequencing.