### PR TITLE
[DO NOT REVIEW] K3 perf series: AOT-lowerable backbone, KDA memory fixes, fused decode loop

### DIFF
--- a/tests/kernels/kda_reference_test.py
+++ b/tests/kernels/kda_reference_test.py
@@ -327,3 +327,63 @@ def test_cross_impl_golden_parity(case):
                                    z[f"{case}.state_fp64"][i],
                                    atol=3e-5,
                                    rtol=3e-4)
+
+
+def test_decode_bucket_larger_than_slots_matches_exact_batch():
+    """Decode-only tokens past the slot count are padding: a bucket 8x the
+    slot count must produce the same valid outputs and state as the
+    exactly-sized batch, with zeros in the tail.
+
+    Guards the decode-branch slicing in `ragged_kda_decode_only`: the
+    per-token [R, H, K, V] state tensors are sized by the slot count, and
+    tokens past it (which can never be real requests in a decode-only batch)
+    must neither leak into outputs nor perturb the state pool.
+    """
+    rng = np.random.default_rng(7)
+    H, K, V = 4, 64, 64
+    slots, valid, bucket = 4, 3, 32
+    q, k, v, g, b = _rand_inputs(rng, slots, H, K, V)
+    A_log, dt_bias = _params(rng, H, K)
+
+    state = jnp.asarray(rng.normal(size=(slots, H, K, V)), dtype=jnp.float32)
+    state_indices = jnp.arange(slots, dtype=jnp.int32)
+    distribution = jnp.array([valid, 0, valid], dtype=jnp.int32)
+    qsl = jnp.arange(slots + 1, dtype=jnp.int32)
+
+    def pad(x, fill=7.7):
+        widths = ((0, bucket - slots), ) + ((0, 0), ) * (x.ndim - 1)
+        return jnp.pad(jnp.asarray(x), widths, constant_values=fill)
+
+    state_exact, out_exact = ragged_kda_decode_only(
+        jnp.asarray(q),
+        jnp.asarray(k),
+        jnp.asarray(v),
+        jnp.asarray(b),
+        jnp.asarray(g),
+        state,
+        jnp.asarray(A_log),
+        jnp.asarray(dt_bias),
+        qsl,
+        state_indices,
+        distribution,
+        gate_lower_bound=LOWER_BOUND)
+    state_padded, out_padded = ragged_kda_decode_only(
+        pad(q),
+        pad(k),
+        pad(v),
+        pad(b),
+        pad(g),
+        state,
+        jnp.asarray(A_log),
+        jnp.asarray(dt_bias),
+        qsl,
+        state_indices,
+        distribution,
+        gate_lower_bound=LOWER_BOUND)
+
+    assert out_padded.shape[0] == bucket
+    np.testing.assert_allclose(np.asarray(out_padded[:slots]),
+                               np.asarray(out_exact))
+    np.testing.assert_allclose(np.asarray(out_padded[slots:]), 0.0)
+    np.testing.assert_allclose(np.asarray(state_padded),
+                               np.asarray(state_exact))

--- a/tests/kernels/kda_reference_test.py
+++ b/tests/kernels/kda_reference_test.py
@@ -329,6 +329,70 @@ def test_cross_impl_golden_parity(case):
                                    rtol=3e-4)
 
 
+def test_mixed_prefill_padded_bucket_matches_exact_batch():
+    """Runner-style mixed-prefill padding: the token bucket is larger than
+    the real token count (garbage tail past query_start_loc[-1]) AND
+    distribution[2] < the number of query_start_loc segments (trailing
+    zero-length padding sequences mapped to the null state slot). Real
+    outputs and the whole state pool must be bit-identical to the
+    exactly-sized batch.
+
+    Guards the per-seq finals carry in `ragged_kda_mixed_prefill`: padded
+    tokens must stay inert in the packed stream, and zero-length padding
+    sequences never own a chunk, so their finals rows (gathered at entry)
+    write back as no-ops.
+    """
+    rng = np.random.default_rng(11)
+    H, K, V = 4, 64, 64
+    lens = [5, 63]
+    n = len(lens)
+    T = sum(lens)
+    num_pad_seqs, token_pad = 3, 60
+
+    q, k, v, g, b = _rand_inputs(rng, T + token_pad, H, K, V)
+    for arr in (q, k, v, g, b):
+        arr[T:] = 7.7  # garbage token tail: must not leak anywhere
+    A_log, dt_bias = _params(rng, H, K)
+
+    num_slots = n + num_pad_seqs + 2
+    state = jnp.asarray(rng.normal(size=(num_slots, H, K, V)),
+                        dtype=jnp.float32)
+    qsl_exact = np.cumsum([0] + lens).astype(np.int32)
+    # Runner-style padding: query_start_loc repeats the final offset
+    # (tail-only zero-length seqs), which map to null state slot 0.
+    qsl_padded = np.concatenate(
+        [qsl_exact, np.full(num_pad_seqs, qsl_exact[-1], np.int32)])
+    si_exact = np.arange(1, n + 1, dtype=np.int32)
+    si_padded = np.concatenate([si_exact, np.zeros(num_pad_seqs, np.int32)])
+    distribution = jnp.array([0, 0, n], dtype=jnp.int32)
+    his = np.arange(n + num_pad_seqs) % 2 == 0
+
+    def run(q_, k_, v_, g_, b_, qsl, si, his_):
+        return ragged_kda_mixed_prefill(jnp.asarray(q_),
+                                        jnp.asarray(k_),
+                                        jnp.asarray(v_),
+                                        jnp.asarray(b_),
+                                        jnp.asarray(g_),
+                                        jnp.asarray(A_log),
+                                        jnp.asarray(dt_bias),
+                                        jnp.asarray(qsl),
+                                        state,
+                                        jnp.asarray(si),
+                                        distribution,
+                                        has_initial_state=jnp.asarray(his_),
+                                        chunk_size=64,
+                                        gate_lower_bound=LOWER_BOUND)
+
+    state_exact, out_exact = run(q[:T], k[:T], v[:T], g[:T], b[:T], qsl_exact,
+                                 si_exact, his[:n])
+    state_padded, out_padded = run(q, k, v, g, b, qsl_padded, si_padded, his)
+
+    np.testing.assert_array_equal(np.asarray(out_padded[:T]),
+                                  np.asarray(out_exact))
+    np.testing.assert_array_equal(np.asarray(state_padded),
+                                  np.asarray(state_exact))
+
+
 def test_decode_bucket_larger_than_slots_matches_exact_batch():
     """Decode-only tokens past the slot count are padding: a bucket 8x the
     slot count must produce the same valid outputs and state as the

--- a/tests/layers/common/test_ragged_conv1d.py
+++ b/tests/layers/common/test_ragged_conv1d.py
@@ -364,6 +364,10 @@ class RaggedConv1dJaxTest(parameterized.TestCase):
         anti-vacuity control compiles the unsliced internal the old wrapper
         used and shows it exceeds the same bound.
         """
+        if jax.default_backend() == "cpu":
+            self.skipTest(
+                "temp_size_in_bytes bound is a TPU XLA property; CPU XLA "
+                "budgets the executable differently and blows the bound")
         dtype = jnp.bfloat16
         dim = 2048
         kernel_size = 4

--- a/tests/layers/common/test_ragged_conv1d.py
+++ b/tests/layers/common/test_ragged_conv1d.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
+
+import jax
 import jax.numpy as jnp
 import numpy as np
 from absl.testing import parameterized
@@ -298,3 +301,117 @@ class RaggedConv1dJaxTest(parameterized.TestCase):
             dtype=dtype,
         )
         np.testing.assert_allclose(updated_state, expected_state, atol=1e-6)
