### PR TITLE
[DO NOT REVIEW] K3 split 3/6: MXFP4 loading

### DIFF
--- a/tests/layers/jax/quantization/test_compressed_tensors.py
+++ b/tests/layers/jax/quantization/test_compressed_tensors.py
@@ -19,6 +19,8 @@ right JAX quant method (or skipped)? They mirror `test_fp8.py::TestFp8Config`,
 which asserts `layer.quant_method` types rather than running a forward pass.
 """
 
+import json
+
 import jax
 import numpy as np
 import pytest
@@ -174,3 +176,113 @@ class TestCompressedTensorsConfig:
         # proj1 ignored, proj2 still quantized.
         assert isinstance(mlp.proj1.quant_method, UnquantizedLinearMethod)
         assert isinstance(mlp.proj2.quant_method, Fp8BlockwiseLinearMethod)
+
+
+class TestPackedModuleInspection:
+    """Which modules the checkpoint itself stores compressed.
+
+    The config's target/ignore lists are not a reliable statement of that (a
+    checkpoint may leave a targeted module uncompressed), so the config reads
+    the checkpoint's own tensor names. These tests cover the two ways that
+    reading has to work: from the safetensors index, and from the shards.
+    """
+
+    def _index(self, tmp_path, tensor_names):
+        (tmp_path / "model.safetensors.index.json").write_text(
+            json.dumps({
+                "metadata": {},
+                "weight_map": {
+                    n: "model-00001-of-00001.safetensors"
+                    for n in tensor_names
+                },
+            }))
+        return str(tmp_path)
+
+    def test_reads_the_index_when_the_shards_are_not_local(self, tmp_path):
+        """Streamed weights leave only the config files on disk.
+
+        Loading from object storage downloads `*.json` -- the index among them
+        -- and streams the shards, so a scan that opens `*.safetensors` finds
+        nothing and silently falls back to trusting the config.
+        """
+        path = self._index(tmp_path, [
+            "model.layers.0.mlp.experts.0.w1.weight_packed",
+            "model.layers.0.mlp.experts.0.w1.weight_scale",
+            "model.layers.0.self_attn.q_proj.weight"
+        ])
+        assert not list(tmp_path.glob("*.safetensors"))
+
+        config = CompressedTensorsConfig(_fp8_block_config(),
+                                         model_name_or_path=path)
+        assert config._compressed_modules is not None, (
+            "the checkpoint was not inspected at all")
+        assert config._is_compressed_in_checkpoint(
+            "model.layers.0.mlp.experts.0.w1")
+        # ...including for the parent that owns the per-expert subtree.
+        assert config._is_compressed_in_checkpoint(
+            "model.layers.0.mlp.experts")
+        # The attention projection is stored plain, and must stay that way.
+        assert not config._is_compressed_in_checkpoint(
+            "model.layers.0.self_attn.q_proj")
+
+    def test_the_wrapper_prefix_is_stripped_from_index_paths(self, tmp_path):
+        """`*ForConditionalGeneration` checkpoints nest the text stack.
+
+        Their tensor names carry a `language_model.` the model's own module
+        paths do not, so an unnormalized comparison finds no compressed module
+        anywhere and every quantized layer falls back to unquantized.
+        """
+        path = self._index(
+            tmp_path,
+            ["language_model.model.layers.0.mlp.experts.0.w1.weight_packed"])
+        config = CompressedTensorsConfig(_fp8_block_config(),
+                                         model_name_or_path=path)
+        # Anti-vacuity: an uninspected checkpoint answers True to everything,
+        # so pin that this one was read before believing the True below.
+        assert config._compressed_modules is not None
+        assert not config._is_compressed_in_checkpoint(
+            "model.layers.0.self_attn")
+
+        assert config._is_compressed_in_checkpoint(
+            "model.layers.0.mlp.experts.0.w1")
+        assert config._is_compressed_in_checkpoint(
+            "model.layers.0.mlp.experts")
+
+    def test_fp8_checkpoints_mark_compression_with_weight_scale_alone(
+            self, tmp_path):
+        """Float-quantized checkpoints have no `weight_packed` at all.
+
+        FP8 compressed-tensors (e.g. gemma-4 FP8-Dynamic) stores a plain
+        `weight` plus `weight_scale`. Keying compression on `weight_packed`
+        alone classified every module of such a checkpoint as uncompressed and
+        silently built the whole model unquantized -- the loader then crashed
+        on the resulting fused bf16 qkv_proj (CI build 23675). A module owning
+        `weight_scale` must count as compressed; one owning only `weight`
+        (norms, embeddings) must not.
+        """
+        path = self._index(tmp_path, [
+            "model.layers.0.self_attn.qkv_proj.weight",
+            "model.layers.0.self_attn.qkv_proj.weight_scale",
+            "model.layers.0.self_attn.o_proj.weight",
+            "model.layers.0.self_attn.o_proj.weight_scale",
+            "model.layers.0.input_layernorm.weight",
+            "model.embed_tokens.weight",
+        ])
+        config = CompressedTensorsConfig(_fp8_block_config(),
+                                         model_name_or_path=path)
+        assert config._compressed_modules is not None
+        assert config._is_compressed_in_checkpoint(
+            "model.layers.0.self_attn.qkv_proj")
+        assert config._is_compressed_in_checkpoint(
+            "model.layers.0.self_attn.o_proj")
+        assert not config._is_compressed_in_checkpoint(
+            "model.layers.0.input_layernorm")
+        assert not config._is_compressed_in_checkpoint("model.embed_tokens")
+
+    def test_an_uninspectable_checkpoint_falls_back_to_the_config(
+            self, tmp_path):
+        """No index and no shards -> no information, trust the config."""
+        config = CompressedTensorsConfig(_fp8_block_config(),
+                                         model_name_or_path=str(tmp_path))
+        assert config._compressed_modules is None
+        assert config._is_compressed_in_checkpoint("anything.at.all")

--- a/tests/layers/jax/quantization/test_compressed_tensors.py
+++ b/tests/layers/jax/quantization/test_compressed_tensors.py
@@ -20,6 +20,7 @@ which asserts `layer.quant_method` types rather than running a forward pass.
 """
 
 import json
+from unittest import mock
 
 import jax
 import numpy as np
@@ -27,14 +28,18 @@ import pytest
 from flax import nnx
 from jax.sharding import Mesh
 
+from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
 from tpu_inference.layers.jax.linear import JaxLinear
+from tpu_inference.layers.jax.moe.moe import JaxMoE
+from tpu_inference.layers.jax.quantization import \
+    compressed_tensors as ct_module
 from tpu_inference.layers.jax.quantization.compressed_tensors import \
     CompressedTensorsConfig
 from tpu_inference.layers.jax.quantization.fp8 import (
     Fp8BlockwiseLinearMethod, Fp8TensorwiseLinearMethod)
-from tpu_inference.layers.jax.quantization.unquantized import \
-    UnquantizedLinearMethod
+from tpu_inference.layers.jax.quantization.unquantized import (
+    UnquantizedFusedMoEMethod, UnquantizedLinearMethod)
 
 
 # A compressed-tensors `quantization_config` modeled on
@@ -286,3 +291,154 @@ class TestPackedModuleInspection:
                                          model_name_or_path=str(tmp_path))
         assert config._compressed_modules is None
         assert config._is_compressed_in_checkpoint("anything.at.all")
+
+
+def _write_index(tmp_path, tensor_names):
+    index = tmp_path / "model.safetensors.index.json"
+    index.write_text(
+        json.dumps({
+            "metadata": {},
+            "weight_map": {
+                n: "model-00001-of-00001.safetensors"
+                for n in tensor_names
+            },
+        }))
+    return index
+
+
+class TestPlainDemotionLogging:
+    """Checkpoint-driven demotions to unquantized must be visible in the log.
+
+    A module the config targets but the checkpoint stores plain is built
+    unquantized; each such demotion logs an info line naming the module, so a
+    model that silently loses its quantization can be diagnosed from the load
+    log alone.
+    """
+
+    _DEMOTION_MARKER = "targeted by quant config but stored plain"
+
+    def _demotions(self, mock_logger):
+        return [
+            call.args[1] for call in mock_logger.info.call_args_list
+            if self._DEMOTION_MARKER in call.args[0]
+        ]
+
+    def test_targeted_but_plain_linear_logs_demotion(self, rngs, mesh,
+                                                     tmp_path):
+        """proj1 stored plain -> demoted with a log; proj2 stays quantized."""
+        _write_index(tmp_path, [
+            "mlp.proj1.weight",
+            "mlp.proj2.weight",
+            "mlp.proj2.weight_scale",
+        ])
+        config = CompressedTensorsConfig(_fp8_block_config(),
+                                         model_name_or_path=str(tmp_path))
+
+        with mock.patch.object(ct_module, "logger") as mock_logger:
+            with jax.set_mesh(mesh):
+                mlp = _MLP(16, 16, rngs, config, prefix="mlp")
+
+        assert isinstance(mlp.proj1.quant_method, UnquantizedLinearMethod)
+        assert isinstance(mlp.proj2.quant_method, Fp8BlockwiseLinearMethod)
+        demoted = self._demotions(mock_logger)
+        assert "mlp.proj1" in demoted, (
+            f"expected a demotion log for mlp.proj1, saw {demoted}")
+        assert "mlp.proj2" not in demoted, (
+            "the quantized layer must not log a demotion")
+
+    def test_targeted_but_plain_moe_logs_demotion(self, tmp_path):
+        """The MoE branch logs the same demotion line."""
+        _write_index(tmp_path,
+                     ["model.layers.0.self_attn.q_proj.weight_scale"])
+        config = CompressedTensorsConfig(_fp8_block_config(),
+                                         model_name_or_path=str(tmp_path))
+
+        # `__dict__.update` sidesteps `JaxMoE.__init__` (needs a vLLM config
+        # and TPU devices); dispatch reads only isinstance and moe_backend.
+        class _FakeJaxMoE(JaxMoE):
+
+            def __init__(self, **kwargs):
+                self.__dict__.update(kwargs)
+
+        layer = _FakeJaxMoE(moe_backend=MoEBackend.MEGABLX_GMM)
+
+        with mock.patch.object(ct_module, "logger") as mock_logger:
+            method = config.get_quant_method(
+                layer, prefix="model.layers.0.mlp.experts")
+
+        assert isinstance(method, UnquantizedFusedMoEMethod)
+        assert self._demotions(mock_logger) == ["model.layers.0.mlp.experts"]
+
+
+class TestHfRepoIndexFetch:
+    """For HF repo ids, only the safetensors index is downloaded.
+
+    Reading tensor names off the weight shards would download every shard of
+    a multi-TB checkpoint just to list names; the index is one small JSON.
+    """
+
+    def test_repo_id_fetches_only_the_index(self, tmp_path):
+        index = _write_index(tmp_path, [
+            "model.layers.0.mlp.experts.0.w1.weight_packed",
+            "model.layers.0.self_attn.q_proj.weight",
+        ])
+
+        with mock.patch("huggingface_hub.hf_hub_download",
+                        return_value=str(index)) as mock_download, \
+                mock.patch(
+                    "tpu_inference.models.jax.utils.weight_utils."
+                    "get_model_weights_files",
+                    side_effect=AssertionError(
+                        "weight shards must not be downloaded")):
+            config = CompressedTensorsConfig(
+                _fp8_block_config(),
+                model_name_or_path="some-org/some-mxfp4-model",
+                download_dir="/tmp/some-download-dir")
+
+        mock_download.assert_called_once_with(
+            repo_id="some-org/some-mxfp4-model",
+            filename="model.safetensors.index.json",
+            cache_dir="/tmp/some-download-dir")
+        assert config._compressed_modules is not None
+        assert config._is_compressed_in_checkpoint(
+            "model.layers.0.mlp.experts")
+        assert not config._is_compressed_in_checkpoint(
+            "model.layers.0.self_attn.q_proj")
+
+    def test_repo_without_index_falls_back_to_shard_headers(self, tmp_path):
+        """Single-file repos ship no index; their one shard's header is read."""
+        from huggingface_hub.errors import EntryNotFoundError
+        from safetensors.numpy import save_file
+        shard = tmp_path / "model.safetensors"
+        save_file(
+            {
+                "model.embed.weight": np.zeros((1, ), dtype=np.float32),
+                "model.layers.0.q.weight_packed": np.zeros(
+                    (1, ), dtype=np.uint8),
+            }, str(shard))
+
+        with mock.patch("huggingface_hub.hf_hub_download",
+                        side_effect=EntryNotFoundError("no index")), \
+                mock.patch(
+                    "tpu_inference.models.jax.utils.weight_utils."
+                    "get_model_weights_files",
+                    return_value=[str(shard)]):
+            config = CompressedTensorsConfig(
+                _fp8_block_config(),
+                model_name_or_path="some-org/single-file-model")
+
+        assert config._compressed_modules is not None
+        assert config._is_compressed_in_checkpoint("model.layers.0.q")
+        assert not config._is_compressed_in_checkpoint("model.embed")
+
+    def test_local_directory_never_touches_the_hub(self, tmp_path):
+        """Local checkpoints keep reading the local index, no hub calls."""
+        _write_index(tmp_path, ["model.layers.0.q.weight_packed"])
+
+        with mock.patch("huggingface_hub.hf_hub_download",
+                        side_effect=AssertionError(
+                            "local paths must not hit the hub")):
+            config = CompressedTensorsConfig(_fp8_block_config(),
+                                             model_name_or_path=str(tmp_path))
+
+        assert config._is_compressed_in_checkpoint("model.layers.0.q")

