### PR TITLE
[DO NOT REVIEW] Per-host sharded expert streaming for MXFP4 MoE loads

### DIFF
--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -183,6 +183,7 @@ steps:
               /workspace/tpu_inference/tests/models/jax/test_kimi_k3_mxfp4.py \
               /workspace/tpu_inference/tests/models/jax/test_kimi_k3_mxfp4_real_layer.py \
               /workspace/tpu_inference/tests/models/jax/test_kimi_k3_mxfp4_shard_decode.py \
+              /workspace/tpu_inference/tests/models/jax/test_kimi_k3_sharded_stream.py \
               /workspace/tpu_inference/tests/layers/common/test_kda_attention.py \
               /workspace/tpu_inference/tests/layers/common/test_kda_attention_dp.py
 

--- a/tests/models/jax/test_kimi_k3_sharded_stream.py
+++ b/tests/models/jax/test_kimi_k3_sharded_stream.py
@@ -1,0 +1,455 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Per-host sharded expert streaming: filter, gate, and decode guarantees.
+
+Covers the four load-bearing pieces of ``K3_SHARDED_EXPERT_STREAMING=1``:
+
+1. The needed-expert set derived from the kernels' sharding partitions the
+   experts across simulated hosts and matches the per-device index map the
+   shard decode itself uses.
+2. The filtered streaming requests cover exactly the kept tensors' byte
+   ranges (contiguous runs coalesced), and streaming them yields the kept
+   tensors bit-identically to ``safetensors.safe_open``.
+3. Decoding from a host's staged subset (non-local experts left ``None``)
+   is bit-identical to the full decode, and never touches an unstaged slot.
+4. The relaxed completeness gate waits on the local set only, and a needed
+   expert that never arrives fails loudly with its ids, not as a
+   half-loaded model.
+
+Needs 8 devices for the mesh shapes. On a host without them, run with
+``XLA_FLAGS=--xla_force_host_platform_device_count=8 JAX_PLATFORMS=cpu``.
+"""
+
+import json
+import struct
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import torch
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from safetensors import safe_open
+from safetensors.torch import save_file
+
+from tpu_inference import envs
+from tpu_inference.layers.common.quantization import (e8m0_to_fp32,
+                                                      u8_unpack_e2m1)
+from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
+from tpu_inference.layers.jax.moe.moe import MoEBackend
+from tpu_inference.layers.jax.quantization.mxfp4 import (
+    _SHARDED_STREAM_NEEDED_ATTR, CompressedTensorsMxfp4MoEMethod,
+    _staged_expert_bytes, _staging_complete)
+from tpu_inference.models.jax.utils.sharded_stream import (
+    build_filtered_requests, expert_id_from_tensor_name,
+    maybe_load_with_sharded_expert_streaming, needed_expert_ids,
+    validate_sharded_streaming_complete)
+
+EXPERT_AXIS = "attn_dp_expert"
+MODEL_AXIS = "model"
+
+# Staged checkpoint orientation is `[E, out, in]` with `in` packed 2 fp4 per
+# byte; the decoded kernel is `[E, in, out]`. Sizes divide by 8 the way K3's
+# do.
+NUM_EXPERTS = 8
+OUT = 64
+PACKED_IN = 128
+GROUP = 32
+
+EDF_SPEC = P(EXPERT_AXIS, None, MODEL_AXIS)
+EFD_SPEC = P(EXPERT_AXIS, MODEL_AXIS, None)
+
+
+def _mesh(num_expert: int, num_model: int) -> Mesh:
+    needed = num_expert * num_model
+    devices = jax.devices()
+    if len(devices) < needed:
+        pytest.skip(f"needs {needed} devices, have {len(devices)}")
+    sizes = {EXPERT_AXIS: num_expert, MODEL_AXIS: num_model}
+    shape = tuple(sizes.get(name, 1) for name in MESH_AXIS_NAMES)
+    grid = np.array(devices[:needed]).reshape(shape)
+    return Mesh(grid, axis_names=MESH_AXIS_NAMES)
+
+
+def _expert_groups(mesh: Mesh):
+    """Device lists per expert-axis coordinate: one simulated host each."""
+    axis = MESH_AXIS_NAMES.index(EXPERT_AXIS)
+    return [
+        list(np.take(mesh.devices, g, axis=axis).ravel())
+        for g in range(mesh.devices.shape[axis])
+    ]
+
+
+# --- 1. Needed-set derivation -------------------------------------------
+
+
+def test_expert_id_from_tensor_name():
+    name = ("language_model.model.layers.3.block_sparse_moe.experts.17.w1."
+            "weight_packed")
+    assert expert_id_from_tensor_name(name) == 17
+    assert expert_id_from_tensor_name("experts.0.w2.weight_scale") == 0
+    assert expert_id_from_tensor_name("model.embed_tokens.weight") is None
+    assert expert_id_from_tensor_name(
+        "model.layers.0.mlp.experts.gate") is None
+    assert expert_id_from_tensor_name(
+        "model.layers.0.mlp.shared_experts.w1.weight") is None
+
+
+@pytest.mark.parametrize("spec", (EDF_SPEC, EFD_SPEC))
+def test_needed_expert_ids_partitions_across_expert_groups(spec):
+    """Two simulated hosts' sets partition range(E) and follow the map."""
+    mesh = _mesh(2, 4)
+    groups = _expert_groups(mesh)
+    sets = [
+        needed_expert_ids(spec, mesh, NUM_EXPERTS, local_devices=group)
+        for group in groups
+    ]
+    assert sets[0] == frozenset(range(0, 4))
+    assert sets[1] == frozenset(range(4, 8))
+    assert sets[0] | sets[1] == frozenset(range(NUM_EXPERTS))
+    assert not sets[0] & sets[1]
+
+
+def test_needed_expert_ids_default_covers_all_addressable():
+    """Single process addresses the whole mesh, so the default is all E."""
+    mesh = _mesh(2, 4)
+    assert needed_expert_ids(EDF_SPEC, mesh,
+                             NUM_EXPERTS) == frozenset(range(NUM_EXPERTS))
+
+
+def test_needed_expert_ids_matches_devices_indices_map_ground_truth():
+    """Per device, the real staged-shape index map's expert slice is inside
+    the host set derived from the dummy-shape map."""
+    mesh = _mesh(2, 4)
+    named = NamedSharding(mesh, EDF_SPEC)
+    shape = (NUM_EXPERTS, PACKED_IN * 2, OUT)
+    index_map = named.devices_indices_map(shape)
+    for group in _expert_groups(mesh):
+        needed = needed_expert_ids(EDF_SPEC,
+                                   mesh,
+                                   NUM_EXPERTS,
+                                   local_devices=group)
+        for device in group:
+            expert_slice = index_map[device][0]
+            start = expert_slice.start or 0
+            stop = (expert_slice.stop
+                    if expert_slice.stop is not None else NUM_EXPERTS)
+            assert set(range(start, stop)) <= needed
+
+
+def test_needed_expert_ids_replicated_expert_axis_needs_everything():
+    """A spec that does not shard the expert axis keeps all experts local."""
+    mesh = _mesh(2, 4)
+    for group in _expert_groups(mesh):
+        needed = needed_expert_ids(P(None, None, MODEL_AXIS),
+                                   mesh,
+                                   NUM_EXPERTS,
+                                   local_devices=group)
+        assert needed == frozenset(range(NUM_EXPERTS))
+
+
+# --- 2. Filtered request construction and streaming ----------------------
+
+
+def _write_checkpoint(path):
+    """A small safetensors file with expert and non-expert tensors."""
+    g = torch.Generator().manual_seed(7)
+
+    def u8(*shape):
+        return torch.randint(0, 256, shape, dtype=torch.uint8, generator=g)
+
+    tensors = {}
+    for i in range(4):
+        tensors[f"model.layers.0.mlp.experts.{i}.w1.weight_packed"] = u8(
+            16, 32)
+    tensors["model.embed_tokens.weight"] = u8(8, 64)
+    for i in range(4, 8):
+        tensors[f"model.layers.0.mlp.experts.{i}.w1.weight_packed"] = u8(
+            16, 32)
+        tensors[f"model.layers.0.mlp.experts.{i}.w1.weight_scale"] = u8(16, 2)
+    tensors["lm_head.weight"] = u8(8, 64)
+    save_file(tensors, path)
+    return set(tensors)
+
+
+def _parse_metadata(path):
+    """`(data_start, [SafetensorMetadata by offset], [sizes])` from the raw
+    header, the same triple `prepare_request` builds."""
+    from runai_model_streamer.safetensors_streamer.safetensors_pytorch import \
+        SafetensorsMetadata
+
+    with open(path, "rb") as f:
+        header_size = struct.unpack("<Q", f.read(8))[0]
+        blob = json.loads(f.read(header_size))
+    meta = SafetensorsMetadata(blob, 8 + header_size)
+    return meta.offset, meta.tensors_metadata, meta.read_sizes
+
+
+KEEP_EXPERTS = frozenset({0, 1, 4, 5})
+
+
+def _keep(name):
+    expert_id = expert_id_from_tensor_name(name)
+    return expert_id is None or expert_id in KEEP_EXPERTS
+
+
+def test_build_filtered_requests_covers_exactly_the_kept_ranges(tmp_path):
+    pytest.importorskip("runai_model_streamer")
+    path = str(tmp_path / "model.safetensors")
+    _write_checkpoint(path)
+    data_start, tensors_metadata, sizes = _parse_metadata(path)
+
+    requests, id_to_meta, stats = build_filtered_requests(
+        [path], [(data_start, tensors_metadata, sizes)], _keep)
+
+    kept = [m for m in tensors_metadata if _keep(m.name)]
+    dropped = [m for m in tensors_metadata if not _keep(m.name)]
+    assert stats.total_tensors == len(tensors_metadata)
+    assert stats.kept_tensors == len(kept)
+    assert stats.kept_bytes == sum(m.get_bytesize() for m in kept)
+    assert stats.skipped_bytes == sum(m.get_bytesize() for m in dropped)
+    assert dropped, "filter dropped nothing; the test is vacuous"
+
+    # Every kept tensor appears exactly once, in a request whose byte range
+    # is the run's contiguous span.
+    covered = []
+    assert sorted(id_to_meta) == [r.id for r in requests]
+    for request in requests:
+        metas = id_to_meta[request.id]
+        assert request.chunks == [m.get_bytesize() for m in metas]
+        assert request.offset == data_start + metas[0].offsets.start
+        # Chunks within a request are contiguous in the file.
+        cursor = metas[0].offsets.start
+        for m in metas:
+            assert m.offsets.start == cursor
+            cursor = m.offsets.end
+        covered.extend(m.name for m in metas)
+    assert sorted(covered) == sorted(m.name for m in kept)
+
+    # Runs are maximal: consecutive requests are separated by at least one
+    # dropped tensor, so no two requests could have been merged.
+    boundaries = {m.offsets.start for m in dropped}
+    for first, second in zip(requests, requests[1:]):
+        gap_start = id_to_meta[first.id][-1].offsets.end
+        assert gap_start in boundaries
+
+
+def test_filtered_stream_yields_kept_tensors_bit_identically(tmp_path):
+    pytest.importorskip("runai_model_streamer")
+    from runai_model_streamer import SafetensorsStreamer
+
+    from tpu_inference.models.jax.utils.sharded_stream import _filtered_stream
+
+    path = str(tmp_path / "model.safetensors")
+    all_names = _write_checkpoint(path)
+    expected = {name for name in all_names if _keep(name)}
+    assert expected != all_names
+
+    got = {}
+    with SafetensorsStreamer() as streamer:
+        stats = _filtered_stream(streamer, [path], _keep)
+        for name, tensor in streamer.get_tensors():
+            got[name] = tensor.clone()
+    assert set(got) == expected
+    assert stats.kept_tensors == len(expected)
+
+    with safe_open(path, framework="pt") as f:
+        for name in expected:
+            assert torch.equal(got[name], f.get_tensor(name)), name
+
+
+# --- 3. Subset decode == full decode -------------------------------------
+
+
+def _stage(rng, out, packed_in, group):
+    packed = [
+        jnp.asarray(rng.integers(0, 256, (1, out, packed_in), dtype=np.uint8))
+        for _ in range(NUM_EXPERTS)
+    ]
+    scale = [
+        jnp.asarray(
+            rng.integers(0,
+                         256, (1, out, packed_in * 2 // group),
+                         dtype=np.uint8)) for _ in range(NUM_EXPERTS)
+    ]
+    return packed, scale
+
+
+def _slices(index, shape):
+    out = []
+    for s, size in zip(index, shape):
+        out.append(slice(s.start or 0, size if s.stop is None else s.stop))
+    return tuple(out)
+
+
+@pytest.mark.parametrize("spec", (EDF_SPEC, EFD_SPEC))
+def test_subset_decode_is_bit_identical_to_full_decode(spec):
+    """Each simulated host decodes from only its staged subset; every device
+    shard matches the full-staging host decode bit for bit."""
+    mesh = _mesh(2, 4)
+    rng = np.random.default_rng(11)
+    packed, scale = _stage(rng, OUT, PACKED_IN, GROUP)
+
+    full_values, full_scale = CompressedTensorsMxfp4MoEMethod._decode_on_host(
+        packed, scale, spec, mesh)
+    np_full_values = np.asarray(full_values).view(np.uint8)
+    np_full_scale = np.asarray(full_scale).view(np.uint32)
+
+    named = NamedSharding(mesh, spec)
+    for staged, decode, expansion, np_full, raw in (
+        (packed, u8_unpack_e2m1, 2, np_full_values, np.uint8),
+        (scale, e8m0_to_fp32, 1, np_full_scale, np.uint32),
+    ):
+        packed_in = staged[0].shape[-1]
+        shape = (NUM_EXPERTS, packed_in * expansion, OUT)
+        index_map = named.devices_indices_map(shape)
+        for group in _expert_groups(mesh):
+            needed = needed_expert_ids(spec,
+                                       mesh,
+                                       NUM_EXPERTS,
+                                       local_devices=group)
+            subset = [w if i in needed else None for i, w in enumerate(staged)]
+            cache = {}
+            for device in group:
+                expert_slice, in_slice, out_slice = _slices(
+                    index_map[device], shape)
+                assert in_slice.start % expansion == 0
+                assert in_slice.stop % expansion == 0
+                packed_slice = slice(in_slice.start // expansion,
+                                     in_slice.stop // expansion)
+                # The gather `_decode_sharded` performs, from the subset:
+                # absent experts must never be touched (they would raise).
+                local = np.concatenate([
+                    _staged_expert_bytes(subset, cache, e)[:, out_slice,
+                                                           packed_slice]
+                    for e in range(expert_slice.start, expert_slice.stop)
+                ],
+                                       axis=0)
+                shard = np.asarray(
+                    jnp.swapaxes(decode(jnp.asarray(local)), 1, 2)).view(raw)
+                want = np_full[expert_slice, in_slice, out_slice]
+                assert shard.shape == want.shape
+                assert np.array_equal(shard, want), (
+                    f"{spec} {device}: subset-decoded shard differs from "
+                    f"the full decode")
+
+
+def test_gather_raises_loudly_on_an_unstaged_needed_expert():
+    staged = [
+        jnp.zeros((1, 4, 4), dtype=jnp.uint8), None, None,
+        jnp.zeros((1, 4, 4), dtype=jnp.uint8)
+    ]
+    cache = {}
+    _staged_expert_bytes(staged, cache, 0)  # staged: fine
+    with pytest.raises(ValueError, match=r"\[mxfp4-ct\] expert 2"):
+        _staged_expert_bytes(staged, cache, 2)
+
+
+# --- 4. Completeness gate and the loud missing-expert failure -------------
+
+
+def _param(weights):
+    return SimpleNamespace(_weights_to_load=list(weights))
+
+
+_STAGED_ATTRS = ("gate_packed", "gate_scale", "up_packed", "up_scale",
+                 "down_packed", "down_scale")
+
+
+def _fake_layer(staged_slots, needed=None, prefix="layers.0.mlp"):
+    """A stand-in MoE layer: six staging attrs sharing one slot pattern."""
+    layer = SimpleNamespace(prefix=prefix, moe_backend=MoEBackend.DENSE_MAT)
+    for attr in _STAGED_ATTRS:
+        setattr(layer, attr, _param(staged_slots))
+    if needed is not None:
+        setattr(layer, _SHARDED_STREAM_NEEDED_ATTR, frozenset(needed))
+    layer.quant_method = CompressedTensorsMxfp4MoEMethod(layer)
+    return layer
+
+
+W = object()  # any staged (non-None) sentinel
+
+
+def test_gate_without_needed_set_requires_every_expert():
+    assert _staging_complete(_fake_layer([W, W, W, W]), list(_STAGED_ATTRS))
+    assert not _staging_complete(_fake_layer([W, W, None, W]),
+                                 list(_STAGED_ATTRS))
+
+
+def test_gate_with_needed_set_waits_on_local_experts_only():
+    # Non-local experts 2,3 never arrive; the relaxed gate must pass.
+    assert _staging_complete(_fake_layer([W, W, None, None], needed={0, 1}),
+                             list(_STAGED_ATTRS))
+    # A missing LOCAL expert must hold the gate.
+    assert not _staging_complete(
+        _fake_layer([W, None, None, None], needed={0, 1}), list(_STAGED_ATTRS))
+
+
+def _fake_model(*layers):
+    return SimpleNamespace(named_modules=lambda: [(
+        f"model.layers.{i}.mlp", layer) for i, layer in enumerate(layers)])
+
+
+def test_missing_local_expert_fails_loudly_after_load():
+    bad = _fake_layer([W, None, None, None], needed={0, 1})
+    with pytest.raises(ValueError,
+                       match=r"\[mxfp4\].*missing local expert ids \[1\]"):
+        validate_sharded_streaming_complete(_fake_model(bad))
+
+
+def test_decoded_layer_passes_validation():
+    # Healthy end state: the decode ran and deleted the staging attributes.
+    decoded = _fake_layer([W, W, None, None], needed={0, 1})
+    for attr in _STAGED_ATTRS:
+        delattr(decoded, attr)
+    validate_sharded_streaming_complete(_fake_model(decoded))
+    # Layers never marked for sharded streaming are not validated here; the
+    # unrelaxed gate already guarantees all-experts staging for them.
+    unmarked = _fake_layer([W, None, None, None])
+    validate_sharded_streaming_complete(_fake_model(unmarked))
+
+
+def test_undecoded_layer_with_complete_staging_still_fails():
+    # Validation runs after the load: staging attributes still present means
+    # the decode never fired, even when every local expert arrived.
+    stuck = _fake_layer([W, W, None, None], needed={0, 1})
+    with pytest.raises(ValueError, match="decode never ran"):
+        validate_sharded_streaming_complete(_fake_model(stuck))
+
+
+def test_host_decode_with_filtered_staging_is_refused(monkeypatch):
+    layer = _fake_layer([W, W, None, None], needed={0, 1})
+    monkeypatch.setattr(envs, "MXFP4_SHARD_THEN_DECODE", False, raising=False)
+    with pytest.raises(ValueError, match="MXFP4_SHARD_THEN_DECODE"):
+        layer.quant_method.process_weights_after_loading(layer)
+
+
+def test_flag_off_is_a_noop(monkeypatch):
+    monkeypatch.setattr(envs,
+                        "K3_SHARDED_EXPERT_STREAMING",
+                        False,
+                        raising=False)
+    # Nothing may be touched when the flag is off: passing junk proves it.
+    assert maybe_load_with_sharded_expert_streaming(None, None, None) is False
+
+
+def test_flag_on_with_non_runai_loader_falls_back(monkeypatch):
+    monkeypatch.setattr(envs,
+                        "K3_SHARDED_EXPERT_STREAMING",
+                        True,
+                        raising=False)
+    assert maybe_load_with_sharded_expert_streaming(object(), None,
+                                                    None) is False

--- a/tests/models/jax/test_kimi_k3_sharded_stream.py
+++ b/tests/models/jax/test_kimi_k3_sharded_stream.py
@@ -52,11 +52,12 @@ from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
 from tpu_inference.layers.jax.moe.moe import MoEBackend
 from tpu_inference.layers.jax.quantization.mxfp4 import (
     _SHARDED_STREAM_NEEDED_ATTR, CompressedTensorsMxfp4MoEMethod,
-    _staged_expert_bytes, _staging_complete)
+    _decode_one_shard, _staged_expert_bytes, _staged_layer_shape,
+    _staging_complete)
 from tpu_inference.models.jax.utils.sharded_stream import (
     build_filtered_requests, expert_id_from_tensor_name,
     maybe_load_with_sharded_expert_streaming, needed_expert_ids,
-    validate_sharded_streaming_complete)
+    plan_sharded_expert_streaming, validate_sharded_streaming_complete)
 
 EXPERT_AXIS = "attn_dp_expert"
 MODEL_AXIS = "model"