+
+    def test_decode_bucket_larger_than_slots_matches_exact_batch(self):
+        """Decode-only tokens past the slot count are padding: a bucket 4x
+        the slot count must produce the same valid outputs and state as the
+        exactly-sized batch, with zeros in the tail."""
+        dtype = jnp.float32
+        dim = 2
+        kernel_size = 4
+        max_reqs = 6
+        num_valid_reqs = 4
+        rng = np.random.default_rng(0)
+
+        conv_state = jnp.asarray(rng.normal(size=(max_reqs, kernel_size - 1,
+                                                  dim)),
+                                 dtype=dtype)
+        conv_weight = jnp.asarray(rng.normal(size=(dim, 1, kernel_size)),
+                                  dtype=dtype)
+        conv_bias = jnp.asarray(rng.normal(size=(dim, )), dtype=dtype)
+        query_start_loc = jnp.array([0, 1, 2, 3, 4, 1, 1], dtype=jnp.int32)
+        state_indices = jnp.arange(max_reqs, dtype=jnp.int32)
+        distribution = jnp.array([num_valid_reqs] * 3, dtype=jnp.int32)
+        has_initial_state = jnp.array([True] * max_reqs, dtype=bool)
+
+        x_exact = jnp.asarray(rng.normal(size=(max_reqs, dim)), dtype=dtype)
+        # The padded bucket carries NONZERO garbage past the slot count; it
+        # must not leak into outputs or state.
+        bucket = 4 * max_reqs
+        x_padded = jnp.concatenate([
+            x_exact,
+            jnp.full((bucket - max_reqs, dim), 7.7, dtype=dtype),
+        ])
+
+        run = functools.partial(
+            ragged_conv1d_jax.ragged_conv1d,
+            conv_weight=conv_weight,
+            conv_bias=conv_bias,
+            query_start_loc=query_start_loc,
+            state_indices=state_indices,
+            distribution=distribution,
+            has_initial_state=has_initial_state,
+            kernel_size=kernel_size,
+        )
+        # `ragged_conv1d` donates conv_state; each call gets its own copy.
+        out_exact, state_exact = run(x_exact, jnp.array(conv_state))
+        out_padded, state_padded = run(x_padded, jnp.array(conv_state))
+
+        self.assertEqual(out_padded.shape, (bucket, dim))
+        np.testing.assert_allclose(out_padded[:max_reqs], out_exact)
+        np.testing.assert_allclose(out_padded[max_reqs:],
+                                   np.zeros((bucket - max_reqs, dim)))
+        np.testing.assert_allclose(state_padded, state_exact)
+
+    def test_decode_branch_memory_scales_with_slots_not_bucket(self):
+        """The compiled decode-only executable's temporaries must be sized by
+        the state-slot count, not the token bucket.
+
+        Guards the decode-branch slicing in `ragged_conv1d`: unsliced, the
+        per-token state gathers cost O(bucket * kernel_size * dim) of HLO
+        temporaries in EVERY mixed-bucket executable (the `lax.cond` makes
+        the compiler budget for the decode branch at full bucket size). The
+        anti-vacuity control compiles the unsliced internal the old wrapper
+        used and shows it exceeds the same bound.
+        """
+        dtype = jnp.bfloat16
+        dim = 2048
+        kernel_size = 4
+        num_slots = 8
+        bucket = 4096
+
+        x = jnp.ones((bucket, dim), dtype=dtype)
+        conv_state = jnp.zeros((num_slots, kernel_size - 1, dim), dtype=dtype)
+        conv_weight = jnp.ones((dim, 1, kernel_size), dtype=dtype)
+        query_start_loc = jnp.zeros((num_slots + 1, ), dtype=jnp.int32)
+        state_indices = jnp.arange(num_slots, dtype=jnp.int32)
+        distribution = jnp.array([num_slots] * 3, dtype=jnp.int32)
+        has_initial_state = jnp.array([True] * num_slots, dtype=bool)
+
+        compiled = jax.jit(
+            functools.partial(ragged_conv1d_jax.ragged_conv1d,
+                              kernel_size=kernel_size),
+            donate_argnums=(1, ),
+        ).lower(x, conv_state, conv_weight, None, query_start_loc,
+                state_indices, distribution, has_initial_state).compile()
+        stats = compiled.memory_analysis()
+        if stats is None:
+            self.skipTest("memory_analysis unavailable on this backend")
+
+        # One [bucket, kernel_size-1, dim] gather alone is 3x this bound.
+        bound = 8 * 1024 * 1024
+        self.assertLess(
+            stats.temp_size_in_bytes, bound,
+            "decode branch temporaries scale with the token bucket again")
+
+        # Anti-vacuity: the unsliced internal (what the wrapper used to call)
+        # must blow the same bound, or the assertion above proves nothing.
+        def unsliced(x, conv_state):
+            padded_indices = jnp.pad(state_indices, (0, bucket - num_slots),
+                                     mode='constant')
+            return ragged_conv1d_jax.ragged_conv1d_decode_only(
+                x,
+                conv_state,
+                conv_weight,
+                None,
+                query_start_loc,
+                padded_indices,
+                distribution,
+                has_initial_state,
+                kernel_size=kernel_size,
+            )
+
+        unsliced_stats = jax.jit(unsliced, donate_argnums=(1, )).lower(
+            x, conv_state).compile().memory_analysis()
+        if unsliced_stats is not None:
+            self.assertGreater(unsliced_stats.temp_size_in_bytes, bound)