--- a/tests/layers/jax/quantization/test_mxfp4.py
+++ b/tests/layers/jax/quantization/test_mxfp4.py
@@ -810,3 +810,25 @@ class TestCompressedTensorsMxfp4ShardVsHostParity:
                 f"{name}: {shard.sharding} vs {host.sharding}")
             _assert_bit_equal(shard, np.asarray(host.astype(jnp.float32)),
                               name)
+
+
+class TestCompressedTensorsMxfp4ApplyGuard:
+
+    def test_apply_jax_raises_a_self_contained_error(self):
+        """The staged fp4+scales must not reach backends that drop the scales.
+
+        At this revision the unfused MoE backends consume only bf16 kernels,
+        so a forward pass would silently compute garbage; apply_jax fails
+        loudly instead until the scale-consuming backends land.
+        """
+        layer = SimpleNamespace(
+            moe_backend=MoEBackend.MEGABLX_GMM,
+            prefix="model.layers.1.block_sparse_moe.experts")
+        method = mxfp4.CompressedTensorsMxfp4MoEMethod(layer)
+
+        with pytest.raises(NotImplementedError,
+                           match=r"\[mxfp4-ct\].*scale-consuming MoE backends "
+                           r"land with the kernel layer change"):
+            method.apply_jax(layer,
+                             jnp.ones((3, 4), dtype=jnp.float32),
+                             router_logits=jnp.ones((3, 2), dtype=jnp.float32))