@@ -298,7 +299,16 @@ def _slices(index, shape):
 @pytest.mark.parametrize("spec", (EDF_SPEC, EFD_SPEC))
 def test_subset_decode_is_bit_identical_to_full_decode(spec):
     """Each simulated host decodes from only its staged subset; every device
-    shard matches the full-staging host decode bit for bit."""
+    shard matches the full-staging host decode bit for bit.
+
+    This drives the REAL shard path -- `_staged_layer_shape` for the shape
+    (the None-tolerant template derivation) and `_decode_one_shard` for the
+    gather + on-device decode, exactly what `_decode_sharded` runs per
+    device -- with a None-holed staged list, restricted to the simulated
+    host's devices via the sharding's own device->index map. Only the final
+    cross-host array assembly is not exercised, because a single process
+    cannot hold a subset of a mesh's addressable shards.
+    """
     mesh = _mesh(2, 4)
     rng = np.random.default_rng(11)
     packed, scale = _stage(rng, OUT, PACKED_IN, GROUP)
@@ -313,34 +323,27 @@ def test_subset_decode_is_bit_identical_to_full_decode(spec):
         (packed, u8_unpack_e2m1, 2, np_full_values, np.uint8),
         (scale, e8m0_to_fp32, 1, np_full_scale, np.uint32),
     ):
-        packed_in = staged[0].shape[-1]
-        shape = (NUM_EXPERTS, packed_in * expansion, OUT)
-        index_map = named.devices_indices_map(shape)
         for group in _expert_groups(mesh):
             needed = needed_expert_ids(spec,
                                        mesh,
                                        NUM_EXPERTS,
                                        local_devices=group)
             subset = [w if i in needed else None for i, w in enumerate(staged)]
+            # The production shape derivation, on the holed list. Expert 0
+            # is None for the second host's subset, so `staged[0].shape`
+            # would crash here -- that is the point.
+            shape = _staged_layer_shape(subset, expansion)
+            assert shape == (NUM_EXPERTS, staged[0].shape[-1] * expansion, OUT)
+            index_map = named.devices_indices_map(shape)
             cache = {}
             for device in group:
-                expert_slice, in_slice, out_slice = _slices(
-                    index_map[device], shape)
-                assert in_slice.start % expansion == 0
-                assert in_slice.stop % expansion == 0
-                packed_slice = slice(in_slice.start // expansion,
-                                     in_slice.stop // expansion)
-                # The gather `_decode_sharded` performs, from the subset:
-                # absent experts must never be touched (they would raise).
-                local = np.concatenate([
-                    _staged_expert_bytes(subset, cache, e)[:, out_slice,
-                                                           packed_slice]
-                    for e in range(expert_slice.start, expert_slice.stop)
-                ],
-                                       axis=0)
                 shard = np.asarray(
-                    jnp.swapaxes(decode(jnp.asarray(local)), 1, 2)).view(raw)
-                want = np_full[expert_slice, in_slice, out_slice]
+                    _decode_one_shard(subset, cache, decode, expansion, shape,
+                                      device, index_map[device])).view(raw)
+                # `_decode_one_shard` returns the decoded-and-transposed
+                # `[e, in, out]` shard; compare against the same slice of
+                # the full-staging host decode.
+                want = np_full[_slices(index_map[device], shape)]
                 assert shard.shape == want.shape
                 assert np.array_equal(shard, want), (
                     f"{spec} {device}: subset-decoded shard differs from "
@@ -453,3 +456,157 @@ def test_flag_on_with_non_runai_loader_falls_back(monkeypatch):
                         raising=False)
     assert maybe_load_with_sharded_expert_streaming(object(), None,
                                                     None) is False
+
+
+def test_flag_on_with_distributed_runai_loader_falls_back(monkeypatch):
+    # The runai distributed mode re-broadcasts every chunk to all ranks and
+    # would fight the per-host filter; the loader must fall back.
+    from vllm.model_executor.model_loader.runai_streamer_loader import \
+        RunaiModelStreamerLoader
+    monkeypatch.setattr(envs,
+                        "K3_SHARDED_EXPERT_STREAMING",
+                        True,
+                        raising=False)
+    loader = object.__new__(RunaiModelStreamerLoader)
+    loader._is_distributed = True
+    assert maybe_load_with_sharded_expert_streaming(loader, None,
+                                                    None) is False
+
+
+# --- 5. Dropped tensors must be accounted for by a marked layer -----------
+
+
+def test_dropped_names_must_belong_to_a_marked_layer():
+    # The marked layer's prefix is spelled the way Kimi-K3 spells it; the
+    # dropped names carry the checkpoint's extra wrapper prefix.
+    marked = _fake_layer([W, W, None, None],
+                         needed={0, 1},
+                         prefix="model.layers.0.block_sparse_moe.experts")
+    for attr in _STAGED_ATTRS:
+        delattr(marked, attr)
+    model = _fake_model(marked)
+
+    covered = [
+        "language_model.model.layers.0.block_sparse_moe.experts.2.w1"
+        ".weight_packed",
+        "language_model.model.layers.0.block_sparse_moe.experts.3.w2"
+        ".weight_scale",
+    ]
+    validate_sharded_streaming_complete(model, dropped_names=covered)
+
+    # An expert tensor of a module that is NOT a marked MXFP4 MoE layer
+    # would silently keep its initialization weights -- must fail loudly.
+    foreign = covered + [
+        "vision_tower.blocks.1.moe.experts.7.w1.weight",
+    ]
+    with pytest.raises(ValueError, match=r"\[sharded-stream\].*vision_tower"):
+        validate_sharded_streaming_complete(model, dropped_names=foreign)
+
+
+def test_dropped_name_guard_accepts_module_tree_name(monkeypatch):
+    # Marked layers are also matched by their module-tree name (the fake
+    # model names them model.layers.<i>.mlp), with or without the trailing
+    # `.experts` segment in the dropped name's stem.
+    marked = _fake_layer([W, W, None, None], needed={0, 1}, prefix="")
+    for attr in _STAGED_ATTRS:
+        delattr(marked, attr)
+    model = _fake_model(marked)
+    validate_sharded_streaming_complete(
+        model,
+        dropped_names=[
+            "wrapper.model.layers.0.mlp.experts.3.w1.weight_packed"
+        ])
+
+
+# --- 6. Stream-count and zero-byte-run guards -----------------------------
+
+
+class _FakeOffsets:
+
+    def __init__(self, start, end):
+        self.start, self.end = start, end
+
+
+class _FakeMeta:
+
+    def __init__(self, name, start, end):
+        self.name = name
+        self.offsets = _FakeOffsets(start, end)
+
+    def get_bytesize(self):
+        return self.offsets.end - self.offsets.start
+
+
+def test_zero_byte_run_is_refused_loudly():
+    # A kept run consisting solely of zero-byte tensors cannot be submitted
+    # to the streamer (an all-empty request reads as end-of-queue) and must
+    # not be dropped silently.
+    metas = [
+        _FakeMeta("model.a", 0, 0),
+        _FakeMeta("model.layers.0.mlp.experts.0.w1.weight_packed", 0, 4),
+    ]
+    with pytest.raises(ValueError, match=r"\[sharded-stream\].*zero-byte"):
+        build_filtered_requests(
+            ["f"], [(8, metas, [0, 4])],
+            lambda name: expert_id_from_tensor_name(name) is None)
+
+
+def test_stream_yield_count_mismatch_fails_loudly(tmp_path, monkeypatch):
+    pytest.importorskip("runai_model_streamer")
+    import tpu_inference.models.jax.utils.sharded_stream as ss
+
+    path = str(tmp_path / "model.safetensors")
+    _write_checkpoint(path)
+
+    real_filtered_stream = ss._filtered_stream
+
+    def inflated(streamer, paths, keep, device="cpu"):
+        stats = real_filtered_stream(streamer, paths, keep, device)
+        stats.kept_tensors += 1  # claim one more tensor than will arrive
+        return stats
+
+    monkeypatch.setattr(ss, "_filtered_stream", inflated)
+    with pytest.raises(ValueError, match=r"\[sharded-stream\].*yielded"):
+        list(
+            ss.sharded_expert_weights_iterator([path], KEEP_EXPERTS,
+                                               NUM_EXPERTS))
+
+
+# --- 7. Disagreeing layers fall back instead of raising -------------------
+
+
+def _fake_planned_layer(mesh, num_experts):
+    layer = SimpleNamespace(prefix="model.layers.x.mlp.experts",
+                            moe_backend=MoEBackend.DENSE_MAT,
+                            edf_sharding=EDF_SPEC,
+                            efd_sharding=EFD_SPEC,
+                            mesh=mesh,
+                            num_local_experts=num_experts)
+    layer.quant_method = CompressedTensorsMxfp4MoEMethod(layer)
+    return layer
+
+
+def test_plan_falls_back_and_marks_nothing_when_layers_disagree():
+    mesh = _mesh(2, 4)
+    agree = _fake_planned_layer(mesh, NUM_EXPERTS)
+    disagree = _fake_planned_layer(mesh, NUM_EXPERTS * 2)
+    model = _fake_model(agree, disagree)
+    assert plan_sharded_expert_streaming(model) is None
+    # Nothing may be marked: a relaxed gate without the filter running
+    # would decode from partial staging under the stock full read.
+    for layer in (agree, disagree):
+        assert getattr(layer, _SHARDED_STREAM_NEEDED_ATTR, None) is None
+
+
+def test_plan_marks_every_layer_when_they_agree():
+    mesh = _mesh(2, 4)
+    layers = [
+        _fake_planned_layer(mesh, NUM_EXPERTS),
+        _fake_planned_layer(mesh, NUM_EXPERTS)
+    ]
+    model = _fake_model(*layers)
+    needed, num_experts = plan_sharded_expert_streaming(model)
+    assert num_experts == NUM_EXPERTS
+    assert needed == frozenset(range(NUM_EXPERTS))  # single process = all
+    for layer in layers:
+        assert getattr(layer, _SHARDED_STREAM_NEEDED_ATTR) == needed

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -27,6 +27,7 @@ if TYPE_CHECKING:
     USE_UNFUSED_MEGABLOCKS: bool = False
     USE_DENSE_MOE: bool = False
     MXFP4_SHARD_THEN_DECODE: bool = True
+    K3_SHARDED_EXPERT_STREAMING: bool = False
     NUM_SLICES: int = 1
     RAY_USAGE_STATS_ENABLED: bool = False
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: str = "shm"
@@ -284,6 +285,16 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # host decode.
     "MXFP4_SHARD_THEN_DECODE":
     env_bool("MXFP4_SHARD_THEN_DECODE", default=True),
+    # Stream only this host's routed-expert tensors from the checkpoint when
+    # loading compressed-tensors MXFP4 MoE weights through the runai streamer.
+    # Each expert's bytes are read only by the hosts whose devices keep a
+    # shard of it (derived from the expert kernels' sharding), instead of
+    # every host reading every expert and slicing after the bytes arrived.
+    # With experts sharded E-ways across hosts this cuts the per-host read of
+    # the expert bytes (the overwhelming majority of a large MoE checkpoint)
+    # by ~E x. Default off: the full-read path is unchanged unless opted in.
+    "K3_SHARDED_EXPERT_STREAMING":
+    env_bool("K3_SHARDED_EXPERT_STREAMING", default=False),
     # Number of TPU slices for multi-slice mesh
     "NUM_SLICES":
     lambda: int(os.getenv("NUM_SLICES") or "1"),

--- a/tpu_inference/layers/jax/quantization/mxfp4.py
+++ b/tpu_inference/layers/jax/quantization/mxfp4.py
@@ -304,6 +304,35 @@ _CT_FINAL_ATTRS = {
     "down_proj": "kernel_down_proj_EFD",
 }
 
+# Attribute set by the sharded-expert-streaming loader (see
+# `models/jax/utils/sharded_stream.py`) naming the expert ids this host's
+# devices keep. When present, only those staging slots can ever be filled --
+# the checkpoint filter dropped the rest before their bytes were read -- so
+# the completeness gate below waits on the local set instead of all experts.
+_SHARDED_STREAM_NEEDED_ATTR = "_sharded_stream_needed_experts"
+
+
+def _staging_complete(layer, staged_attrs: list[str]) -> bool:
+    """Whether every expert slot this decode will touch has been staged.
+
+    Full-read loading (the default) requires every expert of every staging
+    attribute: expert weights can be split across safetensors files, so an
+    unfilled slot just means a later file has not streamed in yet. Under
+    sharded expert streaming, non-local experts are filtered out of the read
+    entirely and their slots stay `None` forever; the gate then requires
+    exactly the host's needed set, which `_decode_sharded` alone touches.
+    """
+    needed = getattr(layer, _SHARDED_STREAM_NEEDED_ATTR, None)
+    for attr in staged_attrs:
+        staged = getattr(layer, attr)._weights_to_load
+        if needed is None:
+            if any(w is None for w in staged):
+                return False
+        else:
+            if any(staged[i] is None for i in needed):
+                return False
+    return True
+
 
 def _named_sharding(sharding, mesh: Mesh) -> NamedSharding:
     """Normalize the spellings `shard_put` accepts into a `NamedSharding`."""
@@ -358,6 +387,36 @@ def _decode_executable(decode: Callable, shape: tuple[int, ...],
     return executable
 
 
+def _staged_expert_bytes(staged: list, cache: dict, expert_id: int):
+    """The staged packed bytes of one expert, as numpy, materialized lazily.
+
+    With sharded expert streaming only this host's experts are staged (the
+    rest stay `None`), so the numpy views are built per expert as a shard
+    loop first touches it rather than for the whole list up front -- an
+    absent non-local expert must never be converted. Touching a `None` slot
+    means a shard needs an expert that never arrived; fail with the ids so
+    the log alone identifies what is missing.
+    """
+    arr = cache.get(expert_id)
+    if arr is None:
+        w = staged[expert_id]
+        if w is None:
+            present = [i for i, s in enumerate(staged) if s is not None]
+            raise ValueError(
+                f"[mxfp4-ct] expert {expert_id} is needed by a local device "
+                f"shard but was never staged; {len(present)} of "
+                f"{len(staged)} experts arrived "
+                f"(first staged ids: {present[:8]}). With sharded expert "
+                f"streaming this means the checkpoint filter dropped an "
+                f"expert this host's devices keep.")
+        # numpy view of the staged tensor: the per-shard gather is pure
+        # slicing and concatenation, which numpy does without a jax dispatch
+        # per expert (there are hundreds of experts per shard).
+        arr = np.asarray(w)
+        cache[expert_id] = arr
+    return arr
+
+
 def _decode_sharded(staged: list[jax.Array], decode: Callable, expansion: int,
                     sharding, mesh: Mesh) -> jax.Array:
     """Build one decoded, sharded expert tensor a device shard at a time.
