### PR TITLE
[DO NOT REVIEW] K3 split 2/6: runner plumbing

### DIFF
--- a/tests/kernels/gdn_attention_v3_test.py
+++ b/tests/kernels/gdn_attention_v3_test.py
@@ -39,7 +39,7 @@ def gdn_attention_ref(
     query_start_loc: jnp.ndarray,
     state_indices: jnp.ndarray,
     distribution: jnp.ndarray,
-    seq_lens: jnp.ndarray,
+    has_initial_state: jnp.ndarray,
     n_kq: int,
     n_v: int,
     d_k: int,
@@ -68,7 +68,7 @@ def gdn_attention_ref(
         if query_len <= 0:
             continue
 
-        has_init = bool((seq_lens[req_idx] - query_len) > 0)
+        has_init = bool(has_initial_state[req_idx])
         if has_init:
             c_state = new_conv_state[s]
         else:
@@ -164,7 +164,7 @@ def gdn_attention_spec_ref(
     state_indices: jnp.ndarray,
     read_offsets: jnp.ndarray,
     num_spec_seqs: int,
-    seq_lens: jnp.ndarray,
+    has_initial_state: jnp.ndarray,
     n_kq: int,
     n_v: int,
     d_k: int,
@@ -191,7 +191,7 @@ def gdn_attention_spec_ref(
         if query_len <= 0:
             continue
 
-        has_init = bool((seq_lens[req_idx] - query_len) > 0)
+        has_init = bool(has_initial_state[req_idx])
         c_state = (conv_state[read_slot]
                    if has_init else jnp.zeros_like(conv_state[read_slot]))
         r_state = (recurrent_state[read_slot]
@@ -385,11 +385,9 @@ class GDNAttentionTest(parameterized.TestCase):
 
         # All sequences in this test start from a fresh slot; the existing
         # parametrizations don't exercise prefix-cache-hit / chunked-prefill
-        # continuation. ``seq_lens == query_lens`` (context_len = 0)
-        # reproduces the prior behavior (zero initial state regardless of
-        # slot contents).
-        seq_lens = jnp.asarray(q_loc[1:max_reqs + 1] - q_loc[:max_reqs],
-                               dtype=jnp.int32)
+        # continuation. An all-zero ``has_initial_state`` reproduces the
+        # prior behavior (zero initial state regardless of slot contents).
+        has_initial_state = jnp.zeros((max_reqs, ), dtype=jnp.int32)
 
         common_kwargs = dict(
             qkv=mixed_qkv,
@@ -404,7 +402,7 @@ class GDNAttentionTest(parameterized.TestCase):
             query_start_loc=q_loc,
             state_indices=state_indices,
             distribution=distribution,
-            seq_lens=seq_lens,
+            has_initial_state=has_initial_state,
             n_kq=n_kq,
             n_v=n_v,
             d_k=kq_head_dim,
@@ -506,11 +504,11 @@ class GDNAttentionTest(parameterized.TestCase):
         A_log = jax.random.normal(next(rngs), (n_v, ))
         dt_bias = jax.random.normal(next(rngs), (n_v, ))
 
-        # All sequences continue an existing context (has_initial=True) for
-        # the spec windows; prefills start fresh (context_len = 0).
-        seq_lens = jnp.array([16 + length for length in spec_lengths] +
-                             list(prefill_lengths),
-                             dtype=jnp.int32)
+        # The spec windows continue an existing context; the prefills start
+        # fresh.
+        has_initial_state = jnp.array([1] * len(spec_lengths) +
+                                      [0] * len(prefill_lengths),
+                                      dtype=jnp.int32)
 
         run_jitted = jax.jit(
             wrapper.fused_conv1d_gdn,
@@ -532,7 +530,7 @@ class GDNAttentionTest(parameterized.TestCase):
             q_loc,
             state_indices,
             distribution,
-            seq_lens,
+            has_initial_state,
             read_offsets_arr,
             n_kq=n_kq,
             n_v=n_v,
@@ -557,7 +555,7 @@ class GDNAttentionTest(parameterized.TestCase):
             state_indices=state_indices,
             read_offsets=read_offsets_arr,
             num_spec_seqs=num_spec_seqs,
-            seq_lens=seq_lens,
+            has_initial_state=has_initial_state,
             n_kq=n_kq,
             n_v=n_v,
             d_k=kq_head_dim,
@@ -582,7 +580,7 @@ class GDNAttentionTest(parameterized.TestCase):
                 state_indices=state_indices[num_spec_seqs:],
                 distribution=jnp.array([0, 0, num_seqs - num_spec_seqs],
                                        dtype=jnp.int32),
-                seq_lens=seq_lens[num_spec_seqs:],
+                has_initial_state=has_initial_state[num_spec_seqs:],
                 n_kq=n_kq,
                 n_v=n_v,
                 d_k=kq_head_dim,
@@ -682,9 +680,8 @@ class GDNAttentionTest(parameterized.TestCase):
             static_argnames=["n_kq", "n_v", "d_k", "d_v", "kernel_size"],
         )
 
-        # Both requests are brand new — no prior context. seq_lens equals
-        # query_lens so context_len = 0 → has_initial_state = False.
-        seq_lens_new = jnp.asarray(lengths, dtype=jnp.int32)
+        # Both requests are brand new — no prior context.
+        has_initial_state_new = jnp.zeros((len(lengths), ), dtype=jnp.int32)
 
         common_kwargs = dict(
             qkv=mixed_qkv,
@@ -697,7 +694,7 @@ class GDNAttentionTest(parameterized.TestCase):
             query_start_loc=q_loc,
             state_indices=state_indices,
             distribution=distribution,
-            seq_lens=seq_lens_new,
+            has_initial_state=has_initial_state_new,
             n_kq=n_kq,
             n_v=n_v,
             d_k=kq_head_dim,
@@ -805,8 +802,7 @@ class GDNAttentionTest(parameterized.TestCase):
             kernel_size=kernel_size,
         )
 
-        # Single-shot reference (all 64 tokens, zero state, has_initial=False
-        # encoded as seq_lens == query_lens == [full]).
+        # Single-shot reference (all 64 tokens, zero state, has_initial=0).
         (_, _), output_ref = run_jitted(
             qkv=mixed_qkv_full,
             b=b,
@@ -815,11 +811,11 @@ class GDNAttentionTest(parameterized.TestCase):
             recurrent_state=recurrent_state_zero,
             query_start_loc=jnp.array([0, full]),
             distribution=jnp.array([0, 1, 1], dtype=jnp.int32),
-            seq_lens=jnp.array([full], dtype=jnp.int32),
+            has_initial_state=jnp.array([0], dtype=jnp.int32),
             **common_static,
         )
 
-        # Step A: first 32 tokens, zero state, has_initial=False.
+        # Step A: first 32 tokens, zero state, has_initial=0.
         (conv_after_a, rec_after_a), output_a = run_jitted(
             qkv=mixed_qkv_a,
             b=b[:half],
@@ -828,13 +824,12 @@ class GDNAttentionTest(parameterized.TestCase):
             recurrent_state=recurrent_state_zero,
             query_start_loc=jnp.array([0, half]),
             distribution=jnp.array([0, 1, 1], dtype=jnp.int32),
-            seq_lens=jnp.array([half], dtype=jnp.int32),
+            has_initial_state=jnp.array([0], dtype=jnp.int32),
             **common_static,
         )
 
-        # Step B: next 32 tokens, slot now holds Step A's state.
-        # seq_lens=[full] with query_lens=[half] gives context_len=half>0,
-        # i.e., has_initial=True so the kernel continues from that state.
+        # Step B: next 32 tokens, slot now holds Step A's state, so
+        # has_initial=1 and the kernel continues from that state.
         (_, _), output_b = run_jitted(
             qkv=mixed_qkv_b,
             b=b[half:],
@@ -843,7 +838,7 @@ class GDNAttentionTest(parameterized.TestCase):
             recurrent_state=rec_after_a,
             query_start_loc=jnp.array([0, half]),
             distribution=jnp.array([0, 1, 1], dtype=jnp.int32),
-            seq_lens=jnp.array([full], dtype=jnp.int32),
+            has_initial_state=jnp.array([1], dtype=jnp.int32),
             **common_static,
         )
 

--- a/tests/layers/common/test_gdn_attention_dp.py
+++ b/tests/layers/common/test_gdn_attention_dp.py
@@ -1,0 +1,248 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GDN under attention data parallelism.
+
+`run_jax_gdn_attention` shards its ragged-batch metadata over
+`ShardingAxisName.ATTN_DATA`, so each rank's kernel invocation must see
+exactly what it would see running alone. This pins that equivalence for the
+runner-published `has_initial_state` in particular: it arrives as one global
+`(max_num_seqs,)` array and is sliced per rank by the shard_map, unlike
+`query_start_loc`, whose per-rank blocks carry an extra entry each.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.sharding import Mesh
+
+from tpu_inference.kernels.gdn.v3 import wrapper
+from tpu_inference.layers.common import sharding as sharding_mod
+from tpu_inference.layers.common.gdn_attention import run_jax_gdn_attention
+from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
+                                                  ShardingAxisNameBase)
+
+DP_SIZE = 2
+REQS_PER_RANK = 2
+BLOCKS_PER_RANK = 3  # slot 0 is the null block
+TOKENS_PER_RANK = 16
+# Two prefills per rank; the tail of each rank's token budget is padding.
+LENGTHS = [8, 4]
+
+N_KQ = 2
+N_V = 2
+D_K = 128
+D_V = 128
+KERNEL_SIZE = 4
+KQ_DIM = N_KQ * D_K
+CONV_DIM = 2 * KQ_DIM + N_V * D_V
+
+
+@pytest.fixture
+def dp_mesh():
+    """A mesh whose only nontrivial axis is `attn_dp`, so ATTN_DATA splits
+    2 ways and every other sharding axis is a no-op."""
+    if len(jax.devices()) < DP_SIZE:
+        pytest.skip(f"needs >= {DP_SIZE} devices")
+    shape = tuple(DP_SIZE if name == "attn_dp" else 1
+                  for name in MESH_AXIS_NAMES)
+    devices = np.array(jax.devices()[:DP_SIZE]).reshape(shape)
+    # `run_jax_gdn_attention` partitions on the multi-axis names, which only
+    # the base (non-2D) sharding class defines.
+    saved = sharding_mod.ShardingAxisName._cls
+    sharding_mod.ShardingAxisName._cls = ShardingAxisNameBase
+    try:
+        # Deliberately NOT installed as the default mesh: the single-device
+        # reference calls below must stay unsharded, and a default multi-device
+        # mesh makes XLA try to auto-partition their Mosaic kernel (which it
+        # cannot). `run_jax_gdn_attention` takes the mesh explicitly for its
+        # shard_map, so nothing here needs it ambient.
+        yield Mesh(devices, axis_names=MESH_AXIS_NAMES)
+    finally:
+        sharding_mod.ShardingAxisName._cls = saved
+
+
+def _rank_inputs(rank, has_init_flags):
+    """Everything one rank's kernel call consumes, in rank-local indexing."""
+    rngs = iter(jax.random.split(jax.random.key(100 + rank), 8))
+    qkv = jax.random.normal(next(rngs), (TOKENS_PER_RANK, CONV_DIM))
+    b = jax.random.normal(next(rngs), (TOKENS_PER_RANK, N_V))
+    a = jax.random.normal(next(rngs), (TOKENS_PER_RANK, N_V))
+    # Nonzero slot contents, so resuming and zero-initializing differ.
+    conv_state = jax.random.normal(
+        next(rngs), (BLOCKS_PER_RANK, KERNEL_SIZE - 1, CONV_DIM))
+    recurrent_state = jax.random.normal(next(rngs),
+                                        (BLOCKS_PER_RANK, N_V, D_K, D_V))
+    conv_state = conv_state.at[0].set(0.0)  # null block
+    recurrent_state = recurrent_state.at[0].set(0.0)
+
+    qsl = jnp.asarray([0] + list(np.cumsum(LENGTHS)), jnp.int32)
+    return dict(
+        qkv=qkv,
+        b=b,
+        a=a,
+        conv_state=conv_state,
+        recurrent_state=recurrent_state,
+        query_start_loc=qsl,
+        # Slots 1..REQS_PER_RANK; rank-local, as `_prepare_inputs` publishes.
+        state_indices=jnp.arange(1, REQS_PER_RANK + 1, dtype=jnp.int32),
+        distribution=jnp.asarray([0, REQS_PER_RANK, REQS_PER_RANK], jnp.int32),
+        has_initial_state=jnp.asarray(has_init_flags, jnp.int32),
+    )
+
+
+def _weights():
+    rngs = iter(jax.random.split(jax.random.key(7), 4))
+    return dict(
+        conv_weight=jax.random.normal(next(rngs), (CONV_DIM, 1, KERNEL_SIZE)),
+        conv_bias=jax.random.normal(next(rngs), (CONV_DIM, )),
+        a_log=jax.random.normal(next(rngs), (N_V, )),
+        dt_bias=jax.random.normal(next(rngs), (N_V, )),
+    )
+
+
+# Rank 0 resumes its first request and starts its second fresh; rank 1 is the
+# mirror image. Any rank-agnostic handling of the flag gets one of them wrong.
+FLAGS = [[1, 0], [0, 1]]
+
+
+def test_attention_dp_gdn_matches_per_rank_single_device_runs(dp_mesh):
+    weights = _weights()
+    per_rank = [_rank_inputs(r, FLAGS[r]) for r in range(DP_SIZE)]
+
+    # Reference: each rank on its own, no sharding involved.
+    ref = []
+    for inputs in per_rank:
+        (conv_out, rec_out), out = jax.jit(
+            wrapper.fused_conv1d_gdn,
+            static_argnames=["n_kq", "n_v", "d_k", "d_v", "kernel_size"],
+        )(inputs["qkv"],
+          inputs["b"],
+          inputs["a"],
+          inputs["conv_state"],
+          inputs["recurrent_state"],
+          weights["conv_weight"],
+          weights["conv_bias"],
+          weights["a_log"],
+          weights["dt_bias"],
+          inputs["query_start_loc"],
+          inputs["state_indices"],
+          inputs["distribution"],
+          inputs["has_initial_state"],
+          n_kq=N_KQ,
+          n_v=N_V,
+          d_k=D_K,
+          d_v=D_V,
+          kernel_size=KERNEL_SIZE)
+        ref.append(
+            (np.asarray(conv_out), np.asarray(rec_out), np.asarray(out)))
+
+    # Under test: one sharded call over the globally packed metadata. Note
+    # `query_start_loc` concatenates REQS_PER_RANK + 1 entries per rank while
+    # `has_initial_state` concatenates REQS_PER_RANK -- the asymmetry that
+    # makes a global `seq_lens - query_lens` derivation invalid.
+    def cat(key):
+        return jnp.concatenate([r[key] for r in per_rank], axis=0)
+
+    packed_qsl = cat("query_start_loc")
+    packed_flags = cat("has_initial_state")
+    assert packed_qsl.shape == (DP_SIZE * (REQS_PER_RANK + 1), )
+    assert packed_flags.shape == (DP_SIZE * REQS_PER_RANK, )
+
+    (conv_out, rec_out), out = run_jax_gdn_attention(
+        cat("qkv"),
+        cat("b"),
+        cat("a"),
+        cat("conv_state"),
+        cat("recurrent_state"),
+        weights["conv_weight"],
+        weights["conv_bias"],
+        weights["a_log"],
+        weights["dt_bias"],
+        cat("state_indices"),
+        packed_qsl,
+        cat("distribution"),
+        packed_flags,
+        N_KQ,
+        N_V,
+        D_K,
+        D_V,
+        KERNEL_SIZE,
+        mesh=dp_mesh,
+    )
+
+    conv_out, rec_out, out = map(np.asarray, (conv_out, rec_out, out))
+    for rank, (ref_conv, ref_rec, ref_out) in enumerate(ref):
+        tok = slice(rank * TOKENS_PER_RANK, (rank + 1) * TOKENS_PER_RANK)
+        blk = slice(rank * BLOCKS_PER_RANK, (rank + 1) * BLOCKS_PER_RANK)
+        np.testing.assert_allclose(out[tok],
+                                   ref_out,
+                                   rtol=2e-2,
+                                   atol=2e-2,
+                                   err_msg=f"output, rank {rank}")
+        np.testing.assert_allclose(conv_out[blk],
+                                   ref_conv,
+                                   rtol=2e-2,
+                                   atol=2e-2,
+                                   err_msg=f"conv state, rank {rank}")
+        np.testing.assert_allclose(rec_out[blk],
+                                   ref_rec,
+                                   rtol=2e-2,
+                                   atol=2e-2,
+                                   err_msg=f"recurrent state, rank {rank}")
+
+
+def test_flipping_one_ranks_flag_changes_only_that_rank(dp_mesh):
+    """Guards against the flag being read rank-agnostically (e.g. broadcast
+    from rank 0): rank 1's flags change, rank 0's output must not."""
+    weights = _weights()
+
+    def cat(rows, key):
+        return jnp.concatenate([r[key] for r in rows], axis=0)
+
+    outs = []
+    for rank1_flags in ([0, 1], [1, 1]):
+        rows = [_rank_inputs(0, FLAGS[0]), _rank_inputs(1, rank1_flags)]
+        _, out = run_jax_gdn_attention(
+            cat(rows, "qkv"),
+            cat(rows, "b"),
+            cat(rows, "a"),
+            cat(rows, "conv_state"),
+            cat(rows, "recurrent_state"),
+            weights["conv_weight"],
+            weights["conv_bias"],
+            weights["a_log"],
+            weights["dt_bias"],
+            cat(rows, "state_indices"),
+            cat(rows, "query_start_loc"),
+            cat(rows, "distribution"),
+            cat(rows, "has_initial_state"),
+            N_KQ,
+            N_V,
+            D_K,
+            D_V,
+            KERNEL_SIZE,
+            mesh=dp_mesh,
+        )
+        outs.append(np.asarray(out))
+
+    rank0 = slice(0, TOKENS_PER_RANK)
+    rank1_first_seq = slice(TOKENS_PER_RANK, TOKENS_PER_RANK + LENGTHS[0])
+    np.testing.assert_allclose(outs[0][rank0], outs[1][rank0], rtol=0, atol=0)
+    assert not np.allclose(
+        outs[0][rank1_first_seq],
+        outs[1][rank1_first_seq],
+        rtol=1e-3,
+        atol=1e-3), ("rank 1's first request resumed vs zeroed its "
+                     "state but produced identical output")

--- a/tests/layers/common/test_has_initial_state_contract.py
+++ b/tests/layers/common/test_has_initial_state_contract.py
@@ -1,0 +1,191 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pins the `AttentionMetadata.has_initial_state` contract.
+
+Linear-attention ops (GDN, KDA) need to know which persistent-batch slots
+resume conv/recurrent state from an earlier step. The tempting derivation is
+``(seq_lens - query_lens) > 0`` with
+``query_lens = query_start_loc[1:] - query_start_loc[:-1]``. These tests pin
+why that derivation is only conditionally valid, and that the runner-published
+field is the unconditional answer.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tpu_inference.kernels.gdn.v3 import config, metadata
+
+
+def _runner_layout(num_computed, num_scheduled, max_reqs_per_rank):
+    """Emulates how `TPUModelRunner._prepare_inputs` packs metadata under DP.
+
+    `num_computed` / `num_scheduled` are per-rank lists of per-request values.
+    Returns `(query_start_loc, seq_lens, has_initial_state)` in the packed
+    global layout: `query_start_loc` gets `max_reqs_per_rank + 1` entries per
+    rank (each rank's block restarts at 0), while the other two get
+    `max_reqs_per_rank`.
+    """
+    dp_size = len(num_computed)
+    qsl = np.zeros(dp_size * (max_reqs_per_rank + 1), dtype=np.int32)
+    seq_lens = np.zeros(dp_size * max_reqs_per_rank, dtype=np.int32)
+    has_init = np.zeros(dp_size * max_reqs_per_rank, dtype=np.int32)
+    for rank, (computed,
+               scheduled) in enumerate(zip(num_computed, num_scheduled)):
+        n = len(computed)
+        qsl_off = rank * (max_reqs_per_rank + 1)
+        req_off = rank * max_reqs_per_rank
+        np.cumsum(scheduled, out=qsl[qsl_off + 1:qsl_off + n + 1])
+        qsl[qsl_off + n + 1:qsl_off + max_reqs_per_rank + 1] = qsl[qsl_off + n]
+        seq_lens[req_off:req_off +
+                 n] = np.array(computed) + np.array(scheduled)
+        has_init[req_off:req_off + n] = np.array(computed) > 0
+    return qsl, seq_lens, has_init
+
+
+def _rank_shard(packed, rank, per_rank):
+    """One rank's view of a packed array, as `shard_map(in_specs=P(ATTN_DATA))`
+    slices it: contiguous equal-sized blocks along axis 0."""
+    return packed[rank * per_rank:(rank + 1) * per_rank]
+
+
+# Two ranks hold requests mid-stream (nonzero computed tokens => resuming),
+# two hold fresh prefills, and ranks are unevenly filled so padding is
+# exercised. 8 ranks x 4 slots = 32 slots, mirroring max_num_seqs=32 at dp=8.
+DP_SIZE = 8
+MAX_REQS_PER_RANK = 4
+NUM_COMPUTED = [[0, 0], [16, 0, 4], [0], [7, 7, 7, 7], [0, 32], [], [64], [0]]
+NUM_SCHEDULED = [[8, 8], [1, 12, 1], [5], [1, 1, 1, 1], [3, 1], [], [1], [9]]
+
+
+def test_global_derivation_has_the_wrong_shape_under_attention_dp():
+    """The (32,) vs (39,) break: the derivation cannot even be evaluated."""
+    qsl, seq_lens, _ = _runner_layout(NUM_COMPUTED, NUM_SCHEDULED,
+                                      MAX_REQS_PER_RANK)
+
+    # `query_start_loc` carries one extra entry *per rank*, not one overall.
+    assert qsl.shape == (DP_SIZE * MAX_REQS_PER_RANK + DP_SIZE, ) == (40, )
+    assert seq_lens.shape == (DP_SIZE * MAX_REQS_PER_RANK, ) == (32, )
+
+    query_lens = qsl[1:] - qsl[:-1]
+    assert query_lens.shape == (39, )
+    with pytest.raises(TypeError,
+                       match=r"incompatible shapes.*\(32,\).*\(39,\)"):
+        _ = jnp.asarray(seq_lens) - jnp.asarray(query_lens)
+
+
+def test_global_derivation_is_valid_per_dp_rank_shard():
+    """Why the GDN kernel path never hit the break.
+
+    `run_jax_gdn_attention` hands `query_start_loc` to a `shard_map` whose
+    in_spec is `P(ATTN_DATA)`, so the kernel-side code sees one rank's block:
+    `max_reqs_per_rank + 1` offsets restarting at 0, against
+    `max_reqs_per_rank` sequence lengths. The shapes line up and the values
+    are right. The break is reachable only from ops that run on the *packed*
+    arrays, i.e. outside such a shard_map -- which is where the JAX-native
+    model path (KDA) runs.
+    """
+    qsl, seq_lens, has_init = _runner_layout(NUM_COMPUTED, NUM_SCHEDULED,
+                                             MAX_REQS_PER_RANK)
+
+    for rank in range(DP_SIZE):
+        qsl_r = _rank_shard(qsl, rank, MAX_REQS_PER_RANK + 1)
+        seq_lens_r = _rank_shard(seq_lens, rank, MAX_REQS_PER_RANK)
+        derived = (seq_lens_r - (qsl_r[1:] - qsl_r[:-1])) > 0
+        np.testing.assert_array_equal(
+            derived,
+            _rank_shard(has_init, rank, MAX_REQS_PER_RANK).astype(bool),
+            f"rank {rank}")
+
+
+def test_published_flag_matches_the_per_rank_derivation_everywhere():
+    """The migration is behavior-preserving for the paths that were correct."""
+    qsl, seq_lens, has_init = _runner_layout(NUM_COMPUTED, NUM_SCHEDULED,
+                                             MAX_REQS_PER_RANK)
+    derived = np.concatenate([
+        (_rank_shard(seq_lens, r, MAX_REQS_PER_RANK) -
+         (_rank_shard(qsl, r, MAX_REQS_PER_RANK + 1)[1:] -
+          _rank_shard(qsl, r, MAX_REQS_PER_RANK + 1)[:-1])) > 0
+        for r in range(DP_SIZE)
+    ])
+    np.testing.assert_array_equal(derived, has_init.astype(bool))
+
+
+def test_dp1_derivation_agrees_with_the_published_flag():
+    """At dp_size == 1 the packed layout degenerates to the classic one, which
+    is why the derivation shipped correct for so long."""
+    qsl, seq_lens, has_init = _runner_layout([[0, 3, 20]], [[6, 2, 1]],
+                                             max_reqs_per_rank=3)
+    derived = (seq_lens - (qsl[1:] - qsl[:-1])) > 0
+    np.testing.assert_array_equal(derived, has_init.astype(bool))
+    np.testing.assert_array_equal(has_init, [0, 1, 1])
+
+
+def _gdn_cfg(mode, batch_size, tile_size):
+    return config.GDNConfig(
+        mode=mode,
+        batch_size=batch_size,
+        kernel_size=4,
+        tile_size=tile_size,
+        dim_size=64,
+        num_kq_heads=1,
+        num_v_heads=1,
+        kq_head_dim=32,
+        v_head_dim=32,
+        dtypes=config.Dtypes(
+            act_in=jnp.float32,
+            act_out=jnp.float32,
+            compute=jnp.float32,
+            recurrent_state=jnp.float32,
+            conv_state=jnp.float32,
+        ),
+    )
+
+
+@pytest.mark.parametrize("flags", [[1, 0, 1], [0, 0, 0], [1, 1, 1]])
+def test_gdn_batched_metadata_takes_the_flag_verbatim(flags):
+    """`compute_batched_seq_metadata` must publish the caller's flag, not a
+    re-derivation. All three sequences here have `query_len == 1`, so any
+    derivation from `query_start_loc` alone would give the same answer for
+    every slot regardless of `flags`."""
+    num_seqs = len(flags)
+    meta = metadata.compute_batched_seq_metadata(
+        cfg=_gdn_cfg(config.GDNMode.BATCHED,
+                     batch_size=num_seqs,
+                     tile_size=num_seqs),
+        has_initial_state=jnp.asarray(flags, jnp.int32),
+        query_start_loc=jnp.arange(num_seqs + 1, dtype=jnp.int32),
+        state_indices=jnp.arange(1, num_seqs + 1, dtype=jnp.int32),
+        read_offsets=jnp.zeros(num_seqs, jnp.int32),
+        end_seq=jnp.int32(num_seqs),
+    )
+    np.testing.assert_array_equal(np.asarray(meta.s_idx_has_initial_state),
+                                  np.asarray(flags, bool))
+
+
+@pytest.mark.parametrize("flags", [[1, 0], [0, 1]])
+def test_gdn_per_seq_metadata_takes_the_flag_verbatim(flags):
+    """Same for the prefill/mixed path, which additionally rolls the flag by
+    `start_seq` so it stays aligned with the rolled sequence order."""
+    num_seqs = len(flags)
+    meta = metadata.compute_per_seq_metadata(
+        cfg=_gdn_cfg(config.GDNMode.PER_SEQ, batch_size=8, tile_size=4),
+        has_initial_state=jnp.asarray(flags, jnp.int32),
+        query_start_loc=jnp.asarray([0, 4, 8], jnp.int32),
+        state_indices=jnp.arange(1, num_seqs + 1, dtype=jnp.int32),
+        start_seq=jnp.int32(0),
+        end_seq=jnp.int32(num_seqs),
+    )
+    np.testing.assert_array_equal(np.asarray(meta.s_idx_has_initial_state),
+                                  np.asarray(flags, bool))

--- a/tests/layers/common/test_has_initial_state_contract.py
+++ b/tests/layers/common/test_has_initial_state_contract.py
@@ -175,17 +175,20 @@ def test_gdn_batched_metadata_takes_the_flag_verbatim(flags):
 
 
 @pytest.mark.parametrize("flags", [[1, 0], [0, 1]])
-def test_gdn_per_seq_metadata_takes_the_flag_verbatim(flags):
+@pytest.mark.parametrize("start_seq", [0, 1])
+def test_gdn_per_seq_metadata_takes_the_flag_verbatim(flags, start_seq):
     """Same for the prefill/mixed path, which additionally rolls the flag by
-    `start_seq` so it stays aligned with the rolled sequence order."""
+    `start_seq` so it stays aligned with the rolled sequence order.
+    `start_seq=1` pins that alignment: slot 0 of the published flag must be
+    `flags[1]`, which a verbatim (unrolled) copy would get wrong."""
     num_seqs = len(flags)
     meta = metadata.compute_per_seq_metadata(
         cfg=_gdn_cfg(config.GDNMode.PER_SEQ, batch_size=8, tile_size=4),
         has_initial_state=jnp.asarray(flags, jnp.int32),
         query_start_loc=jnp.asarray([0, 4, 8], jnp.int32),
         state_indices=jnp.arange(1, num_seqs + 1, dtype=jnp.int32),
-        start_seq=jnp.int32(0),
+        start_seq=jnp.int32(start_seq),
         end_seq=jnp.int32(num_seqs),
     )
     np.testing.assert_array_equal(np.asarray(meta.s_idx_has_initial_state),
-                                  np.asarray(flags, bool))
+                                  np.roll(np.asarray(flags, bool), -start_seq))

--- a/tests/models/common/test_linear_attention.py
+++ b/tests/models/common/test_linear_attention.py
@@ -1,0 +1,120 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Config -> recurrent-state layout for JAX-native hybrid models."""
+
+from types import SimpleNamespace
+
+import torch
+
+from tpu_inference.models.common.linear_attention import (
+    compute_linear_attention_layers, compute_linear_attention_layout,
+    linear_attn_config)
+
+
+def _config(**linear_attn):
+    return SimpleNamespace(linear_attn_config=dict(linear_attn))
+
+
+# Kimi-Linear-48B: 27 layers, KDA everywhere except the 7 full-attention ones.
+_K48_KDA = [
+    1, 2, 3, 5, 6, 7, 9, 10, 11, 13, 14, 15, 17, 18, 19, 21, 22, 23, 25, 26
+]
+
+
+def test_no_linear_attention_config_returns_none():
+    """Every attention-only model must take the unchanged code path."""
+    assert compute_linear_attention_layout(SimpleNamespace(hidden_size=8),
+                                           torch.bfloat16) is None
+    assert compute_linear_attention_layers(SimpleNamespace(hidden_size=8)) == \
+        frozenset()
+
+
+def test_empty_kda_layer_list_returns_none():
+    """A config that declares the sub-config but lists no KDA layers is not
+    hybrid -- e.g. an all-full-attention ablation."""
+    cfg = _config(kda_layers=[], num_heads=2, head_dim=8)
+    assert compute_linear_attention_layout(cfg, torch.bfloat16) is None
+
+
+def test_kda_layers_are_converted_from_one_indexed():
+    """The checkpoint lists layers 1..N; everything downstream indexes 0..N-1.
+    An off-by-one here would put the recurrent state on the wrong layers,
+    which is silent -- the model would still run."""
+    cfg = _config(kda_layers=[1, 2, 3, 5, 6, 7], num_heads=2, head_dim=8)
+    assert compute_linear_attention_layers(cfg) == frozenset(
+        {0, 1, 2, 4, 5, 6})
+    assert 8 not in compute_linear_attention_layers(cfg)
+
+
+def test_state_layout_matches_the_kda_state_tuple():
+    """Three conv windows (q/k/v) at the model dtype, then the fp32
+    recurrent matrix -- the field order of `KDAState`."""
+    cfg = _config(kda_layers=[1],
+                  num_heads=8,
+                  head_dim=128,
+                  short_conv_kernel_size=4)
+    layout = compute_linear_attention_layout(cfg, torch.bfloat16)
+    assert layout.shapes == ((3, 1024), (3, 1024), (3, 1024), (8, 128, 128))
+    assert layout.dtypes == (torch.bfloat16, torch.bfloat16, torch.bfloat16,
+                             torch.float32)
+    # 3 * 3 * 1024 * 2 bytes + 8 * 128 * 128 * 4 bytes
+    assert layout.page_size_bytes == 3 * 3 * 1024 * 2 + 8 * 128 * 128 * 4
+
+
+def test_conv_window_depth_follows_the_kernel_size():
+    """The conv state holds `kernel_size - 1` past positions."""
+    for kernel in (2, 4, 8):
+        layout = compute_linear_attention_layout(
+            _config(kda_layers=[1],
+                    num_heads=2,
+                    head_dim=8,
+                    short_conv_kernel_size=kernel), torch.bfloat16)
+        assert layout.shapes[0] == (kernel - 1, 16)
+
+
+def test_model_dtype_is_threaded_into_the_conv_states_only():
+    """The recurrent state accumulates over the whole sequence and stays fp32
+    regardless of the model dtype."""
+    layout = compute_linear_attention_layout(
+        _config(kda_layers=[1], num_heads=2, head_dim=8), torch.float32)
+    assert layout.dtypes == (torch.float32, ) * 4
+    layout = compute_linear_attention_layout(
+        _config(kda_layers=[1], num_heads=2, head_dim=8), torch.float16)
+    assert layout.dtypes[:3] == (torch.float16, ) * 3
+    assert layout.dtypes[3] == torch.float32
+
+
+def test_sub_config_may_be_an_object_rather_than_a_dict():
+    """HF hands back a dict from config.json, but a config *class* that
+    declares the field exposes an object instead."""
+    cfg = SimpleNamespace(linear_attn_config=SimpleNamespace(
+        kda_layers=[1, 3], num_heads=2, head_dim=8))
+    assert linear_attn_config(cfg)["num_heads"] == 2
+    assert compute_linear_attention_layers(cfg) == frozenset({0, 2})
+
+
+def test_kimi_linear_48b_layer_split():
+    """The shipped 48B config: 20 KDA + 7 full-attention out of 27."""
+    cfg = SimpleNamespace(num_hidden_layers=27,
+                          linear_attn_config={
+                              "kda_layers": _K48_KDA,
+                              "num_heads": 32,
+                              "head_dim": 128,
+                              "short_conv_kernel_size": 4
+                          })
+    layers = compute_linear_attention_layers(cfg)
+    assert len(layers) == 20
+    assert len(set(range(27)) - layers) == 7
+    # The final layer (index 26) is full attention, as in the checkpoint.
+    assert 26 not in layers

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -19,6 +19,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 import torch
+from torchax.ops.mappings import t2j_dtype
 from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
                          SchedulerConfig, VllmConfig, set_current_vllm_config)
 from vllm.model_executor.layers.attention import Attention
@@ -1745,3 +1746,295 @@ class TestKVCacheManager:
 
         with pytest.raises(ValueError, match=r"\[kv-cache\].*state_cache"):
             self._init_ds_v4(kv_cache_config)
+
+    # ---------------------------------------------------------------
+    # JAX-native hybrid models (linear attention + full attention)
+    # ---------------------------------------------------------------
+
+    _HYBRID_BLOCK_SIZE = 16
+    _HYBRID_ATTN_HEAD_SIZE = 64
+    _HYBRID_MAMBA_SHAPES = ((3, 32), (3, 32), (3, 32), (2, 8, 8))
+    _HYBRID_MAMBA_DTYPES = (torch.bfloat16, torch.bfloat16, torch.bfloat16,
+                            torch.float32)
+
+    @staticmethod
+    def _vllm_shared_by_layout(num_attn: int, num_mamba: int):
+        """vLLM's kv-cache grouping, as (groups, shared_by-lists).
+
+        Transcribes `_get_kv_cache_groups_uniform_page_size`: split each layer
+        type into groups of `group_size`, then build one `KVCacheTensor` per
+        slot, `shared_by` the layer occupying that slot in each group. The
+        last group of the larger type is short when the count doesn't divide
+        evenly, which is what makes `shared_by` non-uniform.
+        """
+        min_count, max_count = min(num_attn,
+                                   num_mamba), max(num_attn, num_mamba)
+        group_size = max_count if max_count < min_count * 1.5 else min_count
+        attn = [f"layer.attn{i}" for i in range(num_attn)]
+        mamba = [f"layer.mamba{i}" for i in range(num_mamba)]
+        groups = [
+            attn[i:i + group_size] for i in range(0, num_attn, group_size)
+        ]
+        groups += [
+            mamba[i:i + group_size] for i in range(0, num_mamba, group_size)
+        ]
+        shared_by = [[g[slot] for g in groups if slot < len(g)]
+                     for slot in range(group_size)]
+        return groups, shared_by
+
+    def _hybrid_kv_cache_config(self, num_attn: int, num_mamba: int,
+                                num_blocks: int):
+        """A KVCacheConfig shaped like vLLM produces for a hybrid model."""
+        mamba_spec = MambaSpec(shapes=self._HYBRID_MAMBA_SHAPES,
+                               dtypes=self._HYBRID_MAMBA_DTYPES,
+                               block_size=self._HYBRID_BLOCK_SIZE)
+        attn_spec = FullAttentionSpec(block_size=self._HYBRID_BLOCK_SIZE,
+                                      num_kv_heads=1,
+                                      head_size=self._HYBRID_ATTN_HEAD_SIZE,
+                                      dtype=torch.bfloat16)
+        attn_page = get_attention_page_size_bytes(self.runner.mesh,
+                                                  self._HYBRID_BLOCK_SIZE, 1,
+                                                  self._HYBRID_ATTN_HEAD_SIZE,
+                                                  torch.bfloat16, False)
+
+        groups, shared_by = self._vllm_shared_by_layout(num_attn, num_mamba)
+        kv_cache_groups = [
+            KVCacheGroupSpec(layer_names=names,
+                             kv_cache_spec=(mamba_spec if "mamba" in names[0]
+                                            else attn_spec))
+            for names in groups
+        ]
+        # vLLM gives every tensor the same byte budget, sized from the widest
+        # group. Short groups therefore have spare room -- that is exactly the
+        # case the leading-dimension clamp has to handle.
+        widest = max(
+            sum(mamba_spec.page_size_bytes if "mamba" in n else attn_page
+                for n in names) for names in shared_by)
+        tensors = [
+            KVCacheTensor(size=widest * num_blocks, shared_by=names)
+            for names in shared_by
+        ]
+        return KVCacheConfig(num_blocks=num_blocks,
+                             kv_cache_tensors=tensors,
+                             kv_cache_groups=kv_cache_groups)
+
+    def _init_hybrid(self, num_attn: int, num_mamba: int, num_blocks: int = 8):
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+        self.runner.kv_caches = []
+        self.runner.layer_name_to_kvcache_index = {}
+        config = self._hybrid_kv_cache_config(num_attn, num_mamba, num_blocks)
+        manager.initialize_kv_cache(config)
+        return manager, config
+
+    @pytest.mark.parametrize(
+        "num_attn,num_mamba,uniform_groups",
+        [
+            # Kimi-K3: 24 MLA + 69 KDA. group_size=24 => KDA splits 24/24/21,
+            # so 3 of the 24 tensors are shared_by 3 layers, not 4.
+            (24, 69, False),
+            # The K3-tiny proxy: 3 + 6 divides evenly (2 KDA groups of 3).
+            (3, 6, True),
+            # Qwen3.5-shaped control: 15 + 45, evenly divisible.
+            (15, 45, True),
+        ])
+    def test_hybrid_layer_indices_cover_every_layer(self, num_attn, num_mamba,
+                                                    uniform_groups):
+        """Every layer gets its own array and its own index, whether or not
+        the `shared_by` groups all have the same size."""
+        manager, config = self._init_hybrid(num_attn, num_mamba)
+
+        group_sizes = {len(t.shared_by) for t in config.kv_cache_tensors}
+        assert (len(group_sizes) == 1) is uniform_groups, (
+            f"expected uniform_groups={uniform_groups}, got sizes {group_sizes}"
+        )
+
+        num_layers = num_attn + num_mamba
+        index_map = self.runner.layer_name_to_kvcache_index
+        assert len(index_map) == num_layers
+        assert len(self.runner.kv_caches) == num_layers
+        # A bijection onto the array list: no layer aliases another's state.
+        assert sorted(index_map.values()) == list(range(num_layers))
+
+        # ...and each layer's index really points at an array of its own kind.
+        for name, idx in index_map.items():
+            entry = self.runner.kv_caches[idx]
+            is_mamba_entry = isinstance(entry, tuple)
+            assert is_mamba_entry == ("mamba" in name), (
+                f"{name} -> kv_caches[{idx}] of the wrong kind")
+
+    def test_hybrid_all_layers_share_one_leading_dimension(self):
+        """Short groups must not get more blocks than the full ones: block
+        IDs are handed out from a single pool, so a layer with a shorter
+        leading dimension would silently clip writes."""
+        num_attn, num_mamba = 24, 69
+        manager, _ = self._init_hybrid(num_attn, num_mamba)
+
+        attn_blocks = {
+            self.runner.kv_caches[idx].shape[0]
+            for name, idx in self.runner.layer_name_to_kvcache_index.items()
+            if "attn" in name
+        }
+        mamba_blocks = {
+            state.shape[0]
+            for name, idx in self.runner.layer_name_to_kvcache_index.items()
+            if "mamba" in name for state in self.runner.kv_caches[idx]
+        }
+        assert len(attn_blocks) == 1, f"ragged attention pool: {attn_blocks}"
+        assert len(mamba_blocks) == 1, f"ragged mamba pool: {mamba_blocks}"
+
+    def test_hybrid_mamba_state_shapes_and_dtypes_follow_the_spec(self):
+        """A 4-state KDA layer allocates all four arrays, with the conv
+        windows at the model dtype and the recurrent state in fp32."""
+        _, _ = self._init_hybrid(3, 6)
+        idx = self.runner.layer_name_to_kvcache_index["layer.mamba0"]
+        states = self.runner.kv_caches[idx]
+        assert len(states) == len(self._HYBRID_MAMBA_SHAPES)
+        for state, shape, dtype in zip(states, self._HYBRID_MAMBA_SHAPES,
+                                       self._HYBRID_MAMBA_DTYPES):
+            assert state.shape[1:] == shape
+            assert state.dtype == t2j_dtype(dtype)
+
+    # ---------------------------------------------------------------
+    # JAX-native hybrid: per-layer spec emission from the HF config
+    # ---------------------------------------------------------------
+
+    def _jax_hybrid_text_config(self, num_layers: int, kda_layers_1indexed):
+        """A Kimi-shaped text config: MLA everywhere except `kda_layers`."""
+        from types import SimpleNamespace
+        return SimpleNamespace(
+            num_hidden_layers=num_layers,
+            linear_attn_config={
+                "kda_layers": list(kda_layers_1indexed),
+                "num_heads": 2,
+                "head_dim": 8,
+                "short_conv_kernel_size": 4,
+            },
+            # MLA geometry (read only when use_mla is on).
+            qk_rope_head_dim=64,
+            kv_lora_rank=512,
+            # Plain-attention geometry (read only when use_mla is off).
+            num_key_value_heads=1,
+            head_dim=64,
+            num_global_key_value_heads=None,
+            global_head_dim=None,
+            layer_types=None,
+            num_kv_shared_layers=0,
+        )
+
+    def _jax_hybrid_spec(self,
+                         num_layers,
+                         kda_layers_1indexed,
+                         *,
+                         use_mla=True,
+                         mamba_block_size=1024):
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        text_config = self._jax_hybrid_text_config(num_layers,
+                                                   kda_layers_1indexed)
+        model_config = MagicMock()
+        model_config.hf_text_config = text_config
+        model_config.hf_config = text_config
+        model_config.use_mla = use_mla
+        model_config.dtype = torch.bfloat16
+        model_config.get_num_layers.return_value = num_layers
+        model_config.get_total_num_kv_heads.return_value = 1
+        model_config.get_head_size.return_value = 64
+        self.runner.model_config = model_config
+        self.runner.cache_config.mamba_block_size = mamba_block_size
+        self.runner.speculative_config = None
+        self.runner.vllm_config.speculative_config = None
+        # The JAX branch is the one taken when no attention module registered
+        # itself in the forward context.
+        self.runner.vllm_config.compilation_config.static_forward_context.clear(
+        )
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = use_mla
+        return manager, manager.get_kv_cache_spec()
+
+    def test_jax_hybrid_spec_is_per_layer_not_model_wide(self):
+        """Kimi-K3's real split: 93 layers, 69 KDA + 24 MLA. The KDA layers
+        must get a MambaSpec even though `use_mla` is on model-wide."""
+        kda = sorted(
+            set(range(1, 94)) - {
+                70, 71, 72, 73, 74, 75, 76, 77, 78, 79, 80, 81, 82, 83, 84, 85,
+                86, 87, 88, 89, 90, 91, 92, 93
+            })
+        manager, spec = self._jax_hybrid_spec(93, kda)
+
+        assert len(spec) == 93
+        mamba_layers = {
+            int(name.split(".")[1])
+            for name, s in spec.items() if isinstance(s, MambaSpec)
+        }
+        mla_layers = {
+            int(name.split(".")[1])
+            for name, s in spec.items() if isinstance(s, MLAAttentionSpec)
+        }
+        assert len(mamba_layers) == 69 and len(mla_layers) == 24
+        assert mamba_layers == {i - 1 for i in kda}, "kda_layers is 1-indexed"
+        assert mamba_layers.isdisjoint(mla_layers)
+
+        # Every layer reports the same page size, which is what lets vLLM
+        # group them: 1 attn group + 3 KDA groups (69 = 24+24+21).
+        page_sizes = {s.page_size_bytes for s in spec.values()}
+        assert len(page_sizes) == 1
+        assert page_sizes == {manager._hybrid_uniform_page_size_bytes}
+
+    def test_jax_hybrid_mamba_spec_matches_the_config_layout(self):
+        from tpu_inference.models.common.linear_attention import \
+            compute_linear_attention_layout
+        _, spec = self._jax_hybrid_spec(9, [1, 2, 3, 5, 6, 7])
+        layout = compute_linear_attention_layout(
+            self._jax_hybrid_text_config(9, [1, 2, 3, 5, 6, 7]),
+            torch.bfloat16)
+        mamba = spec["layer.0"]
+        assert isinstance(mamba, MambaSpec)
+        assert mamba.shapes == layout.shapes
+        assert mamba.dtypes == layout.dtypes
+        assert mamba.block_size == 1024
+        # Three conv windows at the model dtype, one fp32 recurrent state.
+        assert mamba.dtypes == (torch.bfloat16, torch.bfloat16, torch.bfloat16,
+                                torch.float32)
+
+    def test_jax_hybrid_spec_falls_back_when_vllm_left_block_size_unset(self):
+        """If vLLM didn't classify the model as hybrid it leaves
+        `mamba_block_size` unset; one block must then cover a whole
+        sequence rather than crashing or silently using the attention
+        block size."""
+        _, spec = self._jax_hybrid_spec(9, [1, 2, 3], mamba_block_size=None)
+        assert spec["layer.0"].block_size == self.runner.max_model_len
+
+    def test_jax_non_hybrid_spec_is_unchanged(self):
+        """A config with no `linear_attn_config` must produce exactly the
+        attention-only specs it did before, with no page-size padding."""
+        from types import SimpleNamespace
+
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        text_config = SimpleNamespace(num_hidden_layers=4,
+                                      num_key_value_heads=1,
+                                      head_dim=64,
+                                      num_global_key_value_heads=None,
+                                      global_head_dim=None,
+                                      layer_types=None,
+                                      num_kv_shared_layers=0)
+        model_config = MagicMock()
+        model_config.hf_text_config = text_config
+        model_config.hf_config = text_config
+        model_config.use_mla = False
+        model_config.dtype = torch.bfloat16
+        model_config.get_num_layers.return_value = 4
+        model_config.get_total_num_kv_heads.return_value = 1
+        model_config.get_head_size.return_value = 64
+        self.runner.model_config = model_config
+        self.runner.speculative_config = None
+        self.runner.vllm_config.compilation_config.static_forward_context.clear(
+        )
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+        spec = manager.get_kv_cache_spec()
+
+        assert len(spec) == 4
+        assert all(isinstance(s, FullAttentionSpec) for s in spec.values())
+        assert manager._hybrid_uniform_page_size_bytes is None
+        assert manager._mamba_num_blocks is None

--- a/tpu_inference/kernels/gdn/v3/metadata.py
+++ b/tpu_inference/kernels/gdn/v3/metadata.py
@@ -21,7 +21,7 @@ from tpu_inference.kernels.gdn.v3 import config, memory_ref
 
 def compute_batched_seq_metadata(
     cfg: config.GDNConfig,
-    seq_lens: jax.Array,
+    has_initial_state: jax.Array,
     query_start_loc: jax.Array,
     state_indices: jax.Array,
     read_offsets: jax.Array,
@@ -34,9 +34,18 @@ def compute_batched_seq_metadata(
     `cfg.window_size` of them. The initial state is read from
     `state_indices[s] + read_offsets[s]` and one state checkpoint per window
     position is written back to `state_indices[s] + t`.
+
+    `has_initial_state` is `[num_seqs]`, nonzero where the sequence resumes
+    state written by an earlier step. The caller supplies it instead of this
+    function deriving `(seq_lens - query_lens) > 0`: that derivation assumes
+    `query_start_loc` holds exactly `num_seqs + 1` entries for the same
+    sequences `seq_lens` describes, which is only true per DP rank -- the
+    runner packs the global array as one `num_seqs_per_rank + 1` block per
+    rank. Taking the flag from the runner keeps that layout knowledge in one
+    place instead of in every op.
     """
 
-    max_seqs = seq_lens.size
+    max_seqs = has_initial_state.size
     all_seqs = jnp.arange(max_seqs)
 
     # NOTE: Only supports use case where query_lens[i] <= cfg.window_size where
@@ -44,7 +53,7 @@ def compute_batched_seq_metadata(
     # TODO(kyuyeunk): Add error handling when above condition is not met.
     query_lens = query_start_loc[1:] - query_start_loc[:-1]
     is_valid_seqs = jnp.where(all_seqs < end_seq, True, False)
-    has_initial_state = (seq_lens - query_lens) > 0
+    has_initial_state = has_initial_state.astype(jnp.bool_)
     all_valid_seqs = jnp.where(is_valid_seqs, all_seqs, 0)
 
     return memory_ref.MetadataRef.create(
@@ -63,27 +72,33 @@ def compute_batched_seq_metadata(
 
 def compute_per_seq_metadata(
     cfg: config.GDNConfig,
-    seq_lens: jax.Array,
+    has_initial_state: jax.Array,
     query_start_loc: jax.Array,
     state_indices: jax.Array,
     start_seq: jax.Array,
     end_seq: jax.Array,
 ) -> memory_ref.MetadataRef:
-    """Metadata for computing single sequence per tile."""
+    """Metadata for computing single sequence per tile.
 
-    max_seqs = seq_lens.size
+    See `compute_batched_seq_metadata` for why `has_initial_state` is passed
+    in rather than derived from `seq_lens - query_lens`.
+    """
+
+    max_seqs = has_initial_state.size
     max_tokens = cfg.batch_size
     all_seqs = jnp.arange(max_seqs)
     all_tokens = jnp.arange(max_tokens)
 
     # Shift to ensure first element is for start_seq.
     query_start_loc = jnp.roll(query_start_loc, shift=-start_seq)
-    seq_lens = jnp.roll(seq_lens, shift=-start_seq)
+    has_initial_state = jnp.roll(has_initial_state.astype(jnp.bool_),
+                                 shift=-start_seq)
     state_indices = jnp.roll(state_indices, shift=-start_seq)
 
     query_lens = query_start_loc[1:] - query_start_loc[:-1]
     # NOTE: query_lens is used for calculating num_tiles. Defensive programming
-    # that masks out all the other values (seq_lens, state_indices) are not needed
+    # that masks out all the other values (has_initial_state, state_indices) are
+    # not needed
     # since they will not be visited as long as num_tiles is correct.
     num_seqs = end_seq - start_seq
     query_lens = jnp.where(all_seqs < num_seqs, query_lens, 0)
@@ -123,7 +138,6 @@ def compute_per_seq_metadata(
     # is the first tile of a sequence and the sequence had been computed before
     # (chunked prefill, decode, etc). State is written if the program id is the
     # last tile of a sequence.
-    has_initial_state = (seq_lens - query_lens) > 0
     p_id_is_first_tile = p_id_to_t_id == 0
     p_id_is_last_tile = p_id_to_t_id == (s_idx_to_num_tiles[p_id_to_s_idx] - 1)
 

--- a/tpu_inference/kernels/gdn/v3/wrapper.py
+++ b/tpu_inference/kernels/gdn/v3/wrapper.py
@@ -284,7 +284,7 @@ def fused_conv1d_gdn(
     query_start_loc: jax.Array,  # [num_seqs + 1]
     state_indices: jax.Array,  # [num_seqs]
     distribution: jax.Array,  # [3]
-    seq_lens: jax.Array,  # [num_seqs]
+    has_initial_state: jax.Array,  # [num_seqs]
     read_offsets: jax.Array | None = None,  # [num_seqs]
     *,
     n_kq: int,
@@ -327,7 +327,11 @@ def fused_conv1d_gdn(
             mixed_end]. With `num_spec_tokens > 0`, the first segment holds
             speculative verify windows of up to `num_spec_tokens + 1` tokens
             rather than 1-token decodes.
-        seq_lens: Sequence lengths for each sequence of shape [num_seqs].
+        has_initial_state: [num_seqs], nonzero where the sequence resumes
+            conv/recurrent state written by an earlier step (chunked prefill,
+            decode) rather than starting from zeros. Supplied by the caller;
+            see `metadata.compute_batched_seq_metadata` for why it is not
+            derived from `seq_lens - query_lens` in here.
         read_offsets: Optional [num_seqs] int32 — per-sequence state read
             offset (num_accepted - 1 from the last verify step). Windowed
             sequences read their initial state from
@@ -481,7 +485,7 @@ def fused_conv1d_gdn(
         if mode != config.GDNMode.PER_SEQ:
             metadata_obj = metadata.compute_batched_seq_metadata(
                 cfg=cfg,
-                seq_lens=seq_lens,
+                has_initial_state=has_initial_state,
                 query_start_loc=query_start_loc,
                 state_indices=state_indices,
                 read_offsets=read_offsets,
@@ -490,7 +494,7 @@ def fused_conv1d_gdn(
         else:
             metadata_obj = metadata.compute_per_seq_metadata(
                 cfg=cfg,
-                seq_lens=seq_lens,
+                has_initial_state=has_initial_state,
                 query_start_loc=query_start_loc,
                 state_indices=state_indices,
                 start_seq=distribution[0],

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -55,6 +55,7 @@ class PCPMetadata:
         "query_start_loc",
         "request_distribution",
         "mamba_state_indices",
+        "has_initial_state",
         "pcp",
     ],
     meta_fields=["padded_num_reqs", "pcp_cache_pages"],
@@ -81,6 +82,33 @@ class AttentionMetadata(object):
     # use this field, only hybrid models exercise it today.
     mamba_state_indices: jax.Array | None = None
 
+    # (max_num_seqs,) int32, 0/1 — 1 when the request occupying this
+    # persistent-batch position already has recurrent/conv state in its mamba
+    # slot from an earlier step, i.e. this step must resume from that state
+    # rather than zero-initialize it. Runner-computed and authoritative;
+    # linear-attention ops must consume it and must NOT re-derive it.
+    #
+    # Why published rather than derived: the natural derivation
+    # `(seq_lens - query_lens) > 0` needs `query_lens`, and
+    # `query_start_loc` is laid out as a per-DP-rank concatenation of
+    # `max_num_reqs_per_dp_rank + 1` entries — total `max_num_seqs +
+    # dp_size`, not `max_num_seqs + 1`. Differencing it globally yields
+    # `max_num_seqs + dp_size - 1` values (one bogus entry per rank seam)
+    # instead of `max_num_seqs`, so the derivation is only valid at
+    # dp_size == 1, or inside a `shard_map` whose in_spec slices both arrays
+    # per rank. Ops that run outside such a shard_map (the JAX-native model
+    # path) silently get the wrong shape/values under attention DP.
+    #
+    # int32 rather than bool because the runner packs it through the int32
+    # `DeviceBuffer` blob; consumers should treat any nonzero as True.
+    # A boolean flag rather than a `num_computed_tokens` count: with
+    # speculative decoding the host-side count is optimistic (it assumes every
+    # proposed token was accepted, corrected on device afterwards), while the
+    # "> 0" predicate is exact — a request cannot have had tokens rejected
+    # before it has been prefilled at all.
+    # None for models without mamba layers.
+    has_initial_state: jax.Array | None = None
+
     # PCP-specific metadata. None when not running prefill context parallelism.
     pcp: PCPMetadata | None = None
 
@@ -103,6 +131,7 @@ class AttentionMetadata(object):
         "query_start_loc",
         "request_distribution",
         "mamba_state_indices",
+        "has_initial_state",
     ],
     meta_fields=["padded_num_reqs"],
 )
@@ -124,6 +153,9 @@ class SharedAttentionMetadata(object):
     # None for models without mamba layers; pure-mamba models would also
     # use this field, only hybrid models exercise it today.
     mamba_state_indices: jax.Array | None = None
+
+    # (max_num_seqs,) int32, 0/1 — see `AttentionMetadata.has_initial_state`.
+    has_initial_state: jax.Array | None = None
 
     # The actual number of requests padded to the compiled buckets. The bucket
     # contains only max_reqs by default to reduce model precompilation time.

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -15,7 +15,6 @@
 Bridge the torch gdn_attention_core op for gated deltanet attention TPU impl
 
 """
-import functools
 from typing import Optional, Tuple
 
 import jax
@@ -23,7 +22,8 @@ import jax.numpy as jnp
 from jax.sharding import PartitionSpec as P
 
 from tpu_inference.kernels.gdn.v3 import wrapper
-from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.common.sharding import (ShardingAxisName,
+                                                  rank_local_slot_indices)
 from tpu_inference.utils import get_mesh_shape_product
 
 
@@ -40,7 +40,7 @@ def run_jax_gdn_attention(
     state_indices: jnp.ndarray,
     query_start_loc: jnp.ndarray,
     distribution: jnp.ndarray,
-    seq_lens: jnp.ndarray,
+    has_initial_state: jnp.ndarray,
     n_kq: int,
     n_v: int,
     d_k: int,
@@ -71,9 +71,13 @@ def run_jax_gdn_attention(
           each sequence.
         distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
           mixed_end)`.
-        seq_lens: Tensor of shape `(max_reqs,)` with the total sequence length
-          per request (computed + scheduled). Used inside the local function
-          to derive ``has_initial_state``.
+        has_initial_state: Tensor of shape `(max_reqs,)`, nonzero where the
+          request resumes conv/recurrent state written by an earlier step.
+          Published by the runner in ``AttentionMetadata``; it is passed in
+          rather than derived from ``seq_lens - query_lens`` so that the
+          per-DP-rank layout of ``query_start_loc`` is accounted for in
+          exactly one place (see the field docs in
+          ``layers/common/attention_metadata.py``).
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Dimension of key.
@@ -106,7 +110,7 @@ def run_jax_gdn_attention(
         P(ShardingAxisName.ATTN_DATA),  # query_start_loc
         P(ShardingAxisName.ATTN_DATA),  # state_indices
         P(ShardingAxisName.ATTN_DATA),  # distribution
-        P(ShardingAxisName.ATTN_DATA),  # seq_lens
+        P(ShardingAxisName.ATTN_DATA),  # has_initial_state
     )
 
     out_specs = (
@@ -121,17 +125,34 @@ def run_jax_gdn_attention(
 
     tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
 
-    p_run_jax_gdn_attention_local = functools.partial(
-        wrapper.fused_conv1d_gdn,
-        n_kq=n_kq // tp_size,
-        n_v=n_v // tp_size,
-        d_k=d_k,
-        d_v=d_v,
-        kernel_size=kernel_size,
-    )
+    def _local(qkv, b, a, conv_state, recurrent_state, conv_weight, conv_bias,
+               a_log, dt_bias, qsl, state_indices, dist, has_init):
+        # `state_indices` are global slot ids while `conv_state` /
+        # `recurrent_state` here are this rank's shard of the pool, so rebase
+        # before the kernel indexes them (identity at dp_size == 1).
+        return wrapper.fused_conv1d_gdn(
+            qkv,
+            b,
+            a,
+            conv_state,
+            recurrent_state,
+            conv_weight,
+            conv_bias,
+            a_log,
+            dt_bias,
+            qsl,
+            rank_local_slot_indices(state_indices, conv_state.shape[0]),
+            dist,
+            has_init,
+            n_kq=n_kq // tp_size,
+            n_v=n_v // tp_size,
+            d_k=d_k,
+            d_v=d_v,
+            kernel_size=kernel_size,
+        )
 
     mapped_fn = jax.shard_map(
-        p_run_jax_gdn_attention_local,
+        _local,
         mesh=mesh,
         in_specs=in_specs,
         out_specs=out_specs,
@@ -151,7 +172,7 @@ def run_jax_gdn_attention(
         query_start_loc,
         state_indices,
         distribution,
-        seq_lens,
+        has_initial_state,
     )
 
     return (new_conv_state, new_recurrent_state), output

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -22,8 +22,7 @@ import jax.numpy as jnp
 from jax.sharding import PartitionSpec as P
 
 from tpu_inference.kernels.gdn.v3 import wrapper
-from tpu_inference.layers.common.sharding import (ShardingAxisName,
-                                                  rank_local_slot_indices)
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.utils import get_mesh_shape_product
 
 
@@ -66,7 +65,10 @@ def run_jax_gdn_attention(
         j_A_log: Log of A parameter tensor of shape `(n_v,)`.
         j_dt_bias: Delta T bias tensor of shape `(n_v,)`.
         state_indices: Tensor of shape `(max_reqs,)` mapping request index to
-          state index.
+          state index. Rank-local: the runner rebases global slot ids per DP
+          rank before publishing ``AttentionMetadata.mamba_state_indices``,
+          so each id indexes directly into that rank's shard of the state
+          pool.
         query_start_loc: Tensor of shape `(num_seqs + 1,)` with start locations of
           each sequence.
         distribution: Tensor of shape `(3,)` int32 — `(decode_end, prefill_end,
@@ -127,9 +129,11 @@ def run_jax_gdn_attention(
 
     def _local(qkv, b, a, conv_state, recurrent_state, conv_weight, conv_bias,
                a_log, dt_bias, qsl, state_indices, dist, has_init):
-        # `state_indices` are global slot ids while `conv_state` /
-        # `recurrent_state` here are this rank's shard of the pool, so rebase
-        # before the kernel indexes them (identity at dp_size == 1).
+        # `state_indices` arrive already rank-local: the runner rebases the
+        # global slot ids per DP rank (`global % local_slots`, see the
+        # mamba_state_indices block in `TPURunner._prepare_inputs`) before
+        # publishing `AttentionMetadata.mamba_state_indices`, so they index
+        # this rank's shard of the state pool directly.
         return wrapper.fused_conv1d_gdn(
             qkv,
             b,
@@ -141,7 +145,7 @@ def run_jax_gdn_attention(
             a_log,
             dt_bias,
             qsl,
-            rank_local_slot_indices(state_indices, conv_state.shape[0]),
+            state_indices,
             dist,
             has_init,
             n_kq=n_kq // tp_size,

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -151,6 +151,27 @@ def is_attn_dp(mesh: Mesh) -> bool:
     return (attn_dp_size // dp_size) > 1
 
 
+def rank_local_slot_indices(state_indices, num_local_blocks: int):
+    """Rebase global mamba slot ids onto one ``ATTN_DATA`` shard.
+
+    The mamba state pool is allocated with its leading (block) dimension
+    sharded over ``ShardingAxisName.ATTN_DATA``, and the slot allocator hands
+    DP rank ``k`` slots out of ``[k * L, (k + 1) * L)``, where
+    ``L = mamba_num_blocks // dp_size`` (see ``InputBatch._build_mamba_pools``
+    and the ``MambaSpec`` branch of ``KVCacheManager.initialize_kv_cache``).
+    The ids published in ``AttentionMetadata.mamba_state_indices`` are global,
+    so inside a ``shard_map`` — where rank ``k`` sees only its own ``L``
+    blocks, indexed from 0 — they have to be rebased or every rank but 0 reads
+    and writes another rank's slots.
+
+    ``num_local_blocks`` is the leading dimension of the *shard* (i.e.
+    ``conv_state.shape[0]`` as seen inside the ``shard_map``), which equals
+    ``L`` by construction. At ``dp_size == 1`` every id is already below ``L``,
+    so this is the identity.
+    """
+    return state_indices % num_local_blocks
+
+
 @dataclass
 class ShardingStrategy:
     """Defines the high-level parallelism strategy.

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -151,27 +151,6 @@ def is_attn_dp(mesh: Mesh) -> bool:
     return (attn_dp_size // dp_size) > 1
 
 
-def rank_local_slot_indices(state_indices, num_local_blocks: int):
-    """Rebase global mamba slot ids onto one ``ATTN_DATA`` shard.
-
-    The mamba state pool is allocated with its leading (block) dimension
-    sharded over ``ShardingAxisName.ATTN_DATA``, and the slot allocator hands
-    DP rank ``k`` slots out of ``[k * L, (k + 1) * L)``, where
-    ``L = mamba_num_blocks // dp_size`` (see ``InputBatch._build_mamba_pools``
-    and the ``MambaSpec`` branch of ``KVCacheManager.initialize_kv_cache``).
-    The ids published in ``AttentionMetadata.mamba_state_indices`` are global,
-    so inside a ``shard_map`` — where rank ``k`` sees only its own ``L``
-    blocks, indexed from 0 — they have to be rebased or every rank but 0 reads
-    and writes another rank's slots.
-
-    ``num_local_blocks`` is the leading dimension of the *shard* (i.e.
-    ``conv_state.shape[0]`` as seen inside the ``shard_map``), which equals
-    ``L`` by construction. At ``dp_size == 1`` every id is already below ``L``,
-    so this is the identity.
-    """
-    return state_indices % num_local_blocks
-
-
 @dataclass
 class ShardingStrategy:
     """Defines the high-level parallelism strategy.

--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -66,8 +66,18 @@ def gdn_attention_core_tpu(
     padded_num_reqs = first_attn_metadata.padded_num_reqs
     request_distribution = first_attn_metadata.request_distribution
     query_start_loc = first_attn_metadata.query_start_loc
-    seq_lens = first_attn_metadata.seq_lens
+    has_initial_state = first_attn_metadata.has_initial_state
     state_indices = first_attn_metadata.mamba_state_indices
+    if has_initial_state is None:
+        raise ValueError(
+            "[gdn] AttentionMetadata.has_initial_state is None for layer "
+            f"{layer_name}, so the kernel cannot tell which slots must resume "
+            "conv/recurrent state. The runner publishes the field for models "
+            "that register mamba kv-cache layers; a None here means this "
+            "model's GDN layers were not registered as such. Not re-deriving "
+            "it from query_start_loc on purpose -- that derivation is wrong "
+            "under attention DP (see the field docs in "
+            "layers/common/attention_metadata.py).")
 
     layer_module = fc.no_compile_layers[layer_name]
     vllm_context = get_vllm_model_wrapper_context()
@@ -132,8 +142,9 @@ def gdn_attention_core_tpu(
                                                    dp_size)
     query_start_loc_sliced = truncate_sharded_tensor(
         query_start_loc, padded_num_reqs_per_dp + 1, dp_size)
-    seq_lens_sliced = truncate_sharded_tensor(seq_lens, padded_num_reqs_per_dp,
-                                              dp_size)
+    has_initial_state_sliced = truncate_sharded_tensor(has_initial_state,
+                                                       padded_num_reqs_per_dp,
+                                                       dp_size)
 
     (new_conv_state_extracted,
      new_recurrent_state), j_output = run_jax_gdn_attention(
@@ -149,7 +160,7 @@ def gdn_attention_core_tpu(
          state_indices_sliced,
          query_start_loc_sliced,
          request_distribution,
-         seq_lens_sliced,
+         has_initial_state_sliced,
          n_kq,
          n_v,
          d_k,

--- a/tpu_inference/models/common/linear_attention.py
+++ b/tpu_inference/models/common/linear_attention.py
@@ -1,0 +1,124 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Recurrent-state layout for JAX-native hybrid (linear-attention) models.
+
+The torchax path gets this from vLLM: every linear-attention layer is a
+`MambaBase` torch module that reports its own `MambaSpec`. JAX-native models
+have no such runtime module -- the layer list and the state shapes are only
+knowable from the HF text config -- so the KV-cache manager derives them here,
+the same way it derives cross-layer KV sharing in `kv_share.py`.
+
+Returns `None` for every config that has no linear-attention layers, which is
+every JAX-native model except the Kimi family today, so the non-hybrid path is
+untouched.
+"""
+
+from dataclasses import dataclass
+from math import prod
+from typing import Any, Dict, Optional, Tuple
+
+import torch
+from vllm.utils.torch_utils import get_dtype_size
+
+__all__ = [
+    "LinearAttentionStateLayout",
+    "linear_attn_config",
+    "compute_linear_attention_layers",
+    "compute_linear_attention_layout",
+]
+
+
+@dataclass(frozen=True)
+class LinearAttentionStateLayout:
+    """Which layers are recurrent, and the per-slot state they own.
+
+    `shapes` / `dtypes` are exactly the `MambaSpec` fields, in the order the
+    model's state NamedTuple declares them, so the arrays allocated from this
+    layout can be handed to the layer positionally. Shapes are *global* (not
+    divided by any parallelism degree): the JAX KV-cache arrays carry a
+    `NamedSharding` that splits them across the mesh, matching how
+    `get_attention_page_size_bytes` reports global per-block bytes for the
+    attention layers.
+    """
+    layer_indices: frozenset[int]
+    shapes: Tuple[Tuple[int, ...], ...]
+    dtypes: Tuple[torch.dtype, ...]
+
+    @property
+    def page_size_bytes(self) -> int:
+        """Unpadded bytes for one request's state in one layer."""
+        return sum(
+            prod(shape) * get_dtype_size(dtype)
+            for shape, dtype in zip(self.shapes, self.dtypes))
+
+
+def linear_attn_config(text_config: Any) -> Dict[str, Any]:
+    """The `linear_attn_config` sub-config as a plain dict ({} when absent).
+
+    HF ships it as a dict in `config.json`, but a config class that declares
+    it as an attribute hands back an object instead.
+    """
+    cfg = getattr(text_config, "linear_attn_config", None)
+    if not cfg:
+        return {}
+    if not isinstance(cfg, dict):
+        cfg = vars(cfg)
+    return cfg
+
+
+def compute_linear_attention_layers(text_config: Any) -> frozenset:
+    """0-indexed indices of the layers that carry recurrent state.
+
+    Kimi (`Kimi-Linear-48B`, `Kimi-K3`) marks its KDA layers with a
+    **1-indexed** `linear_attn_config.kda_layers` list; every other layer is
+    full attention. Empty for models with no linear-attention layers.
+    """
+    kda_layers = linear_attn_config(text_config).get("kda_layers") or ()
+    return frozenset(i - 1 for i in kda_layers)
+
+
+def compute_linear_attention_layout(
+        text_config: Any,
+        model_dtype: torch.dtype) -> Optional[LinearAttentionStateLayout]:
+    """Derive the recurrent-state layout, or None if the model has none.
+
+    The state is the three depthwise-conv windows (one each
+    for q/k/v, `short_conv_kernel_size - 1` positions deep) plus the
+    `[heads, head_dim, head_dim]` recurrent matrix. This mirrors
+    `KDAState` in `layers/common/kda_attention.py`.
+
+    The conv windows follow the model dtype; the recurrent state is always
+    fp32 (it accumulates over the whole sequence). Same split vLLM applies in
+    `MambaStateDtypeCalculator.kda_state_dtype`, which pairs a
+    `mamba_cache_dtype`-driven conv dtype with an fp32 recurrent state --
+    except that we keep the conv windows at the model dtype rather than
+    exposing a separate cache dtype knob, because the KDA op reads them as
+    activations.
+    """
+    layer_indices = compute_linear_attention_layers(text_config)
+    if not layer_indices:
+        return None
+
+    cfg = linear_attn_config(text_config)
+    num_heads = cfg["num_heads"]
+    head_dim = cfg["head_dim"]
+    conv_kernel_size = cfg.get("short_conv_kernel_size", 4)
+
+    conv_shape = (conv_kernel_size - 1, num_heads * head_dim)
+    recurrent_shape = (num_heads, head_dim, head_dim)
+    return LinearAttentionStateLayout(
+        layer_indices=layer_indices,
+        shapes=(conv_shape, conv_shape, conv_shape, recurrent_shape),
+        dtypes=(model_dtype, model_dtype, model_dtype, torch.float32),
+    )

--- a/tpu_inference/models/common/linear_attention.py
+++ b/tpu_inference/models/common/linear_attention.py
@@ -93,10 +93,10 @@ def compute_linear_attention_layout(
         model_dtype: torch.dtype) -> Optional[LinearAttentionStateLayout]:
     """Derive the recurrent-state layout, or None if the model has none.
 
-    The state is the three depthwise-conv windows (one each
-    for q/k/v, `short_conv_kernel_size - 1` positions deep) plus the
-    `[heads, head_dim, head_dim]` recurrent matrix. This mirrors
-    `KDAState` in `layers/common/kda_attention.py`.
+    The state is four buffers per layer: three depthwise-conv windows (one
+    each for q/k/v, `short_conv_kernel_size - 1` positions deep) plus the
+    `[heads, head_dim, head_dim]` recurrent matrix — exactly what the KDA op
+    reads at the start of a step and writes back at the end.
 
     The conv windows follow the model dtype; the recurrent state is always
     fp32 (it accumulates over the whole sequence). Same split vLLM applies in

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -117,6 +117,21 @@ class CompilationManager:
             return device_array(self.runner.mesh, tensor, sharding=sharding)
         return device_array(self.runner.mesh, tensor)
 
+    def _create_dummy_mamba_fields(self,
+                                   sharding: NamedSharding) -> Tuple[Any, Any]:
+        """Dummy `(mamba_state_indices, has_initial_state)` for precompilation.
+
+        Both are `None` for pure-attention models because `_prepare_inputs`
+        passes `None` at runtime, and the precompile primer must match that
+        pytree for the cached HLO to be reused (otherwise the ForbidCompile
+        guard fires on the first real step).
+        """
+        if not self.runner.kv_cache_config.has_mamba_layers:
+            return None, None
+        zeros = np.zeros(self.runner.max_num_reqs, dtype=np.int32)
+        return (device_array(self.runner.mesh, zeros, sharding=sharding),
+                device_array(self.runner.mesh, zeros, sharding=sharding))
+
     def _should_skip_padding_combination(self, outer_val: int, inner_val: int,
                                          only_equal: bool) -> bool:
         """Helper to determine if we should skip this padding combination."""
@@ -425,18 +440,9 @@ class CompilationManager:
                                            sharding=pcp_spec),
                 cache_pages=pcp_cache_pages,
             )
-        # Dummy mamba_state_indices for compile-cache pre-tracing. Only
-        # populate for hybrid attn+mamba models — for pure-attention models we
-        # pass None at runtime (see `_prepare_inputs`), and the precompile
-        # primer must match that shape so the cached HLO is reused.
-        if self.runner.kv_cache_config.has_mamba_layers:
-            mamba_state_indices = device_array(self.runner.mesh,
-                                               np.zeros(
-                                                   self.runner.max_num_reqs,
-                                                   dtype=np.int32),
-                                               sharding=metadata_attn_sharding)
-        else:
-            mamba_state_indices = None
+        # Dummy mamba fields for compile-cache pre-tracing.
+        (mamba_state_indices, has_initial_state) = (
+            self._create_dummy_mamba_fields(metadata_attn_sharding))
 
         def build_block_table(kv_cache_gid: int) -> jax.Array:
             block_table_obj = self.runner.input_batch.block_table[kv_cache_gid]
@@ -457,6 +463,7 @@ class CompilationManager:
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                has_initial_state=has_initial_state,
                 padded_num_reqs=num_reqs,
                 pcp=pcp,
             )
@@ -470,6 +477,7 @@ class CompilationManager:
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                has_initial_state=has_initial_state,
                 padded_num_reqs=num_reqs,
             )
 
@@ -1471,19 +1479,12 @@ class CompilationManager:
         request_distribution = device_array(self.runner.mesh,
                                             request_distribution,
                                             sharding=dp_sharding)
-        # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
-        # Must match the ATTN_DATA sharding `_prepare_inputs_*` produces at
+        # Dummy mamba fields for spec-decode compile-cache pre-tracing. Must
+        # match the ATTN_DATA sharding `_prepare_inputs_*` produces at
         # runtime — otherwise the draft model_fn cache misses and the
-        # ForbidCompile guard inside `Eagle3Proposer.propose` raises. None for
-        # pure-attention models (the common eagle3 case) so the field stays
-        # absent end-to-end.
-        if self.runner.kv_cache_config.has_mamba_layers:
-            eagle3_mamba_state_indices = device_array(
-                self.runner.mesh,
-                np.zeros(self.runner.max_num_reqs, dtype=np.int32),
-                sharding=dp_sharding)
-        else:
-            eagle3_mamba_state_indices = None
+        # ForbidCompile guard inside `Eagle3Proposer.propose` raises.
+        (eagle3_mamba_state_indices, eagle3_has_initial_state
+         ) = self._create_dummy_mamba_fields(dp_sharding)
 
         num_reqs_dp = self._create_dummy_tensor((dp_size, ),
                                                 jnp.int32,
@@ -1501,6 +1502,7 @@ class CompilationManager:
                     query_start_loc=query_start_loc,
                     request_distribution=request_distribution,
                     mamba_state_indices=eagle3_mamba_state_indices,
+                    has_initial_state=eagle3_has_initial_state,
                     padded_num_reqs=num_reqs,
                 )
 
@@ -1606,20 +1608,12 @@ class CompilationManager:
         request_distribution = device_array(self.runner.mesh,
                                             request_distribution,
                                             sharding=dp_sharding)
-        # Dummy mamba_state_indices for spec-decode compile-cache pre-tracing.
-        # Must match the ATTN_DATA sharding `_prepare_inputs_*` produces at
+        # Dummy mamba fields for spec-decode compile-cache pre-tracing. Must
+        # match the ATTN_DATA sharding `_prepare_inputs_*` produces at
         # runtime — otherwise the draft model_fn cache misses and the
-        # ForbidCompile guard inside `Eagle3Proposer.propose` raises. None for
-        # pure-attention models (the common eagle3 case) so the field stays
-        # absent end-to-end.
-        if self.runner.kv_cache_config.has_mamba_layers:
-            mamba_state_indices = device_array(self.runner.mesh,
-                                               np.zeros(
-                                                   self.runner.max_num_reqs,
-                                                   dtype=np.int32),
-                                               sharding=dp_sharding)
-        else:
-            mamba_state_indices = None
+        # ForbidCompile guard inside `Eagle3Proposer.propose` raises.
+        (mamba_state_indices,
+         has_initial_state) = self._create_dummy_mamba_fields(dp_sharding)
 
         num_reqs_dp = self._create_dummy_tensor((dp_size, ),
                                                 jnp.int32,
@@ -1645,6 +1639,7 @@ class CompilationManager:
                     query_start_loc=query_start_loc,
                     request_distribution=request_distribution,
                     mamba_state_indices=mamba_state_indices,
+                    has_initial_state=has_initial_state,
                     padded_num_reqs=num_reqs,
                 )
 
@@ -1736,13 +1731,8 @@ class CompilationManager:
                                             request_distribution,
                                             sharding=dp_sharding)
 
-        if self.runner.kv_cache_config.has_mamba_layers:
-            dflash_mamba_state_indices = device_array(
-                self.runner.mesh,
-                np.zeros(self.runner.max_num_reqs, dtype=np.int32),
-                sharding=dp_sharding)
-        else:
-            dflash_mamba_state_indices = None
+        (dflash_mamba_state_indices, dflash_has_initial_state
+         ) = self._create_dummy_mamba_fields(dp_sharding)
 
         num_reqs_dp = self._create_dummy_tensor((dp_size, ),
                                                 jnp.int32,
@@ -1779,6 +1769,7 @@ class CompilationManager:
                     query_start_loc=query_start_loc,
                     request_distribution=request_distribution,
                     mamba_state_indices=dflash_mamba_state_indices,
+                    has_initial_state=dflash_has_initial_state,
                     padded_num_reqs=num_reqs,
                 )
 
@@ -1838,6 +1829,7 @@ class CompilationManager:
                     query_start_loc=query_start_loc,
                     request_distribution=request_distribution,
                     mamba_state_indices=dflash_mamba_state_indices,
+                    has_initial_state=dflash_has_initial_state,
                     padded_num_reqs=num_reqs,
                 )
 
@@ -1950,13 +1942,8 @@ class CompilationManager:
                                                 request_distribution,
                                                 sharding=dp_sharding)
 
-            if self.runner.kv_cache_config.has_mamba_layers:
-                mamba_state_indices = device_array(
-                    self.runner.mesh,
-                    np.zeros(self.runner.max_num_reqs, dtype=np.int32),
-                    sharding=dp_sharding)
-            else:
-                mamba_state_indices = None
+            (mamba_state_indices,
+             has_initial_state) = self._create_dummy_mamba_fields(dp_sharding)
 
             def build_block_table(kv_cache_gid: int) -> jax.Array:
                 block_table_obj = self.runner.input_batch.block_table[
@@ -1982,6 +1969,7 @@ class CompilationManager:
                     query_start_loc=query_start_loc,
                     request_distribution=request_distribution,
                     mamba_state_indices=mamba_state_indices,
+                    has_initial_state=has_initial_state,
                     padded_num_reqs=num_reqs,
                 )
             else:
@@ -1994,6 +1982,7 @@ class CompilationManager:
                         query_start_loc=query_start_loc,
                         request_distribution=request_distribution,
                         mamba_state_indices=mamba_state_indices,
+                        has_initial_state=has_initial_state,
                         padded_num_reqs=num_reqs,
                     )
                     for gid, kv_cache_group in enumerate(

--- a/tpu_inference/runner/decode_loop.py
+++ b/tpu_inference/runner/decode_loop.py
@@ -137,6 +137,7 @@ def _decode_core(
     query_start_loc,
     request_distribution,
     mamba_state_indices,
+    has_initial_state,
     current_tokens,
     active_mask,
     input_positions,
@@ -172,6 +173,7 @@ def _decode_core(
             query_start_loc=query_start_loc,
             request_distribution=request_distribution,
             mamba_state_indices=mamba_state_indices,
+            has_initial_state=has_initial_state,
         )
         shared_attn_metadata = SharedAttentionMetadata(
             input_positions=pos,
@@ -179,6 +181,7 @@ def _decode_core(
             query_start_loc=query_start_loc,
             request_distribution=request_distribution,
             mamba_state_indices=mamba_state_indices,
+            has_initial_state=has_initial_state,
         )
         kvc, hidden_states, _, expert_indices_step = model_fn(
             state,
@@ -430,6 +433,7 @@ def continue_decode(
                 query_start_loc=attn.query_start_loc,
                 request_distribution=attn.request_distribution,
                 mamba_state_indices=attn.mamba_state_indices,
+                has_initial_state=attn.has_initial_state,
             )
             shared_am = SharedAttentionMetadata(
                 input_positions=input_positions,
@@ -437,6 +441,7 @@ def continue_decode(
                 query_start_loc=attn.query_start_loc,
                 request_distribution=attn.request_distribution,
                 mamba_state_indices=attn.mamba_state_indices,
+                has_initial_state=attn.has_initial_state,
             )
             _, _, _, experts = model_fn(state,
                                         kv_caches,
@@ -478,6 +483,7 @@ def continue_decode(
          query_start_loc=attn.query_start_loc,
          request_distribution=attn.request_distribution,
          mamba_state_indices=attn.mamba_state_indices,
+         has_initial_state=attn.has_initial_state,
          current_tokens=init_state.current_tokens,
          active_mask=init_state.active_mask,
          input_positions=attn.input_positions,
@@ -513,6 +519,7 @@ def continue_decode(
             query_start_loc=attn.query_start_loc,
             request_distribution=attn.request_distribution,
             mamba_state_indices=attn.mamba_state_indices,
+            has_initial_state=attn.has_initial_state,
         ),
         step_counter=step_counter.astype(jnp.int32),
     )

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -30,6 +30,7 @@ from vllm.models.deepseek_v4.attention import (DeepseekV4Attention,
 from vllm.models.deepseek_v4.compressor import CompressorStateCache
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache
+from vllm.v1.attention.backends.registry import MambaAttentionBackendEnum
 from vllm.v1.attention.backends.utils import (get_kv_cache_layout,
                                               set_kv_cache_layout)
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
@@ -42,6 +43,8 @@ from tpu_inference import utils as common_utils
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
 from tpu_inference.models.common.kv_share import compute_kv_share_map
+from tpu_inference.models.common.linear_attention import (
+    LinearAttentionStateLayout, compute_linear_attention_layout)
 from tpu_inference.offload.utils import get_kv_connector_cache_layout
 from tpu_inference.runner import utils as runner_utils
 from tpu_inference.runner.input_batch import CachedRequestState, InputBatch
@@ -143,6 +146,66 @@ class KVCacheManager:
                                          dtype=self.runner.kv_cache_dtype,
                                          page_size_padded=page_size_padded)
 
+    def _duplicated_group_page_size(self, kv_cache_tensor,
+                                    layer_name_to_spec: dict) -> int:
+        """Bytes per block for one `shared_by` group, when every layer in it
+        gets its own array.
+
+        Uses the per-layer *TPU-actual* per-block bytes so the sum equals the
+        `page_size_padded` that `install_hybrid_page_size_padding` put on
+        every spec (== attn_page + N × mamba_unpadded). For attention, the
+        TPU-actual size includes dtype-specific packing (e.g., fp8 KV packs 4
+        elements per 32-bit word) which `spec.real_page_size_bytes` doesn't
+        account for — on fp8 models they differ by 2×, which would break the
+        num_blocks match here.
+        """
+        total = 0
+        for name in kv_cache_tensor.shared_by:
+            spec = layer_name_to_spec[name]
+            if isinstance(spec, MambaSpec):
+                total += dataclasses.replace(
+                    spec, page_size_padded=None).page_size_bytes
+            else:
+                total += get_attention_page_size_bytes(
+                    self.runner.mesh, spec.block_size, spec.num_kv_heads,
+                    spec.head_size, spec.dtype, self.use_mla)
+        return total
+
+    def _create_linear_attention_spec(
+            self, layout: LinearAttentionStateLayout) -> MambaSpec:
+        """The recurrent-state spec for one JAX-native linear-attention layer.
+
+        Mirrors `MambaBase.get_kv_cache_spec` field for field, reading from
+        the config-derived layout instead of a torch module. `mamba_type` is
+        `GDN_ATTN` because that is what vLLM's own KDA layer reports (it
+        subclasses the gated-delta-net base); on the JAX path it only selects
+        vLLM-side metadata bookkeeping, never a device kernel.
+        """
+        cache_config = self.runner.cache_config
+        mamba_block_size = cache_config.mamba_block_size
+        if mamba_block_size is None:
+            # vLLM sets this when it recognises the architecture as hybrid.
+            # If it didn't, one block must still cover a whole sequence --
+            # recurrent state is not block-addressable.
+            mamba_block_size = self.runner.max_model_len
+            logger.warning(
+                "[kv-cache] cache_config.mamba_block_size was unset for a "
+                "hybrid model; falling back to max_model_len=%d. vLLM did "
+                "not classify this architecture as hybrid -- check that the "
+                "registered vLLM class reports mamba layers.",
+                mamba_block_size)
+        speculative_config = self.runner.vllm_config.speculative_config
+        return MambaSpec(
+            shapes=layout.shapes,
+            dtypes=layout.dtypes,
+            block_size=mamba_block_size,
+            page_size_padded=self._hybrid_uniform_page_size_bytes,
+            mamba_type=MambaAttentionBackendEnum.GDN_ATTN,
+            mamba_cache_mode=cache_config.mamba_cache_mode,
+            num_speculative_blocks=(speculative_config.num_speculative_tokens
+                                    if speculative_config else 0),
+        )
+
     def update_mamba_page_size_padded(
             self, layers: dict[str, AttentionLayerBase]) -> None:
         """Pad attention and mamba page sizes so vLLM's num_blocks matches
@@ -229,6 +292,33 @@ class KVCacheManager:
         unpadded_mamba_page_size = dataclasses.replace(
             first_mamba_spec, page_size_padded=None).page_size_bytes
 
+        self.install_hybrid_page_size_padding(
+            attn_page_size_bytes=int(attn_page_size_bytes),
+            unpadded_mamba_page_size=int(unpadded_mamba_page_size),
+            num_attn=len(attn_modules),
+            num_mamba=len(mamba_modules))
+
+    def install_hybrid_page_size_padding(self, *, attn_page_size_bytes: int,
+                                         unpadded_mamba_page_size: int,
+                                         num_attn: int,
+                                         num_mamba: int) -> None:
+        """Set the uniform page size (and compact-mamba sizing) from counts.
+
+        Split out of `update_mamba_page_size_padded` so the JAX-native path can
+        reach it: there the layer counts and both page sizes come from the HF
+        config rather than from `MambaBase` / `Attention` torch modules, but
+        the grouping arithmetic and everything it feeds is identical. Must run
+        *before* any spec is created -- `_create_attention_spec` reads
+        `_hybrid_uniform_page_size_bytes`.
+
+        Args:
+            attn_page_size_bytes: TPU-actual bytes per block per attention
+                layer.
+            unpadded_mamba_page_size: bytes per slot per mamba layer, with no
+                padding applied.
+            num_attn: number of attention layers.
+            num_mamba: number of recurrent-state layers.
+        """
         # Derive vLLM's kv-cache group layout. vLLM splits each type into
         # equal-sized groups of `group_size` layers, then allocates
         # `group_size` `KVCacheTensor`s, each `shared_by` one layer from
@@ -254,8 +344,6 @@ class KVCacheManager:
         # spec creation depends on padding). Keep in sync if that
         # heuristic ever changes — it has been stable since the hybrid
         # allocator landed.
-        num_attn = len(attn_modules)
-        num_mamba = len(mamba_modules)
         min_count = min(num_attn, num_mamba)
         max_count = max(num_attn, num_mamba)
         # Match vLLM exactly: float comparison, no int() truncation (matters
@@ -494,7 +582,76 @@ class KVCacheManager:
             # the common case.
             kv_share_map = compute_kv_share_map(text_config)
 
-            for i in range(model_config.get_num_layers(parallel_config)):
+            num_layers = model_config.get_num_layers(parallel_config)
+
+            def attention_heads_and_size(layer_idx: int):
+                """`(num_kv_heads, head_size)` for a non-MLA JAX-path layer."""
+                # TODO(kwang3939): unify the hybrid kv cache of jax path and tochax path.
+                # `or ()` because the attribute is present but None on some
+                # configs, which `hasattr` alone does not screen out.
+                layer_types = getattr(text_config, "layer_types", None) or ()
+                layer_type = "full_attention"
+                if layer_idx < len(layer_types):
+                    layer_type = layer_types[layer_idx]
+
+                is_sliding = layer_type == "sliding_attention"
+                # Use `or` instead of getattr default so we also handle
+                # the case where the attribute is present but None
+                # (e.g. Gemma-4 E2B has num_global_key_value_heads=None).
+                # `or` also coerces 0 → fallback, which is fine because
+                # 0 num_kv_heads / head_dim is never a valid config and
+                # would crash get_padded_num_heads downstream anyway.
+                if not is_sliding:
+                    num_kv_heads = (getattr(text_config,
+                                            "num_global_key_value_heads", None)
+                                    or base_num_kv_heads)
+                    head_size = (getattr(text_config, "global_head_dim", None)
+                                 or base_head_size)
+                else:
+                    num_kv_heads = (getattr(text_config, "num_key_value_heads",
+                                            None) or base_num_kv_heads)
+                    head_size = (getattr(text_config, "head_dim", None)
+                                 or base_head_size)
+                # Pad num_kv_heads to multiple of TP size.
+                return (common_utils.get_padded_num_heads(
+                    num_kv_heads,
+                    model_cnt), common_utils.get_padded_head_dim(head_size))
+
+            # Hybrid models. The torchax path learns which layers are
+            # recurrent by finding `MambaBase` modules in the forward context;
+            # a JAX-native model registers no such module, so the layer list
+            # and state layout are derived from the HF config. `None` for
+            # attention-only models, which leaves everything below unchanged.
+            linear_attn = compute_linear_attention_layout(
+                text_config, model_config.dtype)
+            if linear_attn is not None:
+                attn_layer_indices = [
+                    i for i in range(num_layers)
+                    if i not in linear_attn.layer_indices
+                    and i not in kv_share_map
+                ]
+                assert attn_layer_indices, (
+                    "[kv-cache] hybrid model has no full-attention layers: "
+                    f"num_layers={num_layers}, "
+                    f"linear_attn_layers={sorted(linear_attn.layer_indices)}")
+                if self.use_mla:
+                    probe_heads, probe_head_size = 1, mla_head_size
+                else:
+                    probe_heads, probe_head_size = attention_heads_and_size(
+                        attn_layer_indices[0])
+                # Installs `_hybrid_uniform_page_size_bytes`, which every
+                # spec created below reports, so it has to run first.
+                self.install_hybrid_page_size_padding(
+                    attn_page_size_bytes=int(
+                        get_attention_page_size_bytes(
+                            self.runner.mesh, block_size, probe_heads,
+                            probe_head_size, self.runner.kv_cache_dtype,
+                            self.use_mla)),
+                    unpadded_mamba_page_size=linear_attn.page_size_bytes,
+                    num_attn=len(attn_layer_indices),
+                    num_mamba=len(linear_attn.layer_indices))
+
+            for i in range(num_layers):
                 # If this layer is KV-shared, register the redirect and skip
                 # spec creation (so no slot is allocated). The forward-time
                 # remap at line ~835 picks the source layer's slot.
@@ -503,39 +660,15 @@ class KVCacheManager:
                         f"layer.{i}"] = f"layer.{kv_share_map[i]}"
                     continue
 
-                if self.use_mla:
+                if linear_attn is not None and i in linear_attn.layer_indices:
+                    kv_cache_spec[
+                        f"layer.{i}"] = self._create_linear_attention_spec(
+                            linear_attn)
+                elif self.use_mla:
                     kv_cache_spec[f"layer.{i}"] = self._create_attention_spec(
                         block_size, 1, mla_head_size)
                 else:
-                    # TODO(kwang3939): unify the hybrid kv cache of jax path and tochax path.
-                    layer_type = "full_attention"
-                    if hasattr(text_config, "layer_types") and i < len(
-                            text_config.layer_types):
-                        layer_type = text_config.layer_types[i]
-
-                    is_sliding = layer_type == "sliding_attention"
-                    # Use `or` instead of getattr default so we also handle
-                    # the case where the attribute is present but None
-                    # (e.g. Gemma-4 E2B has num_global_key_value_heads=None).
-                    # `or` also coerces 0 → fallback, which is fine because
-                    # 0 num_kv_heads / head_dim is never a valid config and
-                    # would crash get_padded_num_heads downstream anyway.
-                    if not is_sliding:
-                        num_kv_heads = (getattr(
-                            text_config, "num_global_key_value_heads", None)
-                                        or base_num_kv_heads)
-                        head_size = (getattr(text_config, "global_head_dim",
-                                             None) or base_head_size)
-                    else:
-                        num_kv_heads = (getattr(text_config,
-                                                "num_key_value_heads", None)
-                                        or base_num_kv_heads)
-                        head_size = (getattr(text_config, "head_dim", None)
-                                     or base_head_size)
-                    # Pad num_kv_heads to multiple of TP size.
-                    num_kv_heads = common_utils.get_padded_num_heads(
-                        num_kv_heads, model_cnt)
-                    head_size = common_utils.get_padded_head_dim(head_size)
+                    num_kv_heads, head_size = attention_heads_and_size(i)
                     # TODO(kwang3939): Re-enable sliding_window once mixed dims with sliding_window is supported.
                     sliding_window = None
                     kv_cache_spec[f"layer.{i}"] = self._create_attention_spec(
@@ -786,43 +919,42 @@ class KVCacheManager:
                         "MambaSpec does not support shared layers for now, defaulting to single KV cache per layer..."
                     )
                     duplicate_shared_layers = True
-                    non_mtp_tensors = [
-                        t for t in kv_cache_config.kv_cache_tensors
-                        if not any("mtp" in name for name in t.shared_by)
-                    ]
-                    if non_mtp_tensors:
-                        # assert that each kv_cache_tensor in kv_cache_config.kv_cache_tensors has the same number of shared layers
-                        # This is needed for models like Qwen3.5 where every 4 layers share the same KV cache (3 linear attn and 1 full attn)
-                        num_shared_layers = len(non_mtp_tensors[0].shared_by)
-                        for kv_cache_tensor in non_mtp_tensors:
-                            assert len(
-                                kv_cache_tensor.shared_by
-                            ) == num_shared_layers, f"Expected all non-MTP kv_cache_tensors to have the same number of shared layers {num_shared_layers}, but found {len(kv_cache_tensor.shared_by)}"
                     break
 
+        # `kv_caches` is indexed positionally by the model, so a layer's index
+        # is simply where its array landed in this list. Deriving it from the
+        # list length rather than from `tensor_index × group_size` is what
+        # lets `shared_by` groups differ in size: vLLM's grouping rule splits
+        # the larger layer type into `ceil(max/min)` groups, and the last one
+        # is short whenever the count doesn't divide evenly (Kimi-K3's 24 MLA
+        # + 69 KDA gives groups of 24/24/21, so 3 of the 24 tensors are
+        # `shared_by` 3 layers while the rest are `shared_by` 4).
+        first_cache_index = len(kv_caches)
+        # When groups differ in size, a short group divides the same byte
+        # budget among fewer layers and so could afford more blocks. Every
+        # layer is addressed by the same block IDs, so they all have to
+        # present the same leading dimension: take the smallest count, which
+        # is the only one guaranteed to fit inside every tensor's budget.
+        # No-op when the groups are uniform (all counts are equal).
+        # MTP draft tensors are excluded: they are sized independently of the
+        # target model's groups, so folding them in would shrink the pool for
+        # everyone.
+        shared_num_blocks = None
+        if duplicate_shared_layers:
+            sized_tensors = [
+                t for t in kv_cache_config.kv_cache_tensors
+                if not any("mtp" in name for name in t.shared_by)
+            ] or list(kv_cache_config.kv_cache_tensors)
+            shared_num_blocks = min(
+                t.size //
+                self._duplicated_group_page_size(t, layer_name_to_spec)
+                for t in sized_tensors)
         for i, kv_cache_tensor in enumerate(kv_cache_config.kv_cache_tensors):
             if duplicate_shared_layers:
-                total_group_page_size = 0
-                for name in kv_cache_tensor.shared_by:
-                    spec = layer_name_to_spec[name]
-                    # Use the per-layer *TPU-actual* per-block bytes so the
-                    # sum equals the `page_size_padded` that
-                    # `update_mamba_page_size_padded` installed on every
-                    # spec (== attn_page + N × mamba_unpadded). For
-                    # attention, the TPU-actual size includes dtype-
-                    # specific packing (e.g., fp8 KV packs 4 elements per
-                    # 32-bit word) which `spec.real_page_size_bytes`
-                    # doesn't account for — on fp8 models they differ by
-                    # 2×, which would break the num_blocks match here.
-                    if isinstance(spec, MambaSpec):
-                        total_group_page_size += dataclasses.replace(
-                            spec, page_size_padded=None).page_size_bytes
-                    else:
-                        total_group_page_size += get_attention_page_size_bytes(
-                            self.runner.mesh, spec.block_size,
-                            spec.num_kv_heads, spec.head_size, spec.dtype,
-                            self.use_mla)
-                num_blocks = kv_cache_tensor.size // total_group_page_size
+                num_blocks = min(
+                    shared_num_blocks,
+                    kv_cache_tensor.size // self._duplicated_group_page_size(
+                        kv_cache_tensor, layer_name_to_spec))
             elif kv_cache_tensor.block_stride:
                 # DeepseekV4 packed layout: vLLM overlays every cache
                 # (main MLA latent + indexer k_cache + compressor state +
@@ -871,17 +1003,23 @@ class KVCacheManager:
                 layer_spec = layer_name_to_spec[layer_name]
                 if isinstance(layer_spec, MambaSpec):
                     mamba_states = []
-                    for state_index, (shape, dtype) in enumerate(
-                            zip(layer_spec.shapes, layer_spec.dtypes)):
+                    for shape, dtype in zip(layer_spec.shapes,
+                                            layer_spec.dtypes):
                         jax_dtype = t2j_dtype(dtype)
                         cache_shape = (mamba_num_blocks, *shape)
-                        if state_index == 0:
-                            # conv_state: [num_blocks, conv_kernel_size, intermediate_size]
+                        # Pick the layout by rank rather than by position in
+                        # `shapes`: mamba2/GDN declare exactly one conv state
+                        # then one recurrent state, but a KDA layer declares
+                        # three conv states (q/k/v) before its recurrent one.
+                        # The two ranks are unambiguous and the mapping is
+                        # identical for the 2-state models.
+                        if len(cache_shape) == 3:
+                            # conv state: [num_blocks, window, channels]
                             spec = PartitionSpec(ShardingAxisName.ATTN_DATA,
                                                  None,
                                                  ShardingAxisName.ATTN_HEAD)
-                        elif state_index == 1:
-                            # ssm_state: [num_blocks, num_heads, head_dim, state_size]
+                        elif len(cache_shape) == 4:
+                            # recurrent state: [num_blocks, heads, ...]
                             spec = PartitionSpec(ShardingAxisName.ATTN_DATA,
                                                  ShardingAxisName.ATTN_HEAD,
                                                  None, None)
@@ -945,8 +1083,11 @@ class KVCacheManager:
                 if j == 0 or duplicate_shared_layers:
                     num_blocks_list.append(mamba_num_blocks if isinstance(
                         layer_spec, MambaSpec) else num_blocks)
-                layer_idx = (i * num_shared_layers
-                             ) + j if duplicate_shared_layers else i
+                # Every layer got its own array when duplicating, so it is the
+                # one just appended; otherwise all of `shared_by` reads the
+                # single array created for this tensor.
+                layer_idx = (len(kv_caches) - 1 if duplicate_shared_layers else
+                             first_cache_index + i)
                 self.runner.layer_name_to_kvcache_index[layer_name] = layer_idx
         if self.shared_kv_cache_layers:
             for layer_name, target_layer_name in self.shared_kv_cache_layers.items(

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -151,9 +151,9 @@ class KVCacheManager:
         """Bytes per block for one `shared_by` group, when every layer in it
         gets its own array.
 
-        Uses the per-layer *TPU-actual* per-block bytes so the sum equals the
-        `page_size_padded` that `install_hybrid_page_size_padding` put on
-        every spec (== attn_page + N × mamba_unpadded). For attention, the
+        Uses the per-layer *TPU-actual* per-block bytes so the sum is at most
+        the `page_size_padded` that `install_hybrid_page_size_padding` put on
+        every spec (attn_page + N × mamba_unpadded). For attention, the
         TPU-actual size includes dtype-specific packing (e.g., fp8 KV packs 4
         elements per 32-bit word) which `spec.real_page_size_bytes` doesn't
         account for — on fp8 models they differ by 2×, which would break the

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -2691,6 +2691,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             (self.max_num_reqs + dp_size, ), key="query_start_loc")
         seq_lens_view = self.device_buffer.get_view((self.max_num_reqs, ),
                                                     key="seq_lens")
+        # Only hybrid attn+mamba models consume `has_initial_state`; leaving it
+        # out of the blob for pure-attention models keeps their metadata layout
+        # (and so the primed HLO) unchanged.
+        has_initial_state_view = None
+        if self.kv_cache_config.has_mamba_layers:
+            has_initial_state_view = self.device_buffer.get_view(
+                (self.max_num_reqs, ), key="has_initial_state")
 
         if self.speculative_config:
             padded_logits_length = None
@@ -2772,6 +2779,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 dp_rank + 1]
             seq_lens_cpu = seq_lens_view[req_offset:req_offset +
                                          max_num_reqs_per_dp_rank]
+            has_initial_state_cpu = (
+                None if has_initial_state_view is None else
+                has_initial_state_view[req_offset:req_offset +
+                                       max_num_reqs_per_dp_rank])
             _num_reqs = num_req_per_dp_rank[dp_rank]
             req_indices = req_indices_dp[dp_rank]
             num_scheduled_tokens_per_req = scheduled_tokens_per_dp_rank[
@@ -2780,6 +2791,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             if _num_reqs == 0:
                 query_start_loc_cpu[:] = 0
                 seq_lens_cpu[:] = 0
+                if has_initial_state_cpu is not None:
+                    has_initial_state_cpu[:] = 0
                 continue
 
             # After buffer.reset(), the buffer is still dirty, so we need to zero
@@ -2796,6 +2809,17 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 self.input_batch.num_computed_tokens_cpu[req_indices] +
                 num_scheduled_tokens_per_req)
             seq_lens_cpu[_num_reqs:] = 0
+
+            if has_initial_state_cpu is not None:
+                # A request resumes state iff it already has computed tokens.
+                # Computed here, per DP rank, because this is the only place
+                # the rank -> persistent-batch-position mapping is known; ops
+                # downstream see only the packed arrays. Padded positions get
+                # 0 so their slot (index 0, the null block) is zero-filled
+                # rather than resumed.
+                has_initial_state_cpu[:_num_reqs] = (
+                    self.input_batch.num_computed_tokens_cpu[req_indices] > 0)
+                has_initial_state_cpu[_num_reqs:] = 0
 
         # populate logits_indices
         for dp_rank in range(dp_size):
@@ -3045,6 +3069,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         input_ids = metadata["input_ids"]
         query_start_loc = metadata["query_start_loc"]
         seq_lens = metadata["seq_lens"]
+        has_initial_state = metadata.get("has_initial_state")
         logits_indices = metadata["logits_indices"]
 
         # The host-side `num_computed_tokens_cpu` assumes all speculatively
@@ -3062,6 +3087,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                has_initial_state=has_initial_state,
                 padded_num_reqs=attn_padded_num_reqs,
                 pcp=pcp_metadata,
             )
@@ -3075,6 +3101,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                has_initial_state=has_initial_state,
                 padded_num_reqs=attn_padded_num_reqs,
             )
 


### PR DESCRIPTION
Piece 2 of 6 of the Kimi-K3 enablement stack. Adds the hybrid-model runner plumbing: the has_initial_state field in AttentionMetadata (runner-computed, replacing the seq_lens-based derivation that is wrong under attention DP), the GDN v3 kernel/op migration to that contract, rank-local mamba slot rebasing in sharding.py, the compact mamba KV-cache layout in kv_cache_manager.py with the linear-attention state-layout helper (models/common/linear_attention.py), dummy mamba precompile fields in compilation_manager.py, and the decode_loop/tpu_runner threading — plus their tests. Depends on split 1/6 (its base branch). The full stack was validated end-to-end in #3292: CI green, gsm8k 0.976.