--- a/tests/layers/jax/quantization/test_mxfp4.py
+++ b/tests/layers/jax/quantization/test_mxfp4.py
@@ -21,6 +21,16 @@ lifecycle (`create_weights_jax` -> `load_weights` ->
 tensors laid out like gpt-oss-20b's expert tensors, scaled down.
 """
 
+import os
+
+if "--xla_force_host_platform_device_count" not in os.environ.get(
+        "XLA_FLAGS", ""):
+    # Multi-device coverage for the sharded-decode tests on CPU-only hosts.
+    # A no-op on TPU (the flag only sizes the CPU backend) and when jax was
+    # already initialized by an earlier test module.
+    os.environ["XLA_FLAGS"] = (os.environ.get("XLA_FLAGS", "") +
+                               " --xla_force_host_platform_device_count=8")
+
 from types import SimpleNamespace
 
 import jax
@@ -652,3 +662,151 @@ class TestCompressedTensorsMxfp4MultiHostPlacement:
         # Sharded 2 ways on the last axis.
         assert values.addressable_shards[0].data.shape == (self.E, self.D,
                                                            self.F // 2)
+
+
+# Every fp4 (E2M1) code point by nibble value: sign bit 3, two exponent bits
+# (bias 1), one mantissa bit. Written out so the reference below shares
+# nothing with the implementation under test.
+_E2M1_VALUES = np.array([
+    0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0, -0.0, -0.5, -1.0, -1.5, -2.0, -3.0,
+    -4.0, -6.0
+],
+                        dtype=np.float32)
+
+
+def _ref_unpack_e2m1(packed: np.ndarray) -> np.ndarray:
+    """Numpy reference unpack: the LOW nibble of each byte comes first."""
+    low = packed & 0xF
+    high = (packed >> 4) & 0xF
+    pairs = np.stack([_E2M1_VALUES[low], _E2M1_VALUES[high]], axis=-1)
+    return pairs.reshape(packed.shape[:-1] + (-1, ))
+
+
+def _ref_e8m0_to_fp32(u8: np.ndarray) -> np.ndarray:
+    """Numpy reference E8M0 expansion: exact powers of two, bias 127."""
+    return np.float32(2.0)**(u8.astype(np.int32) - 127)
+
+
+def _assert_bit_equal(actual: jax.Array, expected: np.ndarray, name: str):
+    """fp4/fp32 equality that distinguishes -0.0 from +0.0."""
+    actual_f32 = np.asarray(actual.astype(jnp.float32))
+    np.testing.assert_array_equal(actual_f32, expected, err_msg=name)
+    np.testing.assert_array_equal(np.signbit(actual_f32),
+                                  np.signbit(expected),
+                                  err_msg=f"{name}: -0.0 vs +0.0 mismatch")
+
+
+class TestCompressedTensorsMxfp4GoldenDecode:
+    """Hand-computed reference for the lossless decode.
+
+    Pins the three properties the checkpoint bytes must survive: the nibble
+    order of the fp4 unpack (low nibble of each byte first), the E8M0 scale
+    expansion (exact powers of two, exponent bias 127), and the final
+    checkpoint-orientation `[E, out, in]` -> kernel `[E, in, out]` transpose.
+    """
+
+    def _mesh(self):
+        return Mesh(
+            np.array(jax.devices()[:1]).reshape(1, 1), ("data", "model"))
+
+    def test_golden_bytes_decode_to_hand_computed_values(self):
+        # One expert, out=2 rows of in=4 values (2 packed bytes per row), one
+        # E8M0 scale byte per row.
+        packed = np.array([[[0x2E, 0x71], [0x10, 0x9F]]], dtype=np.uint8)
+        scales = np.array([[[126], [128]]], dtype=np.uint8)
+
+        values, scale = \
+            mxfp4.CompressedTensorsMxfp4MoEMethod._decode_on_host(
+                [jnp.asarray(packed)], [jnp.asarray(scales)],
+                (None, None, None), self._mesh())
+
+        assert values.dtype == jnp.float4_e2m1fn
+        assert scale.dtype == jnp.float32
+        # [E=1, out=2, in=4] checkpoint orientation -> [E, in, out].
+        assert values.shape == (1, 4, 2)
+        assert scale.shape == (1, 1, 2)
+        # Byte 0x2E holds nibbles (low 0xE, high 0x2) -> (-4.0, 1.0): the low
+        # nibble is the earlier element. Hand decode, pre-transpose:
+        #   row 0: 0x2E, 0x71 -> [-4.0, 1.0, 0.5, 6.0]
+        #   row 1: 0x10, 0x9F -> [ 0.0, 0.5, -6.0, -0.5]
+        expected = np.array(
+            [[[-4.0, 0.0], [1.0, 0.5], [0.5, -6.0], [6.0, -0.5]]],
+            dtype=np.float32)
+        _assert_bit_equal(values, expected, "values")
+        # E8M0 bytes are exponents biased by 127: 126 -> 2^-1, 128 -> 2^1.
+        np.testing.assert_array_equal(
+            np.asarray(scale), np.array([[[0.5, 2.0]]], dtype=np.float32))
+
+    def test_host_decode_matches_numpy_reference_on_random_data(self):
+        rng = np.random.RandomState(7)
+        num_experts, out, in_, gs = 3, 4, 16, 8
+        packed = rng.randint(0, 256, (num_experts, out, in_ // 2), np.uint8)
+        scales = rng.randint(100, 150, (num_experts, out, in_ // gs), np.uint8)
+
+        values, scale = \
+            mxfp4.CompressedTensorsMxfp4MoEMethod._decode_on_host(
+                [jnp.asarray(packed[e:e + 1]) for e in range(num_experts)],
+                [jnp.asarray(scales[e:e + 1]) for e in range(num_experts)],
+                (None, None, None), self._mesh())
+
+        _assert_bit_equal(values, np.swapaxes(_ref_unpack_e2m1(packed), 1, 2),
+                          "values")
+        np.testing.assert_array_equal(
+            np.asarray(scale), np.swapaxes(_ref_e8m0_to_fp32(scales), 1, 2))
+
+
+class TestCompressedTensorsMxfp4ShardVsHostParity:
+    """`_decode_sharded` must be bit-equal to the host decode.
+
+    The sharded path exists purely as a memory/traffic optimization, so for
+    the same synthetic MXFP4 bytes it must assemble exactly the array
+    `_decode_on_host` produces -- same values (down to -0.0), same scales,
+    same sharding -- for shards cut along each of the three axes.
+    """
+
+    E, OUT, IN, GS = 4, 6, 64, 32
+
+    def _mesh(self):
+        devices = jax.devices()[:2]
+        if len(devices) < 2:
+            pytest.skip(f"needs 2 devices, have {len(devices)}")
+        return Mesh(np.array(devices).reshape(1, 2), ("data", "model"))
+
+    @pytest.mark.parametrize(
+        "sharding",
+        [
+            (None, None, "model"),  # output axis
+            (None, "model", None),  # decoded (packed) input axis
+            ("model", None, None),  # expert axis
+        ])
+    def test_shard_decode_bit_equals_host_decode(self, sharding):
+        mesh = self._mesh()
+        rng = np.random.RandomState(11)
+        staged_packed = [
+            jnp.asarray(
+                rng.randint(0, 256, (1, self.OUT, self.IN // 2), np.uint8))
+            for _ in range(self.E)
+        ]
+        staged_scale = [
+            jnp.asarray(
+                rng.randint(96, 160, (1, self.OUT, self.IN // self.GS),
+                            np.uint8)) for _ in range(self.E)
+        ]
+
+        host_values, host_scale = \
+            mxfp4.CompressedTensorsMxfp4MoEMethod._decode_on_host(
+                staged_packed, staged_scale, sharding, mesh)
+        shard_values = mxfp4._decode_sharded(staged_packed,
+                                             mxfp4.u8_unpack_e2m1, 2, sharding,
+                                             mesh)
+        shard_scale = mxfp4._decode_sharded(staged_scale, mxfp4.e8m0_to_fp32,
+                                            1, sharding, mesh)
+
+        for name, host, shard in (("values", host_values, shard_values),
+                                  ("scale", host_scale, shard_scale)):
+            assert shard.shape == host.shape, name
+            assert shard.dtype == host.dtype, name
+            assert shard.sharding == host.sharding, (
+                f"{name}: {shard.sharding} vs {host.sharding}")
+            _assert_bit_equal(shard, np.asarray(host.astype(jnp.float32)),
+                              name)

--- a/tests/layers/jax/quantization/test_mxfp4.py
+++ b/tests/layers/jax/quantization/test_mxfp4.py
@@ -30,6 +30,7 @@ import pytest
 import torch
 from flax import nnx
 from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
 
 import tpu_inference.layers.jax.quantization.mxfp4 as mxfp4
 from tpu_inference.layers.common.moe import MoEBackend
@@ -134,11 +135,18 @@ class TestMxfp4Config:
 
     def test_registry_returns_mxfp4_config(self):
         """`gpt_oss_mxfp4` selects Mxfp4Config in the quant config registry."""
-        vllm_config = SimpleNamespace(model_config=SimpleNamespace(
-            quantization=MXFP4,
-            hf_config=SimpleNamespace(
-                quantization_config={"quant_method": MXFP4}),
-        ))
+        vllm_config = SimpleNamespace(
+            model_config=SimpleNamespace(
+                quantization=MXFP4,
+                model="openai/gpt-oss-120b",
+                hf_config=SimpleNamespace(
+                    quantization_config={"quant_method": MXFP4}),
+            ),
+            # Configs are handed where the weights live so they can consult
+            # the checkpoint itself; `Mxfp4Config` ignores it, but the
+            # registry reads both off the vLLM config.
+            load_config=SimpleNamespace(download_dir=None),
+        )
 
         quant_config = get_tpu_quantization_config(vllm_config)
 
@@ -420,3 +428,227 @@ class TestMxfp4FusedMoEMethod:
                                  jnp.ones((3, 4), dtype=jnp.float32),
                                  router_logits=jnp.ones((3, 2),
                                                         dtype=jnp.float32))
+
+
+class TestCompressedTensorsMxfp4MultiHostPlacement:
+    """Placing the decoded MXFP4 experts must work when the mesh spans hosts.
+
+    Under the Ray multi-host backend each process addresses only its own
+    devices, so `jax.device_put(x, NamedSharding(full_mesh, ...))` is rejected
+    ("must be a Device or a Sharding which represents addressable devices").
+
+    `process_weights_after_loading` has two decode paths and each reaches that
+    constraint its own way, so both are covered here:
+
+    - the host decode (`MXFP4_SHARD_THEN_DECODE=0`) produces process-local
+      arrays on CPU and must hand them to `general_device_put` (via
+      `shard_put`) rather than to a plain `device_put`;
+    - the shard decode (the default) needs no multi-host branch at all,
+      because it only ever builds one array per *addressable* device and
+      assembles the global array from those.
+
+    Everything below runs in one process, so the path and the multi-host
+    branch are both selected by patching env vars -- the same way
+    `tests/layers/common/test_utils.py` covers `general_device_put`.
+    """
+
+    E, D, F, GS = 2, 64, 32, 32
+
+    def _mesh(self, num_devices):
+        devices = jax.devices()[:num_devices]
+        if len(devices) < num_devices:
+            pytest.skip(f"needs {num_devices} devices, have {len(devices)}")
+        return Mesh(
+            np.array(devices).reshape(1, num_devices), ("data", "model"))
+
+    def _layer(self, mesh, sharding=(None, None, "model")):
+        return SimpleNamespace(
+            dtype=jnp.float32,
+            num_local_experts=self.E,
+            hidden_size=self.D,
+            intermediate_size_moe=self.F,
+            moe_backend=MoEBackend.MEGABLX_GMM,
+            mesh=mesh,
+            prefix="model.layers.1.block_sparse_moe.experts",
+            edf_sharding=sharding,
+            efd_sharding=sharding,
+            kernel_gating_EDF=nnx.Param(jnp.zeros((self.E, self.D, self.F))),
+            kernel_up_proj_EDF=nnx.Param(jnp.zeros((self.E, self.D, self.F))),
+            kernel_down_proj_EFD=nnx.Param(jnp.zeros(
+                (self.E, self.F, self.D))),
+        )
+
+    def _staged_checkpoint(self):
+        """Per-expert `weight_packed`/`weight_scale`, checkpoint-oriented."""
+        rng = np.random.RandomState(0)
+        out = []
+        for e in range(self.E):
+            for proj, (o, i) in (("w1", (self.F, self.D)),
+                                 ("w3", (self.F, self.D)), ("w2", (self.D,
+                                                                   self.F))):
+                base = f"model.layers.1.block_sparse_moe.experts.{e}.{proj}"
+                out.append((f"{base}.weight_packed",
+                            torch.from_numpy(
+                                rng.randint(0,
+                                            256, (o, i // 2),
+                                            dtype=np.uint8))))
+                # E8M0 exponents around 127 so the decoded scales are ~1.
+                out.append((f"{base}.weight_scale",
+                            torch.from_numpy(
+                                rng.randint(120,
+                                            132, (o, i // self.GS),
+                                            dtype=np.uint8))))
+        return out
+
+    def _loaded_method(self, mesh):
+        layer = self._layer(mesh)
+        method = mxfp4.CompressedTensorsMxfp4MoEMethod(layer)
+        method.create_weights_jax(layer, rngs=nnx.Rngs(0))
+        method.load_weights(layer=layer,
+                            original_load_weights_fn=None,
+                            weights=self._staged_checkpoint())
+        return layer, method
+
+    def _decode(self, mesh, backend):
+        """Run the real load + host decode with the given multi-host backend.
+
+        Pins `MXFP4_SHARD_THEN_DECODE=0`: the `shard_put` contract these tests
+        assert belongs to the host decode. The default path is covered by
+        `test_shard_decode_places_only_process_local_shards` below.
+        """
+        from unittest import mock
+
+        from tpu_inference import envs
+        layer, method = self._loaded_method(mesh)
+        real = jax.make_array_from_callback
+        calls = []
+
+        def spy(shape, sharding, cb):
+            calls.append((tuple(shape), sharding))
+            return real(shape, sharding, cb)
+
+        with mock.patch.object(envs, "TPU_MULTIHOST_BACKEND", backend), \
+                mock.patch.object(envs, "MXFP4_SHARD_THEN_DECODE", False), \
+                mock.patch("jax.make_array_from_callback", side_effect=spy):
+            assert method.process_weights_after_loading(layer)
+        return layer, calls
+
+    def _shard_decode(self, mesh, backend):
+        """Run the real load + shard decode, recording how it assembles each
+        global array and out of which devices' shards."""
+        from unittest import mock
+
+        from tpu_inference import envs
+        layer, method = self._loaded_method(mesh)
+        real = jax.make_array_from_single_device_arrays
+        real_device_put = jax.device_put
+        calls, put_targets = [], []
+
+        def spy(shape, sharding, arrays):
+            calls.append((tuple(shape), sharding,
+                          {d
+                           for a in arrays
+                           for d in a.devices()}))
+            return real(shape, sharding, arrays)
+
+        def device_put_spy(x, device=None, **kwargs):
+            put_targets.append(device)
+            return real_device_put(x, device, **kwargs)
+
+        with mock.patch.object(envs, "TPU_MULTIHOST_BACKEND", backend), \
+                mock.patch.object(envs, "MXFP4_SHARD_THEN_DECODE", True), \
+                mock.patch("jax.device_put", side_effect=device_put_spy), \
+                mock.patch("jax.make_array_from_single_device_arrays",
+                           side_effect=spy):
+            assert method.process_weights_after_loading(layer)
+        return layer, calls, put_targets
+
+    def test_shard_decode_places_only_process_local_shards(self):
+        """The shard decode is multi-host-safe by construction rather than by
+        branching: every array it builds is assembled from exactly the shards
+        of the devices this process addresses, so no placement is ever asked
+        for a device the process cannot reach. Asserted under both backends,
+        because unlike the host decode this path does not read the env var.
+
+        One process addresses the whole mesh here, so the set of devices the
+        shards land on cannot by itself separate the addressable enumeration
+        from the global one. What it can check is the thing that actually
+        breaks across hosts: every placement names a single `Device`, never a
+        `Sharding` spanning the mesh.
+
+        That the shards themselves decode to the same bytes as the host decode
+        is `tests/models/jax/test_kimi_k3_mxfp4_shard_decode.py`.
+        """
+        mesh = self._mesh(2)
+        for backend in ("ray", ""):
+            layer, calls, put_targets = self._shard_decode(mesh, backend)
+            # 3 projections x (values, scale).
+            assert len(calls) == 6, (
+                f"backend={backend!r}: expected 6 assembled arrays, saw "
+                f"{len(calls)}: {calls}")
+            for shape, sharding, devices in calls:
+                assert sharding.mesh is mesh
+                addressable = set(
+                    sharding.addressable_devices_indices_map(shape))
+                assert devices == addressable, (
+                    f"backend={backend!r}: {shape} assembled from {devices}, "
+                    f"expected the addressable devices {addressable}")
+            assert put_targets, f"backend={backend!r}: nothing was placed"
+            for target in put_targets:
+                assert isinstance(target, jax.Device), (
+                    f"backend={backend!r}: a shard was placed with target "
+                    f"{target!r}; a process that addresses only part of the "
+                    "mesh can name a device but not a mesh-wide Sharding.")
+            assert layer.kernel_gating_EDF.value.sharding.spec == P(
+                None, None, "model")
+
+    def test_multihost_placement_uses_the_process_local_api(self):
+        """The fix, stated as the assertion that fails without it: the
+        multi-host branch must build each parameter with
+        `make_array_from_callback`. A raw `device_put` never calls it."""
+        mesh = self._mesh(2)
+        _layer, calls = self._decode(mesh, "ray")
+        # 3 projections x (values, scale).
+        assert len(calls) == 6, (
+            f"expected 6 process-local placements, saw {len(calls)}: {calls}")
+        for _shape, sharding in calls:
+            assert sharding.mesh is mesh
+
+    def test_single_host_placement_does_not_take_that_branch(self):
+        """Anti-vacuity for the test above: with the backend unset the count
+        is 0, so a passing multi-host assertion is really about the branch."""
+        _layer, calls = self._decode(self._mesh(2), "")
+        assert calls == []
+
+    def test_multihost_decode_equals_single_host_decode(self):
+        """The shard math, not just the API: assembling the global array from
+        process-local shards must produce the same weights, and the same
+        sharding, as the single-process path."""
+        mesh = self._mesh(2)
+        single, _ = self._decode(mesh, "")
+        multi, _ = self._decode(mesh, "ray")
+        checked = 0
+        for attr in ("kernel_gating_EDF", "kernel_up_proj_EDF",
+                     "kernel_down_proj_EFD"):
+            for name in (attr, f"{attr}_weight_scale"):
+                a, b = getattr(single, name).value, getattr(multi, name).value
+                assert a.shape == b.shape, name
+                assert a.sharding == b.sharding, (
+                    f"{name}: {a.sharding} vs {b.sharding}")
+                np.testing.assert_array_equal(
+                    np.asarray(a.astype(jnp.float32)),
+                    np.asarray(b.astype(jnp.float32)),
+                    err_msg=f"{name} differs between the two placements")
+                checked += 1
+        assert checked == 6
+
+    def test_placement_shards_the_expert_kernels(self):
+        """The sharding is actually applied -- otherwise the comparison above
+        would hold trivially for two replicated arrays."""
+        mesh = self._mesh(2)
+        layer, _ = self._decode(mesh, "ray")
+        values = layer.kernel_gating_EDF.value
+        assert values.sharding.spec == P(None, None, "model")
+        # Sharded 2 ways on the last axis.
+        assert values.addressable_shards[0].data.shape == (self.E, self.D,
+                                                           self.F // 2)

--- a/tests/models/common/test_model_loader.py
+++ b/tests/models/common/test_model_loader.py
@@ -14,6 +14,7 @@
 
 import os
 import tempfile
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import jax
@@ -540,3 +541,78 @@ class TestGetModel:
         mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False,
                                               None)
         assert result == "vllm_model_sentinel"
+
+
+class TestResolveModelArchitectureStreaming:
+    """The `--load-format runai_streamer` capability check.
+
+    Under `MODEL_IMPL_TYPE=auto`, `resolve_model_architecture` must keep a
+    JAX model on the flax_nnx implementation when it can actually consume
+    streamed weights, and fall back to vllm only when it cannot.
+    """
+
+    class _LoadableModel(model_loader.LoadableWithIterator):
+        """Streams via `LoadableWithIterator.load_weights`."""
+
+    class _WeightLoaderModel:
+        """Streams via a declared `WeightLoader`."""
+        WeightLoader = model_loader.BaseWeightLoader
+
+    class _PlainModel:
+        """Supports neither streaming path."""
+
+    def _config(self, load_format="runai_streamer"):
+        return SimpleNamespace(
+            load_config=SimpleNamespace(load_format=load_format),
+            model_config=SimpleNamespace(hf_config=SimpleNamespace(
+                architectures=["NotAVllmPreferredArch"])))
+
+    def test_loadable_with_iterator_can_stream(self):
+        assert model_loader._jax_model_can_stream_weights(self._LoadableModel)
+
+    def test_weight_loader_model_can_stream(self):
+        assert model_loader._jax_model_can_stream_weights(
+            self._WeightLoaderModel)
+
+    def test_plain_model_cannot_stream(self):
+        assert not model_loader._jax_model_can_stream_weights(self._PlainModel)
+
+    def test_streamer_keeps_flax_nnx_for_loadable_with_iterator(self):
+        with patch.object(model_loader,
+                          "_get_model_architecture",
+                          return_value=self._LoadableModel):
+            assert model_loader.resolve_model_architecture(
+                self._config(), False) == "flax_nnx"
+
+    def test_streamer_keeps_flax_nnx_for_weight_loader_model(self):
+        with patch.object(model_loader,
+                          "_get_model_architecture",
+                          return_value=self._WeightLoaderModel):
+            assert model_loader.resolve_model_architecture(
+                self._config(), False) == "flax_nnx"
+
+    def test_streamer_falls_back_to_vllm_for_non_streamable_model(self):
+        with patch.object(model_loader,
+                          "_get_model_architecture",
+                          return_value=self._PlainModel):
+            assert model_loader.resolve_model_architecture(
+                self._config(), False) == "vllm"
+
+    def test_streamer_with_unregistered_arch_falls_through_to_flax_nnx(self):
+        """Not-in-JAX architectures resolve to flax_nnx; the caller then
+        tries the flax path, fails, and falls back to vllm with a warning."""
+        with patch.object(
+                model_loader,
+                "_get_model_architecture",
+                side_effect=model_loader.UnsupportedArchitectureError(
+                    "not registered")):
+            assert model_loader.resolve_model_architecture(
+                self._config(), False) == "flax_nnx"
+
+    def test_non_streamer_load_skips_the_capability_check(self):
+        with patch.object(model_loader,
+                          "_get_model_architecture",
+                          side_effect=AssertionError(
+                              "must not inspect the JAX registry")):
+            assert model_loader.resolve_model_architecture(
+                self._config(load_format="auto"), False) == "flax_nnx"

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -26,6 +26,7 @@ if TYPE_CHECKING:
     USE_MOE_EP_KERNEL: bool = False
     USE_UNFUSED_MEGABLOCKS: bool = False
     USE_DENSE_MOE: bool = False
+    MXFP4_SHARD_THEN_DECODE: bool = True
     NUM_SLICES: int = 1
     RAY_USAGE_STATS_ENABLED: bool = False
     VLLM_USE_RAY_COMPILED_DAG_CHANNEL_TYPE: str = "shm"
@@ -277,6 +278,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # NOTE: this is a naive implementation and should not be used in production
     "USE_DENSE_MOE":
     env_bool("USE_DENSE_MOE", default=False),
+    # Decode compressed-tensors MXFP4 experts one device shard at a time, on
+    # the device that will keep the shard, instead of decoding a whole layer
+    # on the host and slicing the decoded result. Set to 0 to fall back to the
+    # host decode.
+    "MXFP4_SHARD_THEN_DECODE":
+    env_bool("MXFP4_SHARD_THEN_DECODE", default=True),
     # Number of TPU slices for multi-slice mesh
     "NUM_SLICES":
     lambda: int(os.getenv("NUM_SLICES") or "1"),

--- a/tpu_inference/layers/jax/quantization/__init__.py
+++ b/tpu_inference/layers/jax/quantization/__init__.py
@@ -49,7 +49,9 @@ def get_tpu_quantization_config(vllm_config: VllmConfig):
     # There are some cases to be supported in the future:
     # 1) Some vision model keep quantization config under text_config
     # 2) overriding through `--hf_overrides`
-    return quant_config(hg_quant_config)
+    return quant_config(hg_quant_config,
+                        model_name_or_path=model_config.model,
+                        download_dir=vllm_config.load_config.download_dir)
 
 
 class QuantizeMethodBase(ABC):

--- a/tpu_inference/layers/jax/quantization/compressed_tensors.py
+++ b/tpu_inference/layers/jax/quantization/compressed_tensors.py
@@ -88,8 +88,24 @@ def _checkpoint_tensor_names(model_name_or_path: str,
     Falls back to the shard headers for single-file checkpoints, which have no
     index.
     """
-    index = os.path.join(model_name_or_path, _SAFETENSORS_INDEX)
-    if os.path.isfile(index):
+    index = None
+    if os.path.isdir(model_name_or_path):
+        local_index = os.path.join(model_name_or_path, _SAFETENSORS_INDEX)
+        if os.path.isfile(local_index):
+            index = local_index
+    else:
+        # An HF repo id: fetch only the index (one small JSON) rather than
+        # materializing every weight shard just to read tensor names off it.
+        from huggingface_hub import hf_hub_download
+        from huggingface_hub.errors import EntryNotFoundError
+        try:
+            index = hf_hub_download(repo_id=model_name_or_path,
+                                    filename=_SAFETENSORS_INDEX,
+                                    cache_dir=download_dir)
+        except EntryNotFoundError:
+            # Single-file repos ship no index; read the shard header below.
+            index = None
+    if index is not None:
         with open(index) as f:
             yield from json.load(f)["weight_map"]
         return
@@ -197,6 +213,20 @@ class CompressedTensorsConfig(QuantizationConfig):
             return True
         return prefix in self._compressed_modules
 
+    def _stored_plain(self, prefix: str) -> bool:
+        """True when a config-targeted ``prefix`` is stored uncompressed.
+
+        Every such demotion is logged: the config says the module should be
+        quantized, so building it unquantized must be visible in the load log
+        rather than silent.
+        """
+        if self._is_compressed_in_checkpoint(prefix):
+            return False
+        logger.info(
+            "[compressed-tensors] %s targeted by quant config but stored "
+            "plain in checkpoint; using unquantized.", prefix)
+        return True
+
     def _match_target(self, layer: JaxModule, prefix: str) -> Optional[dict]:
         """Return the config-group scheme for ``layer``, or None if unmatched.
 
@@ -223,7 +253,7 @@ class CompressedTensorsConfig(QuantizationConfig):
                                    fused_mapping=self._fused_mapping):
                 return UnquantizedFusedMoEMethod(layer)
             scheme = self._match_target(layer, prefix)
-            if scheme is None or not self._is_compressed_in_checkpoint(prefix):
+            if scheme is None or self._stored_plain(prefix):
                 return UnquantizedFusedMoEMethod(layer)
             weight_quant = scheme.get("weights")
             input_quant = scheme.get("input_activations")
@@ -242,12 +272,12 @@ class CompressedTensorsConfig(QuantizationConfig):
                                fused_mapping=self._fused_mapping):
             return UnquantizedLinearMethod(linear_config)
 