@@ -376,18 +435,22 @@ def _decode_sharded(staged: list[jax.Array], decode: Callable, expansion: int,
     whole-layer decode would have produced -- while the host never
     materializes the ~4.5x-larger decoded layer, only packed bytes cross the
     host/device boundary, and each process touches just the experts its own
-    devices keep instead of all of them.
+    devices keep instead of all of them. Under sharded expert streaming,
+    `staged` may hold `None` for experts no local device keeps; the shard
+    loop below never reaches them.
     """
     num_experts = len(staged)
-    _, out, packed_in = staged[0].shape
+    template = next((w for w in staged if w is not None), None)
+    if template is None:
+        raise ValueError(
+            "[mxfp4-ct] no experts staged for this layer at all; cannot "
+            "infer the expert tensor shape. The weights iterator yielded "
+            "nothing for this projection.")
+    _, out, packed_in = template.shape
     shape = (num_experts, packed_in * expansion, out)
     sharding = _named_sharding(sharding, mesh)
 
-    # numpy views of the staged tensors: the per-shard gather below is pure
-    # slicing and concatenation, which numpy does without a jax dispatch per
-    # expert (there are hundreds of experts per shard).
-    source = [np.asarray(w) for w in staged]
-
+    source: dict = {}
     shards = []
     for device, index in sharding.addressable_devices_indices_map(
             shape).items():
@@ -403,8 +466,8 @@ def _decode_sharded(staged: list[jax.Array], decode: Callable, expansion: int,
                              in_slice.stop // expansion)
         # `[e, out, in_]` for the experts this device keeps, still packed.
         local = np.concatenate([
-            w[:, out_slice, packed_slice]
-            for w in source[expert_slice.start:expert_slice.stop]
+            _staged_expert_bytes(staged, source, e)[:, out_slice, packed_slice]
+            for e in range(expert_slice.start, expert_slice.stop)
         ],
                                axis=0)
         executable = _decode_executable(decode, local.shape, device)
@@ -518,10 +581,20 @@ class CompressedTensorsMxfp4MoEMethod(QuantizeMethodBase, FusedMoEMethodBase):
     def process_weights_after_loading(self, layer: JaxMoE) -> bool:
         """Decode the staged tensors into device-resident fp4 + fp32 scales."""
         staged_attrs = [a for pair in _CT_STAGED_ATTRS.values() for a in pair]
-        if not all(
-                all(w is not None
-                    for w in getattr(layer, attr)._weights_to_load)
-                for attr in staged_attrs):
+        needed = getattr(layer, _SHARDED_STREAM_NEEDED_ATTR, None)
+        if needed is not None and not envs.MXFP4_SHARD_THEN_DECODE:
+            # `_decode_on_host` concatenates every expert; with only the
+            # local set staged it would crash on the `None` slots (or worse,
+            # silently mis-index). The streaming loader refuses to filter
+            # when the host decode is selected, so reaching here means the
+            # two flags changed between marking and decoding.
+            raise ValueError(
+                f"[mxfp4-ct] {layer.prefix}: sharded expert streaming staged "
+                f"only {len(needed)} local experts, but "
+                f"MXFP4_SHARD_THEN_DECODE=0 selects the host decode, which "
+                f"needs all of them. Unset K3_SHARDED_EXPERT_STREAMING or "
+                f"set MXFP4_SHARD_THEN_DECODE=1.")
+        if not _staging_complete(layer, staged_attrs):
             # Expert weights can be split across safetensors files, so this is
             # called more than once; wait until every expert has arrived.
             return False

--- a/tpu_inference/layers/jax/quantization/mxfp4.py
+++ b/tpu_inference/layers/jax/quantization/mxfp4.py
@@ -417,6 +417,55 @@ def _staged_expert_bytes(staged: list, cache: dict, expert_id: int):
     return arr
 
 
+def _staged_layer_shape(staged: list, expansion: int) -> tuple[int, int, int]:
+    """The decoded `[E, in_ * expansion, out]` shape of one staged layer.
+
+    Derived from the first staged expert rather than `staged[0]`: under
+    sharded expert streaming only this host's experts are staged and expert
+    0 need not be one of them.
+    """
+    template = next((w for w in staged if w is not None), None)
+    if template is None:
+        raise ValueError(
+            "[mxfp4-ct] no experts staged for this layer at all; cannot "
+            "infer the expert tensor shape. The weights iterator yielded "
+            "nothing for this projection.")
+    _, out, packed_in = template.shape
+    return (len(staged), packed_in * expansion, out)
+
+
+def _decode_one_shard(staged: list, source_cache: dict, decode: Callable,
+                      expansion: int, shape: tuple[int, int, int],
+                      device: jax.Device, index) -> jax.Array:
+    """Gather one device's packed slice out of `staged` and decode it there.
+
+    `index` is the device's entry in the sharding's device->index map over
+    the decoded `shape`. Only the experts in the device's expert slice are
+    touched, so staged slots no local device needs may be `None`.
+    """
+    num_experts, in_total, out = shape
+    expert_slice = _full_slice(index[0], num_experts)
+    in_slice = _full_slice(index[1], in_total)
+    out_slice = _full_slice(index[2], out)
+    if in_slice.start % expansion or in_slice.stop % expansion:
+        raise ValueError(
+            f"[mxfp4-ct] shard {in_slice} of the {shape} decoded tensor "
+            f"splits a packed uint8 word ({expansion} values each); "
+            f"cannot decode this shard on its own.")
+    packed_slice = slice(in_slice.start // expansion,
+                         in_slice.stop // expansion)
+    # `[e, out, in_]` for the experts this device keeps, still packed.
+    local = np.concatenate([
+        _staged_expert_bytes(staged, source_cache, e)[:, out_slice,
+                                                      packed_slice]
+        for e in range(expert_slice.start, expert_slice.stop)
+    ],
+                           axis=0)
+    executable = _decode_executable(decode, local.shape, device)
+    with jax.set_mesh(_one_device_mesh(device)):
+        return executable(jax.device_put(local, device))
+
+
 def _decode_sharded(staged: list[jax.Array], decode: Callable, expansion: int,
                     sharding, mesh: Mesh) -> jax.Array:
     """Build one decoded, sharded expert tensor a device shard at a time.
@@ -439,40 +488,15 @@ def _decode_sharded(staged: list[jax.Array], decode: Callable, expansion: int,
     `staged` may hold `None` for experts no local device keeps; the shard
     loop below never reaches them.
     """
-    num_experts = len(staged)
-    template = next((w for w in staged if w is not None), None)
-    if template is None:
-        raise ValueError(
-            "[mxfp4-ct] no experts staged for this layer at all; cannot "
-            "infer the expert tensor shape. The weights iterator yielded "
-            "nothing for this projection.")
-    _, out, packed_in = template.shape
-    shape = (num_experts, packed_in * expansion, out)
+    shape = _staged_layer_shape(staged, expansion)
     sharding = _named_sharding(sharding, mesh)
 
     source: dict = {}
-    shards = []
-    for device, index in sharding.addressable_devices_indices_map(
-            shape).items():
-        expert_slice = _full_slice(index[0], num_experts)
-        in_slice = _full_slice(index[1], packed_in * expansion)
-        out_slice = _full_slice(index[2], out)
-        if in_slice.start % expansion or in_slice.stop % expansion:
-            raise ValueError(
-                f"[mxfp4-ct] shard {in_slice} of the {shape} decoded tensor "
-                f"splits a packed uint8 word ({expansion} values each); "
-                f"cannot decode this shard on its own.")
-        packed_slice = slice(in_slice.start // expansion,
-                             in_slice.stop // expansion)
-        # `[e, out, in_]` for the experts this device keeps, still packed.
-        local = np.concatenate([
-            _staged_expert_bytes(staged, source, e)[:, out_slice, packed_slice]
-            for e in range(expert_slice.start, expert_slice.stop)
-        ],
-                               axis=0)
-        executable = _decode_executable(decode, local.shape, device)
-        with jax.set_mesh(_one_device_mesh(device)):
-            shards.append(executable(jax.device_put(local, device)))
+    shards = [
+        _decode_one_shard(staged, source, decode, expansion, shape, device,
+                          index) for device, index in
+        sharding.addressable_devices_indices_map(shape).items()
+    ]
     return jax.make_array_from_single_device_arrays(shape, sharding, shards)
 
 

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -41,6 +41,8 @@ from tpu_inference.models.jax.utils.qwix.qwix_utils import (
     apply_qwix_on_abstract_model, apply_qwix_quantization,
     load_random_weights_into_qwix_abstract_model,
     update_vllm_config_for_qwix_quantization)
+from tpu_inference.models.jax.utils.sharded_stream import \
+    maybe_load_with_sharded_expert_streaming
 from tpu_inference.models.jax.utils.weight_utils import (BaseWeightLoader,
                                                          LoadableWithIterator)
 from tpu_inference.runner.mm_encoder_jit_manager import \
@@ -287,7 +289,13 @@ def _get_nnx_model(
             loader = get_model_loader(vllm_config.load_config)
             if isinstance(model, LoadableWithIterator):
                 assert isinstance(model, JaxModule)
-                loader.load_weights(model, model_config)
+                # Opt-in (K3_SHARDED_EXPERT_STREAMING=1): stream only the
+                # routed-expert tensors this host's devices keep instead of
+                # the whole checkpoint; returns False (and logs why) when it
+                # does not apply, leaving the stock path untouched.
+                if not maybe_load_with_sharded_expert_streaming(
+                        loader, model, model_config):
+                    loader.load_weights(model, model_config)
             elif isinstance(loader, RunaiModelStreamerLoader):
                 model_weights = model_config.model
                 if hasattr(model_config, "model_weights"):

--- a/tpu_inference/models/jax/utils/sharded_stream.py
+++ b/tpu_inference/models/jax/utils/sharded_stream.py
@@ -46,7 +46,7 @@ This module removes that waste at the request level, opt-in via
 """
 
 import re
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Callable, Iterable, Optional
 
 import jax
@@ -131,6 +131,9 @@ class FilterStats:
     total_tensors: int = 0
     kept_bytes: int = 0
     skipped_bytes: int = 0
+    # Every dropped tensor name, so the post-load validation can prove each
+    # one belonged to a layer whose decode gate knows about the filtering.
+    dropped_names: list = field(default_factory=list)
 
 
 def build_filtered_requests(paths: list[str], safetensors_metadatas: list,
@@ -165,9 +168,18 @@ def build_filtered_requests(paths: list[str], safetensors_metadatas: list,
                 return
             if sum(run_sizes) == 0:
                 # The streamer's request iterator treats an all-empty request
-                # as end-of-queue; zero-byte tensors carry no data to read
-                # anyway.
-                return
+                # as end-of-queue, so a run consisting solely of zero-byte
+                # tensors cannot be submitted -- and silently dropping it
+                # would starve `get_tensors` of those names. No real
+                # checkpoint stores zero-byte expert neighbours; refuse
+                # loudly rather than mis-stream.
+                raise ValueError(
+                    "[sharded-stream] a contiguous run of kept tensors is "
+                    "entirely zero-byte, which the filtered streamer cannot "
+                    "submit: "
+                    f"{[m.name for m in run_meta][:8]}. Unset "
+                    "K3_SHARDED_EXPERT_STREAMING to load this checkpoint "
+                    "with the stock full read.")
             request_id = len(requests)
             requests.append(
                 FileChunks(request_id, path, file_offset + run_start,
@@ -187,6 +199,7 @@ def build_filtered_requests(paths: list[str], safetensors_metadatas: list,
                 flush()
                 run_meta, run_sizes = [], []
                 stats.skipped_bytes += size
+                stats.dropped_names.append(meta.name)
         flush()
 
     return requests, id_to_meta, stats
@@ -221,10 +234,16 @@ def _filtered_stream(streamer,
 def sharded_expert_weights_iterator(hf_weights_files: list[str],
                                     needed_experts: frozenset,
                                     num_experts: int,
-                                    use_tqdm_on_load: bool = False):
+                                    use_tqdm_on_load: bool = False,
+                                    dropped_names_sink: Optional[list] = None):
     """Yield `(name, torch.Tensor)` like the stock runai iterator, but only
     reading the expert tensors this host's devices keep (plus every
-    non-expert tensor)."""
+    non-expert tensor).
+
+    `dropped_names_sink`, when given, receives every dropped tensor name so
+    the caller can validate after the load that each one belonged to a layer
+    whose decode gate expects the filtering.
+    """
     from runai_model_streamer import SafetensorsStreamer
     from tqdm.auto import tqdm
 
@@ -234,6 +253,8 @@ def sharded_expert_weights_iterator(hf_weights_files: list[str],
 
     with SafetensorsStreamer() as streamer:
         stats = _filtered_stream(streamer, hf_weights_files, keep)
+        if dropped_names_sink is not None:
+            dropped_names_sink.extend(stats.dropped_names)
         logger.info(
             "[sharded-stream] process %d streams %d/%d routed experts: "
             "keeping %d/%d checkpoint tensors (%.1f GiB), skipping %.1f GiB "
@@ -246,11 +267,22 @@ def sharded_expert_weights_iterator(hf_weights_files: list[str],
                            desc="Loading safetensors (sharded expert read)",
                            disable=not use_tqdm_on_load,
                            mininterval=2)
+        yielded = 0
         for name, tensor in tensor_iter:
+            yielded += 1
             # The streamer reuses its CPU buffer across requests; detach the
             # tensor from it before handing it out, as the stock iterator
             # does.
             yield name, tensor.clone()
+        if yielded != stats.kept_tensors:
+            # A silent shortfall here would surface much later as a
+            # partially-initialized model (or not at all); convert any
+            # request/metadata misalignment into a load failure.
+            raise ValueError(
+                f"[sharded-stream] the filtered stream yielded {yielded} "
+                f"tensors but the request filter kept {stats.kept_tensors}; "
+                f"the streamer dropped or duplicated part of the "
+                f"checkpoint. Unset K3_SHARDED_EXPERT_STREAMING and reload.")
 
 
 def _mxfp4_moe_layers(model):
@@ -273,6 +305,11 @@ def plan_sharded_expert_streaming(model) -> Optional[tuple[frozenset, int]]:
     if not layers:
         return None
 
+    # Two passes: compute every layer's set first, mark only if they all
+    # agree. Marking any layer relaxes its decode gate, which is only sound
+    # when the filter (driven by the shared set) actually runs -- so on
+    # disagreement nothing may be marked and the caller falls back to the
+    # stock full read, whose unrelaxed gates need no filter.
     needed: Optional[frozenset] = None
     num_experts: Optional[int] = None
     for name, layer in layers:
@@ -283,27 +320,88 @@ def plan_sharded_expert_streaming(model) -> Optional[tuple[frozenset, int]]:
         if needed is None:
             needed, num_experts = layer_needed, layer.num_local_experts
         elif (layer_needed, layer.num_local_experts) != (needed, num_experts):
-            raise ValueError(
-                f"[sharded-stream] MoE layers disagree on the local expert "
-                f"set: {name} needs {len(layer_needed)} of "
-                f"{layer.num_local_experts} experts, an earlier layer needs "
-                f"{len(needed)} of {num_experts}. A single checkpoint filter "
-                f"cannot serve both; not filtering would be required.")
-        setattr(layer, _SHARDED_STREAM_NEEDED_ATTR, frozenset(layer_needed))
+            logger.warning(
+                "[sharded-stream] MoE layers disagree on the local expert "
+                "set (%s needs %d of %d experts, an earlier layer %d of %d); "
+                "one checkpoint filter cannot serve both, falling back to "
+                "the full checkpoint read.", name, len(layer_needed),
+                layer.num_local_experts, len(needed), num_experts)
+            return None
+    for _, layer in layers:
+        setattr(layer, _SHARDED_STREAM_NEEDED_ATTR, frozenset(needed))
     return needed, num_experts
 
 
-def validate_sharded_streaming_complete(model) -> None:
-    """Fail loudly if any marked layer never decoded its local experts.
+def _marked_layer_prefixes(layers) -> list[str]:
+    """Name paths under which dropped expert tensors are accounted for."""
+    prefixes = []
+    for module_name, layer in layers:
+        for prefix in (getattr(layer, "prefix", ""), module_name):
+            if prefix:
+                prefixes.append(prefix)
+    return prefixes
 
-    The decode gate returns False while streaming is still in flight, so a
-    needed expert the filter wrongly dropped surfaces only here, after the
-    weights iterator is exhausted: the layer's staging attributes are still
-    present (decode deletes them) with `None` in needed slots.
+
+def _covered_by_marked_layer(dropped_name: str, prefixes: list[str]) -> bool:
+    """Whether a dropped checkpoint tensor belongs to a marked MoE layer.
+
+    The checkpoint namespace may carry an extra wrapper prefix the module
+    tree does not (`language_model.` on Kimi-K3), so the tensor's path up to
+    its expert id is suffix-matched against each marked layer's prefix.
     """
+    match = _EXPERT_TENSOR_RE.search(dropped_name)
+    if not match:
+        return False
+    # `...layers.3.block_sparse_moe.experts` -- the path up to the id.
+    stem = dropped_name[:match.start(1) - 1]
+    for prefix in prefixes:
+        # The marked prefix may or may not spell the trailing `.experts`
+        # segment itself, depending on how the module names it.
+        candidates = [prefix]
+        if not prefix.endswith(".experts"):
+            candidates.append(prefix + ".experts")
+        for candidate in candidates:
+            if stem == candidate or stem.endswith("." + candidate):
+                return True
+    return False
+
+
+def validate_sharded_streaming_complete(model, dropped_names=()) -> None:
+    """Fail loudly if the filtered load left anything unaccounted for.
+
+    Two checks, both after the weights iterator is exhausted:
+
+    * every marked layer decoded its local experts -- the decode gate
+      returns False while streaming is in flight, so a needed expert the
+      filter wrongly dropped surfaces here as staging attributes that are
+      still present (decode deletes them) with `None` in needed slots;
+    * every DROPPED tensor name belongs to a marked layer. The name filter
+      drops `.experts.<id>.` tensors model-wide, but only the marked
+      (compressed-tensors MXFP4) layers have the relaxed gate that knows
+      slots may stay empty -- an expert tensor of any other module would be
+      silently missing (the auto-loader has no missing-weight check) and
+      that module would serve its initialization values.
+    """
+    layers = _mxfp4_moe_layers(model)
+    marked = [(name, layer) for name, layer in layers
+              if getattr(layer, _SHARDED_STREAM_NEEDED_ATTR, None) is not None]
+    prefixes = _marked_layer_prefixes(marked)
+    unaccounted = [
+        name for name in dropped_names
+        if not _covered_by_marked_layer(name, prefixes)
+    ]
+    if unaccounted:
+        raise ValueError(
+            f"[sharded-stream] {len(unaccounted)} dropped checkpoint "
+            f"tensors do not belong to any marked MXFP4 MoE layer (e.g. "
+            f"{unaccounted[:8]}); their module would silently keep its "
+            f"initialization weights. Marked layer prefixes: "
+            f"{sorted(set(prefixes))[:8]}. Unset K3_SHARDED_EXPERT_STREAMING "
+            f"for this model.")
+
     staged_attrs = [a for pair in _CT_STAGED_ATTRS.values() for a in pair]
     problems = []
-    for name, layer in _mxfp4_moe_layers(model):
+    for name, layer in layers:
         needed = getattr(layer, _SHARDED_STREAM_NEEDED_ATTR, None)
         if needed is None:
             continue
@@ -353,6 +451,13 @@ def maybe_load_with_sharded_expert_streaming(loader, model,
             "full checkpoint read.",
             type(loader).__name__)
         return False
+    if getattr(loader, "_is_distributed", False):
+        logger.warning(
+            "[sharded-stream] K3_SHARDED_EXPERT_STREAMING=1 but the runai "
+            "loader is in distributed mode, which re-broadcasts every chunk "
+            "to all ranks and would defeat (and fight) the per-host filter; "
+            "falling back to the full checkpoint read.")
+        return False
     if not envs.MXFP4_SHARD_THEN_DECODE:
         logger.warning(
             "[sharded-stream] K3_SHARDED_EXPERT_STREAMING=1 requires "
@@ -375,8 +480,12 @@ def maybe_load_with_sharded_expert_streaming(loader, model,
         model_weights = model_config.model_weights
     hf_weights_files = loader._prepare_weights(model_weights,
                                                model_config.revision)
+    dropped_names: list = []
     model.load_weights(
-        sharded_expert_weights_iterator(hf_weights_files, needed, num_experts,
-                                        loader.load_config.use_tqdm_on_load))
-    validate_sharded_streaming_complete(model)
+        sharded_expert_weights_iterator(hf_weights_files,
+                                        needed,
+                                        num_experts,
+                                        loader.load_config.use_tqdm_on_load,
+                                        dropped_names_sink=dropped_names))
+    validate_sharded_streaming_complete(model, dropped_names=dropped_names)
     return True

--- a/tpu_inference/models/jax/utils/sharded_stream.py
+++ b/tpu_inference/models/jax/utils/sharded_stream.py
@@ -1,0 +1,382 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Per-host sharded checkpoint reads for compressed-tensors MXFP4 experts.
+
+The default runai-streamer load path makes every host read every byte of the
+checkpoint and slice to its devices' shards only after the bytes arrived. For
+a large MoE model the routed-expert tensors are the overwhelming majority of
+those bytes (Kimi-K3: ~1.4 TB of a 1.45 TB checkpoint), and with the expert
+axis sharded E-ways across hosts each host ultimately keeps only 1/E of them
+-- so with 4 expert groups, ~3/4 of a ~110-minute cold-start read is spent on
+bytes the host immediately throws away, and the aggregate object-store egress
+is hosts x checkpoint size.
+
+This module removes that waste at the request level, opt-in via
+``K3_SHARDED_EXPERT_STREAMING=1``:
+
+1. Derive the set of expert ids any of this process's devices keep from the
+   expert kernels' sharding -- the same
+   ``sharding.addressable_devices_indices_map`` primitive the shard-by-shard
+   decode (``mxfp4._decode_sharded``) already trusts, so misalignment between
+   the expert axis and hosts can only shrink the saving, never break
+   correctness.
+2. Stream the safetensors files through a filtered request list: the
+   per-file header reads stay as they are (small ranged GETs), but every
+   ``.experts.<id>.`` tensor whose id is not in the needed set is dropped
+   from the byte ranges before they are requested. Non-expert tensors always
+   stream. Surviving tensors are coalesced into contiguous runs, one
+   ``FileChunks`` request per run -- the layout the streamer's own
+   distributed partitioner emits, so no streamer-library change is needed.
+3. Mark each MXFP4 MoE layer with its needed set so the decode gate in
+   ``mxfp4.process_weights_after_loading`` waits on the local set instead of
+   all experts (the rest will never arrive), and verify after the load that
+   every layer actually decoded -- a needed expert the filter dropped fails
+   loudly with its ids rather than as a half-loaded model.
+"""
+
+import re
+from dataclasses import dataclass
+from typing import Callable, Iterable, Optional
+
+import jax
+from jax.sharding import Mesh
+
+from tpu_inference import envs
+from tpu_inference.layers.jax.quantization.mxfp4 import (
+    _CT_STAGED_ATTRS, _SHARDED_STREAM_NEEDED_ATTR,
+    CompressedTensorsMxfp4MoEMethod, _full_slice, _named_sharding)
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+# `<...>.experts.<id>.<projection>.<weight_packed|weight_scale>` -- the name
+# shape `mxfp4.load_weights` asserts. Anchored on the `.experts.` segment so
+# router / shared-expert / non-MoE tensors never match.
+_EXPERT_TENSOR_RE = re.compile(r"(?:^|\.)experts\.(\d+)\.")
+
+_GiB = 1024**3
+
+
+def expert_id_from_tensor_name(name: str) -> Optional[int]:
+    """The routed-expert id in a checkpoint tensor name, or None."""
+    match = _EXPERT_TENSOR_RE.search(name)
+    return int(match.group(1)) if match else None
+
+
+def needed_expert_ids(
+        sharding,
+        mesh: Mesh,
+        num_experts: int,
+        local_devices: Optional[Iterable[jax.Device]] = None) -> frozenset:
+    """Expert ids some device of this host keeps a shard of.
+
+    The union of the expert-axis (axis 0) slices in the sharding's
+    device->index map, restricted to `local_devices` -- by default this
+    process's addressable devices, exactly the devices
+    `mxfp4._decode_sharded` will later cut shards for. Passing an explicit
+    subset makes the derivation testable on a single host: a simulated
+    host's device group yields the set that host would stream.
+    """
+    named = _named_sharding(sharding, mesh)
+    # A stand-in shape for the index map: the expert axis is exact, and each
+    # trailing axis is sized to the product of the mesh axes sharding it so
+    # every slice divides evenly. Axis 0's slices depend only on
+    # `num_experts` and the expert-axis device count, so they match what the
+    # real staged shape would produce.
+    dims = [num_experts]
+    for axis_spec in tuple(named.spec)[1:]:
+        if axis_spec is None:
+            dims.append(1)
+        else:
+            names = axis_spec if isinstance(axis_spec,
+                                            tuple) else (axis_spec, )
+            size = 1
+            for axis_name in names:
+                size *= mesh.shape[axis_name]
+            dims.append(size)
+    shape = tuple(dims)
+
+    if local_devices is None:
+        index_map = named.addressable_devices_indices_map(shape)
+    else:
+        wanted = set(local_devices)
+        index_map = {
+            device: index
+            for device, index in named.devices_indices_map(shape).items()
+            if device in wanted
+        }
+
+    needed: set = set()
+    for index in index_map.values():
+        expert_slice = _full_slice(index[0], num_experts)
+        needed.update(range(expert_slice.start, expert_slice.stop))
+    return frozenset(needed)
+
+
+@dataclass
+class FilterStats:
+    """What the checkpoint filter kept vs dropped, in tensors and bytes."""
+    kept_tensors: int = 0
+    total_tensors: int = 0
+    kept_bytes: int = 0
+    skipped_bytes: int = 0
+
+
+def build_filtered_requests(paths: list[str], safetensors_metadatas: list,
+                            keep: Callable[[str], bool]):
+    """Filtered, coalesced streaming requests for the given files.
+
+    `safetensors_metadatas` is `prepare_request`'s output: per file,
+    `(data_start_offset, [SafetensorMetadata sorted by offset], [sizes])`.
+    Dropped tensors split a file's single all-covering request into one
+    request per contiguous run of kept tensors (the safetensors data region
+    has no gaps, so a run of kept tensors is one contiguous byte range).
+    Request ids are fresh and unique across files; the returned metadata map
+    is keyed by them in chunk order, which is exactly what
+    `SafetensorsStreamer.get_tensors` walks.
+
+    Returns `(requests, id_to_tensors_metadata, stats)`.
+    """
+    from runai_model_streamer.file_streamer import FileChunks
+
+    requests: list = []
+    id_to_meta: dict = {}
+    stats = FilterStats()
+
+    for path, (file_offset, tensors_metadata,
+               tensor_sizes) in zip(paths, safetensors_metadatas):
+        run_meta: list = []
+        run_sizes: list = []
+        run_start = 0
+
+        def flush():
+            if not run_meta:
+                return
+            if sum(run_sizes) == 0:
+                # The streamer's request iterator treats an all-empty request
+                # as end-of-queue; zero-byte tensors carry no data to read
+                # anyway.
+                return
+            request_id = len(requests)
+            requests.append(
+                FileChunks(request_id, path, file_offset + run_start,
+                           list(run_sizes)))
+            id_to_meta[request_id] = list(run_meta)
+
+        for meta, size in zip(tensors_metadata, tensor_sizes):
+            stats.total_tensors += 1
+            if keep(meta.name):
+                if not run_meta:
+                    run_start = meta.offsets.start
+                run_meta.append(meta)
+                run_sizes.append(size)
+                stats.kept_tensors += 1
+                stats.kept_bytes += size
+            else:
+                flush()
+                run_meta, run_sizes = [], []
+                stats.skipped_bytes += size
+        flush()
+
+    return requests, id_to_meta, stats
+
+
+def _filtered_stream(streamer,
+                     paths: list[str],
+                     keep: Callable[[str], bool],
+                     device: str = "cpu") -> FilterStats:
+    """`SafetensorsStreamer.stream_files`, minus the filtered-out tensors.
+
+    Runs the same per-file header reads (`prepare_request`), then submits
+    only the kept tensors' byte ranges. `streamer.get_tensors` then works
+    unchanged: it looks tensors up by `(request id, chunk index)`, which the
+    filtered request map preserves.
+    """
+    from runai_model_streamer.safetensors_streamer import safetensors_pytorch
+
+    streamer.files_to_tensors_metadata = {}
+    metadatas = safetensors_pytorch.prepare_request(streamer.file_streamer,
+                                                    paths, None)
+    requests, id_to_meta, stats = build_filtered_requests(
+        paths, metadatas, keep)
+    streamer.files_to_tensors_metadata = id_to_meta
+    streamer.file_streamer.stream_files(requests,
+                                        credentials=None,
+                                        device=device,
+                                        is_distributed=False)
+    return stats
+
+
+def sharded_expert_weights_iterator(hf_weights_files: list[str],
+                                    needed_experts: frozenset,
+                                    num_experts: int,
+                                    use_tqdm_on_load: bool = False):
+    """Yield `(name, torch.Tensor)` like the stock runai iterator, but only
+    reading the expert tensors this host's devices keep (plus every
+    non-expert tensor)."""
+    from runai_model_streamer import SafetensorsStreamer
+    from tqdm.auto import tqdm
+
+    def keep(name: str) -> bool:
+        expert_id = expert_id_from_tensor_name(name)
+        return expert_id is None or expert_id in needed_experts
+
+    with SafetensorsStreamer() as streamer:
+        stats = _filtered_stream(streamer, hf_weights_files, keep)
+        logger.info(
+            "[sharded-stream] process %d streams %d/%d routed experts: "
+            "keeping %d/%d checkpoint tensors (%.1f GiB), skipping %.1f GiB "
+            "of non-local expert bytes before they are read.",
+            jax.process_index(), len(needed_experts), num_experts,
+            stats.kept_tensors, stats.total_tensors, stats.kept_bytes / _GiB,
+            stats.skipped_bytes / _GiB)
+        tensor_iter = tqdm(streamer.get_tensors(),
+                           total=stats.kept_tensors,
+                           desc="Loading safetensors (sharded expert read)",
+                           disable=not use_tqdm_on_load,
+                           mininterval=2)
+        for name, tensor in tensor_iter:
+            # The streamer reuses its CPU buffer across requests; detach the
+            # tensor from it before handing it out, as the stock iterator
+            # does.
+            yield name, tensor.clone()
+
+
+def _mxfp4_moe_layers(model):
+    return [(name, module) for name, module in model.named_modules()
+            if isinstance(getattr(module, "quant_method", None),
+                          CompressedTensorsMxfp4MoEMethod)]
+
+
+def plan_sharded_expert_streaming(model) -> Optional[tuple[frozenset, int]]:
+    """Mark every MXFP4 MoE layer with this host's needed expert set.
+
+    Returns `(needed_expert_ids, num_experts)`, or None when the model has
+    no compressed-tensors MXFP4 MoE layers (nothing worth filtering; other
+    quant paths stage and require all experts). The union over the gate/up
+    (EDF) and down (EFD) shardings is used for both the checkpoint filter
+    and the per-layer decode gate, so anything the decode can touch is
+    guaranteed to have streamed.
+    """
+    layers = _mxfp4_moe_layers(model)
+    if not layers:
+        return None
+
+    needed: Optional[frozenset] = None
+    num_experts: Optional[int] = None
+    for name, layer in layers:
+        layer_needed = needed_expert_ids(
+            layer.edf_sharding, layer.mesh,
+            layer.num_local_experts) | needed_expert_ids(
+                layer.efd_sharding, layer.mesh, layer.num_local_experts)
+        if needed is None:
+            needed, num_experts = layer_needed, layer.num_local_experts
+        elif (layer_needed, layer.num_local_experts) != (needed, num_experts):
+            raise ValueError(
+                f"[sharded-stream] MoE layers disagree on the local expert "
+                f"set: {name} needs {len(layer_needed)} of "
+                f"{layer.num_local_experts} experts, an earlier layer needs "
+                f"{len(needed)} of {num_experts}. A single checkpoint filter "
+                f"cannot serve both; not filtering would be required.")
+        setattr(layer, _SHARDED_STREAM_NEEDED_ATTR, frozenset(layer_needed))
+    return needed, num_experts
+
+
+def validate_sharded_streaming_complete(model) -> None:
+    """Fail loudly if any marked layer never decoded its local experts.
+
+    The decode gate returns False while streaming is still in flight, so a
+    needed expert the filter wrongly dropped surfaces only here, after the
+    weights iterator is exhausted: the layer's staging attributes are still
+    present (decode deletes them) with `None` in needed slots.
+    """
+    staged_attrs = [a for pair in _CT_STAGED_ATTRS.values() for a in pair]
+    problems = []
+    for name, layer in _mxfp4_moe_layers(model):
+        needed = getattr(layer, _SHARDED_STREAM_NEEDED_ATTR, None)
+        if needed is None:
+            continue
+        for attr in staged_attrs:
+            param = getattr(layer, attr, None)
+            if param is None:
+                # Decode ran and deleted the staging tensor -- healthy.
+                continue
+            missing = sorted(i for i in needed
+                             if param._weights_to_load[i] is None)
+            if missing:
+                problems.append(
+                    f"{name}.{attr}: missing local expert ids "
+                    f"{missing[:16]}{'...' if len(missing) > 16 else ''} "
+                    f"({len(missing)} of {len(needed)} needed)")
+            else:
+                problems.append(
+                    f"{name}.{attr}: all {len(needed)} local experts are "
+                    f"staged but the decode never ran")
+    if problems:
+        raise ValueError(
+            "[mxfp4] sharded expert streaming finished but these MoE layers "
+            "never decoded -- experts local to this host are missing from "
+            "the stream (filter bug or truncated checkpoint): " +
+            "; ".join(problems))
+
+
+def maybe_load_with_sharded_expert_streaming(loader, model,
+                                             model_config) -> bool:
+    """Load via the per-host filtered read when it is enabled and applicable.
+
+    Returns True when the model was loaded here; False means the caller
+    should fall back to the stock full-read path. Every bail-out is logged:
+    an operator who set the flag should be able to see from the log alone
+    why a host still read the whole checkpoint.
+    """
+    if not envs.K3_SHARDED_EXPERT_STREAMING:
+        return False
+
+    from vllm.model_executor.model_loader.runai_streamer_loader import \
+        RunaiModelStreamerLoader
+
+    if not isinstance(loader, RunaiModelStreamerLoader):
+        logger.warning(
+            "[sharded-stream] K3_SHARDED_EXPERT_STREAMING=1 but the model "
+            "loader is %s, not RunaiModelStreamerLoader; falling back to the "
+            "full checkpoint read.",
+            type(loader).__name__)
+        return False
+    if not envs.MXFP4_SHARD_THEN_DECODE:
+        logger.warning(
+            "[sharded-stream] K3_SHARDED_EXPERT_STREAMING=1 requires "
+            "MXFP4_SHARD_THEN_DECODE=1 (the host decode concatenates all "
+            "experts, so filtering the read would break it); falling back "
+            "to the full checkpoint read.")
+        return False
+
+    plan = plan_sharded_expert_streaming(model)
+    if plan is None:
+        logger.warning(
+            "[sharded-stream] K3_SHARDED_EXPERT_STREAMING=1 but the model "
+            "has no compressed-tensors MXFP4 MoE layers; falling back to "
+            "the full checkpoint read.")
+        return False
+    needed, num_experts = plan
+
+    model_weights = model_config.model
+    if getattr(model_config, "model_weights", None):
+        model_weights = model_config.model_weights
+    hf_weights_files = loader._prepare_weights(model_weights,
+                                               model_config.revision)
+    model.load_weights(
+        sharded_expert_weights_iterator(hf_weights_files, needed, num_experts,
+                                        loader.load_config.use_tqdm_on_load))
+    validate_sharded_streaming_complete(model)
+    return True


### PR DESCRIPTION
Stacked on the K3 perf series (diff shows only this change). Env-gated (default OFF) filtered streaming: each host reads only the routed-expert tensors its devices keep, instead of the full checkpoint. On a 4-host 1.45 TB load: est. ~110 -> ~33 min and 5.8 -> 1.7 TB GCS egress per cold start.

Safety: the needed-expert set derives from the same device-indices primitive the decoder trusts (mesh mismatch shrinks the win, never correctness); loud completeness validation for the local set; single-host A/B gate showed the filter as a byte-identical no-op (dev build: kept 38012/38012 tensors, outputs identical flag OFF vs ON). 19 new CPU tests, mutation-verified.

Marked DO NOT REVIEW pending the perf series landing.