--- a/tests/runner/test_compilation_manager_aot.py
+++ b/tests/runner/test_compilation_manager_aot.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""`_run_compilation` must AOT-lower anything that exposes `lower`.
+
+The flax_nnx model path hands the runner `wrapped_model_fn`, a plain closure
+over the jitted `run_model` that filters kwargs and forwards a `lower`
+attribute. Before that attribute existed, `hasattr(fn, 'lower')` was False
+and the backbone silently took the "AOT lower skipped (not a jit)" path --
+compiled only inside warmup, reported no `memory_analysis`, and left OOMs
+during warmup unattributable to a bucket. These tests pin the contract from
+both sides: a `lower`-bearing wrapper gets its `lower` called and compiled,
+and a bare closure still falls back to warmup-only (the control that keeps
+the first assertion honest).
+"""
+import os
+from unittest.mock import MagicMock, patch
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+os.environ.setdefault("NUM_PRECOMPILE_WORKERS", "1")
+
+import tpu_inference.runner.compilation_manager as cm
+
+
+@pytest.fixture
+def manager():
+    mesh = jax.sharding.Mesh(np.array(jax.devices()[:1]), ("x", ))
+    runner = MagicMock()
+    runner.mesh = mesh
+    mgr = cm.CompilationManager(runner)
+    # Force the synchronous path regardless of NUM_PRECOMPILE_WORKERS.
+    mgr._compile_executor = None
+    return mgr
+
+
+def _wrapped_jit_pair():
+    """A (wrapper, lower_calls) pair shaped like model_loader's
+    wrapped_model_fn: a kwargs-filtering closure with a forwarded `lower`."""
+    jitted = jax.jit(lambda a: a * 2 + 1)
+    lower_calls = []
+
+    def wrapper(*args, **kwargs):
+        kwargs.pop("shared_attention_metadata", None)
+        return jitted(*args, **kwargs)
+
+    def _lower(*args, **kwargs):
+        kwargs.pop("shared_attention_metadata", None)
+        lower_calls.append(args)
+        return jitted.lower(*args, **kwargs)
+
+    wrapper.lower = _lower
+    return wrapper, lower_calls
+
+
+def test_lower_bearing_wrapper_is_aot_compiled(manager):
+    wrapper, lower_calls = _wrapped_jit_pair()
+    with patch.object(cm, "logger") as mock_logger:
+        manager._run_compilation("wrapped_backbone", wrapper,
+                                 jnp.ones((8, ), dtype=jnp.float32))
+    assert len(lower_calls) == 1, "the wrapper's lower() was never invoked"
+    skip_logs = [
+        c for c in mock_logger.info.call_args_list
+        if "AOT lower skipped" in str(c.args[0])
+    ]
+    assert not skip_logs, f"backbone took the skip path: {skip_logs}"
+    # The warmup task must still be queued: AOT compilation primes the cache,
+    # the warmup call populates the jit's own dispatch path.
+    assert len(manager._warmup_tasks) == 1
+
+
+def test_bare_closure_still_skips_aot(manager):
+    jitted = jax.jit(lambda a: a * 2 + 1)
+
+    def bare(*args, **kwargs):
+        return jitted(*args, **kwargs)
+
+    with patch.object(cm, "logger") as mock_logger:
+        manager._run_compilation("bare_backbone", bare,
+                                 jnp.ones((8, ), dtype=jnp.float32))
+    skip_logs = [
+        c for c in mock_logger.info.call_args_list
+        if "AOT lower skipped" in str(c.args[0])
+    ]
+    assert len(skip_logs) == 1
+    assert len(manager._warmup_tasks) == 1

--- a/tests/runner/test_decode_loop_hybrid.py
+++ b/tests/runner/test_decode_loop_hybrid.py
@@ -1,0 +1,140 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The fused decode loop must run hybrid models' per-layer metadata dict.
+
+Hybrid models (>1 kv-cache group: attention + linear-attention layers)
+carry `attn_metadata` as a dict of per-layer `AttentionMetadata` whose
+entries share every per-step field and differ only in `block_tables`.
+`continue_decode` used to assume a single object and crashed on
+`init_state.attn_metadata.seq_lens` during its own precompile warmup
+(`'dict' object has no attribute 'seq_lens'`), which alone kept the loop
+unusable on any hybrid model. The stub model below asserts the dict shape
+survives into every step and that per-group block_tables stay distinct.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.runner.decode_loop import (TpuSamplingState,
+                                              _first_group_metadata,
+                                              _with_step_dynamics,
+                                              continue_decode)
+
+_BATCH = 4
+_VOCAB = 11
+
+
+def _metadata(block_fill: int) -> AttentionMetadata:
+    return AttentionMetadata(
+        input_positions=jnp.zeros((_BATCH, ), dtype=jnp.int32),
+        block_tables=jnp.full((_BATCH, 2), block_fill, dtype=jnp.int32),
+        seq_lens=jnp.ones((_BATCH, ), dtype=jnp.int32),
+        query_start_loc=jnp.arange(_BATCH + 1, dtype=jnp.int32),
+        request_distribution=jnp.array([_BATCH, 0, _BATCH], dtype=jnp.int32),
+        mamba_state_indices=jnp.arange(_BATCH, dtype=jnp.int32),
+        has_initial_state=jnp.ones((_BATCH, ), dtype=jnp.int32),
+    )
+
+
+def test_with_step_dynamics_updates_only_positions_and_seq_lens():
+    template = {"attn": _metadata(7), "linear": _metadata(9)}
+    pos = jnp.full((_BATCH, ), 5, dtype=jnp.int32)
+    sl = jnp.full((_BATCH, ), 6, dtype=jnp.int32)
+    stepped = _with_step_dynamics(template, pos, sl)
+    assert set(stepped) == {"attn", "linear"}
+    for name, group in stepped.items():
+        np.testing.assert_array_equal(group.input_positions, pos)
+        np.testing.assert_array_equal(group.seq_lens, sl)
+        # Everything else is loop-invariant, including the per-group part.
+        np.testing.assert_array_equal(group.block_tables,
+                                      template[name].block_tables)
+    ref = _first_group_metadata(template)
+    assert ref is next(iter(template.values()))
+
+
+def _stub_model_fn(state,
+                   kv_caches,
+                   tokens,
+                   attn_metadata,
+                   inputs_embeds,
+                   positions,
+                   layer_name_to_kvcache_index,
+                   lora_metadata,
+                   intermediate_tensors,
+                   is_first_rank,
+                   is_last_rank,
+                   shared_attention_metadata=None):
+    # The hybrid contract: the loop must hand the model the SAME dict shape
+    # the runner primed it with, with distinct per-group block_tables.
+    assert isinstance(attn_metadata, dict)
+    assert set(attn_metadata) == {"attn", "linear"}
+    delta = (attn_metadata["linear"].block_tables[0, 0] -
+             attn_metadata["attn"].block_tables[0, 0])
+    hidden = (positions.astype(jnp.float32)[:, None] +
+              delta.astype(jnp.float32) * 0.0) * jnp.ones((1, 3))
+    return kv_caches, hidden, [], None
+
+
+def _stub_compute_logits_fn(state, hidden, _):
+    # Deterministic argmax = floor(position) + 1, capped inside the vocab.
+    idx = jnp.clip(hidden[:, 0].astype(jnp.int32) + 1, 0, _VOCAB - 1)
+    return jax.nn.one_hot(idx, _VOCAB, dtype=jnp.float32)
+
+
+def _stub_sample_fn(rng, mesh, logits, sampling_metadata):
+    return jnp.argmax(logits, axis=-1).astype(jnp.int32), logits
+
+
+def test_continue_decode_runs_a_hybrid_metadata_dict():
+    if jax.default_backend() == "cpu":
+        import pytest
+        pytest.skip("the decode loop's jit carries TPU compiler options")
+    mesh = jax.sharding.Mesh(np.array(jax.devices()[:1]), ("x", ))
+    template = {"attn": _metadata(7), "linear": _metadata(9)}
+    init_state = TpuSamplingState(
+        current_tokens=jnp.zeros((_BATCH, ), dtype=jnp.int32),
+        active_mask=jnp.ones((_BATCH, ), dtype=bool),
+        attn_metadata=template,
+        step_counter=jnp.array(0, dtype=jnp.int32),
+    )
+    steps = 3
+    (token_buffer, kv_caches, final_state, _, expert_indices,
+     logprobs) = continue_decode(
+         state={},
+         model_fn=_stub_model_fn,
+         compute_logits_fn=_stub_compute_logits_fn,
+         sample_fn=_stub_sample_fn,
+         init_state=init_state,
+         kv_caches=[jnp.zeros((2, 2), dtype=jnp.float32)],
+         max_decode_steps=jnp.array(steps, dtype=jnp.int32),
+         static_max_decode_steps=steps,
+         eos_token_id=(_VOCAB - 1, ),
+         padding_token_id=0,
+         rng=jax.random.key(0),
+         mesh=mesh,
+         sampling_metadata=None,
+     )
+    assert token_buffer.shape == (steps, _BATCH)
+    assert expert_indices is None and logprobs is None
+    # Every step ran: positions advanced by `steps` for every active row, and
+    # the final metadata kept the dict shape with per-group tables intact.
+    assert isinstance(final_state.attn_metadata, dict)
+    np.testing.assert_array_equal(
+        _first_group_metadata(final_state.attn_metadata).input_positions,
+        np.full((_BATCH, ), steps, dtype=np.int32))
+    np.testing.assert_array_equal(
+        final_state.attn_metadata["linear"].block_tables,
+        np.full((_BATCH, 2), 9, dtype=np.int32))

--- a/tpu_inference/kernels/gdn/reference/ragged_gated_delta_rule_chunked.py
+++ b/tpu_inference/kernels/gdn/reference/ragged_gated_delta_rule_chunked.py
@@ -110,8 +110,9 @@ def pack_inputs_single_stream(
       g_dtype: Dtype the packed gate stream is stored in. fp32 (the default)
         preserves the GDN behaviour of packing the post-gate log-decay; a
         caller that packs the RAW gate input and applies the gate math
-        per-chunk (the KDA path) can keep the stream in the input dtype and
-        halve the packed-gate HBM footprint without a numerics change.
+        per-chunk (the KDA path) can keep the stream in the input dtype
+        without a numerics change (a saving only when that input is
+        narrower than fp32; the production KDA path passes fp32 inputs).
 
     Returns:
       A tuple containing:

--- a/tpu_inference/kernels/gdn/reference/ragged_gated_delta_rule_chunked.py
+++ b/tpu_inference/kernels/gdn/reference/ragged_gated_delta_rule_chunked.py
@@ -57,6 +57,7 @@ def pack_inputs_single_stream(
     distribution: jnp.ndarray,
     chunk_size: int,
     compute_dtype: jnp.dtype = jnp.bfloat16,
+    g_dtype: jnp.dtype = jnp.float32,
 ) -> tuple[
         jnp.ndarray,
         jnp.ndarray,
@@ -106,6 +107,11 @@ def pack_inputs_single_stream(
         index 2.
       chunk_size: Chunk size for padding.
       compute_dtype: Dtype for computation (Q, K, V, beta).
+      g_dtype: Dtype the packed gate stream is stored in. fp32 (the default)
+        preserves the GDN behaviour of packing the post-gate log-decay; a
+        caller that packs the RAW gate input and applies the gate math
+        per-chunk (the KDA path) can keep the stream in the input dtype and
+        halve the packed-gate HBM footprint without a numerics change.
 
     Returns:
       A tuple containing:
@@ -176,10 +182,10 @@ def pack_inputs_single_stream(
     packed_value = packed_combined_qkvb[..., 2 * K_dim:2 * K_dim + V_dim]
     packed_beta = packed_combined_qkvb[..., 2 * K_dim + V_dim]
 
-    # For g (float32)
-    output_shape_f32 = (max_packed_tokens, ) + g.shape[1:]
-    packed_g = jnp.zeros(output_shape_f32, dtype=jnp.float32)
-    packed_g = packed_g.at[padded_indices_valid].set(g.astype(jnp.float32))
+    # For g (fp32 unless the caller keeps the raw-gate stream narrow)
+    output_shape_g = (max_packed_tokens, ) + g.shape[1:]
+    packed_g = jnp.zeros(output_shape_g, dtype=g_dtype)
+    packed_g = packed_g.at[padded_indices_valid].set(g.astype(g_dtype))
 
     num_chunks_total = max_packed_tokens // chunk_size
     reset_mask = jnp.zeros((num_chunks_total, ), dtype=bool)

--- a/tpu_inference/kernels/kda/reference/ragged_kda_chunked.py
+++ b/tpu_inference/kernels/kda/reference/ragged_kda_chunked.py
@@ -388,19 +388,32 @@ def ragged_kda_decode_only(
 
     Mirrors ``ragged_gated_delta_rule_decode_only``; ``a_reshaped`` is
     ``[num_tokens, H, K]`` and the gate form follows ``gate_lower_bound``.
+
+    HBM note: decode-only means one token per sequence, so at most
+    ``recurrent_state.shape[0]`` (the rank's state-slot count) leading tokens
+    can be real -- everything past that is bucket padding whose output is
+    zeroed anyway. The per-token state tensors ([R, H, K, V] fp32, three of
+    them) are therefore sized by the SLOT count, not by the token bucket:
+    unsliced, this branch alone contributed ~2.3 MiB of HLO temporaries per
+    padded token to every mixed-bucket executable on Kimi-K3 (96 heads),
+    because `lax.cond` makes the compiler budget for it at full bucket size.
     """
     num_tokens = query.shape[0]
     max_reqs = recurrent_state.shape[0]