-        if not self._is_compressed_in_checkpoint(prefix):
-            # Targeted by the config groups, but stored uncompressed.
-            return UnquantizedLinearMethod(linear_config)
-
         scheme = self._match_target(layer, prefix)
         if scheme is None:
+            return UnquantizedLinearMethod(linear_config)
+
+        if self._stored_plain(prefix):
+            # Targeted by the config groups, but stored uncompressed.
             return UnquantizedLinearMethod(linear_config)
 
         weight_quant = scheme.get("weights")

--- a/tpu_inference/layers/jax/quantization/compressed_tensors.py
+++ b/tpu_inference/layers/jax/quantization/compressed_tensors.py
@@ -18,9 +18,12 @@ reuse its config-group parsing and scheme detection, then dispatches each layer
 to the existing JAX fp8 quant methods.
 """
 
+import json
+import os
 from types import MappingProxyType
-from typing import Optional
+from typing import Iterator, Optional
 
+from safetensors import safe_open
 from vllm.model_executor.layers.quantization.compressed_tensors.compressed_tensors import \
     CompressedTensorsConfig as VllmUpstreamCTConfig
 from vllm.model_executor.layers.quantization.compressed_tensors.utils import (
@@ -36,8 +39,13 @@ from tpu_inference.layers.jax.quantization.configs import (QuantizationConfig,
 from tpu_inference.layers.jax.quantization.fp8 import (
     Fp8BlockwiseLinearMethod, Fp8FusedMoEMethod, Fp8TensorwiseLinearMethod,
     Fp8TensorwiseMergedLinearMethod)
+from tpu_inference.layers.jax.quantization.mxfp4 import (
+    MXFP4_PACK_QUANTIZED_FORMAT, CompressedTensorsMxfp4MoEMethod)
 from tpu_inference.layers.jax.quantization.unquantized import (
     UnquantizedFusedMoEMethod, UnquantizedLinearMethod)
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
 
 
 class _Fp8BlockConfigShim:
@@ -57,10 +65,104 @@ def _weight_block_size(weight_quant) -> Optional[list[int]]:
     return list(block) if block is not None else None
 
 
+# A ``*ForConditionalGeneration`` checkpoint nests the whole text stack under
+# this prefix (Kimi-K3, Llama-4, Gemma-4-MM all do), while the model's own
+# module paths -- what ``get_quant_method`` is asked about -- do not carry it.
+_WRAPPER_TEXT_PREFIX = "language_model."
+
+_SAFETENSORS_INDEX = "model.safetensors.index.json"
+
+
+def _checkpoint_tensor_names(model_name_or_path: str,
+                             download_dir: Optional[str]) -> Iterator[str]:
+    """Every tensor name in the checkpoint.
+
+    Prefers the safetensors index, for two reasons. It is one small JSON
+    instead of every shard's header (the alternative opens 96+ files for a
+    multi-TB checkpoint), and it is present locally even when the weights
+    themselves never are: loading from object storage downloads the config
+    files -- the index among them -- and streams only the shards, so reading
+    tensor names off the shards fails with "cannot find any *.safetensors
+    files" and takes the checkpoint's own layout out of the decision.
+
+    Falls back to the shard headers for single-file checkpoints, which have no
+    index.
+    """
+    index = os.path.join(model_name_or_path, _SAFETENSORS_INDEX)
+    if os.path.isfile(index):
+        with open(index) as f:
+            yield from json.load(f)["weight_map"]
+        return
+    # Imported here: weight_utils pulls in the model stack, and this module is
+    # imported from the quantization package that stack itself imports.
+    from tpu_inference.models.jax.utils.weight_utils import \
+        get_model_weights_files
+    for path in get_model_weights_files(model_name_or_path, download_dir):
+        with safe_open(path, framework="numpy") as f:
+            yield from f.keys()
+
+
+# A module is stored compressed when the checkpoint gives it one of these
+# companion tensors. Pack-quantized formats (MXFP4) rename the weight itself
+# to `weight_packed`; float-quantized formats (FP8) keep a plain `weight` and
+# mark compression with `weight_scale` alone. Matching only `weight_packed`
+# classified EVERY module of an FP8 checkpoint as uncompressed and silently
+# built the whole model unquantized (caught by gemma-4 FP8-Dynamic in CI).
+_COMPRESSED_COMPANION_SUFFIXES = (".weight_packed", ".weight_scale")
+
+
+def _compressed_module_paths(
+        model_name_or_path: Optional[str],
+        download_dir: Optional[str]) -> Optional[set[str]]:
+    """Module paths the checkpoint stores compressed.
+
+    The returned set also holds every ancestor of such a path, so a caller
+    asking about a parent module (an MoE block owns a subtree of per-expert
+    modules) is a plain set lookup rather than a scan over a checkpoint that
+    can have hundreds of thousands of tensors.
+
+    Returns ``None`` when the checkpoint cannot be inspected, which callers
+    read as "no information, trust the config".
+    """
+    if not model_name_or_path:
+        return None
+    try:
+        packed = set()
+        for name in _checkpoint_tensor_names(model_name_or_path, download_dir):
+            for suffix in _COMPRESSED_COMPANION_SUFFIXES:
+                if name.endswith(suffix):
+                    path = name[:-len(suffix)]
+                    break
+            else:
+                continue
+            if path.startswith(_WRAPPER_TEXT_PREFIX):
+                path = path[len(_WRAPPER_TEXT_PREFIX):]
+            while path and path not in packed:
+                packed.add(path)
+                path = path.rpartition(".")[0]
+    except Exception as e:
+        logger.warning(
+            "[compressed-tensors] could not read the checkpoint tensor names "
+            "for %s (%s: %s); falling back to the config's target/ignore lists "
+            "to decide which layers are compressed. If the checkpoint leaves "
+            "some targeted modules uncompressed, loading them will fail.",
+            model_name_or_path,
+            type(e).__name__, e)
+        return None
+    logger.info(
+        "[compressed-tensors] checkpoint %s stores %d module paths compressed "
+        "(counting the parents of each); using that, not the config ignore "
+        "list, to select quant methods.", model_name_or_path, len(packed))
+    return packed
+
+
 class CompressedTensorsConfig(QuantizationConfig):
     """JAX-native ``compressed-tensors`` config; registered in the quant map."""
 
-    def __init__(self, hf_quant_config: dict):
+    def __init__(self,
+                 hf_quant_config: dict,
+                 model_name_or_path: str | None = None,
+                 download_dir: str | None = None):
         # Reuse upstream parsing of config_groups -> target_scheme_map + ignore.
         self._ct = VllmUpstreamCTConfig.from_config(hf_quant_config)
         self._target_scheme_map = self._ct.target_scheme_map
@@ -69,6 +171,31 @@ class CompressedTensorsConfig(QuantizationConfig):
         # semantics; not yet wired for the JAX path, so match on plain names.
         self._fused_mapping = getattr(self._ct, "packed_modules_mapping",
                                       MappingProxyType({}))
+        self._format = hf_quant_config.get("format")
+        # The config's ignore list is not a reliable statement of what is
+        # actually compressed: a checkpoint can leave a target module
+        # uncompressed without listing it (Kimi-K3 stores the MoE latent
+        # down/up projections and the attention-residual projections as plain
+        # bf16 while its ignore list only covers self_attn / shared_experts /
+        # mlp / lm_head). The checkpoint's own tensor names are authoritative,
+        # so record which module paths carry a compression companion tensor.
+        self._compressed_modules = _compressed_module_paths(
+            model_name_or_path, download_dir)
+
+    def _is_compressed_in_checkpoint(self, prefix: str) -> bool:
+        """Whether the checkpoint actually stores ``prefix`` compressed.
+
+        True for a compressed module and for any ancestor of one -- an MoE
+        block is asked about by the path that owns the per-expert subtree
+        (`<prefix>.<expert_id>.<proj>`), never by a leaf path.
+
+        Falls back to trusting the config when the checkpoint could not be
+        inspected (``None``), so behaviour is unchanged for callers that do not
+        pass a model path.
+        """
+        if self._compressed_modules is None:
+            return True
+        return prefix in self._compressed_modules
 
     def _match_target(self, layer: JaxModule, prefix: str) -> Optional[dict]:
         """Return the config-group scheme for ``layer``, or None if unmatched.
@@ -96,10 +223,12 @@ class CompressedTensorsConfig(QuantizationConfig):
                                    fused_mapping=self._fused_mapping):
                 return UnquantizedFusedMoEMethod(layer)
             scheme = self._match_target(layer, prefix)
-            if scheme is None:
+            if scheme is None or not self._is_compressed_in_checkpoint(prefix):
                 return UnquantizedFusedMoEMethod(layer)
             weight_quant = scheme.get("weights")
             input_quant = scheme.get("input_activations")
+            if self._format == MXFP4_PACK_QUANTIZED_FORMAT:
+                return CompressedTensorsMxfp4MoEMethod(layer, weight_quant)
             if self._ct._is_fp8_w8a8(weight_quant, input_quant):
                 return Fp8FusedMoEMethod(_weight_block_size(weight_quant))
             return UnquantizedFusedMoEMethod(layer)
@@ -111,6 +240,10 @@ class CompressedTensorsConfig(QuantizationConfig):
         if should_ignore_layer(prefix,
                                ignore=self._ignore,
                                fused_mapping=self._fused_mapping):
+            return UnquantizedLinearMethod(linear_config)
+
+        if not self._is_compressed_in_checkpoint(prefix):
+            # Targeted by the config groups, but stored uncompressed.
             return UnquantizedLinearMethod(linear_config)
 
         scheme = self._match_target(layer, prefix)

--- a/tpu_inference/layers/jax/quantization/configs.py
+++ b/tpu_inference/layers/jax/quantization/configs.py
@@ -26,7 +26,19 @@ from tpu_inference.layers.jax.quantization import QuantizeMethodBase
 
 class QuantizationConfig(ABC):
 