+    num_step_tokens = min(num_tokens, max_reqs)
 
-    token_idx = jnp.arange(num_tokens)
+    token_idx = jnp.arange(num_step_tokens)
     req_indices = jnp.clip(token_idx, 0, max_reqs - 1)
     valid_mask = token_idx < distribution[2]
 
-    beta = jax.nn.sigmoid(b_reshaped.astype(jnp.float32))
-    g = kda_gate(a_reshaped, A_log, dt_bias, gate_lower_bound)
+    beta = jax.nn.sigmoid(
+        b_reshaped[:num_step_tokens].astype(jnp.float32))
+    g = kda_gate(a_reshaped[:num_step_tokens], A_log, dt_bias,
+                 gate_lower_bound)
 
-    query = l2norm(query)
-    key = l2norm(key)
+    query = l2norm(query[:num_step_tokens])
+    key = l2norm(key[:num_step_tokens])
+    value = value[:num_step_tokens]
     scale = query.shape[-1]**-0.5
     query = query * jnp.asarray(scale, dtype=query.dtype)
 
@@ -415,7 +428,10 @@ def ragged_kda_decode_only(
                                              state=current_states)
 
     outputs = jnp.where(valid_mask[:, None, None], outputs, 0.0)
-    outputs = outputs.reshape(num_tokens, -1)
+    outputs = outputs.reshape(num_step_tokens, -1)
+    if num_step_tokens < num_tokens:
+        outputs = jnp.pad(outputs,
+                          ((0, num_tokens - num_step_tokens), (0, 0)))
 
     states_to_set = jnp.where(valid_mask[:, None, None, None], new_states,
                               current_states)

--- a/tpu_inference/kernels/kda/reference/ragged_kda_chunked.py
+++ b/tpu_inference/kernels/kda/reference/ragged_kda_chunked.py
@@ -402,16 +402,19 @@ def ragged_kda_decode_only(
     ``[num_tokens, H, K]`` and the gate form follows ``gate_lower_bound``.
 
     HBM note: decode-only means one token per sequence, so at most
-    ``recurrent_state.shape[0]`` (the rank's state-slot count) leading tokens
-    can be real -- everything past that is bucket padding whose output is
-    zeroed anyway. The per-token state tensors ([R, H, K, V] fp32, three of
-    them) are therefore sized by the SLOT count, not by the token bucket:
-    unsliced, this branch alone contributed ~2.3 MiB of HLO temporaries per
-    padded token to every mixed-bucket executable on Kimi-K3 (96 heads),
-    because `lax.cond` makes the compiler budget for it at full bucket size.
+    ``state_indices.shape[0]`` (the padded request count) leading tokens can
+    be real -- everything past that is bucket padding whose output is zeroed
+    anyway. The per-token state tensors ([R, H, K, V] fp32, three of them)
+    are therefore sized by the REQUEST-slot count, not by the token bucket
+    and not by the state pool: `lax.cond` makes the compiler budget for this
+    branch at full size, so bounding by the token bucket cost ~2.3 MiB of
+    HLO temporaries per padded token, and bounding by the state-pool slot
+    count (``recurrent_state.shape[0]``) blew up to ~118 GiB the moment the
+    pool ran unpinned (thousands of slots). ``ragged_conv1d_jax`` uses the
+    same request-count bound.
     """
     num_tokens = query.shape[0]
-    max_reqs = recurrent_state.shape[0]
+    max_reqs = state_indices.shape[0]
     num_step_tokens = min(num_tokens, max_reqs)
 
     token_idx = jnp.arange(num_step_tokens)

--- a/tpu_inference/kernels/kda/reference/ragged_kda_chunked.py
+++ b/tpu_inference/kernels/kda/reference/ragged_kda_chunked.py
@@ -102,7 +102,6 @@ def ragged_kda_mixed_prefill(
     has_initial_state: jnp.ndarray | None = None,
     chunk_size: int = 64,
     gate_lower_bound: float | None = None,
-    compute_dtype: jnp.dtype = jnp.float32,
     precision: jax.lax.Precision = jax.lax.Precision.HIGHEST,
 ) -> tuple[jnp.ndarray, jnp.ndarray]:
     """Chunked KDA for the mixed / prefill case (ragged sequences).
@@ -116,16 +115,20 @@ def ragged_kda_mixed_prefill(
     Returns ``(updated_recurrent_state, output)`` with output shape
     ``[num_tokens, H * V]``.
 
-    HBM note: the packed q/k/v/gate streams stay in the INPUT dtype and all
-    fp32 math (l2norm, sigmoid, gate, delta rule) happens per chunk inside
-    the scan — casting bf16 up to fp32 per chunk produces bit-identical
-    values to casting the whole stream up front, so this is a memory layout
-    change, not a numerics change. Likewise the per-chunk recurrent-state
-    stacks (``[num_chunks, H, K, V]`` init snapshots and scan-stacked
-    finals) are replaced by a ``[num_seqs, H, K, V]`` carry: at 96 heads
-    those stacks dominated the compiled step function's HLO temporaries
-    (measured ~2.3 MiB per padded token per model on Kimi-K3, ~100 GiB at
-    the largest precompile bucket).
+    HBM note: the memory win on the production path is the removal of the
+    per-chunk recurrent-state stacks — the ``[num_chunks, H, K, V]`` init
+    snapshots and scan-stacked finals are replaced by a
+    ``[num_seqs, H, K, V]`` carry with a single dynamic row update per
+    chunk. At 96 heads those stacks dominated the compiled step function's
+    HLO temporaries (measured ~2.3 MiB per padded token per model on
+    Kimi-K3, ~100 GiB at the largest precompile bucket). The packed
+    q/k/v/gate streams are kept in the INPUT dtype with all fp32 math
+    (l2norm, sigmoid, gate, delta rule) done per chunk inside the scan;
+    casting up per chunk is bit-identical to casting the whole stream up
+    front, so this is dtype-generic — but note it saves nothing on the
+    production KDA path, where `kda_attention` upcasts q/k/v to fp32
+    (post-conv SiLU) before calling in, so the packed streams are fp32
+    there regardless.
     """
     initial_dtype = query.dtype
 
@@ -171,6 +174,12 @@ def ragged_kda_mixed_prefill(
     # Which sequence owns each chunk, and whether the chunk is that
     # sequence's last -- this is what lets the scan write final states into a
     # [num_seqs, ...] carry instead of stacking every chunk's state.
+    # The cumsum attribution assumes zero-length sequences appear only as a
+    # TAIL (the runner pads query_start_loc by repeating the final offset):
+    # a zero-length sequence produces no chunk-start reset, so one
+    # interleaved between real sequences would shift every later chunk's
+    # owner index. Its `finals` row keeps the state gathered at entry, and
+    # the write-back below is then a no-op for it.
     last_chunk_indices = (new_query_start_loc[1:] // chunk_size) - 1
     seq_of_chunk = jnp.cumsum(reset_mask.astype(jnp.int32)) - 1  # [N]
     is_last_chunk = (jnp.arange(num_chunks) == last_chunk_indices[jnp.clip(
@@ -224,8 +233,8 @@ def ragged_kda_mixed_prefill(
         if gate_lower_bound is None:
             g_chunk = -fp32_gate_scale * jax.nn.softplus(x_gate)
         else:
-            g_chunk = gate_lower_bound * jax.nn.sigmoid(fp32_gate_scale *
-                                                        x_gate)
+            g_chunk = gate_lower_bound * jax.nn.sigmoid(
+                fp32_gate_scale * x_gate)
         g_chunk = g_chunk * chunk_valid.astype(jnp.float32)[None, :, None]
         G = jnp.cumsum(g_chunk, axis=-2)  # [H, BT, K]
         beta = jax.nn.sigmoid(b.astype(jnp.float32))
@@ -305,8 +314,11 @@ def ragged_kda_mixed_prefill(
                                            seq_idx,
                                            axis=0,
                                            keepdims=False)
-        finals = jax.lax.dynamic_update_index_in_dim(
-            finals, jnp.where(is_last, h_new, row), seq_idx, axis=0)
+        finals = jax.lax.dynamic_update_index_in_dim(finals,
+                                                     jnp.where(
+                                                         is_last, h_new, row),
+                                                     seq_idx,
+                                                     axis=0)
 
         return (h_new, finals), o_c.astype(initial_dtype)
 
@@ -406,8 +418,7 @@ def ragged_kda_decode_only(
     req_indices = jnp.clip(token_idx, 0, max_reqs - 1)
     valid_mask = token_idx < distribution[2]
 
-    beta = jax.nn.sigmoid(
-        b_reshaped[:num_step_tokens].astype(jnp.float32))
+    beta = jax.nn.sigmoid(b_reshaped[:num_step_tokens].astype(jnp.float32))
     g = kda_gate(a_reshaped[:num_step_tokens], A_log, dt_bias,
                  gate_lower_bound)
 
@@ -430,8 +441,7 @@ def ragged_kda_decode_only(
     outputs = jnp.where(valid_mask[:, None, None], outputs, 0.0)
     outputs = outputs.reshape(num_step_tokens, -1)
     if num_step_tokens < num_tokens:
-        outputs = jnp.pad(outputs,
-                          ((0, num_tokens - num_step_tokens), (0, 0)))
+        outputs = jnp.pad(outputs, ((0, num_tokens - num_step_tokens), (0, 0)))
 
     states_to_set = jnp.where(valid_mask[:, None, None, None], new_states,
                               current_states)

--- a/tpu_inference/kernels/kda/reference/ragged_kda_chunked.py
+++ b/tpu_inference/kernels/kda/reference/ragged_kda_chunked.py
@@ -115,37 +115,48 @@ def ragged_kda_mixed_prefill(
 
     Returns ``(updated_recurrent_state, output)`` with output shape
     ``[num_tokens, H * V]``.
+
+    HBM note: the packed q/k/v/gate streams stay in the INPUT dtype and all
+    fp32 math (l2norm, sigmoid, gate, delta rule) happens per chunk inside
+    the scan — casting bf16 up to fp32 per chunk produces bit-identical
+    values to casting the whole stream up front, so this is a memory layout
+    change, not a numerics change. Likewise the per-chunk recurrent-state
+    stacks (``[num_chunks, H, K, V]`` init snapshots and scan-stacked
+    finals) are replaced by a ``[num_seqs, H, K, V]`` carry: at 96 heads
+    those stacks dominated the compiled step function's HLO temporaries
+    (measured ~2.3 MiB per padded token per model on Kimi-K3, ~100 GiB at
+    the largest precompile bucket).
     """
     initial_dtype = query.dtype
 
-    beta = jax.nn.sigmoid(b_reshaped.astype(jnp.float32))
-    g = kda_gate(a_reshaped, A_log, dt_bias, gate_lower_bound)
-
-    (packed_query, packed_key, packed_value, packed_g, packed_beta, reset_mask,
+    (packed_query, packed_key, packed_value, packed_a, packed_b, reset_mask,
      new_query_start_loc, padded_indices_valid) = pack_inputs_single_stream(
          query,
          key,
          value,
-         g,
-         beta,
+         a_reshaped,
+         b_reshaped,
          query_start_loc,
          distribution,
          chunk_size,
-         compute_dtype=compute_dtype,
+         compute_dtype=initial_dtype,
+         g_dtype=initial_dtype,
      )
-
-    packed_query = l2norm(packed_query, dim=-1, eps=1e-6)
-    packed_key = l2norm(packed_key, dim=-1, eps=1e-6)
-
-    scale = jax.lax.rsqrt(jnp.array(packed_query.shape[-1],
-                                    dtype=jnp.float32)).astype(compute_dtype)
-    packed_query = packed_query * scale
 
     total_tokens = packed_query.shape[0]
     num_chunks = total_tokens // chunk_size
     H = packed_query.shape[1]
     K_dim = packed_query.shape[2]
     V_dim = packed_value.shape[2]
+    num_seqs = new_query_start_loc.shape[0] - 1
+
+    # Padded slots must behave as no-ops: k = v = 0 already makes them inert
+    # in the delta rule, but the gate computed from a zero raw input is
+    # NEGATIVE (both gate forms are <= 0), which would decay the carried
+    # state across padding. `valid` restores the packed-zero-gate behaviour.
+    valid = jnp.zeros((total_tokens, ), dtype=initial_dtype)
+    valid = valid.at[padded_indices_valid].set(1.0)
+    valid_c = valid.reshape(num_chunks, chunk_size)  # [N, BT]
 
     def to_chunk(x):
         return x.reshape(num_chunks, chunk_size, H, -1).transpose(0, 2, 1, 3)
@@ -153,43 +164,71 @@ def ragged_kda_mixed_prefill(
     q_c = to_chunk(packed_query)
     k_c = to_chunk(packed_key)
     v_c = to_chunk(packed_value)
-    g_c = to_chunk(packed_g)  # [N, H, BT, K] fp32 log-decay
-    beta_c = packed_beta.reshape(num_chunks, chunk_size,
-                                 H).transpose(0, 2, 1)  # [N, H, BT]
+    a_c = to_chunk(packed_a)  # [N, H, BT, K] raw gate input
+    b_c = packed_b.reshape(num_chunks, chunk_size,
+                           H).transpose(0, 2, 1)  # [N, H, BT] raw beta input
 
-    # Per-chunk cumulative log-decay (fp32, <= 0, decreasing in time).
-    g_cumsum = jnp.cumsum(g_c, axis=-2)  # [N, H, BT, K]
+    # Which sequence owns each chunk, and whether the chunk is that
+    # sequence's last -- this is what lets the scan write final states into a
+    # [num_seqs, ...] carry instead of stacking every chunk's state.
+    last_chunk_indices = (new_query_start_loc[1:] // chunk_size) - 1
+    seq_of_chunk = jnp.cumsum(reset_mask.astype(jnp.int32)) - 1  # [N]
+    is_last_chunk = (jnp.arange(num_chunks) == last_chunk_indices[jnp.clip(
+        seq_of_chunk, 0, num_seqs - 1)])
 
-    # Initial states per chunk (same slot machinery as the GDN reference).
-    init_h_per_chunk = jnp.zeros((num_chunks, H, K_dim, V_dim),
-                                 dtype=recurrent_state.dtype)
-    start_chunk_indices = new_query_start_loc[:-1] // chunk_size
+    # Per-sequence initial states, gathered once ([num_seqs, H, K, V], pool
+    # dtype); the has_initial_state zero-masking happens per chunk on a
+    # single [H, K, V] slice inside the scan.
     init_states_for_seqs = recurrent_state[state_indices]
-    if has_initial_state is not None:
-        init_states_for_seqs = jnp.where(
-            has_initial_state[:, None, None, None],
-            init_states_for_seqs,
-            jnp.zeros_like(init_states_for_seqs),
-        )
-    init_h_per_chunk = init_h_per_chunk.at[start_chunk_indices].set(
-        init_states_for_seqs)
+    if has_initial_state is None:
+        has_init = jnp.ones((init_states_for_seqs.shape[0], ), dtype=bool)
+    else:
+        has_init = has_initial_state.astype(bool)
+
+    fp32_gate_scale = jnp.exp(A_log.astype(jnp.float32))[:, None, None]
+    dt_bias_f = dt_bias.astype(jnp.float32).reshape(H, 1, K_dim)
 
     h_init = jnp.zeros((H, K_dim, V_dim), dtype=jnp.float32)
+    finals_init = init_states_for_seqs.astype(jnp.float32)
     mask_strict = jnp.tril(jnp.ones((chunk_size, chunk_size), dtype=bool),
                            k=-1)
     mask_incl = jnp.tril(jnp.ones((chunk_size, chunk_size), dtype=bool))
     identity = jnp.eye(chunk_size, dtype=jnp.float32)
+    scale = jax.lax.rsqrt(jnp.array(K_dim, dtype=jnp.float32))
 
-    xs = (q_c, k_c, v_c, g_cumsum, beta_c, reset_mask, init_h_per_chunk)
+    xs = (q_c, k_c, v_c, a_c, b_c, valid_c, reset_mask, seq_of_chunk,
+          is_last_chunk)
 
-    def scan_body(h, args):
-        q, k, v, G, beta, reset, init_h = args
-        # q,k,v: [H, BT, D]; G: [H, BT, K]; beta: [H, BT]; h: [H, K, V].
-        h = jnp.where(reset, init_h.astype(jnp.float32), h)
+    def scan_body(carry, args):
+        h, finals = carry
+        q, k, v, a, b, chunk_valid, reset, seq_idx, is_last = args
+        # q,k,v: [H, BT, D]; a: [H, BT, K]; b: [H, BT]; h: [H, K, V];
+        # finals: [num_seqs, H, K, V] fp32.
+        seq_idx = jnp.clip(seq_idx, 0, num_seqs - 1)
+        init_h = jnp.where(
+            has_init[seq_idx],
+            jax.lax.dynamic_index_in_dim(init_states_for_seqs,
+                                         seq_idx,
+                                         axis=0,
+                                         keepdims=False).astype(jnp.float32),
+            0.0)
+        h = jnp.where(reset, init_h, h)
 
-        kf = k.astype(jnp.float32)
-        qf = q.astype(jnp.float32)
+        kf = l2norm(k.astype(jnp.float32), dim=-1, eps=1e-6)
+        qf = l2norm(q.astype(jnp.float32), dim=-1, eps=1e-6) * scale
         vf = v.astype(jnp.float32)
+
+        # Gate math (fp32, per chunk) -- identical to `kda_gate`, then zeroed
+        # on padded slots so padding neither decays nor updates the state.
+        x_gate = a.astype(jnp.float32) + dt_bias_f
+        if gate_lower_bound is None:
+            g_chunk = -fp32_gate_scale * jax.nn.softplus(x_gate)
+        else:
+            g_chunk = gate_lower_bound * jax.nn.sigmoid(fp32_gate_scale *
+                                                        x_gate)
+        g_chunk = g_chunk * chunk_valid.astype(jnp.float32)[None, :, None]
+        G = jnp.cumsum(g_chunk, axis=-2)  # [H, BT, K]
+        beta = jax.nn.sigmoid(b.astype(jnp.float32))
 
         # Per-channel decay ratios exp(G_r - G_c) for r >= c (safe: <= 1).
         # [H, BT, BT, K]
@@ -259,27 +298,28 @@ def ragged_kda_mixed_prefill(
                                    precision=precision,
                                    preferred_element_type=jnp.float32)
 
-        return h_new, (o_c, h_new)
+        # Record the state for the owning sequence only when this chunk is
+        # its last; a single dynamic row update replaces stacking every
+        # chunk's [H, K, V] state.
+        row = jax.lax.dynamic_index_in_dim(finals,
+                                           seq_idx,
+                                           axis=0,
+                                           keepdims=False)
+        finals = jax.lax.dynamic_update_index_in_dim(
+            finals, jnp.where(is_last, h_new, row), seq_idx, axis=0)
 
-    _, (o_chunks, h_chunks) = lax.scan(scan_body, h_init, xs)
+        return (h_new, finals), o_c.astype(initial_dtype)
+
+    (_, finals), o_chunks = lax.scan(scan_body, (h_init, finals_init), xs)
 
     o = o_chunks.transpose(0, 2, 1, 3).reshape(-1, H, V_dim)
-    o = o.astype(initial_dtype)
     output = o.reshape(-1, H * V_dim)[padded_indices_valid]
 
-    last_chunk_indices = (new_query_start_loc[1:] // chunk_size) - 1
-    final_states = h_chunks[last_chunk_indices]
-
-    num_seqs = last_chunk_indices.shape[0]
-    valid_seq_mask = jnp.arange(num_seqs) < distribution[2]
-    current_states = recurrent_state[state_indices]
-    states_to_set = jnp.where(
-        valid_seq_mask[:, None, None, None],
-        final_states.astype(recurrent_state.dtype),
-        current_states,
-    )
+    # Invalid sequences never own a chunk, so their `finals` rows still hold
+    # the states gathered at entry -- writing them back is a no-op, which is
+    # exactly what the old valid_seq_mask select achieved.
     updated_recurrent_state = recurrent_state.at[state_indices].set(
-        states_to_set)
+        finals.astype(recurrent_state.dtype))
 
     return updated_recurrent_state, output
 

--- a/tpu_inference/layers/common/ragged_conv1d_jax.py
+++ b/tpu_inference/layers/common/ragged_conv1d_jax.py
@@ -293,22 +293,29 @@ def ragged_conv1d(
     is_decode_only = distribution[0] == distribution[2]
 
     def decode_only_branch(_):
+        # Decode-only means one token per sequence, so only the first
+        # `state_indices.shape[0]` (slot count) tokens can be real; the rest
+        # of the bucket is padding whose output is zeroed anyway. Slicing
+        # keeps this branch's per-token state gathers ([R, kernel_size-1,
+        # dim] x several) sized by the slot count instead of the token
+        # bucket -- `lax.cond` makes the compiler budget HBM for the branch
+        # at full bucket size even when it cannot run there.
         num_tokens = x.shape[0]
-        pad_size = max(0, num_tokens - state_indices.shape[0])
-        padded_state_indices = jnp.pad(state_indices, (0, pad_size),
-                                       mode='constant',
-                                       constant_values=0)
-        return ragged_conv1d_decode_only(
-            x,
+        num_step_tokens = min(num_tokens, state_indices.shape[0])
+        out, new_conv_state = ragged_conv1d_decode_only(
+            x[:num_step_tokens],
             conv_state,
             conv_weight,
             conv_bias,
             query_start_loc,
-            padded_state_indices,
+            state_indices[:num_step_tokens],
             distribution,
             has_initial_state,
             kernel_size=kernel_size,
         )
+        if num_step_tokens < num_tokens:
+            out = jnp.pad(out, ((0, num_tokens - num_step_tokens), (0, 0)))
+        return out, new_conv_state
 
     def mixed_prefill_branch(_):
         return ragged_conv1d_mixed_prefill(

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -469,11 +469,23 @@ def get_flax_model(
     model_supports_spec_step = supports_kw(model_class.__call__,
                                            "spec_step_idx")
 
-    def wrapped_model_fn(*args, **kwargs):
+    def _drop_unsupported_kwargs(kwargs):
         if not model_supports_spec_step:
             kwargs.pop("spec_step_idx", None)
         kwargs.pop("shared_attention_metadata", None)
-        return jitted_model_fn(*args, **kwargs)
+        return kwargs
+
+    def wrapped_model_fn(*args, **kwargs):
+        return jitted_model_fn(*args, **_drop_unsupported_kwargs(kwargs))
+
+    def _lower_model_fn(*args, **kwargs):
+        return jitted_model_fn.lower(*args, **_drop_unsupported_kwargs(kwargs))
+
+    # Expose `lower` so the precompile pass can AOT-lower the backbone (and so
+    # report `memory_analysis` for it) instead of taking the "not a jit"
+    # warmup-only path: the wrapper hides the underlying jit from
+    # `_run_compilation`'s `hasattr(fn, 'lower')` check.
+    wrapped_model_fn.lower = _lower_model_fn
 
     compute_logits_fn = run_compute_logits
     embed_input_ids_fn = run_embed_input_ids

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -377,7 +377,12 @@ def get_flax_model(
     # costs ~17 ms/step on Gemma-4-31B decode at TP=2.
     _state_treedef = jax.tree_util.tree_structure(state)
 
-    @jax.jit(
+    def _run_model_impl(state_leaves, *args):
+        state = jax.tree_util.tree_unflatten(_state_treedef, state_leaves)
+        model = nnx.merge(graphdef, state)
+        return model(*args)
+
+    _run_model_jit_kwargs = dict(
         out_shardings=(
             kv_cache_sharding,
             hidden_states_sharding,
@@ -388,12 +393,16 @@ def get_flax_model(
         static_argnums=(
             6, 9, 10
         ),  # 6 is layer_name_to_kvcache_index, 9 is is_first_rank, 10 is is_last_rank
-        compiler_options=get_step_fn_compiler_options(),
     )
-    def run_model(state_leaves, *args):
-        state = jax.tree_util.tree_unflatten(_state_treedef, state_leaves)
-        model = nnx.merge(graphdef, state)
-        return model(*args)
+
+    run_model = jax.jit(_run_model_impl,
+                        **_run_model_jit_kwargs,
+                        compiler_options=get_step_fn_compiler_options())
+    # JAX forbids compiler_options on a jit nested inside another traced
+    # computation, so callers that inline the step function into a larger
+    # jitted program (the fused decode loop, which hoists the same options
+    # onto its own top-level jit) need this variant.
+    run_model_no_options = jax.jit(_run_model_impl, **_run_model_jit_kwargs)
 
     @jax.jit(
         out_shardings=(
@@ -486,6 +495,17 @@ def get_flax_model(
     # warmup-only path: the wrapper hides the underlying jit from
     # `_run_compilation`'s `hasattr(fn, 'lower')` check.
     wrapped_model_fn.lower = _lower_model_fn
+
+    def _wrapped_model_fn_no_options(*args, **kwargs):
+        return run_model_no_options(*args, **_drop_unsupported_kwargs(kwargs))
+
+    # Same attribute name the torchax wrapper uses, for the same reason: the
+    # fused decode loop inlines the step function into its own jit, where the
+    # compiler_options-carrying `run_model` is rejected as a nested jit. The
+    # draft model's jit carries no compiler options, so it is its own
+    # no-options variant.
+    wrapped_model_fn.step_fn_no_options = (wrapped_model_fn if is_draft_model
+                                           else _wrapped_model_fn_no_options)
 
     compute_logits_fn = run_compute_logits
     embed_input_ids_fn = run_embed_input_ids

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -490,10 +490,13 @@ def get_flax_model(
     def _lower_model_fn(*args, **kwargs):
         return jitted_model_fn.lower(*args, **_drop_unsupported_kwargs(kwargs))
 
-    # Expose `lower` so the precompile pass can AOT-lower the backbone (and so
-    # report `memory_analysis` for it) instead of taking the "not a jit"
-    # warmup-only path: the wrapper hides the underlying jit from
-    # `_run_compilation`'s `hasattr(fn, 'lower')` check.
+    # Expose `lower` so the precompile pass can AOT-lower the backbone
+    # instead of taking the "not a jit" warmup-only path: the wrapper hides
+    # the underlying jit from `_run_compilation`'s `hasattr(fn, 'lower')`
+    # check. This buys per-bucket AOT lowering with per-bucket compile-time
+    # attribution (see `_lower_and_compile`'s timing log), and gives the
+    # precompile pass a real Lowered/Compiled object that memory-analysis
+    # tooling (`compiled.memory_analysis()`) can hook into.
     wrapped_model_fn.lower = _lower_model_fn
 
     def _wrapped_model_fn_no_options(*args, **kwargs):

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -2063,8 +2063,13 @@ class CompilationManager:
                 f"worker{self.runner.rank} continue_decode_steps_{user_max_decode_steps}_reqs_{num_reqs}",
                 continue_decode_wrapper,
                 self.runner.state_leaves,
-                getattr(self.runner.model, "step_fn_no_options",
-                        self.runner.model_fn),
+                # Same fallback chain as `_execute_continue_decode`: torchax
+                # keeps the no-options step fn on the model wrapper, flax_nnx
+                # on the model_fn wrapper.
+                getattr(
+                    self.runner.model, "step_fn_no_options",
+                    getattr(self.runner.model_fn, "step_fn_no_options",
+                            self.runner.model_fn)),
                 self.runner.compute_logits_fn,
                 sample,
                 self.runner.mesh,

--- a/tpu_inference/runner/decode_loop.py
+++ b/tpu_inference/runner/decode_loop.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 import functools
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Any, Callable, Optional
 
 import jax
@@ -22,6 +22,39 @@ from vllm.v1.outputs import LogprobsTensors
 
 from tpu_inference.layers.common.attention_metadata import (
     AttentionMetadata, SharedAttentionMetadata)
+
+
+def _first_group_metadata(
+    attn_metadata: AttentionMetadata | dict[str, AttentionMetadata]
+) -> AttentionMetadata:
+    """One representative group's metadata.
+
+    Hybrid models (>1 kv-cache group, e.g. attention + linear-attention
+    layers) carry a per-layer dict whose entries share every per-step field
+    (positions, seq_lens, ragged metadata, mamba fields) and differ only in
+    `block_tables`; any entry is a valid source for the shared fields.
+    """
+    if isinstance(attn_metadata, dict):
+        return next(iter(attn_metadata.values()))
+    return attn_metadata
+
+
+def _with_step_dynamics(
+    attn_metadata: AttentionMetadata | dict[str, AttentionMetadata],
+    input_positions: jax.Array,
+    seq_lens: jax.Array,
+) -> AttentionMetadata | dict[str, AttentionMetadata]:
+    """The same metadata (object or per-layer dict) with this decode step's
+    positions and seq_lens; every other field is loop-invariant."""
+    if isinstance(attn_metadata, dict):
+        return {
+            name:
+            replace(group, input_positions=input_positions, seq_lens=seq_lens)
+            for name, group in attn_metadata.items()
+        }
+    return replace(attn_metadata,
+                   input_positions=input_positions,
+                   seq_lens=seq_lens)
 
 
 @functools.partial(
@@ -133,11 +166,7 @@ def _decode_core(
     inputs_embeds,
     lora_metadata,
     intermediate_tensors,
-    block_tables,
-    query_start_loc,
-    request_distribution,
-    mamba_state_indices,
-    has_initial_state,
+    attn_template,
     current_tokens,
     active_mask,
     input_positions,
@@ -164,24 +193,18 @@ def _decode_core(
 ):
     has_logprobs = False if sampling_metadata is None else sampling_metadata.logprobs
 
+    shared_ref = _first_group_metadata(attn_template)
+
     def _run_one_step(step_idx, ct, am, pos, sl, kvc):
         step_rng = step_rngs[step_idx]
-        attn_metadata = AttentionMetadata(
-            input_positions=pos,
-            block_tables=block_tables,
-            seq_lens=sl,
-            query_start_loc=query_start_loc,
-            request_distribution=request_distribution,
-            mamba_state_indices=mamba_state_indices,
-            has_initial_state=has_initial_state,
-        )
+        attn_metadata = _with_step_dynamics(attn_template, pos, sl)
         shared_attn_metadata = SharedAttentionMetadata(
             input_positions=pos,
             seq_lens=sl,
-            query_start_loc=query_start_loc,
-            request_distribution=request_distribution,
-            mamba_state_indices=mamba_state_indices,
-            has_initial_state=has_initial_state,
+            query_start_loc=shared_ref.query_start_loc,
+            request_distribution=shared_ref.request_distribution,
+            mamba_state_indices=shared_ref.mamba_state_indices,
+            has_initial_state=shared_ref.has_initial_state,
         )
         kvc, hidden_states, _, expert_indices_step = model_fn(
             state,
@@ -189,7 +212,7 @@ def _decode_core(
             ct,
             attn_metadata,
             inputs_embeds,
-            attn_metadata.input_positions,
+            pos,
             layer_name_to_kvcache_index,
             lora_metadata,
             intermediate_tensors,
@@ -407,13 +430,15 @@ def continue_decode(
     """
 
     batch_size = init_state.current_tokens.shape[0]
-    seq_lens_size = init_state.attn_metadata.seq_lens.shape[0]
+    # For hybrid models `attn_metadata` is a per-layer dict (see
+    # `_first_group_metadata`); the per-step fields are shared across groups.
+    attn_template = init_state.attn_metadata
+    attn = _first_group_metadata(attn_template)
+    seq_lens_size = attn.seq_lens.shape[0]
     pad_len = (seq_lens_size - batch_size) // dp_size
 
     step_rngs, current_rng = _split_rngs(rng, static_max_decode_steps,
                                          max_decode_steps)
-
-    attn = init_state.attn_metadata
 
     # Discover the per-step expert-indices shape without executing a step.
     # Gated by the caller's config flag so the abstract trace is skipped for
@@ -426,15 +451,7 @@ def continue_decode(
 
         def _model_experts_only(current_tokens, input_positions, seq_lens,
                                 kv_caches):
-            am = AttentionMetadata(
-                input_positions=input_positions,
-                block_tables=attn.block_tables,
-                seq_lens=seq_lens,
-                query_start_loc=attn.query_start_loc,
-                request_distribution=attn.request_distribution,
-                mamba_state_indices=attn.mamba_state_indices,
-                has_initial_state=attn.has_initial_state,
-            )
+            am = _with_step_dynamics(attn_template, input_positions, seq_lens)
             shared_am = SharedAttentionMetadata(
                 input_positions=input_positions,
                 seq_lens=seq_lens,
@@ -448,7 +465,7 @@ def continue_decode(
                                         current_tokens,
                                         am,
                                         inputs_embeds,
-                                        am.input_positions,
+                                        input_positions,
                                         layer_name_to_kvcache_index,
                                         lora_metadata,
                                         intermediate_tensors,
@@ -479,11 +496,7 @@ def continue_decode(
          inputs_embeds=inputs_embeds,
          lora_metadata=lora_metadata,
          intermediate_tensors=intermediate_tensors,
-         block_tables=attn.block_tables,
-         query_start_loc=attn.query_start_loc,
-         request_distribution=attn.request_distribution,
-         mamba_state_indices=attn.mamba_state_indices,
-         has_initial_state=attn.has_initial_state,
+         attn_template=attn_template,
          current_tokens=init_state.current_tokens,
          active_mask=init_state.active_mask,
          input_positions=attn.input_positions,
@@ -512,15 +525,7 @@ def continue_decode(
     final_state = TpuSamplingState(
         current_tokens=current_tokens,
         active_mask=active_mask,
-        attn_metadata=AttentionMetadata(
-            input_positions=positions,
-            block_tables=attn.block_tables,
-            seq_lens=seq_lens,
-            query_start_loc=attn.query_start_loc,
-            request_distribution=attn.request_distribution,
-            mamba_state_indices=attn.mamba_state_indices,
-            has_initial_state=attn.has_initial_state,
-        ),
+        attn_metadata=_with_step_dynamics(attn_template, positions, seq_lens),
         step_counter=step_counter.astype(jnp.int32),
     )
 

--- a/tpu_inference/runner/decode_loop.py
+++ b/tpu_inference/runner/decode_loop.py
@@ -22,6 +22,8 @@ from vllm.v1.outputs import LogprobsTensors
 
 from tpu_inference.layers.common.attention_metadata import (
     AttentionMetadata, SharedAttentionMetadata)
+from tpu_inference.models.common.compiler_options import \
+    get_step_fn_compiler_options
 
 
 def _first_group_metadata(
@@ -125,38 +127,46 @@ def _split_rngs(rng, static_size, dynamic_size):
     return all_rngs[:static_size], all_rngs[dynamic_size]
 
 
-@functools.partial(
-    jax.jit,
-    static_argnames=(
-        "model_fn",
-        "compute_logits_fn",
-        "sample_fn",
-        "mesh",
-        "static_max_decode_steps",
-        "eos_token_id",
-        "padding_token_id",
-        "dp_size",
-        "pad_len",
-        "has_experts",
-        "expert_shape",
-        "expert_dtype",
-        "layer_name_to_kvcache_index",
-        "is_first_rank",
-        "is_last_rank",
-        "max_logprobs",
-        "logprobs_mode",
-        "continue_decode_eos_check_interval",
-    ),
-    donate_argnames=("kv_caches", ),
-    # Hoisted here from the model's step_fun: JAX forbids compiler_options on
-    # a nested jit, so they must live on this top-level loop jit instead.
-    compiler_options={
-        "xla_tpu_all_gather_collective_matmul_mode": "post_spmd_conservative",
-        "xla_tpu_reduce_scatter_collective_matmul_mode":
-        "post_spmd_conservative",
-        "xla_tpu_use_minor_sharding_for_major_trivial_input": "true"
-    },
-)
+@functools.cache
+def _get_decode_core():
+    """The jitted decode core, built lazily on first use.
+
+    The step-fn compiler options are hoisted here from the model's step_fun:
+    JAX forbids compiler_options on a nested jit, so they must live on this
+    top-level loop jit instead. They come from the same
+    `get_step_fn_compiler_options()` the standalone step fn uses (see
+    `model_loader`), so the fused loop and the per-step path always agree —
+    including the env-gated SparseCore offload flags
+    (SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES). Built lazily (not at import)
+    because resolving those options may query the TPU backend.
+    """
+    return functools.partial(
+        jax.jit,
+        static_argnames=(
+            "model_fn",
+            "compute_logits_fn",
+            "sample_fn",
+            "mesh",
+            "static_max_decode_steps",
+            "eos_token_id",
+            "padding_token_id",
+            "dp_size",
+            "pad_len",
+            "has_experts",
+            "expert_shape",
+            "expert_dtype",
+            "layer_name_to_kvcache_index",
+            "is_first_rank",
+            "is_last_rank",
+            "max_logprobs",
+            "logprobs_mode",
+            "continue_decode_eos_check_interval",
+        ),
+        donate_argnames=("kv_caches", ),
+        compiler_options=get_step_fn_compiler_options(),
+    )(_decode_core)
+
+
 def _decode_core(
     *,
     state,
@@ -488,7 +498,7 @@ def continue_decode(
 
     (step_counter, current_tokens, active_mask, positions, seq_lens, kv_caches,
      token_buffer, expert_buffer, lp_ids_buffer, lp_val_buffer,
-     lp_ranks_buffer) = _decode_core(
+     lp_ranks_buffer) = _get_decode_core()(
          state=state,
          kv_caches=kv_caches,
          step_rngs=step_rngs,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1805,38 +1805,45 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
              set_forward_context(None, self.vllm_config), \
              self.maybe_get_kv_connector_output(
                  scheduler_output) as kv_connector_output:
-            (generated_tokens, final_kv_caches, final_state, final_rng,
-             all_expert_indices, logprobs_tensors) = continue_decode(
-                 state=self.state_leaves,
-                 model_fn=getattr(self.model, "step_fn_no_options",
-                                  self.model_fn),
-                 compute_logits_fn=self.compute_logits_fn,
-                 sample_fn=sample,
-                 mesh=self.mesh,
-                 sampling_metadata=sampling_metadata,
-                 init_state=init_state,
-                 kv_caches=self.kv_caches,
-                 max_decode_steps=max_decode_steps_arr,
-                 static_max_decode_steps=self.static_max_decode_steps,
-                 eos_token_id=self.eos_token_id,
-                 padding_token_id=self.pad_token_id,
-                 rng=self.rng_params_for_sampling,
-                 inputs_embeds=None,
-                 layer_name_to_kvcache_index=tuple(
-                     self.layer_name_to_kvcache_index.items()),
-                 lora_metadata=lora_metadata,
-                 intermediate_tensors=None,
-                 is_first_rank=self.is_first_rank,
-                 is_last_rank=self.is_last_rank,
-                 dp_size=self.dp_size,
-                 collect_expert_indices=getattr(
-                     self.vllm_config.model_config,
-                     "enable_return_routed_experts", False),
-                 max_logprobs=self.model_config.max_logprobs,
-                 logprobs_mode=self.model_config.logprobs_mode,
-                 continue_decode_eos_check_interval=self.
-                 continue_decode_eos_check_interval,
-             )
+            (
+                generated_tokens, final_kv_caches, final_state, final_rng,
+                all_expert_indices, logprobs_tensors
+            ) = continue_decode(
+                state=self.state_leaves,
+                # The no-compiler-options step fn lives on the torchax
+                # wrapper (self.model) or, for flax_nnx, on the model_fn
+                # wrapper itself.
+                model_fn=getattr(
+                    self.model, "step_fn_no_options",
+                    getattr(self.model_fn, "step_fn_no_options",
+                            self.model_fn)),
+                compute_logits_fn=self.compute_logits_fn,
+                sample_fn=sample,
+                mesh=self.mesh,
+                sampling_metadata=sampling_metadata,
+                init_state=init_state,
+                kv_caches=self.kv_caches,
+                max_decode_steps=max_decode_steps_arr,
+                static_max_decode_steps=self.static_max_decode_steps,
+                eos_token_id=self.eos_token_id,
+                padding_token_id=self.pad_token_id,
+                rng=self.rng_params_for_sampling,
+                inputs_embeds=None,
+                layer_name_to_kvcache_index=tuple(
+                    self.layer_name_to_kvcache_index.items()),
+                lora_metadata=lora_metadata,
+                intermediate_tensors=None,
+                is_first_rank=self.is_first_rank,
+                is_last_rank=self.is_last_rank,
+                dp_size=self.dp_size,
+                collect_expert_indices=getattr(self.vllm_config.model_config,
+                                               "enable_return_routed_experts",
+                                               False),
+                max_logprobs=self.model_config.max_logprobs,
+                logprobs_mode=self.model_config.logprobs_mode,
+                continue_decode_eos_check_interval=self.
+                continue_decode_eos_check_interval,
+            )
 
         if self.scheduler_config.async_scheduling:
             self.rng_params_for_sampling = final_rng


### PR DESCRIPTION
Stacked on #3292 (base: cuiq-k3-dev — diff shows only this series). Four atomic commits, each with small-chip tests:

1. flax_nnx: expose .lower on the wrapped model fn so the precompile pass AOT-lowers the backbone with per-bucket compile-time attribution (and a real Lowered/Compiled object that memory-analysis tooling can hook into).
2. KDA chunked prefill: replace the per-chunk [num_chunks, H, K, V] state stacks with a per-seq carry (bit-identical); per-chunk fp32 math over dtype-generic packed streams.
3. KDA/conv decode branches: size per-token state gathers by slot count, not token bucket — top-bucket HLO temporaries drop 100.47G -> 6.42G; the config that OOM'd every unpinned serve now serves with no warmup reserve (dev build A/B: without fix -> fail, with fix -> pass).
4. Fused decode loop on the hybrid path (per-layer metadata dict + no-options step fn): slice TPOT 35.3 -> 18.8 ms, greedy parity 9/9 vs HF reference.

Follow-up commits from internal review: the fused loop now sources its compiler options from get_step_fn_compiler_options() (keeping the env-gated SparseCore offload flags), plus claim-accurate docs and a padded-bucket mixed-prefill regression test.

Marked DO NOT REVIEW until #3292 lands (or its split train is chosen); retarget to main then.