-    def __init__(self, hf_quant_config: dict):
+    def __init__(self,
+                 hf_quant_config: dict,
+                 model_name_or_path: str | None = None,
+                 download_dir: str | None = None):
+        """
+        Args:
+            hf_quant_config: the checkpoint's ``quantization_config`` block.
+            model_name_or_path: local directory or HF repo id the weights are
+                loaded from. Configs that must consult the checkpoint itself --
+                rather than trust a config regex list -- to decide which layers
+                are actually stored compressed use this.
+            download_dir: where HF weights are cached, for the same purpose.
+        """
         pass
 
     @abstractmethod

--- a/tpu_inference/layers/jax/quantization/fp8.py
+++ b/tpu_inference/layers/jax/quantization/fp8.py
@@ -763,7 +763,10 @@ class Fp8Config(QuantizationConfig):
 
     ACTIVATION_SCHEMES = ["dynamic", "static"]
 
-    def __init__(self, hf_quant_config: dict):
+    def __init__(self,
+                 hf_quant_config: dict,
+                 model_name_or_path: str | None = None,
+                 download_dir: str | None = None):
         # Replicating upstream https://github.com/vllm-project/vllm/blob/77c09e1130661197ccac2d968a28cd4a557922d5/vllm/model_executor/layers/quantization/fp8.py#L167-L175
 
         quant_method = self.get_from_keys(hf_quant_config, ["quant_method"])

--- a/tpu_inference/layers/jax/quantization/mxfp4.py
+++ b/tpu_inference/layers/jax/quantization/mxfp4.py
@@ -12,20 +12,28 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Iterable, Optional
+import functools
+import time
+from typing import Callable, Iterable, Optional
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import torch
 from flax import nnx
+from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
+from jax.sharding import SingleDeviceSharding
 
-from tpu_inference.layers.common.moe import MoEBackend, moe_apply
+from tpu_inference import envs
+from tpu_inference.layers.common.moe import (FusedMoEMethodBase, MoEBackend,
+                                             moe_apply)
 from tpu_inference.layers.common.process_weights.moe_weights import (
-    FusedMoEWeights, process_moe_weights, quantize_moe_weights,
-    shard_moe_weights)
+    FusedMoEWeights, UnfusedMoEWeights, process_moe_weights,
+    quantize_moe_weights, shard_moe_weights)
 from tpu_inference.layers.common.quantization import (
-    MXFP4_REQUANTIZED_BLOCK_SIZE, dequantize_tensor_from_mxfp4_packed)
+    MXFP4_BLOCK_SIZE, MXFP4_REQUANTIZED_BLOCK_SIZE,
+    dequantize_tensor_from_mxfp4_packed, e8m0_to_fp32, u8_unpack_e2m1)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.common.utils import cpu_mesh, cpu_mesh_context
 from tpu_inference.layers.jax import JaxModule
@@ -33,8 +41,8 @@ from tpu_inference.layers.jax.moe.moe import JaxMoE, JaxRoutedExperts
 from tpu_inference.layers.jax.quantization import QuantizeMethodBase
 from tpu_inference.layers.jax.quantization.configs import QuantizationConfig
 from tpu_inference.logger import init_logger
-from tpu_inference.models.jax.utils.weight_utils import \
-    jax_array_from_reshaped_torch
+from tpu_inference.models.jax.utils.weight_utils import (
+    jax_array_from_reshaped_torch, shard_put)
 from tpu_inference.utils import get_mesh_shape_product
 
 logger = init_logger(__name__)
@@ -254,6 +262,362 @@ class Mxfp4FusedMoEMethod(QuantizeMethodBase):
                 f"Unsupported moe backend: {layer.moe_backend}! Currently supported: {MXFP4_QUANT_METHOD_SUPPORTED_MOE_BACKENDS}"
             )
 
+        return moe_apply(layer, x_TD, router_logits, weights,
+                         layer.moe_backend, layer.mesh,
+                         self.extra_backend_kwargs)
+
+
+MXFP4_PACK_QUANTIZED_FORMAT = "mxfp4-pack-quantized"
+
+# When the previous MoE layer's decode finished, so each layer can report how
+# long it waited for its own weights to stream in. Loading is single-threaded
+# per process, so one module-level slot is enough.
+_LAST_LAYER_FINISHED_AT = 0.0
+
+# Compiled per-shard decodes, keyed by (decode fn, shard shape, device); see
+# `_decode_executable`.
+_DECODE_EXECUTABLES: dict = {}
+
+# compressed-tensors names each expert projection separately, and checkpoints
+# use either the HF `wN` spelling or the expanded one. `w1`/`gate_proj` is the
+# gate branch, `w3`/`up_proj` the up branch, `w2`/`down_proj` the down branch.
+_CT_EXPERT_PROJECTIONS = {
+    "w1": "gating",
+    "gate_proj": "gating",
+    "w3": "up_proj",
+    "up_proj": "up_proj",
+    "w2": "down_proj",
+    "down_proj": "down_proj",
+}
+
+# Staging attribute names, keyed by the projection above.
+_CT_STAGED_ATTRS = {
+    "gating": ("gate_packed", "gate_scale"),
+    "up_proj": ("up_packed", "up_scale"),
+    "down_proj": ("down_packed", "down_scale"),
+}
+
+# Final parameter names, keyed by the projection above.
+_CT_FINAL_ATTRS = {
+    "gating": "kernel_gating_EDF",
+    "up_proj": "kernel_up_proj_EDF",
+    "down_proj": "kernel_down_proj_EFD",
+}
+
+
+def _named_sharding(sharding, mesh: Mesh) -> NamedSharding:
+    """Normalize the spellings `shard_put` accepts into a `NamedSharding`."""
+    if isinstance(sharding, NamedSharding):
+        return sharding
+    if isinstance(sharding, P):
+        return NamedSharding(mesh, sharding)
+    return NamedSharding(mesh, P(*(sharding or ())))
+
+
+def _full_slice(s: slice | None, size: int) -> slice:
+    """A concrete `[start, stop)` for one axis of a device's index tuple."""
+    if s is None:
+        return slice(0, size)
+    assert s.step in (None, 1), f"unexpected strided shard index {s}"
+    return slice(0 if s.start is None else s.start,
+                 size if s.stop is None else s.stop)
+
+
+@functools.lru_cache(maxsize=None)
+def _one_device_mesh(device: jax.Device) -> Mesh:
+    """A mesh holding just `device`.
+
+    Each shard is decoded by itself, but the loader runs inside a
+    `jax.set_mesh` of the *whole* model mesh, and jitting a single-device
+    computation under that context is rejected ("Received incompatible
+    devices ... jit's context mesh with device ids [0..N]"). Entering this
+    mesh for the decode says which single device the computation belongs to.
+    """
+    return Mesh(np.array([device]).reshape(1), ("mxfp4_shard", ))
+
+
+def _decode_executable(decode: Callable, shape: tuple[int, ...],
+                       device: jax.Device):
+    """A compiled `[e, out, in_] -> [e, in, out]` decode for one device.
+
+    Held as an already-compiled executable rather than a `jax.jit` wrapper
+    because the loader calls `jax.clear_caches()` after every module, which
+    would otherwise re-trace and re-compile these for each of the model's
+    layers -- the shard shapes repeat, so one compile per shape is enough.
+    """
+    key = (decode, shape, device.id)
+    executable = _DECODE_EXECUTABLES.get(key)
+    if executable is None:
+        aval = jax.ShapeDtypeStruct(shape,
+                                    jnp.uint8,
+                                    sharding=SingleDeviceSharding(device))
+        with jax.set_mesh(_one_device_mesh(device)):
+            executable = jax.jit(lambda source: jnp.swapaxes(
+                decode(source), 1, 2)).lower(aval).compile()
+        _DECODE_EXECUTABLES[key] = executable
+    return executable
+
+
+def _decode_sharded(staged: list[jax.Array], decode: Callable, expansion: int,
+                    sharding, mesh: Mesh) -> jax.Array:
+    """Build one decoded, sharded expert tensor a device shard at a time.
+
+    `staged` holds this layer's per-expert checkpoint tensors, each
+    `[1, out, in_]` uint8, where `decode` expands the last axis by
+    `expansion` (2 for the fp4 nibble unpack, 1 for the E8M0 scales). The
+    result is `[E, in_ * expansion, out]` laid out over `mesh` as `sharding`
+    -- the same array the host decode produces, assembled shard by shard:
+    each device's slice is cut out of the *packed* bytes, sent to that
+    device, and decoded there.
+
+    Doing it in this order is what makes it cheap. The decode is elementwise
+    along the packed axis and every shard boundary below falls on a whole
+    uint8 word, so a shard decoded on its own is bit-for-bit the shard the
+    whole-layer decode would have produced -- while the host never
+    materializes the ~4.5x-larger decoded layer, only packed bytes cross the
+    host/device boundary, and each process touches just the experts its own
+    devices keep instead of all of them.
+    """
+    num_experts = len(staged)
+    _, out, packed_in = staged[0].shape
+    shape = (num_experts, packed_in * expansion, out)
+    sharding = _named_sharding(sharding, mesh)
+
+    # numpy views of the staged tensors: the per-shard gather below is pure
+    # slicing and concatenation, which numpy does without a jax dispatch per
+    # expert (there are hundreds of experts per shard).
+    source = [np.asarray(w) for w in staged]
+
+    shards = []
+    for device, index in sharding.addressable_devices_indices_map(
+            shape).items():
+        expert_slice = _full_slice(index[0], num_experts)
+        in_slice = _full_slice(index[1], packed_in * expansion)
+        out_slice = _full_slice(index[2], out)
+        if in_slice.start % expansion or in_slice.stop % expansion:
+            raise ValueError(
+                f"[mxfp4-ct] shard {in_slice} of the {shape} decoded tensor "
+                f"splits a packed uint8 word ({expansion} values each); "
+                f"cannot decode this shard on its own.")
+        packed_slice = slice(in_slice.start // expansion,
+                             in_slice.stop // expansion)
+        # `[e, out, in_]` for the experts this device keeps, still packed.
+        local = np.concatenate([
+            w[:, out_slice, packed_slice]
+            for w in source[expert_slice.start:expert_slice.stop]
+        ],
+                               axis=0)
+        executable = _decode_executable(decode, local.shape, device)
+        with jax.set_mesh(_one_device_mesh(device)):
+            shards.append(executable(jax.device_put(local, device)))
+    return jax.make_array_from_single_device_arrays(shape, sharding, shards)
+
+
+class CompressedTensorsMxfp4MoEMethod(QuantizeMethodBase, FusedMoEMethodBase):
+    """MXFP4 routed experts stored in compressed-tensors `mxfp4-pack-quantized`.
+
+    Unlike the GPT-OSS MXFP4 path above, this decode is **lossless**: the
+    checkpoint's fp4 codes and E8M0 group scales are carried through unchanged
+    (nibbles bitcast to `float4_e2m1fn`, exponents expanded to the exact
+    powers of two they denote) instead of being dequantized to fp32 and
+    re-quantized at a larger block size. Kimi-K3's experts are
+    quantization-aware-trained, so recomputing the scales would move the
+    weights away from the values training converged on.
+
+    Layout differences from GPT-OSS handled here:
+      * one tensor per expert per projection (`experts.<i>.w1.weight_packed`)
+        rather than one stacked `gate_up_proj_blocks` per layer, so the expert
+        axis is built by concatenation while loading;
+      * the checkpoint stores `[out, in]` with the *input* axis packed, while
+        the expert kernels are `(E, in, out)`, so the decoded values and their
+        scales are transposed once at the end of loading.
+    """
+
+    def __init__(self, layer: JaxMoE, weight_quant=None):
+        FusedMoEMethodBase.__init__(self, layer.moe_backend, "model")
+        self.group_size = getattr(weight_quant, "group_size",
+                                  None) or MXFP4_BLOCK_SIZE
+        num_bits = getattr(weight_quant, "num_bits", 4)
+        strategy = getattr(weight_quant, "strategy", "group")
+        if num_bits != 4 or str(strategy).endswith("tensor"):
+            raise NotImplementedError(
+                f"[mxfp4-ct] {layer.prefix}: only 4-bit group-wise MXFP4 is "
+                f"supported, got num_bits={num_bits} strategy={strategy}.")
+        if layer.moe_backend in MoEBackend.fused_moe_backends():
+            # The fused GMM backends pick experts from the raw router logits
+            # themselves, which drops the router's expert-score correction
+            # bias, and they have no `situ` activation branch -- both of which
+            # the Kimi models need. Fail loudly rather than serve wrong tokens.
+            raise NotImplementedError(
+                f"[mxfp4-ct] {layer.prefix}: compressed-tensors MXFP4 experts "
+                f"are wired for the unfused MoE backends (DENSE_MAT, "
+                f"MEGABLX_GMM), got {layer.moe_backend}.")
+
+    def create_weights_jax(self, layer: JaxMoE, *weight_args, rngs,
+                           **extra_weight_attrs) -> None:
+        """Replace the bf16 expert kernels with packed MXFP4 staging tensors."""
+        E = layer.num_local_experts
+        D = layer.hidden_size
+        F = layer.intermediate_size_moe
+        gs = self.group_size
+        for dim, name in ((D, "hidden_size"), (F, "intermediate_size_moe")):
+            if dim % gs:
+                raise ValueError(
+                    f"[mxfp4-ct] {layer.prefix}: {name}={dim} is not a "
+                    f"multiple of the MXFP4 group size {gs}.")
+
+        for param_name in _CT_FINAL_ATTRS.values():
+            delattr(layer, param_name)
+
+        # Checkpoint orientation, expert axis prepended: [E, out, in].
+        for projection, (out, in_) in (("gating", (F, D)), ("up_proj", (F, D)),
+                                       ("down_proj", (D, F))):
+            packed_attr, scale_attr = _CT_STAGED_ATTRS[projection]
+            for attr, shape in ((packed_attr, (E, out, in_ // 2)),
+                                (scale_attr, (E, out, in_ // gs))):
+                param = nnx.Param(jnp.zeros(shape, dtype=jnp.uint8),
+                                  eager_sharding=False)
+                param.set_metadata('mesh', cpu_mesh())
+                param.set_metadata('_weights_to_load', [None] * E)
+                setattr(layer, attr, param)
+
+    def load_weights(self, *, layer: JaxMoE, original_load_weights_fn,
+                     weights: Iterable[tuple[str, torch.Tensor]]) -> set:
+        """Stage per-expert `weight_packed` / `weight_scale` tensors."""
+        loaded_names = set()
+        for torch_name, torch_weight in weights:
+            parts = torch_name.split(".")
+            if len(parts) < 3:
+                raise ValueError(
+                    f"[mxfp4-ct] {layer.prefix}: cannot parse expert tensor "
+                    f"name '{torch_name}'; expected "
+                    f"<...>.<expert_id>.<projection>.<weight_packed|weight_scale>."
+                )
+            kind, projection_name, expert_id = parts[-1], parts[-2], parts[-3]
+            projection = _CT_EXPERT_PROJECTIONS.get(projection_name)
+            if projection is None or kind not in ("weight_packed",
+                                                  "weight_scale"):
+                raise ValueError(
+                    f"[mxfp4-ct] {layer.prefix}: unexpected checkpoint tensor "
+                    f"'{torch_name}'. Expected one of "
+                    f"{sorted(_CT_EXPERT_PROJECTIONS)} carrying weight_packed "
+                    f"or weight_scale.")
+            packed_attr, scale_attr = _CT_STAGED_ATTRS[projection]
+            attr = packed_attr if kind == "weight_packed" else scale_attr
+            jax_param = getattr(layer, attr)
+            slot = int(expert_id)
+            # `[None] + shape` so the expert axis exists for concatenation.
+            jax_param._weights_to_load[slot] = jax_array_from_reshaped_torch(
+                torch_weight, reshape_dims=(1, ) + tuple(torch_weight.shape))
+            loaded_names.add(attr)
+
+        logger.debug(f"Staged {len(loaded_names)} MXFP4 tensor groups for "
+                     f"{layer.prefix} MoE layer.")
+        return loaded_names
+
+    def process_weights_after_loading(self, layer: JaxMoE) -> bool:
+        """Decode the staged tensors into device-resident fp4 + fp32 scales."""
+        staged_attrs = [a for pair in _CT_STAGED_ATTRS.values() for a in pair]
+        if not all(
+                all(w is not None
+                    for w in getattr(layer, attr)._weights_to_load)
+                for attr in staged_attrs):
+            # Expert weights can be split across safetensors files, so this is
+            # called more than once; wait until every expert has arrived.
+            return False
+
+        started = time.perf_counter()
+        global _LAST_LAYER_FINISHED_AT
+        # How long this layer's weights took to stream in, for everything
+        # after the first: loading is a single pass, so the gap since the
+        # previous layer's decode is time spent reading the checkpoint.
+        streamed_in = (f"{started - _LAST_LAYER_FINISHED_AT:.1f}s"
+                       if _LAST_LAYER_FINISHED_AT else "the first layer")
+
+        mesh = layer.mesh
+        shard_then_decode = envs.MXFP4_SHARD_THEN_DECODE
+        for projection, (packed_attr, scale_attr) in _CT_STAGED_ATTRS.items():
+            final_attr = _CT_FINAL_ATTRS[projection]
+            sharding = (layer.efd_sharding
+                        if projection == "down_proj" else layer.edf_sharding)
+            staged_packed = getattr(layer, packed_attr)._weights_to_load
+            staged_scale = getattr(layer, scale_attr)._weights_to_load
+            if shard_then_decode:
+                # [E, out, in//2] uint8 -> [E, in, out] fp4, and
+                # [E, out, in//group] E8M0 -> [E, in//group, out] fp32, one
+                # device shard at a time.
+                values = _decode_sharded(staged_packed, u8_unpack_e2m1, 2,
+                                         sharding, mesh)
+                scale = _decode_sharded(staged_scale, e8m0_to_fp32, 1,
+                                        sharding, mesh)
+            else:
+                values, scale = self._decode_on_host(staged_packed,
+                                                     staged_scale, sharding,
+                                                     mesh)
+            setattr(layer, final_attr, nnx.Param(values))
+            setattr(layer, f"{final_attr}_weight_scale", nnx.Param(scale))
+            delattr(layer, packed_attr)
+            delattr(layer, scale_attr)
+
+        _LAST_LAYER_FINISHED_AT = time.perf_counter()
+        logger.info(
+            "[mxfp4-ct] %s: decoded %d MXFP4 expert projections losslessly "
+            "(group size %d, checkpoint scales passed through) in %.1fs "
+            "[shard_then_decode=%s; waited %s for these weights to stream "
+            "in].", layer.prefix, len(_CT_STAGED_ATTRS), self.group_size,
+            _LAST_LAYER_FINISHED_AT - started, shard_then_decode, streamed_in)
+        return True
+
+    @staticmethod
+    def _decode_on_host(staged_packed: list[jax.Array],
+                        staged_scale: list[jax.Array], sharding,
+                        mesh) -> tuple[jax.Array, jax.Array]:
+        """Decode a whole layer on the host, then cut it into shards.
+
+        Materializes ~4.5x the packed bytes per projection (fp4 values are a
+        byte each on the host and the E8M0 scales expand to fp32) and decodes
+        every expert on every process, so `_decode_sharded` above is the
+        default. Kept as a fallback for the same numbers by a second route.
+        """
+        # Keep the decode off device until the sharding is applied.
+        with cpu_mesh_context():
+            packed = jnp.concatenate(staged_packed, axis=0)
+            scale_u8 = jnp.concatenate(staged_scale, axis=0)
+            # [E, out, in//2] uint8 -> [E, out, in] fp4 -> [E, in, out].
+            values = jnp.swapaxes(u8_unpack_e2m1(packed), 1, 2)
+            # [E, out, in//group] E8M0 -> exact fp32 powers of two, then
+            # [E, in//group, out] to match the kernel's (E, K, N) weights.
+            scale = jnp.swapaxes(e8m0_to_fp32(scale_u8), 1, 2)
+        # `shard_put`, not `jax.device_put(x, NamedSharding(mesh, ...))`.
+        # Under the Ray multi-host backend a process addresses only its own
+        # devices, so naming a sharding over the whole mesh is rejected ("must
+        # be a Device or a Sharding which represents addressable devices").
+        # `shard_put` routes to `general_device_put`, which assembles the
+        # global array out of each process's addressable shards instead. The
+        # decode above runs under `cpu_mesh_context`, so `values`/`scale` are
+        # process-local and fully addressable -- exactly the case that needs
+        # it. Same helper the unquantized expert path already uses.
+        return (shard_put(values, sharding,
+                          mesh=mesh), shard_put(scale, sharding, mesh=mesh))
+
+    def apply_jax(self, layer: JaxMoE, x: jax.Array, *,
+                  router_logits) -> jax.Array:
+        x_TD = jnp.asarray(x, layer.dtype)
+        x_TD = jax.lax.with_sharding_constraint(
+            x_TD,
+            jax.sharding.NamedSharding(layer.mesh,
+                                       P(*layer.activation_ffw_td)))
+        weights = UnfusedMoEWeights(
+            w1_weight=layer.kernel_gating_EDF.value,
+            w1_weight_scale=layer.kernel_gating_EDF_weight_scale.value,
+            w1_bias=None,
+            w2_weight=layer.kernel_up_proj_EDF.value,
+            w2_weight_scale=layer.kernel_up_proj_EDF_weight_scale.value,
+            w2_bias=None,
+            w3_weight=layer.kernel_down_proj_EFD.value,
+            w3_weight_scale=layer.kernel_down_proj_EFD_weight_scale.value,
+            w3_bias=None,
+        )
         return moe_apply(layer, x_TD, router_logits, weights,
                          layer.moe_backend, layer.mesh,
                          self.extra_backend_kwargs)

--- a/tpu_inference/layers/jax/quantization/mxfp4.py
+++ b/tpu_inference/layers/jax/quantization/mxfp4.py
@@ -29,8 +29,8 @@ from tpu_inference import envs
 from tpu_inference.layers.common.moe import (FusedMoEMethodBase, MoEBackend,
                                              moe_apply)
 from tpu_inference.layers.common.process_weights.moe_weights import (
-    FusedMoEWeights, UnfusedMoEWeights, process_moe_weights,
-    quantize_moe_weights, shard_moe_weights)
+    FusedMoEWeights, process_moe_weights, quantize_moe_weights,
+    shard_moe_weights)
 from tpu_inference.layers.common.quantization import (
     MXFP4_BLOCK_SIZE, MXFP4_REQUANTIZED_BLOCK_SIZE,
     dequantize_tensor_from_mxfp4_packed, e8m0_to_fp32, u8_unpack_e2m1)
@@ -619,25 +619,17 @@ class CompressedTensorsMxfp4MoEMethod(QuantizeMethodBase, FusedMoEMethodBase):
 
     def apply_jax(self, layer: JaxMoE, x: jax.Array, *,
                   router_logits) -> jax.Array:
-        x_TD = jnp.asarray(x, layer.dtype)
-        x_TD = jax.lax.with_sharding_constraint(
-            x_TD,
-            jax.sharding.NamedSharding(layer.mesh,
-                                       P(*layer.activation_ffw_td)))
-        weights = UnfusedMoEWeights(
-            w1_weight=layer.kernel_gating_EDF.value,
-            w1_weight_scale=layer.kernel_gating_EDF_weight_scale.value,
-            w1_bias=None,
-            w2_weight=layer.kernel_up_proj_EDF.value,
-            w2_weight_scale=layer.kernel_up_proj_EDF_weight_scale.value,
-            w2_bias=None,
-            w3_weight=layer.kernel_down_proj_EFD.value,
-            w3_weight_scale=layer.kernel_down_proj_EFD_weight_scale.value,
-            w3_bias=None,
-        )
-        return moe_apply(layer, x_TD, router_logits, weights,
-                         layer.moe_backend, layer.mesh,
-                         self.extra_backend_kwargs)
+        # The unfused MoE backends at this revision consume only bf16 expert
+        # kernels: DENSE_MAT einsums the raw weight arrays and MEGABLX_GMM
+        # re-reads `layer.kernel_*` itself, so the fp4 codes and the fp32
+        # group scales decoded above would be dropped on the floor and the
+        # layer would silently compute garbage. Fail loudly instead; the
+        # scale-consuming MoE backends land with the kernel layer change.
+        raise NotImplementedError(
+            f"[mxfp4-ct] {layer.prefix}: the forward pass for "
+            "compressed-tensors MXFP4 experts is not wired up at this "
+            "revision; the scale-consuming MoE backends land with the kernel "
+            "layer change.")
 
 
 class Mxfp4Config(QuantizationConfig):

--- a/tpu_inference/layers/jax/quantization/mxfp4.py
+++ b/tpu_inference/layers/jax/quantization/mxfp4.py
@@ -108,9 +108,8 @@ class Mxfp4FusedMoEMethod(QuantizeMethodBase):
                 "Mxfp4FusedMoEMethod only handles GPT-OSS MXFP4 expert "
                 f"tensors, got unexpected checkpoint tensors: {unexpected}")
 
-        logger.debug(
-            f"Loaded {len(loaded_names)} MXFP4 tensors for {layer.prefix} MoE layer."
-        )
+        logger.debug("[mxfp4] %s: loaded %d MXFP4 tensors for the MoE layer.",
+                     layer.prefix, len(loaded_names))
 
         return loaded_names
 
@@ -435,10 +434,20 @@ class CompressedTensorsMxfp4MoEMethod(QuantizeMethodBase, FusedMoEMethodBase):
 
     def __init__(self, layer: JaxMoE, weight_quant=None):
         FusedMoEMethodBase.__init__(self, layer.moe_backend, "model")
+        # Methods are constructed while the model is being built, before any
+        # weights stream in, so this starts each load from a clean slot
+        # instead of measuring the first layer's wait against whatever model
+        # this process loaded previously.
+        global _LAST_LAYER_FINISHED_AT
+        _LAST_LAYER_FINISHED_AT = 0.0
         self.group_size = getattr(weight_quant, "group_size",
                                   None) or MXFP4_BLOCK_SIZE
         num_bits = getattr(weight_quant, "num_bits", 4)
         strategy = getattr(weight_quant, "strategy", "group")
+        # compressed-tensors parses `strategy` into a str-mixin enum whose
+        # `str()` is "QuantizationStrategy.TENSOR", so compare against the
+        # enum's value (raw configs hand a plain string through unchanged).
+        strategy = getattr(strategy, "value", strategy)
         if num_bits != 4 or str(strategy).endswith("tensor"):
             raise NotImplementedError(
                 f"[mxfp4-ct] {layer.prefix}: only 4-bit group-wise MXFP4 is "
@@ -505,14 +514,22 @@ class CompressedTensorsMxfp4MoEMethod(QuantizeMethodBase, FusedMoEMethodBase):
             packed_attr, scale_attr = _CT_STAGED_ATTRS[projection]
             attr = packed_attr if kind == "weight_packed" else scale_attr
             jax_param = getattr(layer, attr)
-            slot = int(expert_id)
+            try:
+                slot = int(expert_id)
+            except ValueError:
+                raise ValueError(
+                    f"[mxfp4-ct] {layer.prefix}: expert id '{expert_id}' in "
+                    f"checkpoint tensor '{torch_name}' is not an integer; "
+                    f"expected <...>.<expert_id>.<projection>."
+                    f"<weight_packed|weight_scale>.") from None
             # `[None] + shape` so the expert axis exists for concatenation.
             jax_param._weights_to_load[slot] = jax_array_from_reshaped_torch(
                 torch_weight, reshape_dims=(1, ) + tuple(torch_weight.shape))
             loaded_names.add(attr)
 
-        logger.debug(f"Staged {len(loaded_names)} MXFP4 tensor groups for "
-                     f"{layer.prefix} MoE layer.")
+        logger.debug(
+            "[mxfp4-ct] %s: staged %d MXFP4 tensor groups for the MoE layer.",
+            layer.prefix, len(loaded_names))
         return loaded_names
 
     def process_weights_after_loading(self, layer: JaxMoE) -> bool:

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -658,6 +658,28 @@ def get_model(
             raise NotImplementedError(f"Unsupported MODEL_IMPL_TYPE: {impl}")
 
 
+def _jax_model_can_stream_weights(model_class: Any) -> bool:
+    """Whether a flax_nnx model class can load from a weights iterator.
+
+    `get_flax_model` feeds streamed weights to a model in one of two ways, and
+    a model that supports either one can be served with `--load-format
+    runai_streamer`:
+
+    - it subclasses `LoadableWithIterator`, whose `load_weights` takes the
+      iterator directly (the path most flax_nnx models use); or
+    - it declares a `WeightLoader` deriving from `BaseWeightLoader`, which the
+      loader drives instead.
+
+    Checking only for `WeightLoader` sends every `LoadableWithIterator` model
+    to the vLLM implementation under `MODEL_IMPL_TYPE=auto`, which is a silent
+    change of implementation rather than an error.
+    """
+    if issubclass(model_class, LoadableWithIterator):
+        return True
+    return issubclass(getattr(model_class, "WeightLoader", object),
+                      BaseWeightLoader)
+
+
 def resolve_model_architecture(vllm_config: VllmConfig,
                                is_draft_model: bool) -> str:
     """Resolves the model implementation type.
@@ -666,9 +688,9 @@ def resolve_model_architecture(vllm_config: VllmConfig,
     architecture and whether the RunAI model streamer is active.
 
     When the RunAI model streamer is used, this function explicitly checks if
-    the JAX model supports the streaming capability. It returns 'vllm' if:
-    1. The JAX model class is found but does not have a `WeightLoader`.
-    2. The JAX model's `WeightLoader` is not a subclass of `BaseWeightLoader`.
+    the JAX model supports the streaming capability. It returns 'vllm' if the
+    JAX model class is found but supports neither of the two ways a flax_nnx
+    model can consume streamed weights (see `_jax_model_can_stream_weights`).
 
     If the architecture is not registered in JAX (UnsupportedArchitectureError),
     this function returns the default implementation ('flax_nnx'), allowing
@@ -694,10 +716,8 @@ def resolve_model_architecture(vllm_config: VllmConfig,
             # Try to get the JAX model class
             model_class = _get_model_architecture(hf_config)
 
-            # If found, check for WeightLoader capability
-            if not hasattr(model_class, "WeightLoader") or not issubclass(
-                    getattr(model_class, "WeightLoader", object),
-                    BaseWeightLoader):
+            # If found, check that it can actually consume streamed weights.
+            if not _jax_model_can_stream_weights(model_class):
                 return "vllm"
 
         except UnsupportedArchitectureError:


### PR DESCRIPTION
Piece 3 of 6 of the Kimi-K3 enablement stack. Adds the compressed-tensors MXFP4 quantization loading path: shard-then-decode expert loading in mxfp4.py (gated by the new MXFP4_SHARD_THEN_DECODE env), checkpoint-aware FP8-vs-packed layer classification in compressed_tensors.py (reading the safetensors index rather than trusting the config regex list, via the new model_name_or_path/download_dir plumbing through QuantizationConfig), and the streamed-weights capability check in model_loader.py. Tests: test_compressed_tensors, test_mxfp4 (the K3-model-level MXFP4 tests arrive in split 5/6). Depends on split 2/6 (its base branch). The full stack was validated end-to-end in #3292: CI green, gsm8k 0.976.