### PR TITLE
[DO NOT REVIEW] K3 split 4/6: KDA layer + shared JAX layers

### DIFF
--- a/tests/layers/common/test_kda_attention.py
+++ b/tests/layers/common/test_kda_attention.py
@@ -1,0 +1,338 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""KDA sublayer validation against HF-reference goldens.
+
+Set ``K3_TINY_CKPT`` / ``K3_TINY_SOFTPLUS_CKPT`` to K3-tiny checkpoint dirs
+that contain ``goldens_run1.npz`` (produced by the golden harness from the
+HF reference implementation in moonshotai/Kimi-K3); tests skip when unset.
+"""
+
+import os
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tpu_inference.layers.common.kda_attention import (
+    KDAParams, KDAState, kda_a_log_from_checkpoint, kda_attention)
+
+CKPTS = {
+    "sigmoid_fullrank": os.environ.get("K3_TINY_CKPT", ""),
+    "softplus_lowrank": os.environ.get("K3_TINY_SOFTPLUS_CKPT", ""),
+}
+KDA_LAYERS = [0, 1, 2, 4, 5, 6]  # 0-indexed KDA layers in K3-tiny
+H, D, W = 8, 128, 4
+EPS = 1e-5
+
+
+def _load(ckpt, layer):
+    from safetensors import safe_open
+    t = {}
+    with safe_open(os.path.join(ckpt, "model.safetensors"), "np") as f:
+        pre = f"model.layers.{layer}.self_attn."
+        for k in f.keys():
+            if k.startswith(pre):
+                t[k[len(pre):]] = f.get_tensor(k).astype(np.float32)
+    full_rank = "g_proj.weight" in t
+    params = KDAParams(
+        q_proj=jnp.asarray(t["q_proj.weight"]),
+        k_proj=jnp.asarray(t["k_proj.weight"]),
+        v_proj=jnp.asarray(t["v_proj.weight"]),
+        q_conv_weight=jnp.asarray(t["q_conv1d.weight"]),
+        k_conv_weight=jnp.asarray(t["k_conv1d.weight"]),
+        v_conv_weight=jnp.asarray(t["v_conv1d.weight"]),
+        # The two released checkpoints store this per-head vector differently
+        # (Kimi-K3 zero-pads it out to head_dim, Kimi-Linear-48B keeps it
+        # 4-D) and the tiny fixtures mirror each, so read it through the same
+        # helper the model's weight loader uses instead of assuming a layout.
+        A_log=jnp.asarray(kda_a_log_from_checkpoint(t["A_log"], H)),
+        dt_bias=jnp.asarray(t["dt_bias"]),
+        f_a_proj=jnp.asarray(t["f_a_proj.weight"]),
+        f_b_proj=jnp.asarray(t["f_b_proj.weight"]),
+        b_proj=jnp.asarray(t["b_proj.weight"]),
+        o_norm_weight=jnp.asarray(t["o_norm.weight"]),
+        o_proj=jnp.asarray(t["o_proj.weight"]),
+        g_proj=jnp.asarray(t["g_proj.weight"]) if full_rank else None,
+        g_a_proj=None if full_rank else jnp.asarray(t["g_a_proj.weight"]),
+        g_b_proj=None if full_rank else jnp.asarray(t["g_b_proj.weight"]),
+    )
+    lower_bound = -5.0 if full_rank else None  # matches the two variants
+    return params, lower_bound
+
+
+def _zero_state(slots=2):
+    return KDAState(
+        conv_q=jnp.zeros((slots, W - 1, H * D), jnp.float32),
+        conv_k=jnp.zeros((slots, W - 1, H * D), jnp.float32),
+        conv_v=jnp.zeros((slots, W - 1, H * D), jnp.float32),
+        recurrent=jnp.zeros((slots, H, D, D), jnp.float32),
+    )
+
+
+def _run(x,
+         params,
+         lower_bound,
+         state,
+         n_seqs=1,
+         lens=None,
+         decode=False,
+         has_init=False,
+         mesh=None):
+    lens = lens or [x.shape[0]]
+    qsl = jnp.asarray(np.cumsum([0] + lens).astype(np.int32))
+    dist = (jnp.array([n_seqs, n_seqs, n_seqs], jnp.int32)
+            if decode else jnp.array([0, 0, n_seqs], jnp.int32))
+    return kda_attention(jnp.asarray(x),
+                         params,
+                         state,
+                         state_indices=jnp.arange(1,
+                                                  n_seqs + 1,
+                                                  dtype=jnp.int32),
+                         query_start_loc=qsl,
+                         distribution=dist,
+                         has_initial_state=jnp.full((n_seqs, ), has_init),
+                         num_heads=H,
+                         head_dim=D,
+                         kernel_size=W,
+                         gate_lower_bound=lower_bound,
+                         rms_norm_eps=EPS,
+                         mesh=mesh)
+
+
+def _maxerr(a, b):
+    return float(np.abs(np.asarray(a) - np.asarray(b)).max())
+
+
+@pytest.mark.parametrize("variant", list(CKPTS))
+@pytest.mark.parametrize("tag", ["p48", "p64"])
+@pytest.mark.parametrize("layer", KDA_LAYERS)
+def test_sublayer_prefill_golden_parity(variant, tag, layer):
+    """Gate a (prefill): layer out matches HF reference self_attn out."""
+    ckpt = CKPTS[variant]
+    if not ckpt:
+        pytest.skip("checkpoint env var unset")
+    z = np.load(os.path.join(ckpt, "goldens_run1.npz"))
+    params, lb = _load(ckpt, layer)
+    xin = z[f"{tag}.layers.{layer}.self_attn.in"][0]  # [T, hidden]
+    ref = z[f"{tag}.layers.{layer}.self_attn.out"][0]
+    _, out = _run(xin, params, lb, _zero_state())
+    err = _maxerr(out, ref)
+    print(f"[observed] {variant} {tag} L{layer} prefill max_abs={err:.3e}")
+    np.testing.assert_allclose(np.asarray(out), ref, atol=5e-4, rtol=5e-3)
+
+
+@pytest.mark.parametrize("variant", list(CKPTS))
+@pytest.mark.parametrize("layer", [0, 4])
+def test_sublayer_decode_golden_parity(variant, layer):
+    """Gate a (decode): prefill T=32 then 8 decode steps — per-step outs,
+    conv caches, and recurrent states match the HF reference."""
+    ckpt = CKPTS[variant]
+    if not ckpt:
+        pytest.skip("checkpoint env var unset")
+    z = np.load(os.path.join(ckpt, "goldens_run1.npz"))
+    params, lb = _load(ckpt, layer)
+
+    xin = z[f"d32.pre.layers.{layer}.self_attn.in"][0]
+    state = _zero_state()
+    state, _ = _run(xin, params, lb, state)
+
+    # Post-prefill state parity. HF/fla conv cache is [1, dim, W] holding the
+    # last W raw conv inputs (newest at -1); ours is [slots, W-1, dim] holding
+    # the last W-1 (the window needed for the next token).
+    errs = {}
+    errs["S"] = _maxerr(state.recurrent[1],
+                        z[f"d32.layers.{layer}.recurrent_state"][0])
+    for name, mine in (("q", state.conv_q), ("k", state.conv_k),
+                       ("v", state.conv_v)):
+        ref_cache = z[f"d32.layers.{layer}.conv_{name}"][0]  # [dim, W]
+        errs[f"conv_{name}"] = _maxerr(mine[1], ref_cache[:, 1:].T)
+    print(f"[observed] {variant} L{layer} post-prefill " +
+          " ".join(f"{k}={v:.3e}" for k, v in errs.items()))
+    assert errs["S"] < 5e-4
+    for name in ("q", "k", "v"):
+        assert errs[f"conv_{name}"] < 5e-5
+
+    step_errs = []
+    for s in range(8):
+        xs = z[f"d32.step{s}.layers.{layer}.self_attn.in"][0]
+        ref = z[f"d32.step{s}.layers.{layer}.self_attn.out"][0]
+        state, out = _run(xs, params, lb, state, decode=True, has_init=True)
+        step_errs.append(_maxerr(out, ref))
+        np.testing.assert_allclose(np.asarray(out), ref, atol=5e-4, rtol=5e-3)
+    err_final = _maxerr(state.recurrent[1],
+                        z[f"d32.final.layers.{layer}.recurrent_state"][0])
+    print(f"[observed] {variant} L{layer} decode step max_abs="
+          f"{max(step_errs):.3e} final_S={err_final:.3e}")
+    assert err_final < 5e-4
+
+
+@pytest.mark.parametrize("variant", list(CKPTS))
+def test_conv_cache_roundtrip(variant):
+    """Gate b: prefill(T) + n decode steps == one-shot prefill(T+n),
+    crossing a chunk boundary (T=62, n=6)."""
+    ckpt = CKPTS[variant]
+    if not ckpt:
+        pytest.skip("checkpoint env var unset")
+    params, lb = _load(ckpt, KDA_LAYERS[0])
+    rng = np.random.default_rng(7)
+    T, n = 62, 6
+    x = (0.05 * rng.standard_normal((T + n, H * D))).astype(np.float32)
+
+    state_full = _zero_state()
+    state_full, out_full = _run(x, params, lb, state_full)
+
+    state = _zero_state()
+    state, out_pre = _run(x[:T], params, lb, state)
+    outs = [np.asarray(out_pre)]
+    for t in range(T, T + n):
+        state, out_t = _run(x[t:t + 1],
+                            params,
+                            lb,
+                            state,
+                            decode=True,
+                            has_init=True)
+        outs.append(np.asarray(out_t))
+    out_cat = np.concatenate(outs, axis=0)
+    err_o = _maxerr(out_cat, out_full)
+    err_s = _maxerr(state.recurrent[1], state_full.recurrent[1])
+    err_c = max(_maxerr(state.conv_q[1], state_full.conv_q[1]),
+                _maxerr(state.conv_k[1], state_full.conv_k[1]),
+                _maxerr(state.conv_v[1], state_full.conv_v[1]))
+    print(f"[observed] {variant} roundtrip out={err_o:.3e} S={err_s:.3e} "
+          f"conv={err_c:.3e}")
+    np.testing.assert_allclose(out_cat,
+                               np.asarray(out_full),
+                               atol=5e-5,
+                               rtol=5e-4)
+    assert err_s < 5e-5 and err_c < 5e-6
+
+
+@pytest.mark.parametrize("variant", list(CKPTS))
+def test_mixed_batch_equals_separate(variant):
+    """Gate c: one mixed ragged call (two prefills) == two separate calls."""
+    ckpt = CKPTS[variant]
+    if not ckpt:
+        pytest.skip("checkpoint env var unset")
+    params, lb = _load(ckpt, KDA_LAYERS[1])
+    rng = np.random.default_rng(8)
+    la, lc = 50, 17
+    xa = (0.05 * rng.standard_normal((la, H * D))).astype(np.float32)
+    xc = (0.05 * rng.standard_normal((lc, H * D))).astype(np.float32)
+
+    state_m = _zero_state(slots=3)
+    state_m, out_m = _run(np.concatenate([xa, xc]),
+                          params,
+                          lb,
+                          state_m,
+                          n_seqs=2,
+                          lens=[la, lc])
+
+    sa, oa = _run(xa, params, lb, _zero_state())
+    sc, oc = _run(xc, params, lb, _zero_state())
+    err_o = max(_maxerr(out_m[:la], oa), _maxerr(out_m[la:], oc))
+    err_s = max(_maxerr(state_m.recurrent[1], sa.recurrent[1]),
+                _maxerr(state_m.recurrent[2], sc.recurrent[1]))
+    print(f"[observed] {variant} mixed-vs-separate out={err_o:.3e} "
+          f"S={err_s:.3e}")
+    assert err_o < 5e-5 and err_s < 5e-5
+
+
+def _head_mesh(head_ways):
+    """A mesh whose only nontrivial axis is one of the ATTN_HEAD axes."""
+    import jax
+    from jax.sharding import Mesh
+
+    from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
+    if len(jax.devices()) < head_ways:
+        pytest.skip(f"needs >= {head_ways} devices")
+    shape = tuple(head_ways if n == "model" else 1 for n in MESH_AXIS_NAMES)
+    return Mesh(np.array(jax.devices()[:head_ways]).reshape(shape),
+                axis_names=MESH_AXIS_NAMES)
+
+
+@pytest.mark.parametrize("variant", list(CKPTS))
+@pytest.mark.parametrize("decode", [False, True])
+def test_head_sharding_matches_the_unsharded_layer(variant, decode):
+    """Splitting the head axis must not change the answer.
+
+    KDA is head-parallel -- convs are per channel, the gate is per
+    (head, channel), and the recurrent scan keeps one independent state per
+    head -- so sharding heads should be exactly equivalent, not merely close.
+    Both legs use the same weights and the same inputs; the only difference is
+    that one runs the state-carrying core inside a `shard_map` that splits the
+    head axis. Outputs *and* the written-back caches are compared, because a
+    head-axis mix-up shows up in the state before it shows up in the output.
+    """
+    import jax
+    ckpt = CKPTS[variant]
+    if not ckpt:
+        pytest.skip("checkpoint env var unset")
+    params, lb = _load(ckpt, KDA_LAYERS[0])
+
+    rng = np.random.default_rng(0)
+    T = 8 if decode else 32
+    n_seqs = T if decode else 1
+    x = rng.standard_normal((T, params.q_proj.shape[1])).astype(np.float32)
+    lens = [1] * n_seqs if decode else [T]
+
+    ref_state, ref_out = _run(x,
+                              params,
+                              lb,
+                              _zero_state(slots=n_seqs + 1),
+                              n_seqs=n_seqs,
+                              lens=lens,
+                              decode=decode)
+    mesh = _head_mesh(4)
+    assert H % 4 == 0, "test needs the head count to divide the head ways"
+    with jax.set_mesh(mesh):
+        got_state, got_out = _run(x,
+                                  params,
+                                  lb,
+                                  _zero_state(slots=n_seqs + 1),
+                                  n_seqs=n_seqs,
+                                  lens=lens,
+                                  decode=decode,
+                                  mesh=mesh)
+
+    assert float(np.abs(np.asarray(ref_out)).max()) > 0, (
+        "reference output is all zeros; the comparison would be vacuous")
+    np.testing.assert_allclose(np.asarray(got_out),
+                               np.asarray(ref_out),
+                               rtol=2e-5,
+                               atol=2e-5)
+    for name in ("recurrent", "conv_q", "conv_k", "conv_v"):
+        np.testing.assert_allclose(np.asarray(getattr(got_state, name)),
+                                   np.asarray(getattr(ref_state, name)),
+                                   rtol=2e-5,
+                                   atol=2e-5,
+                                   err_msg=f"{name} differs when heads split")
+
+
+def test_head_sharding_refuses_to_tear_a_head():
+    """`num_heads * head_dim` can divide when `num_heads` does not, so the
+    head count is checked explicitly. `shard_map` would also reject this mesh
+    (via `A_log`, which is shaped `[num_heads]`), but only at the first
+    forward and with a message listing several arguments; this fails early
+    and names the head count."""
+    ckpt = CKPTS["sigmoid_fullrank"]
+    if not ckpt:
+        pytest.skip("checkpoint env var unset")
+    params, lb = _load(ckpt, KDA_LAYERS[0])
+    assert (H * D) % 16 == 0 and H % 16 != 0, "premise of this test"
+    with pytest.raises(ValueError, match="do not divide"):
+        _run(np.zeros((4, params.q_proj.shape[1]), np.float32),
+             params,
+             lb,
+             _zero_state(),
+             mesh=_head_mesh(16))

--- a/tests/layers/common/test_kda_attention_dp.py
+++ b/tests/layers/common/test_kda_attention_dp.py
@@ -22,9 +22,11 @@ length nor the right values, which is why `kda_attention` runs its
 state-carrying part inside a `shard_map` over `ShardingAxisName.ATTN_DATA` —
 the same treatment `run_jax_gdn_attention` gives the GDN kernel.
 
-Slot ids in the packed metadata are GLOBAL (rank k allocates out of
-`[k * local_slots, (k + 1) * local_slots)`), so the shard_map also has to
-rebase them onto each rank's shard of the state pool.
+Slot ids in the packed metadata are rank-local: the runner rebases the
+globally allocated slot ids per DP rank (`global % local_slots` in
+`TPURunner._prepare_inputs`) before publishing
+`AttentionMetadata.mamba_state_indices`, so each rank's slice of the packed
+array indexes that rank's shard of the state pool directly.
 """
 
 import jax
@@ -96,11 +98,12 @@ def _params():
     )
 
 
-def _rank_inputs(rank, has_init_flags, global_slots):
+def _rank_inputs(rank, has_init_flags):
     """One rank's view: tokens, its shard of the state pool, its metadata.
 
-    `global_slots` selects whether the slot ids are the global ones the runner
-    publishes (`rank * BLOCKS_PER_RANK + i`) or rank-local ones.
+    Slot ids are rank-local (slots 1..REQS_PER_RANK), exactly as the runner
+    publishes them in `AttentionMetadata.mamba_state_indices` (it rebases
+    global slot ids per DP rank before publishing).
     """
     rngs = iter(jax.random.split(jax.random.key(200 + rank), 8))
     x = jax.random.normal(next(rngs), (TOKENS_PER_RANK, HIDDEN), jnp.float32)
@@ -110,7 +113,6 @@ def _rank_inputs(rank, has_init_flags, global_slots):
         s = jax.random.normal(next(rngs), shape, jnp.float32) * 0.1
         return s.at[0].set(0.0)  # null block
 
-    base = rank * BLOCKS_PER_RANK if global_slots else 0
     return dict(
         x=x,
         state=KDAState(
@@ -120,9 +122,7 @@ def _rank_inputs(rank, has_init_flags, global_slots):
             recurrent=state((BLOCKS_PER_RANK, H, D, D)),
         ),
         query_start_loc=jnp.asarray([0] + list(np.cumsum(LENGTHS)), jnp.int32),
-        state_indices=jnp.arange(base + 1,
-                                 base + REQS_PER_RANK + 1,
-                                 dtype=jnp.int32),
+        state_indices=jnp.arange(1, REQS_PER_RANK + 1, dtype=jnp.int32),
         distribution=jnp.asarray([0, 0, REQS_PER_RANK], jnp.int32),
         has_initial_state=jnp.asarray(has_init_flags, jnp.int32),
     )
@@ -163,15 +163,12 @@ def _packed_state(per_rank):
 def test_kda_attention_dp_matches_per_rank_single_device_runs(dp_mesh):
     """The sharded call over packed metadata == each rank running alone."""
     params = _params()
-    per_rank = [
-        _rank_inputs(r, FLAGS[r], global_slots=True) for r in range(DP_SIZE)
-    ]
+    per_rank = [_rank_inputs(r, FLAGS[r]) for r in range(DP_SIZE)]
 
-    # Reference: each rank alone, on rank-local slot ids (what that rank's
-    # shard of the pool is indexed by).
+    # Reference: each rank alone, on the same rank-local slot ids.
     ref = []
     for rank in range(DP_SIZE):
-        local = dict(_rank_inputs(rank, FLAGS[rank], global_slots=False))
+        local = dict(_rank_inputs(rank, FLAGS[rank]))
         new_state, out = jax.jit(lambda i, p: _call(i, p))(local, params)
         ref.append((new_state, np.asarray(out)))
 
@@ -213,10 +210,7 @@ def test_kda_attention_dp_isolates_ranks(dp_mesh):
     params = _params()
 
     def run(flags):
-        per_rank = [
-            _rank_inputs(r, flags[r], global_slots=True)
-            for r in range(DP_SIZE)
-        ]
+        per_rank = [_rank_inputs(r, flags[r]) for r in range(DP_SIZE)]
         packed = dict(
             x=_pack(per_rank, "x"),
             state=_packed_state(per_rank),
@@ -242,9 +236,7 @@ def test_kda_attention_packed_metadata_needs_the_shard_map():
     """Without the shard_map the packed layout is a shape error, not a
     silently wrong number — this pins the failure the 48B hit."""
     params = _params()
-    per_rank = [
-        _rank_inputs(r, FLAGS[r], global_slots=True) for r in range(DP_SIZE)
-    ]
+    per_rank = [_rank_inputs(r, FLAGS[r]) for r in range(DP_SIZE)]
     packed = dict(
         x=_pack(per_rank, "x"),
         state=_packed_state(per_rank),

--- a/tests/layers/common/test_kda_attention_dp.py
+++ b/tests/layers/common/test_kda_attention_dp.py
@@ -1,0 +1,257 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""KDA under attention data parallelism.
+
+Under attention DP the runner publishes ragged-batch metadata as a per-rank
+concatenation: `query_start_loc` contributes `reqs_per_rank + 1` entries per
+rank (offsets restarting at 0) while `seq_lens` / `has_initial_state` /
+`mamba_state_indices` contribute `reqs_per_rank`. Evaluated on that packed
+array, `query_start_loc[1:] - query_start_loc[:-1]` is neither the right
+length nor the right values, which is why `kda_attention` runs its
+state-carrying part inside a `shard_map` over `ShardingAxisName.ATTN_DATA` —
+the same treatment `run_jax_gdn_attention` gives the GDN kernel.
+
+Slot ids in the packed metadata are GLOBAL (rank k allocates out of
+`[k * local_slots, (k + 1) * local_slots)`), so the shard_map also has to
+rebase them onto each rank's shard of the state pool.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.sharding import Mesh
+
+from tpu_inference.layers.common import sharding as sharding_mod
+from tpu_inference.layers.common.kda_attention import (KDAParams, KDAState,
+                                                       kda_attention)
+from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
+                                                  ShardingAxisNameBase)
+
+DP_SIZE = 2
+REQS_PER_RANK = 2
+BLOCKS_PER_RANK = 3  # slot 0 is the null block
+TOKENS_PER_RANK = 16
+LENGTHS = [8, 4]  # two prefills per rank; the rest of the block is padding
+
+H, D, W = 2, 32, 4
+HP = H * D
+HIDDEN = 64
+EPS = 1e-5
+LOWER_BOUND = -5.0
+
+
+@pytest.fixture
+def dp_mesh():
+    """A mesh whose only nontrivial axis is `attn_dp`, so ATTN_DATA splits
+    2 ways and every other sharding axis is a no-op."""
+    if len(jax.devices()) < DP_SIZE:
+        pytest.skip(f"needs >= {DP_SIZE} devices")
+    shape = tuple(DP_SIZE if name == "attn_dp" else 1
+                  for name in MESH_AXIS_NAMES)
+    devices = np.array(jax.devices()[:DP_SIZE]).reshape(shape)
+    # `kda_attention` partitions on the multi-axis names, which only the base
+    # (non-2D) sharding class defines. Not installed as the default mesh: the
+    # single-rank reference calls below must stay unsharded.
+    saved = sharding_mod.ShardingAxisName._cls
+    sharding_mod.ShardingAxisName._cls = ShardingAxisNameBase
+    try:
+        yield Mesh(devices, axis_names=MESH_AXIS_NAMES)
+    finally:
+        sharding_mod.ShardingAxisName._cls = saved
+
+
+def _params():
+    rngs = iter(jax.random.split(jax.random.key(11), 16))
+
+    def n(shape, scale=0.05):
+        return jax.random.normal(next(rngs), shape, jnp.float32) * scale
+
+    return KDAParams(
+        q_proj=n((HP, HIDDEN)),
+        k_proj=n((HP, HIDDEN)),
+        v_proj=n((HP, HIDDEN)),
+        q_conv_weight=n((HP, 1, W)),
+        k_conv_weight=n((HP, 1, W)),
+        v_conv_weight=n((HP, 1, W)),
+        A_log=n((H, ), 1.0),
+        dt_bias=n((HP, ), 1.0),
+        f_a_proj=n((D, HIDDEN)),
+        f_b_proj=n((HP, D)),
+        b_proj=n((H, HIDDEN)),
+        o_norm_weight=jnp.ones((D, ), jnp.float32),
+        o_proj=n((HIDDEN, HP)),
+        g_proj=n((HP, HIDDEN)),
+    )
+
+
+def _rank_inputs(rank, has_init_flags, global_slots):
+    """One rank's view: tokens, its shard of the state pool, its metadata.
+
+    `global_slots` selects whether the slot ids are the global ones the runner
+    publishes (`rank * BLOCKS_PER_RANK + i`) or rank-local ones.
+    """
+    rngs = iter(jax.random.split(jax.random.key(200 + rank), 8))
+    x = jax.random.normal(next(rngs), (TOKENS_PER_RANK, HIDDEN), jnp.float32)
+
+    def state(shape):
+        # Nonzero slot contents, so resuming and zero-initializing differ.
+        s = jax.random.normal(next(rngs), shape, jnp.float32) * 0.1
+        return s.at[0].set(0.0)  # null block
+
+    base = rank * BLOCKS_PER_RANK if global_slots else 0
+    return dict(
+        x=x,
+        state=KDAState(
+            conv_q=state((BLOCKS_PER_RANK, W - 1, HP)),
+            conv_k=state((BLOCKS_PER_RANK, W - 1, HP)),
+            conv_v=state((BLOCKS_PER_RANK, W - 1, HP)),
+            recurrent=state((BLOCKS_PER_RANK, H, D, D)),
+        ),
+        query_start_loc=jnp.asarray([0] + list(np.cumsum(LENGTHS)), jnp.int32),
+        state_indices=jnp.arange(base + 1,
+                                 base + REQS_PER_RANK + 1,
+                                 dtype=jnp.int32),
+        distribution=jnp.asarray([0, 0, REQS_PER_RANK], jnp.int32),
+        has_initial_state=jnp.asarray(has_init_flags, jnp.int32),
+    )
+
+
+def _call(inputs, params, mesh=None):
+    return kda_attention(inputs["x"],
+                         params,
+                         inputs["state"],
+                         inputs["state_indices"],
+                         inputs["query_start_loc"],
+                         inputs["distribution"],
+                         inputs["has_initial_state"].astype(jnp.bool_),
+                         num_heads=H,
+                         head_dim=D,
+                         kernel_size=W,
+                         gate_lower_bound=LOWER_BOUND,
+                         rms_norm_eps=EPS,
+                         mesh=mesh)
+
+
+# Rank 0 resumes its first request and starts its second fresh; rank 1 is the
+# mirror image. Any rank-agnostic handling of the flag gets one of them wrong.
+FLAGS = [[1, 0], [0, 1]]
+
+
+def _pack(per_rank, key):
+    return jnp.concatenate([r[key] for r in per_rank], axis=0)
+
+
+def _packed_state(per_rank):
+    return KDAState(*[
+        jnp.concatenate([getattr(r["state"], f) for r in per_rank], axis=0)
+        for f in KDAState._fields
+    ])
+
+
+def test_kda_attention_dp_matches_per_rank_single_device_runs(dp_mesh):
+    """The sharded call over packed metadata == each rank running alone."""
+    params = _params()
+    per_rank = [
+        _rank_inputs(r, FLAGS[r], global_slots=True) for r in range(DP_SIZE)
+    ]
+
+    # Reference: each rank alone, on rank-local slot ids (what that rank's
+    # shard of the pool is indexed by).
+    ref = []
+    for rank in range(DP_SIZE):
+        local = dict(_rank_inputs(rank, FLAGS[rank], global_slots=False))
+        new_state, out = jax.jit(lambda i, p: _call(i, p))(local, params)
+        ref.append((new_state, np.asarray(out)))
+
+    packed = dict(
+        x=_pack(per_rank, "x"),
+        state=_packed_state(per_rank),
+        query_start_loc=_pack(per_rank, "query_start_loc"),
+        state_indices=_pack(per_rank, "state_indices"),
+        distribution=_pack(per_rank, "distribution"),
+        has_initial_state=_pack(per_rank, "has_initial_state"),
+    )
+    # The asymmetry that makes a global `query_start_loc` diff invalid: one
+    # extra offset entry per rank.
+    assert packed["query_start_loc"].shape == (DP_SIZE * (REQS_PER_RANK + 1), )
+    assert packed["has_initial_state"].shape == (DP_SIZE * REQS_PER_RANK, )
+
+    new_state, out = _call(packed, params, mesh=dp_mesh)
+    out = np.asarray(out)
+
+    for rank, (ref_state, ref_out) in enumerate(ref):
+        tok = slice(rank * TOKENS_PER_RANK, (rank + 1) * TOKENS_PER_RANK)
+        blk = slice(rank * BLOCKS_PER_RANK, (rank + 1) * BLOCKS_PER_RANK)
+        np.testing.assert_allclose(out[tok],
+                                   ref_out,
+                                   rtol=1e-5,
+                                   atol=1e-5,
+                                   err_msg=f"output, rank {rank}")
+        for field in KDAState._fields:
+            np.testing.assert_allclose(np.asarray(getattr(new_state,
+                                                          field))[blk],
+                                       np.asarray(getattr(ref_state, field)),
+                                       rtol=1e-5,
+                                       atol=1e-5,
+                                       err_msg=f"{field}, rank {rank}")
+
+
+def test_kda_attention_dp_isolates_ranks(dp_mesh):
+    """Flipping one rank's resume flag changes that rank's output only."""
+    params = _params()
+
+    def run(flags):
+        per_rank = [
+            _rank_inputs(r, flags[r], global_slots=True)
+            for r in range(DP_SIZE)
+        ]
+        packed = dict(
+            x=_pack(per_rank, "x"),
+            state=_packed_state(per_rank),
+            query_start_loc=_pack(per_rank, "query_start_loc"),
+            state_indices=_pack(per_rank, "state_indices"),
+            distribution=_pack(per_rank, "distribution"),
+            has_initial_state=_pack(per_rank, "has_initial_state"),
+        )
+        _, out = _call(packed, params, mesh=dp_mesh)
+        return np.asarray(out)
+
+    base = run(FLAGS)
+    flipped = run([FLAGS[0], [1, 1]])  # rank 1 now resumes both requests
+
+    r0 = slice(0, TOKENS_PER_RANK)
+    r1 = slice(TOKENS_PER_RANK, 2 * TOKENS_PER_RANK)
+    np.testing.assert_array_equal(base[r0], flipped[r0])
+    assert not np.allclose(base[r1], flipped[r1]), (
+        "rank 1's resume flag had no effect on rank 1's output")
+
+
+def test_kda_attention_packed_metadata_needs_the_shard_map():
+    """Without the shard_map the packed layout is a shape error, not a
+    silently wrong number — this pins the failure the 48B hit."""
+    params = _params()
+    per_rank = [
+        _rank_inputs(r, FLAGS[r], global_slots=True) for r in range(DP_SIZE)
+    ]
+    packed = dict(
+        x=_pack(per_rank, "x"),
+        state=_packed_state(per_rank),
+        query_start_loc=_pack(per_rank, "query_start_loc"),
+        state_indices=_pack(per_rank, "state_indices"),
+        distribution=_pack(per_rank, "distribution"),
+        has_initial_state=_pack(per_rank, "has_initial_state"),
+    )
+    with pytest.raises(TypeError, match="concatenate|broadcast"):
+        _call(packed, params, mesh=None)

--- a/tests/layers/jax/moe/test_dense_moe.py
+++ b/tests/layers/jax/moe/test_dense_moe.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""CPU tests for the dense-path expert dequantization helper.
+
+`dequantize_unfused_moe_weights` is what lets DENSE_MAT (the reference
+backend) consume block-quantized expert kernels: it expands each (value,
+scale) pair back to `cast_dtype` before the plain einsums run.
+"""
+
+import jax.numpy as jnp
+import numpy as np
+
+from tpu_inference.layers.common.process_weights.moe_weights import \
+    UnfusedMoEWeights
+from tpu_inference.layers.common.quantization import quantize_tensor
+from tpu_inference.layers.jax.moe.dense_moe import \
+    dequantize_unfused_moe_weights
+
+E, K, N = 2, 8, 4
+BLOCK = 4  # contracting-axis block size -> scale shape (E, K // BLOCK, N)
+
+
+def _synthetic_weights(seed: int) -> jnp.ndarray:
+    rng = np.random.default_rng(seed)
+    return jnp.asarray(rng.uniform(-1.0, 1.0, size=(E, K, N)),
+                       dtype=jnp.float32)
+
+
+def _quantized_moe_weights():
+    """Quantize three synthetic (E, K, N) kernels along the contracting axis."""
+    originals = [_synthetic_weights(seed) for seed in (0, 1, 2)]
+    pairs = [
+        quantize_tensor(jnp.int8, w, axis=1, block_size=BLOCK)
+        for w in originals
+    ]
+    weights = UnfusedMoEWeights(
+        w1_weight=pairs[0][0],
+        w1_weight_scale=pairs[0][1],
+        w1_bias=None,
+        w2_weight=pairs[1][0],
+        w2_weight_scale=pairs[1][1],
+        w2_bias=None,
+        w3_weight=pairs[2][0],
+        w3_weight_scale=pairs[2][1],
+        w3_bias=None,
+    )
+    return originals, weights
+
+
+def test_dequantize_round_trips_block_quantized_kernels():
+    originals, weights = _quantized_moe_weights()
+    assert weights.w1_weight_scale.shape == (E, K // BLOCK, N)
+
+    result = dequantize_unfused_moe_weights(weights, jnp.float32)
+
+    for original, dequantized in zip(
+            originals, (result.w1_weight, result.w2_weight, result.w3_weight)):
+        assert dequantized.dtype == jnp.float32
+        assert dequantized.shape == (E, K, N)
+        # int8 absmax quantization: error bounded by half a step per block.
+        atol = float(jnp.max(jnp.abs(original))) / 127.0
+        np.testing.assert_allclose(np.asarray(dequantized),
+                                   np.asarray(original),
+                                   atol=atol)
+    # Scales are consumed: the dense einsums must see plain arrays.
+    assert result.w1_weight_scale is None
+    assert result.w2_weight_scale is None
+    assert result.w3_weight_scale is None
+
+
+def test_dequantize_casts_to_requested_dtype():
+    _, weights = _quantized_moe_weights()
+    result = dequantize_unfused_moe_weights(weights, jnp.bfloat16)
+    assert result.w1_weight.dtype == jnp.bfloat16
+    assert result.w2_weight.dtype == jnp.bfloat16
+    assert result.w3_weight.dtype == jnp.bfloat16
+
+
+def test_dequantize_passes_through_unquantized_weights():
+    originals = [_synthetic_weights(seed) for seed in (3, 4, 5)]
+    weights = UnfusedMoEWeights(
+        w1_weight=originals[0],
+        w1_weight_scale=None,
+        w1_bias=None,
+        w2_weight=originals[1],
+        w2_weight_scale=None,
+        w2_bias=None,
+        w3_weight=originals[2],
+        w3_weight_scale=None,
+        w3_bias=None,
+    )
+    result = dequantize_unfused_moe_weights(weights, jnp.bfloat16)
+    # All-None scales: returned unchanged, no cast, same object.
+    assert result is weights
+    assert result.w1_weight.dtype == jnp.float32
+
+
+def test_dequantize_preserves_biases():
+    _, weights = _quantized_moe_weights()
+    bias = jnp.ones((E, N), dtype=jnp.float32)
+    weights = UnfusedMoEWeights(
+        w1_weight=weights.w1_weight,
+        w1_weight_scale=weights.w1_weight_scale,
+        w1_bias=bias,
+        w2_weight=weights.w2_weight,
+        w2_weight_scale=weights.w2_weight_scale,
+        w2_bias=None,
+        w3_weight=weights.w3_weight,
+        w3_weight_scale=weights.w3_weight_scale,
+        w3_bias=bias,
+    )
+    result = dequantize_unfused_moe_weights(weights, jnp.float32)
+    assert result.w1_bias is bias
+    assert result.w2_bias is None
+    assert result.w3_bias is bias

--- a/tests/layers/jax/moe/test_moe_utils.py
+++ b/tests/layers/jax/moe/test_moe_utils.py
@@ -180,8 +180,7 @@ class TestMoEUtils(unittest.TestCase):
                group_sizes,
                tile_size,
                moe_backend=MoEBackend.MEGABLX_GMM,
-               dtype=jnp.bfloat16,
-               quantized_dtype=None)
+               dtype=jnp.bfloat16)
 
         mock_megablox.assert_called_once()
 
@@ -204,8 +203,7 @@ class TestMoEUtils(unittest.TestCase):
                group_sizes,
                tile_size,
                moe_backend=MoEBackend.MEGABLX_GMM,
-               dtype=jnp.bfloat16,
-               quantized_dtype=jnp.float8_e4m3fn)
+               dtype=jnp.bfloat16)
 
         mock_megablox.assert_called_once()
 

--- a/tests/layers/jax/moe/test_situ_backends.py
+++ b/tests/layers/jax/moe/test_situ_backends.py
@@ -1,0 +1,230 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SiTU reaches the eager MoE expert paths.
+
+The unfused (DENSE_MAT) backend is what Kimi-K3 routes through, so its two
+forward variants have to apply SiTU to both the gate and the up branch. The
+fused/GMM kernels only take a unary activation name today, hence these tests
+pin the eager paths.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+
+from tpu_inference.layers.common.process_weights.moe_weights import \
+    UnfusedMoEWeights
+from tpu_inference.layers.jax.activation import (SITU_BETA, SITU_LINEAR_BETA,
+                                                 apply_gated_activation,
+                                                 situ_params)
+from tpu_inference.layers.jax.moe.dense_moe import (
+    dense_moe_fwd, dense_moe_fwd_preapply_router_weights)
+
+T, D, E, F, TOPK = 6, 8, 4, 16, 2
+
+
+def _situ_numpy(gate, up, beta=SITU_BETA, linear_beta=SITU_LINEAR_BETA):
+    """Straight transcription of HF moonshotai/Kimi-K3 SituAndMul, fp64."""
+    gate = np.asarray(gate, dtype=np.float64)
+    up = np.asarray(up, dtype=np.float64)
+    situ = beta * np.tanh(gate / beta) * (1.0 / (1.0 + np.exp(-gate)))
+    if linear_beta is not None:
+        up = linear_beta * np.tanh(up / linear_beta)
+    return situ * up
+
+
+def _silu_numpy(gate, up):
+    gate = np.asarray(gate, dtype=np.float64)
+    up = np.asarray(up, dtype=np.float64)
+    return gate / (1.0 + np.exp(-gate)) * up
+
+
+class _FakeLayer:
+    """Minimal stand-in for a JaxMoE carrying the SiTU betas."""
+
+    def __init__(self, **attrs):
+        for k, v in attrs.items():
+            setattr(self, k, v)
+
+
+def _fixture(seed=0):
+    rng = np.random.default_rng(seed)
+    x_TD = rng.standard_normal((T, D), dtype=np.float32)
+    w1 = rng.standard_normal((E, D, F), dtype=np.float32)
+    w2 = rng.standard_normal((E, D, F), dtype=np.float32)
+    w3 = rng.standard_normal((E, F, D), dtype=np.float32)
+    # Dense router weights: top-2 of 4 experts, renormalized.
+    scores = rng.random((T, E))
+    keep = np.argsort(-scores, axis=1)[:, :TOPK]
+    full_TE = np.zeros((T, E), dtype=np.float32)
+    for t in range(T):
+        w = scores[t, keep[t]]
+        full_TE[t, keep[t]] = w / w.sum()
+    weights = UnfusedMoEWeights(
+        w1_weight=jnp.asarray(w1),
+        w1_weight_scale=None,
+        w1_bias=None,
+        w2_weight=jnp.asarray(w2),
+        w2_weight_scale=None,
+        w2_bias=None,
+        w3_weight=jnp.asarray(w3),
+        w3_weight_scale=None,
+        w3_bias=None,
+    )
+    return x_TD, w1, w2, w3, full_TE, weights
+
+
+def _reference(x_TE_D, w1, w2, w3, act_fn):
+    """Expert MLPs in fp64: x[.,E,D] @ w1/w2 -> act -> @ w3."""
+    gate = np.einsum('TED,EDF->TEF', x_TE_D, w1.astype(np.float64))
+    up = np.einsum('TED,EDF->TEF', x_TE_D, w2.astype(np.float64))
+    fuse = act_fn(gate, up)
+    return np.einsum('TEF,EFD->TED', fuse, w3.astype(np.float64))
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    devices = np.array(jax.devices()[:1]).reshape(1, 1)
+    return Mesh(devices, axis_names=("data", "model"))
+
+
+@pytest.fixture(autouse=True)
+def exact_matmuls():
+    """These are activation-parity tests, not matmul-precision tests.
+
+    TPU einsums default to a reduced-precision fp32 algorithm (~1e-1 abs error
+    at these magnitudes for silu and situ alike), which would swamp the
+    activation difference we are measuring.
+    """
+    with jax.default_matmul_precision("highest"):
+        yield
+
+
+@pytest.mark.parametrize("hidden_act,act_fn", [("situ", _situ_numpy),
+                                               ("silu", _silu_numpy)])
+def test_dense_moe_fwd_activation(mesh, hidden_act, act_fn):
+    x_TD, w1, w2, w3, full_TE, weights = _fixture()
+    with mesh:
+        got = dense_moe_fwd(weights=weights,
+                            x_TD=jnp.asarray(x_TD),
+                            cast_dtype=jnp.float32,
+                            activation_ffw_td=P(None, None),
+                            hidden_act=hidden_act,
+                            full_weights_TE=jnp.asarray(full_TE),
+                            mesh=mesh)
+    x_TED = np.repeat(x_TD[:, None, :].astype(np.float64), E, axis=1)
+    down = _reference(x_TED, w1, w2, w3, act_fn)
+    ref = np.einsum('TED,TE->TD', down, full_TE.astype(np.float64))
+    err = np.abs(np.asarray(got, dtype=np.float64) - ref).max()
+    print(f"[observed] dense_moe_fwd {hidden_act} max_abs={err:.3e} "
+          f"(ref max_abs={np.abs(ref).max():.3e})")
+    np.testing.assert_allclose(np.asarray(got), ref, rtol=2e-4, atol=2e-4)
+
+
+@pytest.mark.parametrize("hidden_act,act_fn", [("situ", _situ_numpy),
+                                               ("silu", _silu_numpy)])
+def test_dense_moe_fwd_preapply_activation(mesh, hidden_act, act_fn):
+    x_TD, w1, w2, w3, full_TE, weights = _fixture(seed=1)
+    with mesh:
+        got = dense_moe_fwd_preapply_router_weights(
+            weights=weights,
+            x_TD=jnp.asarray(x_TD),
+            cast_dtype=jnp.float32,
+            activation_ffw_ted=P(None, None, None),
+            hidden_act=hidden_act,
+            full_weights_TE=jnp.asarray(full_TE),
+            mesh=mesh)
+    x_TED = (np.repeat(x_TD[:, None, :].astype(np.float64), E, axis=1) *
+             full_TE.astype(np.float64)[..., None])
+    ref = _reference(x_TED, w1, w2, w3, act_fn).sum(axis=1)
+    err = np.abs(np.asarray(got, dtype=np.float64) - ref).max()
+    print(f"[observed] dense_moe_fwd_preapply {hidden_act} max_abs={err:.3e} "
+          f"(ref max_abs={np.abs(ref).max():.3e})")
+    np.testing.assert_allclose(np.asarray(got), ref, rtol=2e-4, atol=2e-4)
+
+
+def test_situ_is_not_silu_on_the_dense_path(mesh):
+    """Anti-vacuity: the parity tests above cannot both pass by accident."""
+    x_TD, _, _, _, full_TE, weights = _fixture()
+    kwargs = dict(weights=weights,
+                  x_TD=jnp.asarray(x_TD),
+                  cast_dtype=jnp.float32,
+                  activation_ffw_td=P(None, None),
+                  full_weights_TE=jnp.asarray(full_TE),
+                  mesh=mesh)
+    with mesh:
+        situ = np.asarray(dense_moe_fwd(hidden_act="situ", **kwargs))
+        silu = np.asarray(dense_moe_fwd(hidden_act="silu", **kwargs))
+    rel = np.abs(situ - silu).max() / max(np.abs(silu).max(), 1e-9)
+    print(f"[observed] situ-vs-silu relative gap={rel:.3f}")
+    assert rel > 0.1, "situ and silu outputs are indistinguishable"
+
+
+def test_dense_moe_fwd_honors_custom_betas(mesh):
+    """Betas must be threaded, not silently defaulted to the K3 constants."""
+    x_TD, w1, w2, w3, full_TE, weights = _fixture(seed=2)
+    beta, linear_beta = 1.0, 2.0
+    with mesh:
+        got = dense_moe_fwd(weights=weights,
+                            x_TD=jnp.asarray(x_TD),
+                            cast_dtype=jnp.float32,
+                            activation_ffw_td=P(None, None),
+                            hidden_act="situ",
+                            full_weights_TE=jnp.asarray(full_TE),
+                            mesh=mesh,
+                            situ_beta=beta,
+                            situ_linear_beta=linear_beta)
+    x_TED = np.repeat(x_TD[:, None, :].astype(np.float64), E, axis=1)
+    down = _reference(
+        x_TED, w1, w2, w3,
+        lambda g, u: _situ_numpy(g, u, beta=beta, linear_beta=linear_beta))
+    ref = np.einsum('TED,TE->TD', down, full_TE.astype(np.float64))
+    err = np.abs(np.asarray(got, dtype=np.float64) - ref).max()
+    print(f"[observed] custom-beta dense_moe_fwd max_abs={err:.3e}")
+    np.testing.assert_allclose(np.asarray(got), ref, rtol=2e-4, atol=2e-4)
+    # And the K3 defaults would give a materially different answer.
+    default = _reference(x_TED, w1, w2, w3, _situ_numpy)
+    default = np.einsum('TED,TE->TD', default, full_TE.astype(np.float64))
+    assert np.abs(default - ref).max() > 1e-2
+
+
+def test_apply_gated_activation_dispatch():
+    rng = np.random.default_rng(3)
+    gate = jnp.asarray(rng.standard_normal((5, 7), dtype=np.float32) * 3)
+    up = jnp.asarray(rng.standard_normal((5, 7), dtype=np.float32) * 3)
+
+    situ = np.asarray(apply_gated_activation("situ", gate, up))
+    np.testing.assert_allclose(situ, _situ_numpy(gate, up), atol=1e-4)
+
+    silu = np.asarray(apply_gated_activation("silu", gate, up))
+    np.testing.assert_allclose(silu, _silu_numpy(gate, up), atol=1e-4)
+
+    # Unary activations ignore the SiTU betas entirely.
+    same = np.asarray(
+        apply_gated_activation("silu",
+                               gate,
+                               up,
+                               situ_beta=0.5,
+                               situ_linear_beta=0.5))
+    np.testing.assert_array_equal(silu, same)
+
+
+def test_situ_params_reads_layer_then_defaults():
+    assert situ_params(_FakeLayer()) == (SITU_BETA, SITU_LINEAR_BETA)
+    assert situ_params(_FakeLayer(situ_beta=1.5)) == (1.5, SITU_LINEAR_BETA)
+    assert situ_params(_FakeLayer(situ_beta=1.5,
+                                  situ_linear_beta=9.0)) == (1.5, 9.0)

--- a/tests/layers/jax/moe/test_sparse_moe.py
+++ b/tests/layers/jax/moe/test_sparse_moe.py
@@ -1,0 +1,119 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Structure-level tests for sparse_moe_func's shard_map spec construction.
+
+The non-qwix quantized path (MXFP4 experts arriving pre-quantized from the
+checkpoint) must pass each expert kernel to shard_map as a (value, scale)
+pair with a matching pair of PartitionSpecs; the unquantized path must pass
+plain arrays with single specs. These tests stub shard_map itself, so they
+run on CPU and pin the argument/in_specs pytree structure rather than the
+numerics (covered by the distributed backend tests).
+"""
+
+from types import SimpleNamespace
+from unittest import mock
+
+import jax
+import jax.numpy as jnp
+import pytest
+from jax.sharding import Mesh, PartitionSpec
+
+from tpu_inference.layers.common.process_weights.moe_weights import \
+    UnfusedMoEWeights
+from tpu_inference.layers.jax.moe import sparse_moe
+
+T, D, E, F, TOPK = 4, 8, 4, 16, 2
+
+
+def _layer():
+    return SimpleNamespace(
+        qwix_quantized_weight_dtype=None,
+        edf_sharding=(None, None, None),
+        efd_sharding=(None, None, None),
+        activation_ffw_td=(None, None),
+    )
+
+
+def _weights(with_scales: tuple[bool, bool, bool]) -> UnfusedMoEWeights:
+    w_edf = jnp.zeros((E, D, F), dtype=jnp.bfloat16)
+    w_efd = jnp.zeros((E, F, D), dtype=jnp.bfloat16)
+    scale_edf = jnp.ones((E, 1, F), dtype=jnp.float32)
+    scale_efd = jnp.ones((E, 1, D), dtype=jnp.float32)
+    return UnfusedMoEWeights(
+        w1_weight=w_edf,
+        w1_weight_scale=scale_edf if with_scales[0] else None,
+        w1_bias=None,
+        w2_weight=w_edf,
+        w2_weight_scale=scale_edf if with_scales[1] else None,
+        w2_bias=None,
+        w3_weight=w_efd,
+        w3_weight_scale=scale_efd if with_scales[2] else None,
+        w3_bias=None,
+    )
+
+
+def _call_with_stubbed_shard_map(weights):
+    """Run sparse_moe_func with shard_map stubbed out; capture its inputs."""
+    captured = {}
+
+    def fake_shard_map(f, mesh=None, in_specs=None, out_specs=None, **kwargs):
+        captured["in_specs"] = in_specs
+
+        def mapped(*args):
+            captured["args"] = args
+            return jnp.zeros((T, D), dtype=jnp.bfloat16)
+
+        return mapped
+
+    x_TD = jnp.zeros((T, D), dtype=jnp.bfloat16)
+    gating = (jnp.zeros(
+        (T, TOPK), dtype=jnp.float32), jnp.zeros((T, TOPK), dtype=jnp.int32))
+    mesh = Mesh(jax.devices()[:1], ("x", ))
+    with mock.patch.object(jax.experimental.shard_map, "shard_map",
+                           fake_shard_map):
+        sparse_moe.sparse_moe_func(weights, x_TD, gating, _layer(), mesh)
+    return captured
+
+
+def test_checkpoint_quantized_weights_become_value_scale_pairs():
+    captured = _call_with_stubbed_shard_map(_weights((True, True, True)))
+
+    # in_specs: (layer, x_TD, router_weights, indices, w1, w2, w3) -- each
+    # quantized kernel spec is a pair of PartitionSpecs, value + scale.
+    for kernel_spec in captured["in_specs"][4:7]:
+        assert isinstance(kernel_spec, tuple) and len(kernel_spec) == 2
+        assert all(isinstance(s, PartitionSpec) for s in kernel_spec)
+
+    # The kernel arguments mirror that structure as (value, scale) tuples.
+    for kernel_arg in captured["args"][4:7]:
+        assert isinstance(kernel_arg, tuple) and len(kernel_arg) == 2
+
+
+def test_unquantized_weights_stay_plain_arrays():
+    captured = _call_with_stubbed_shard_map(_weights((False, False, False)))
+
+    for kernel_spec in captured["in_specs"][4:7]:
+        assert isinstance(kernel_spec, PartitionSpec)
+    for kernel_arg in captured["args"][4:7]:
+        assert isinstance(kernel_arg, jax.Array)
+
+
+@pytest.mark.parametrize("with_scales", [
+    (True, False, False),
+    (True, True, False),
+    (False, False, True),
+])
+def test_partial_weight_scales_fail_fast(with_scales):
+    with pytest.raises(AssertionError, match=r"\[moe\].*all three"):
+        _call_with_stubbed_shard_map(_weights(with_scales))

--- a/tests/layers/jax/quantization/test_mxfp4.py
+++ b/tests/layers/jax/quantization/test_mxfp4.py
@@ -810,25 +810,3 @@ class TestCompressedTensorsMxfp4ShardVsHostParity:
                 f"{name}: {shard.sharding} vs {host.sharding}")
             _assert_bit_equal(shard, np.asarray(host.astype(jnp.float32)),
                               name)
-
-
-class TestCompressedTensorsMxfp4ApplyGuard:
-
-    def test_apply_jax_raises_a_self_contained_error(self):
-        """The staged fp4+scales must not reach backends that drop the scales.
-
-        At this revision the unfused MoE backends consume only bf16 kernels,
-        so a forward pass would silently compute garbage; apply_jax fails
-        loudly instead until the scale-consuming backends land.
-        """
-        layer = SimpleNamespace(
-            moe_backend=MoEBackend.MEGABLX_GMM,
-            prefix="model.layers.1.block_sparse_moe.experts")
-        method = mxfp4.CompressedTensorsMxfp4MoEMethod(layer)
-
-        with pytest.raises(NotImplementedError,
-                           match=r"\[mxfp4-ct\].*scale-consuming MoE backends "
-                           r"land with the kernel layer change"):
-            method.apply_jax(layer,
-                             jnp.ones((3, 4), dtype=jnp.float32),
-                             router_logits=jnp.ones((3, 2), dtype=jnp.float32))

--- a/tests/layers/jax/test_activation.py
+++ b/tests/layers/jax/test_activation.py
@@ -1,0 +1,104 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""SiTU activation parity against the reference formula."""
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tpu_inference.layers.jax.activation import (SITU_BETA, SITU_LINEAR_BETA,
+                                                 situ_and_mul)
+
+
+def _situ_numpy(gate, up, beta=SITU_BETA, linear_beta=SITU_LINEAR_BETA):
+    """Straight transcription of HF moonshotai/Kimi-K3 SituAndMul, fp64."""
+    gate = gate.astype(np.float64)
+    up = up.astype(np.float64)
+    situ = beta * np.tanh(gate / beta) * (1.0 / (1.0 + np.exp(-gate)))
+    if linear_beta is not None:
+        up = linear_beta * np.tanh(up / linear_beta)
+    return situ * up
+
+
+def test_matches_reference_formula():
+    rng = np.random.default_rng(0)
+    gate = rng.standard_normal((64, 128), dtype=np.float32) * 3
+    up = rng.standard_normal((64, 128), dtype=np.float32) * 3
+    got = np.asarray(situ_and_mul(jnp.asarray(gate), jnp.asarray(up)))
+    ref = _situ_numpy(gate, up)
+    err = np.abs(got - ref).max()
+    print(f"[observed] situ max_abs={err:.3e}")
+    np.testing.assert_allclose(got, ref, atol=1e-4, rtol=1e-4)
+
+
+@pytest.mark.parametrize("scale", [1e2, 1e4])
+def test_both_branches_soft_clamped(scale):
+    """Large inputs must saturate rather than blow up.
+
+    The product is bounded by beta * linear_beta, approached from below as
+    the input grows (at gate=up=100 the up branch is only
+    25*tanh(4) = 24.98, so the bound is not yet reached).
+    """
+    limit = SITU_BETA * SITU_LINEAR_BETA
+    big = jnp.full((8, 8), scale, dtype=jnp.float32)
+    out = np.asarray(situ_and_mul(big, big))
+    assert np.isfinite(out).all()
+    assert (out <= limit + 1e-4).all(), f"exceeded soft clamp {limit}"
+    np.testing.assert_allclose(out,
+                               _situ_numpy(np.asarray(big), np.asarray(big)),
+                               rtol=1e-5)
+
+    neg = jnp.full((8, 8), -scale, dtype=jnp.float32)
+    out_neg = np.asarray(situ_and_mul(neg, neg))
+    assert np.isfinite(out_neg).all()
+    # gate branch -> -beta * sigmoid(-inf) = 0
+    np.testing.assert_allclose(out_neg, 0.0, atol=1e-5)
+
+
+def test_saturates_toward_bound_as_input_grows():
+    limit = SITU_BETA * SITU_LINEAR_BETA
+    vals = [
+        np.asarray(
+            situ_and_mul(jnp.full((1, ), s, jnp.float32),
+                         jnp.full((1, ), s, jnp.float32)))[0]
+        for s in (10.0, 100.0, 1000.0)
+    ]
+    assert vals[0] < vals[1] < vals[2] <= limit + 1e-4
+    assert abs(vals[2] - limit) < 1e-3
+
+
+def test_fp32_internals_under_bf16_io():
+    """bf16 in / bf16 out, but the math runs in fp32."""
+    rng = np.random.default_rng(1)
+    gate = rng.standard_normal((32, 64), dtype=np.float32)
+    up = rng.standard_normal((32, 64), dtype=np.float32)
+    out = situ_and_mul(jnp.asarray(gate, jnp.bfloat16),
+                       jnp.asarray(up, jnp.bfloat16))
+    assert out.dtype == jnp.bfloat16
+    ref = _situ_numpy(gate, up)
+    # bf16 has ~3 decimal digits; just check it tracks the reference.
+    np.testing.assert_allclose(np.asarray(out, np.float32),
+                               ref,
+                               atol=5e-2,
+                               rtol=5e-2)
+
+
+def test_linear_beta_none_leaves_up_untouched():
+    rng = np.random.default_rng(2)
+    gate = rng.standard_normal((16, 16), dtype=np.float32)
+    up = rng.standard_normal((16, 16), dtype=np.float32)
+    got = np.asarray(
+        situ_and_mul(jnp.asarray(gate), jnp.asarray(up), linear_beta=None))
+    ref = _situ_numpy(gate, up, linear_beta=None)
+    np.testing.assert_allclose(got, ref, atol=1e-5, rtol=1e-5)

--- a/tpu_inference/layers/common/kda_attention.py
+++ b/tpu_inference/layers/common/kda_attention.py
@@ -39,8 +39,7 @@ from jax.sharding import PartitionSpec as P
 from tpu_inference.kernels.kda.reference.ragged_kda_chunked import (
     ragged_kda_decode_only, ragged_kda_mixed_prefill)
 from tpu_inference.layers.common.ragged_conv1d_jax import ragged_conv1d
-from tpu_inference.layers.common.sharding import (ShardingAxisName,
-                                                  rank_local_slot_indices)
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.utils import get_mesh_shape_product
 
 
@@ -182,10 +181,13 @@ def _kda_ragged_core(
 
     Returns ``(new_conv_q, new_conv_k, new_conv_v, new_recurrent,
     o [num_tokens, H, K])``.
-    """
-    # Global slot ids -> ids within this rank's shard of the state pool.
-    state_indices = rank_local_slot_indices(state_indices, conv_q.shape[0])
 
+    ``state_indices`` arrive already rank-local: the runner rebases the
+    global slot ids per DP rank (``global % local_slots``, see the
+    mamba_state_indices block in ``TPURunner._prepare_inputs``) before
+    publishing ``AttentionMetadata.mamba_state_indices``, so they index
+    this rank's shard of the state pool directly.
+    """
     q, new_conv_q = ragged_conv1d(q,
                                   conv_q,
                                   q_conv_weight,

--- a/tpu_inference/layers/common/kda_attention.py
+++ b/tpu_inference/layers/common/kda_attention.py
@@ -1,0 +1,419 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""KDA (Kimi Delta Attention) sublayer for the Kimi-Linear / Kimi-K3 family.
+
+Full sublayer per the HF reference (`moonshotai/Kimi-K3`
+``modeling_kimi_linear.py::KimiDeltaAttention``):
+
+    q = SiLU(ShortConv4(q_proj(x)));  same for k;  v = SiLU(ShortConv4(v_proj(x)))
+    g_raw = f_b_proj(f_a_proj(x));    beta_raw = b_proj(x)
+    o     = KDA_core(q, k, v, g_raw, beta_raw)      # kernels/kda/reference
+    gate  = g_proj(x)  (full-rank, K3)  |  g_b_proj(g_a_proj(x))  (low-rank, 48B)
+    out   = o_proj( RMSNorm_headwise(o) * sigmoid(gate) )
+
+State per slot: THREE separate conv windows (q/k/v, each
+``(num_blocks, kernel_size-1, proj)``, model dtype) plus the recurrent state
+``(num_blocks, H, K, V)`` (fp32), all slot-indexed with the same mamba-slot
+machinery as GDN (``ragged_conv1d`` handles gathering/scattering and the
+has_initial_state masking).
+"""
+
+import functools
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import PartitionSpec as P
+
+from tpu_inference.kernels.kda.reference.ragged_kda_chunked import (
+    ragged_kda_decode_only, ragged_kda_mixed_prefill)
+from tpu_inference.layers.common.ragged_conv1d_jax import ragged_conv1d
+from tpu_inference.layers.common.sharding import (ShardingAxisName,
+                                                  rank_local_slot_indices)
+from tpu_inference.utils import get_mesh_shape_product
+
+
+class KDAParams(NamedTuple):
+    """KDA sublayer weights, torch ``[out, in]`` layout (as checkpointed).
+
+    ``g_proj`` is set for the full-rank output gate (Kimi-K3,
+    ``use_full_rank_gate=true``); ``g_a_proj``/``g_b_proj`` for the low-rank
+    gate (Kimi-Linear-48B). Exactly one of the two forms must be present.
+    """
+    q_proj: jax.Array  # [H*K, hidden]
+    k_proj: jax.Array  # [H*K, hidden]
+    v_proj: jax.Array  # [H*V, hidden]
+    q_conv_weight: jax.Array  # [H*K, 1, W]
+    k_conv_weight: jax.Array  # [H*K, 1, W]
+    v_conv_weight: jax.Array  # [H*V, 1, W]
+    A_log: jax.Array  # [H]
+    dt_bias: jax.Array  # [H*K]
+    f_a_proj: jax.Array  # [K, hidden]
+    f_b_proj: jax.Array  # [H*K, K]
+    b_proj: jax.Array  # [H, hidden]
+    o_norm_weight: jax.Array  # [V]
+    o_proj: jax.Array  # [hidden, H*V]
+    g_proj: jax.Array | None = None  # [H*V, hidden]
+    g_a_proj: jax.Array | None = None  # [K, hidden]
+    g_b_proj: jax.Array | None = None  # [H*V, K]
+
+
+def kda_a_log_from_checkpoint(stored, num_heads: int, name: str = "A_log"):
+    """Read the per-head KDA decay vector out of a checkpoint tensor.
+
+    KDA's decay is per channel, but ``A_log`` is not the per-channel part: the
+    channel structure comes from ``f_b_proj(f_a_proj(x)) + dt_bias``, and
+    ``exp(A_log[h])`` is a single per-head scale applied to all of head ``h``'s
+    channels. The reference implementations agree on this:
+
+      * ``modeling_kimi_linear.py::KimiDeltaAttention`` allocates ``A_log``
+        with ``num_heads`` entries.
+      * vLLM's KDA gate kernel indexes it by head and broadcasts over the head
+        dimension -- ``b_a = exp(A_log[i_h])`` with ``i_h`` the head program id
+        and the channel offset applied only to ``raw_g``/``dt_bias``
+        (``vllm/models/kimi_k3/nvidia/ops/third_party/kda/fused_recurrent.py``,
+        ``_kda_gate_beta_fwd_kernel``).
+
+    Two storage layouts occur across the released checkpoints:
+
+      * ``moonshotai/Kimi-Linear-48B-A3B-Instruct``: ``[1, 1, num_heads, 1]``.
+      * ``moonshotai/Kimi-K3``: a flat buffer ``head_dim`` entries wide whose
+        leading ``num_heads`` entries are the parameter and whose tail is zero
+        padding. Measured over the released checkpoint, every one of the 69 KDA
+        layers stores ``[128]`` with entries 0..95 non-zero and 96..127 exactly
+        0.0, for ``num_heads=96`` / ``head_dim=128``. (Per-head-dim tensors in
+        the same layers -- ``o_norm.weight``, also ``[128]`` -- are dense, so
+        the zero tail is padding and not a value.)
+
+    Flattening and keeping the leading ``num_heads`` entries reads both. The
+    padding is required to be zero rather than assumed: a checkpoint whose tail
+    is non-zero holds something other than padding, and truncating it silently
+    would corrupt the decay of every head.
+
+    Written against the array protocol rather than a specific array library so
+    that anything reading a Kimi checkpoint directly -- the weight loader, the
+    KDA sublayer testbeds -- applies one convention instead of its own.
+    """
+    flat = stored.reshape(-1)
+    count = flat.shape[0]
+    if count == num_heads:
+        return flat
+    if count < num_heads:
+        raise ValueError(
+            f"[kimi] '{name}': checkpoint stores {count} KDA decay values but "
+            f"the model has {num_heads} heads; A_log holds one scalar per "
+            f"head, so the checkpoint cannot fill it.")
+    tail = flat[num_heads:]
+    if int((tail != 0).sum()):
+        raise ValueError(
+            f"[kimi] '{name}': checkpoint stores {count} KDA decay values for "
+            f"{num_heads} heads and the trailing {count - num_heads} are not "
+            f"zero padding (max |value| {float(abs(tail).max())}). A_log is "
+            f"per head; refusing to drop values that may be a different "
+            f"parameterization.")
+    return flat[:num_heads]
+
+
+class KDAState(NamedTuple):
+    """Slot-indexed KDA caches (block 0 is the null block)."""
+    conv_q: jax.Array  # [num_blocks, W-1, H*K], model dtype
+    conv_k: jax.Array  # [num_blocks, W-1, H*K], model dtype
+    conv_v: jax.Array  # [num_blocks, W-1, H*V], model dtype
+    recurrent: jax.Array  # [num_blocks, H, K, V], fp32
+
+
+def _linear(x: jax.Array, w: jax.Array) -> jax.Array:
+    return jnp.dot(x, w.T, precision=jax.lax.Precision.HIGHEST)
+
+
+def _gated_rmsnorm(o: jax.Array, gate: jax.Array, weight: jax.Array,
+                   eps: float) -> jax.Array:
+    """Headwise RMSNorm then sigmoid-gate multiply, fp32 internals
+    (fla ``FusedRMSNormGated(activation='sigmoid')`` semantics)."""
+    of = o.astype(jnp.float32)
+    y = of * jax.lax.rsqrt((of * of).mean(-1, keepdims=True) + eps)
+    y = y * weight.astype(jnp.float32)
+    return (y * jax.nn.sigmoid(gate.astype(jnp.float32))).astype(o.dtype)
+
+
+def _kda_ragged_core(
+    q: jax.Array,
+    k: jax.Array,
+    v: jax.Array,
+    beta_raw: jax.Array,
+    g_raw: jax.Array,
+    conv_q: jax.Array,
+    conv_k: jax.Array,
+    conv_v: jax.Array,
+    recurrent: jax.Array,
+    q_conv_weight: jax.Array,
+    k_conv_weight: jax.Array,
+    v_conv_weight: jax.Array,
+    A_log: jax.Array,
+    dt_bias: jax.Array,
+    query_start_loc: jax.Array,
+    state_indices: jax.Array,
+    distribution: jax.Array,
+    has_initial_state: jax.Array,
+    *,
+    num_heads: int,
+    head_dim: int,
+    kernel_size: int,
+    gate_lower_bound: float | None,
+    chunk_size: int,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
+    """The state-carrying part of KDA: convs, recurrent scan, state writeback.
+
+    Everything here is indexed by the ragged-batch metadata, so it is what
+    :func:`kda_attention` runs inside a ``shard_map``: under attention DP the
+    metadata is a per-rank concatenation and only makes sense one rank at a
+    time. The pure per-token projections stay outside.
+
+    Returns ``(new_conv_q, new_conv_k, new_conv_v, new_recurrent,
+    o [num_tokens, H, K])``.
+    """
+    # Global slot ids -> ids within this rank's shard of the state pool.
+    state_indices = rank_local_slot_indices(state_indices, conv_q.shape[0])
+
+    q, new_conv_q = ragged_conv1d(q,
+                                  conv_q,
+                                  q_conv_weight,
+                                  None,
+                                  query_start_loc,
+                                  state_indices,
+                                  distribution,
+                                  has_initial_state,
+                                  kernel_size=kernel_size)
+    k, new_conv_k = ragged_conv1d(k,
+                                  conv_k,
+                                  k_conv_weight,
+                                  None,
+                                  query_start_loc,
+                                  state_indices,
+                                  distribution,
+                                  has_initial_state,
+                                  kernel_size=kernel_size)
+    v, new_conv_v = ragged_conv1d(v,
+                                  conv_v,
+                                  v_conv_weight,
+                                  None,
+                                  query_start_loc,
+                                  state_indices,
+                                  distribution,
+                                  has_initial_state,
+                                  kernel_size=kernel_size)
+    q = jax.nn.silu(q.astype(jnp.float32))
+    k = jax.nn.silu(k.astype(jnp.float32))
+    v = jax.nn.silu(v.astype(jnp.float32))
+
+    num_tokens = q.shape[0]
+    q = q.reshape(num_tokens, num_heads, head_dim)
+    k = k.reshape(num_tokens, num_heads, head_dim)
+    v = v.reshape(num_tokens, num_heads, head_dim)
+    g_raw = g_raw.reshape(num_tokens, num_heads, head_dim)
+
+    is_decode_only = distribution[0] == distribution[2]
+
+    def decode_branch(_):
+        return ragged_kda_decode_only(q,
+                                      k,
+                                      v,
+                                      beta_raw,
+                                      g_raw,
+                                      recurrent,
+                                      A_log,
+                                      dt_bias,
+                                      query_start_loc,
+                                      state_indices,
+                                      distribution,
+                                      gate_lower_bound=gate_lower_bound)
+
+    def mixed_branch(_):
+        return ragged_kda_mixed_prefill(q,
+                                        k,
+                                        v,
+                                        beta_raw,
+                                        g_raw,
+                                        A_log,
+                                        dt_bias,
+                                        query_start_loc,
+                                        recurrent,
+                                        state_indices,
+                                        distribution,
+                                        has_initial_state=has_initial_state,
+                                        chunk_size=chunk_size,
+                                        gate_lower_bound=gate_lower_bound)
+
+    new_recurrent, o = jax.lax.cond(is_decode_only, decode_branch,
+                                    mixed_branch, None)
+    return (new_conv_q, new_conv_k, new_conv_v, new_recurrent,
+            o.reshape(num_tokens, num_heads, head_dim))
+
+
+def _core_specs():
+    """shard_map specs for `_kda_ragged_core`'s arguments, in order.
+
+    Resolved per call, not at import: `ShardingAxisName` is a lazy proxy whose
+    backing class is chosen from the runtime sharding configuration.
+
+    Two orthogonal splits, on different dimensions of the same arrays:
+
+    * ATTN_DATA splits tokens and state slots. The ragged metadata splits the
+      same way, which is what makes each rank's view self-consistent, and is
+      a correctness requirement rather than an optimization.
+    * ATTN_HEAD splits the head axis -- the trailing `H * head_dim` of the
+      per-token arrays and the conv windows, and the head dimension of the
+      recurrent state. The per-head parameters carry the same split.
+
+    No head-axis collective appears inside the map because the core is
+    head-parallel throughout: the depthwise conv is per channel, the gate is
+    per (head, channel), the recurrent scan keeps one independent state per
+    head, and the only reduction (`l2norm`, and the scan's own recurrence) is
+    within a head. The one op that does contract the head axis, `o_proj`,
+    lives outside this map.
+
+    The runner already allocates the KDA state head-sharded -- see
+    `kv_cache_manager`, which gives the conv state
+    `P(ATTN_DATA, None, ATTN_HEAD)` and the recurrent state
+    `P(ATTN_DATA, ATTN_HEAD, None, None)` -- so naming ATTN_HEAD here also
+    removes an all-gather that the replicated specs used to force.
+    """
+    data = ShardingAxisName.ATTN_DATA
+    head = ShardingAxisName.ATTN_HEAD
+    in_specs = (
+        P(data, head),  # q            [T, H*K]
+        P(data, head),  # k
+        P(data, head),  # v
+        P(data, head),  # beta_raw     [T, H]
+        P(data, head),  # g_raw        [T, H*K]
+        P(data, None, head),  # conv_q [blocks, W-1, H*K]
+        P(data, None, head),  # conv_k
+        P(data, None, head),  # conv_v
+        P(data, head, None, None),  # recurrent [blocks, H, K, V]
+        P(head, None, None),  # q_conv_weight  [H*K, 1, W]
+        P(head, None, None),  # k_conv_weight
+        P(head, None, None),  # v_conv_weight
+        P(head),  # A_log     [H]
+        P(head),  # dt_bias   [H*K]
+        P(data),  # query_start_loc
+        P(data),  # state_indices
+        P(data),  # distribution
+        P(data),  # has_initial_state
+    )
+    out_specs = (
+        P(data, None, head),  # new_conv_q
+        P(data, None, head),  # new_conv_k
+        P(data, None, head),  # new_conv_v
+        P(data, head, None, None),  # new_recurrent
+        P(data, head, None),  # o   [T, H, K]
+    )
+    return in_specs, out_specs
+
+
+def kda_attention(
+    x: jax.Array,
+    params: KDAParams,
+    state: KDAState,
+    state_indices: jax.Array,
+    query_start_loc: jax.Array,
+    distribution: jax.Array,
+    has_initial_state: jax.Array,
+    *,
+    num_heads: int,
+    head_dim: int,
+    kernel_size: int = 4,
+    gate_lower_bound: float | None = None,
+    rms_norm_eps: float = 1e-5,
+    chunk_size: int = 64,
+    mesh: jax.sharding.Mesh | None = None,
+) -> tuple[KDAState, jax.Array]:
+    """Runs the KDA sublayer over a ragged token batch.
+
+    Args:
+      x: Post-layernorm hidden states, ``[num_tokens, hidden]``.
+      params/state: See :class:`KDAParams` / :class:`KDAState`.
+      state_indices / query_start_loc / distribution / has_initial_state:
+        Standard mamba-slot ragged-batch metadata (same semantics as the GDN
+        path; ``distribution[0] == distribution[2]`` selects decode-only).
+      num_heads/head_dim: H and K (= V for KDA).
+      gate_lower_bound: None -> softplus decay form; float -> sigmoid
+        lower-bound form (K3 uses -5.0).
+      mesh: When given, the state-carrying part runs inside a ``shard_map``
+        over ``ShardingAxisName.ATTN_DATA``, exactly as
+        ``run_jax_gdn_attention`` does. This is REQUIRED under attention DP:
+        the runner packs `query_start_loc` as a per-rank concatenation of
+        `(reqs_per_rank + 1)`-entry blocks, so `query_start_loc[1:] -
+        query_start_loc[:-1]` is only a per-request query-length vector inside
+        one rank's slice — evaluated on the packed global array it is one
+        entry per rank too long and mixes offsets across ranks. `None` skips
+        the shard_map and is for single-rank callers (unit tests).
+
+    Returns ``(new_state, out [num_tokens, hidden])``.
+    """
+    assert (params.g_proj is None) != (
+        params.g_a_proj
+        is None), "exactly one of g_proj / (g_a_proj, g_b_proj) must be set"
+
+    num_tokens = x.shape[0]
+    q = _linear(x, params.q_proj)
+    k = _linear(x, params.k_proj)
+    v = _linear(x, params.v_proj)
+    g_raw = _linear(_linear(x, params.f_a_proj), params.f_b_proj)
+    beta_raw = _linear(x, params.b_proj)  # [T, H]
+
+    # Inside the map every array is this shard's slice, so the core must be
+    # told how many heads it actually holds -- `num_heads` is a static
+    # argument used to unflatten `H * head_dim`, and passing the global count
+    # would reshape a 3-heads-per-device slice as if it had 96.
+    head_ways = (get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
+                 if mesh is not None else 1)
+    if num_heads % head_ways:
+        raise ValueError(
+            f"[kda] {num_heads} heads do not divide by the {head_ways} ways "
+            f"the head axis {ShardingAxisName.ATTN_HEAD} is split; a head "
+            f"cannot be torn across devices.")
+    core = functools.partial(_kda_ragged_core,
+                             num_heads=num_heads // head_ways,
+                             head_dim=head_dim,
+                             kernel_size=kernel_size,
+                             gate_lower_bound=gate_lower_bound,
+                             chunk_size=chunk_size)
+    if mesh is not None:
+        in_specs, out_specs = _core_specs()
+        core = jax.shard_map(core,
+                             mesh=mesh,
+                             in_specs=in_specs,
+                             out_specs=out_specs,
+                             check_vma=False)
+
+    new_conv_q, new_conv_k, new_conv_v, new_recurrent, o = core(
+        q, k, v, beta_raw, g_raw, state.conv_q, state.conv_k, state.conv_v,
+        state.recurrent, params.q_conv_weight, params.k_conv_weight,
+        params.v_conv_weight, params.A_log, params.dt_bias, query_start_loc,
+        state_indices, distribution, has_initial_state)
+
+    if params.g_proj is not None:
+        gate = _linear(x, params.g_proj)
+    else:
+        gate = _linear(_linear(x, params.g_a_proj), params.g_b_proj)
+    gate = gate.reshape(num_tokens, num_heads, head_dim)
+
+    o = _gated_rmsnorm(o, gate, params.o_norm_weight, rms_norm_eps)
+    out = _linear(o.reshape(num_tokens, num_heads * head_dim), params.o_proj)
+
+    new_state = KDAState(conv_q=new_conv_q,
+                         conv_k=new_conv_k,
+                         conv_v=new_conv_v,
+                         recurrent=new_recurrent)
+    return new_state, out

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -180,6 +180,7 @@ def moe_apply(
                 )
             case MoEBackend.DENSE_MAT:
                 # NOTE: circular import avoidance
+                from tpu_inference.layers.jax.activation import situ_params
                 from tpu_inference.layers.jax.moe.dense_moe import \
                     dense_moe_func
                 assert isinstance(
@@ -188,6 +189,7 @@ def moe_apply(
                 assert len(
                     gating_output
                 ) == 2, "Expected the gating output to be have 2 entries: weights and indices"
+                situ_beta, situ_linear_beta = situ_params(layer)
                 return dense_moe_func(
                     weights=weights,
                     x_TD=x,
@@ -199,7 +201,9 @@ def moe_apply(
                     activation_ffw_ted=layer.activation_ffw_ted,
                     activation_ffw_td=layer.activation_ffw_td,
                     hidden_act=layer.hidden_act,
-                    mesh=mesh)
+                    mesh=mesh,
+                    situ_beta=situ_beta,
+                    situ_linear_beta=situ_linear_beta)
 
             case MoEBackend.MEGABLX_GMM:
                 # NOTE: circular import avoidance

--- a/tpu_inference/layers/jax/activation.py
+++ b/tpu_inference/layers/jax/activation.py
@@ -1,0 +1,89 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gated activations that take both the gate and the up branch.
+
+`FlaxUtils.ACT2FN` maps a single tensor to a single tensor, so it can only
+express activations applied to the gate branch alone (``act(gate) * up``).
+Activations that also transform the up branch live here.
+"""
+
+import jax
+import jax.numpy as jnp
+
+# Kimi-K3 config defaults (HF moonshotai/Kimi-K3 `activation_situ_beta` /
+# `activation_situ_linear_beta`).
+SITU_BETA = 4.0
+SITU_LINEAR_BETA = 25.0
+
+
+def situ_and_mul(gate: jax.Array,
+                 up: jax.Array,
+                 beta: float = SITU_BETA,
+                 linear_beta: float | None = SITU_LINEAR_BETA) -> jax.Array:
+    """SiTU ("Sigmoid Tanh Unit"), used by every MLP in Kimi-K3.
+
+        out = beta * tanh(gate / beta) * sigmoid(gate)
+              * linear_beta * tanh(up / linear_beta)
+
+    Both branches are soft-clamped: the gate branch saturates at +-beta and
+    the up branch at +-linear_beta, which is what makes the activation safe
+    for the QAT'd 4-bit expert weights.
+
+    Computed in fp32 regardless of input dtype, matching the reference
+    implementation (HF `moonshotai/Kimi-K3` modeling_kimi_linear.py
+    ``SituAndMul``), then cast back to the input dtype.
+    """
+    out_dtype = gate.dtype
+    gate_f32 = gate.astype(jnp.float32)
+    up_f32 = up.astype(jnp.float32)
+
+    situ = beta * jnp.tanh(gate_f32 / beta) * jax.nn.sigmoid(gate_f32)
+    if linear_beta is not None:
+        up_f32 = linear_beta * jnp.tanh(up_f32 / linear_beta)
+    return (situ * up_f32).astype(out_dtype)
+
+
+def apply_gated_activation(
+        hidden_act: str,
+        gate: jax.Array,
+        up: jax.Array,
+        situ_beta: float = SITU_BETA,
+        situ_linear_beta: float | None = SITU_LINEAR_BETA) -> jax.Array:
+    """Apply a gated MLP activation to a (gate, up) pair.
+
+    ``situ`` transforms both branches (see :func:`situ_and_mul`); every other
+    activation is unary on the gate branch, i.e. ``act(gate) * up``.
+    """
+    if hidden_act == "situ":
+        return situ_and_mul(gate,
+                            up,
+                            beta=situ_beta,
+                            linear_beta=situ_linear_beta)
+    # Imported inside the function: `layers.jax.layers` imports the nnx layer
+    # stack, and several of those modules import this one for `situ_and_mul`.
+    from tpu_inference.layers.jax.layers import modeling_flax_utils
+    return modeling_flax_utils.ACT2FN[hidden_act](gate) * up
+
+
+def situ_params(layer) -> tuple[float, float | None]:
+    """Read a layer's SiTU betas, defaulting to the Kimi-K3 config values.
+
+    The MoE backends are shared across models, so the two SiTU constants ride
+    on the layer instead of widening every backend signature -- the same
+    pattern `layers/common/moe.py` uses for GPT-OSS's ``swiglu_limit``.
+    """
+    beta = getattr(layer, "situ_beta", None)
+    linear_beta = getattr(layer, "situ_linear_beta", None)
+    return (SITU_BETA if beta is None else beta,
+            SITU_LINEAR_BETA if linear_beta is None else linear_beta)

--- a/tpu_inference/layers/jax/attention/mla.py
+++ b/tpu_inference/layers/jax/attention/mla.py
@@ -135,7 +135,9 @@ class MLABaseAttention(JaxModule):
 
         if self.use_nope:
             # No rotary => no YaRN mscale correction; plain 1/sqrt(d) scale.
-            assert self.rope is None or self.use_nope
+            assert self.rope is None, (
+                "[mla] use_nope=True but a rope module was provided; NoPE "
+                "attention must not apply rotary embeddings")
             self.scale = self.qk_head_dim**-0.5
         else:
             assert self.rope is not None, (

--- a/tpu_inference/layers/jax/attention/mla.py
+++ b/tpu_inference/layers/jax/attention/mla.py
@@ -1,0 +1,688 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared Multi-head Latent Attention (MLA) layers.
+
+Extracted from the DeepSeek-V3 model file so other MLA-family models can
+reuse it. Beyond DeepSeek-V3 this supports the Kimi-Linear / Kimi-K3 family
+(HF ``moonshotai/Kimi-Linear-48B-A3B-Instruct``, ``moonshotai/Kimi-K3``),
+which differ in three config-driven ways:
+
+* ``use_nope``: no rotary embedding is applied anywhere. The
+  ``qk_rope_head_dim`` slice still exists and is still MQA-shared through the
+  cache, it simply carries un-rotated values.
+* ``use_output_gate``: ``attn_out *= sigmoid(g_proj(x))`` before ``o_proj``.
+* ``q_lora_rank=None``: the query is produced by a single ``q_proj`` instead
+  of the ``q_a_proj`` / ``q_a_layernorm`` / ``q_b_proj`` low-rank stack.
+
+All three default to the DeepSeek-V3 behaviour, so existing callers are
+unaffected.
+"""
+
+import math
+from abc import abstractmethod
+from dataclasses import InitVar, dataclass
+from typing import Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from flax.typing import Sharding
+from jax import lax
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+
+from tpu_inference import utils
+from tpu_inference.kernels.quantized_matmul.util import quantize_tensor
+from tpu_inference.layers.common.attention_interface import mla_attention
+from tpu_inference.layers.common.quantization import (
+    dequantize_tensor, quantize_kv, static_per_tensor_quantize_tensor)
+from tpu_inference.layers.common.utils import cpu_mesh_context
+from tpu_inference.layers.jax import JaxModule
+from tpu_inference.layers.jax.attention.attention import AttentionMetadata
+from tpu_inference.layers.jax.base import _init_fn as init_fn
+from tpu_inference.layers.jax.base import sharded_initializer
+from tpu_inference.layers.jax.linear import JaxEinsum
+from tpu_inference.layers.jax.norm import JaxRmsNorm
+from tpu_inference.layers.jax.quantization.configs import QuantizationConfig
+from tpu_inference.layers.jax.rope import DeepseekScalingRotaryEmbedding
+from tpu_inference.models.jax.utils.weight_utils import shard_put
+
+KVCache = Tuple[jax.Array, jax.Array]
+
+
+def _weight_init(random_init: bool):
+    return sharded_initializer if random_init else nnx.initializers.uniform()
+
+
+@dataclass(kw_only=True)
+class MLABaseAttention(JaxModule):
+    """
+    Base class containing shared logic for MLA-family attention mechanisms.
+    Handles initialization of common layers and defines skeleton forward pass.
+    """
+    # Core configuration
+    hidden_size: int
+    num_attention_heads: int
+    num_key_value_heads: int
+    head_dim: int
+    dtype: jnp.dtype
+    kv_cache_dtype: str
+    mesh: Mesh
+
+    # Attention-specific configuration
+    kv_lora_rank: int
+    qk_nope_head_dim: int
+    qk_rope_head_dim: int
+    v_head_dim: int
+    rms_norm_eps: float
+
+    # ``None`` selects a single fused q_proj instead of the low-rank
+    # q_a_proj / q_a_layernorm / q_b_proj stack (Kimi-Linear-48B).
+    q_lora_rank: Optional[int] = None
+
+    # Rotary embedding. Required unless ``use_nope`` is set.
+    rope: Optional[DeepseekScalingRotaryEmbedding] = None
+    # Skip rotary entirely; the qk_rope slice carries un-rotated values and
+    # stays MQA-shared through the cache (Kimi-Linear / Kimi-K3).
+    use_nope: bool = False
+    # attn_out *= sigmoid(g_proj(x)) before o_proj (Kimi-K3).
+    use_output_gate: bool = False
+
+    # Sharding
+    rd_sharding: P = P()
+    q_da_sharding: P = P()
+    ap_sharding: P = P()
+    kv_da_sharding: P = P()
+    activation_attention_td: P = P()
+    activation_q_td: P = P()
+    query_nth: P = P()
+    query_tnh: P = P()
+    keyvalue_skh: P = P()
+    attn_o_nth: P = P()
+    activation_attention_out_td: P = P()
+    # Weight initialization
+    random_init: bool = False
+    rope_mscale_all_dim: float = 1.0
+
+    # RNG for weight initialization
+    rngs: InitVar[nnx.Rngs]
+
+    quant_config: Optional[QuantizationConfig] = None
+
+    # Scales for Q/KV quantization (per-tensor)
+    _q_scale: float = 1
+    _k_scale: float = 1
+    _v_scale: float = 1
+
+    prefix: str = ""
+
+    def __post_init__(self, rngs: nnx.Rngs):
+        self.N = self.num_attention_heads
+        self.K = self.num_key_value_heads
+        self.D = self.hidden_size
+        self.qk_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
+
+        if self.use_nope:
+            # No rotary => no YaRN mscale correction; plain 1/sqrt(d) scale.
+            assert self.rope is None or self.use_nope
+            self.scale = self.qk_head_dim**-0.5
+        else:
+            assert self.rope is not None, (
+                "[mla] rope must be provided unless use_nope=True")
+            if self.rope.scaling_factor <= 1.0:
+                yarn_mscale = 1.0
+            else:
+                yarn_mscale = 0.1 * self.rope_mscale_all_dim * math.log(
+                    self.rope.scaling_factor) + 1.0
+
+            self.scale = self.qk_head_dim**-0.5 * yarn_mscale**2
+
+        weight_init = _weight_init(self.random_init)
+
+        if self.q_lora_rank is not None:
+            self.q_a_proj = JaxEinsum(
+                einsum_str="TD,DA->TA",
+                kernel_shape=(self.D, self.q_lora_rank),
+                rngs=rngs,
+                quant_config=self.quant_config,
+                param_dtype=self.dtype,
+                kernel_init=nnx.with_partitioning(weight_init,
+                                                  self.q_da_sharding),
+                prefix=self.prefix + ".q_a_proj",
+            )
+
+            self.q_b_proj = JaxEinsum(
+                einsum_str="TA,AP->TP",
+                kernel_shape=(self.q_lora_rank, self.N * self.qk_head_dim),
+                rngs=rngs,
+                quant_config=self.quant_config,
+                param_dtype=self.dtype,
+                kernel_init=nnx.with_partitioning(weight_init,
+                                                  self.ap_sharding),
+                prefix=self.prefix + ".q_b_proj")
+        else:
+            self.q_proj = JaxEinsum(
+                einsum_str="TD,DP->TP",
+                kernel_shape=(self.D, self.N * self.qk_head_dim),
+                rngs=rngs,
+                quant_config=self.quant_config,
+                param_dtype=self.dtype,
+                kernel_init=nnx.with_partitioning(weight_init,
+                                                  self.ap_sharding),
+                prefix=self.prefix + ".q_proj")
+
+        self.kv_a_proj_with_mqa = JaxEinsum(
+            einsum_str="SD,DA->SA",
+            kernel_shape=(self.D, self.kv_lora_rank + self.qk_rope_head_dim),
+            rngs=rngs,
+            quant_config=self.quant_config,
+            param_dtype=self.dtype,
+            kernel_init=nnx.with_partitioning(weight_init,
+                                              self.kv_da_sharding),
+            prefix=self.prefix + ".kv_a_proj_with_mqa")
+
+        self.o_proj = JaxEinsum(
+            einsum_str="TR,RD->TD",
+            kernel_shape=(self.N * self.v_head_dim, self.D),
+            rngs=rngs,
+            quant_config=self.quant_config,
+            param_dtype=self.dtype,
+            kernel_init=nnx.with_partitioning(weight_init, self.rd_sharding),
+            prefix=self.prefix + ".o_proj")
+
+        # NOTE: parameter creation order below is load-bearing. `nnx.Rngs` is
+        # stateful, so reordering these constructors changes the random weights
+        # a `random_init=True` module gets. Keep q_a_layernorm here (after
+        # o_proj) to stay identical to the pre-extraction DeepSeek-V3 layer.
+        if self.q_lora_rank is not None:
+            self.q_a_layernorm = JaxRmsNorm(
+                self.q_lora_rank,
+                epsilon=self.rms_norm_eps,
+                scale_init=nnx.with_partitioning(init_fn, (None, )),
+                param_dtype=self.dtype,
+                dtype=self.dtype,
+                quant_config=self.quant_config,
+                prefix=self.prefix + ".q_a_layernorm",
+                rngs=rngs)
+
+        if self.use_output_gate:
+            self.g_proj = JaxEinsum(
+                einsum_str="TD,DR->TR",
+                kernel_shape=(self.D, self.N * self.v_head_dim),
+                rngs=rngs,
+                quant_config=self.quant_config,
+                param_dtype=self.dtype,
+                kernel_init=nnx.with_partitioning(weight_init,
+                                                  self.rd_sharding),
+                prefix=self.prefix + ".g_proj")
+
+        self.kv_a_layernorm = JaxRmsNorm(
+            self.kv_lora_rank,
+            epsilon=self.rms_norm_eps,
+            scale_init=nnx.with_partitioning(init_fn, (None, )),
+            param_dtype=self.dtype,
+            dtype=self.dtype,
+            quant_config=self.quant_config,
+            prefix=self.prefix + ".kv_a_layernorm",
+            rngs=rngs)
+
+        self.kv_cache_quantized_dtype = None
+        if self.kv_cache_dtype != "auto":
+            self.kv_cache_quantized_dtype = utils.get_jax_dtype_from_str_dtype(
+                self.kv_cache_dtype)
+
+        self.kv_b_proj = JaxEinsum(
+            einsum_str="SA,AL->SL",
+            kernel_shape=(self.kv_lora_rank,
+                          self.N * (self.qk_nope_head_dim + self.v_head_dim)),
+            rngs=rngs,
+            quant_config=self.quant_config,
+            param_dtype=self.dtype,
+            kernel_init=nnx.with_partitioning(init_fn, self.ap_sharding),
+            prefix=self.prefix + ".kv_b_proj",
+        )
+
+    def _project_q(self, x_q_TD: jax.Array) -> jax.Array:
+        """Query projection up to (but excluding) the head reshape."""
+        if self.q_lora_rank is not None:
+            return self.q_b_proj(self.q_a_layernorm(self.q_a_proj(x_q_TD)))
+        return self.q_proj(x_q_TD)
+
+    @abstractmethod
+    def compute_q_projection(self, *args) -> jax.Array:
+        raise NotImplementedError
+
+    @abstractmethod
+    def compute_kv_projection(self, *args) -> Tuple[jax.Array, jax.Array]:
+        raise NotImplementedError
+
+    @abstractmethod
+    def compute_attention(self, *args) -> Tuple[KVCache, jax.Array]:
+        raise NotImplementedError
+
+    def process_output(self, outputs_TNH) -> jax.Array:
+        return outputs_TNH
+
+    def __call__(
+            self, x: jax.Array, kv_cache: KVCache,
+            attention_metadata: AttentionMetadata
+    ) -> Tuple[KVCache, jax.Array]:
+        """Performs the forward pass of the attention module.  Expects that the
+        child class has implemented the `compute_q_projection`, `compute_kv_projection`,
+        and `compute_attention` methods.
+
+        Args:
+            x: The input tensor of shape `(batch_size, seq_len, d_model)`.
+            kv_cache: The key-value cache for storing past attention states.
+            attention_metadata: Metadata for attention, such as input positions.
+
+        Returns:
+            A tuple containing:
+                - The updated KV cache.
+                - The attention output tensor of shape
+                  `(batch_size, seq_len, d_model)`.
+        """
+
+        md = attention_metadata
+        x = jnp.asarray(x, self.dtype)
+        x_SD = lax.with_sharding_constraint(x, self.activation_attention_td)
+        x_q_TD = lax.with_sharding_constraint(x, self.activation_q_td)
+
+        with jax.named_scope("q_proj"):
+            q_data = self.compute_q_projection(x_q_TD, md.input_positions)
+
+        with jax.named_scope("kv_proj"):
+            kv_data = self.compute_kv_projection(x_SD, md.input_positions)
+
+        with jax.named_scope("attn_op"):
+            new_kv_cache, outputs_TNH = self.compute_attention(
+                q_data, kv_data, kv_cache, md)
+
+            outputs_TNH = self.process_output(outputs_TNH)
+
+            if outputs_TNH.shape[-1] != self.v_head_dim:
+                outputs_TNH = outputs_TNH[..., :self.v_head_dim]
+
+            with jax.named_scope("o_proj"):
+                outputs_TR = outputs_TNH.reshape(outputs_TNH.shape[0],
+                                                 self.N * self.v_head_dim)
+                if self.use_output_gate:
+                    # Sigmoid computed in fp32 to match the reference
+                    # implementation's numerics.
+                    gate_TR = jax.nn.sigmoid(
+                        self.g_proj(x_q_TD).astype(jnp.float32))
+                    outputs_TR = (outputs_TR.astype(jnp.float32) *
+                                  gate_TR).astype(self.dtype)
+                o_TD = self.o_proj(outputs_TR)
+
+            return new_kv_cache, o_TD
+
+
+# The absorbed-MLA forward runs on `k_up_proj`/`v_up_proj`, which `MLAEinsum`
+# splits out of the checkpoint's fused `kv_b_proj` at load time. No checkpoint
+# tensor carries their names, so they never show up as "loaded".
+_ABSORBED_MLA_DERIVED_MODULES = (".k_up_proj.", ".v_up_proj.")
+
+
+def derived_absorbed_mla_param_names(model) -> set:
+    """Parameter names an MLA model materializes instead of loading.
+
+    vLLM's model loader raises if any `named_parameters()` entry is missing
+    from the set a model's `load_weights` returns. Quantized MLA checkpoints
+    get a pass because their `quant_method` declares
+    `process_weights_after_loading`, which the loader whitelists wholesale; an
+    unquantized MLA checkpoint (Kimi-Linear-48B is bf16 throughout, Kimi-K3
+    keeps `self_attn.*` in bf16) has no such method, so the model has to
+    report these names itself.
+    """
+    return {
+        name
+        for name, _ in model.named_parameters()
+        if any(part in name for part in _ABSORBED_MLA_DERIVED_MODULES)
+    }
+
+
+class MLAEinsum(JaxEinsum):
+    """Extending JaxEinsum to handle MLA.
+
+    This class is used for MLA, where:
+    1) the weight is split into k/v parts after loading, and
+    2) modify the MLA layer to set k/v weights
+    """
+
+    def __init__(self,
+                 mla_layer,
+                 einsum_str: str,
+                 kernel_shape: tuple[int, ...],
+                 rngs,
+                 bias_shape: Optional[tuple[int, ...]] = None,
+                 quant_config: Optional[QuantizationConfig] = None,
+                 prefix: str = "",
+                 **kwargs):
+        super().__init__(einsum_str,
+                         kernel_shape,
+                         rngs,
+                         bias_shape=bias_shape,
+                         quant_config=quant_config,
+                         prefix=prefix,
+                         **kwargs)
+        self.loaded = set()
+        self.mla_layer = mla_layer
+        self.quant_config = quant_config
+
+    def named_children(self):
+        # Override, otherwise "mla_layer" will be visited, causing infinite recursion.
+        yield from []
+
+    def _split_unquantized(self):
+        """bf16 path: split the loaded kv_b_proj weight into k_up / v_up.
+
+        The absorbed-MLA forward needs ``k_up_proj``/``v_up_proj`` rather than
+        the fused ``kv_b_proj``; for quantized checkpoints that split happens
+        below in the fp8 branch. Models whose MLA weights are not quantized
+        (Kimi-Linear-48B is bf16 throughout; Kimi-K3 quantizes only the routed
+        experts and leaves ``self_attn.*`` in bf16) need the same split without
+        any (de)quantization.
+        """
+        mla_layer = self.mla_layer
+        A = mla_layer.kv_lora_rank
+        N = mla_layer.N
+        qk_nope_head_dim = mla_layer.qk_nope_head_dim
+        v_head_dim = mla_layer.v_head_dim
+        weight = self.weight.value
+        if weight.shape != (A, N * (qk_nope_head_dim + v_head_dim)):
+            raise ValueError(
+                f"[mla] unexpected kv_b_proj shape {weight.shape}, expected "
+                f"{(A, N * (qk_nope_head_dim + v_head_dim))} "
+                f"(kv_lora_rank={A}, num_heads={N}, "
+                f"qk_nope_head_dim={qk_nope_head_dim}, "
+                f"v_head_dim={v_head_dim})")
+        weight = weight.reshape(A, N, qk_nope_head_dim + v_head_dim)
+        k_ANH, v_ANH = jnp.split(weight, [qk_nope_head_dim], axis=-1)
+
+        setattr(
+            mla_layer, "k_up_proj",
+            JaxEinsum(
+                einsum_str="TNH,ANH->NTA",
+                kernel_shape=(A, N, qk_nope_head_dim),
+                rngs=nnx.Rngs(0),
+                param_dtype=self.weight.value.dtype,
+                prefix=mla_layer.prefix + ".k_up_proj",
+                quant_config=None,
+            ))
+        setattr(
+            mla_layer, "v_up_proj",
+            JaxEinsum(
+                einsum_str="NTA,ANH->TNH",
+                kernel_shape=(A, N, v_head_dim),
+                rngs=nnx.Rngs(0),
+                param_dtype=self.weight.value.dtype,
+                prefix=mla_layer.prefix + ".v_up_proj",
+                quant_config=None,
+            ))
+        mla_layer.k_up_proj.weight.value = shard_put(k_ANH,
+                                                     mla_layer.anh_sharding)
+        mla_layer.v_up_proj.weight.value = shard_put(v_ANH,
+                                                     mla_layer.anh_sharding)
+        delattr(self, 'weight')
+
+    def load_weights(self, weights) -> set:
+        """Load `kv_b_proj`, then split it, and report what was loaded.
+
+        Returns the names of the parameters consumed **in this call**, module-
+        local (``"weight"``, ``"weight_scale_inv"``); the caller qualifies them
+        with this module's prefix. The return value is bookkeeping only -- it
+        does not change what is loaded -- but it is not optional: vLLM's
+        `AutoWeightsLoader._load_module` calls a child module's `load_weights`
+        and, when it returns None, logs "Unable to collect loaded parameters
+        for module %s" at WARNING with the module's full repr interpolated,
+        once per MLA layer on every load that goes through the auto-loader.
+
+        The derived `k_up_proj`/`v_up_proj` params are deliberately not
+        reported here: no checkpoint tensor carries their names and they hang
+        off the parent `MLAAttention`, not off this module, so the model
+        reports them via `derived_absorbed_mla_param_names`.
+        """
+        named_params = dict(self.named_parameters())
+        if len(self.loaded) >= 2:
+            raise ValueError(
+                f"Expect at most 2 params to load for kv_b_proj, already got {self.loaded}, still have {[name for name, _ in weights]} coming."
+            )
+        loaded_now: set = set()
+        for name, weight in weights:
+            param = named_params[name]
+            weight_loader = getattr(param, "weight_loader")
+            weight_loader(param, weight)
+            self.loaded.add(name)
+            loaded_now.add(name)
+        if len(self.loaded) != len(named_params):
+            return loaded_now
+        # Presence of the scale param -- not of a quant_config -- is what
+        # decides the path: an unquantized model still carries a
+        # QuantizationConfig (UnquantizedConfig), it just never creates
+        # `weight_scale_inv`. Kimi-Linear-48B is bf16 throughout and Kimi-K3
+        # keeps `self_attn.*` in bf16, so both land here.
+        if not hasattr(self, "weight_scale_inv"):
+            self._split_unquantized()
+            return loaded_now
+        # After loading, split the weights into k/v
+        with cpu_mesh_context():
+            dequantized_weight = dequantize_tensor(
+                self.weight,
+                self.weight_scale_inv,
+                (0, 1),
+                block_size=None,
+            )
+            A, N, qk_nope_head_dim, v_head_dim = self.mla_layer.kv_lora_rank, self.mla_layer.N, self.mla_layer.qk_nope_head_dim, self.mla_layer.v_head_dim
+            if dequantized_weight.shape != (A, N *
+                                            (qk_nope_head_dim + v_head_dim)):
+                raise ValueError(
+                    f"Unexpected weight shape after dequantization: {dequantized_weight.shape}, expected {(A, N * (qk_nope_head_dim + v_head_dim))=}"
+                )
+            dequantized_weight = dequantized_weight.reshape(
+                A, N, qk_nope_head_dim + v_head_dim)
+            k_ANH, v_ANH = jnp.split(dequantized_weight, [qk_nope_head_dim],
+                                     axis=-1)
+            k_ANH_weight, k_ANH_scale = quantize_tensor(k_ANH,
+                                                        self.weight.dtype,
+                                                        dim=-1)
+            v_ANH_weight, v_1NH_scale = quantize_tensor(v_ANH,
+                                                        self.weight.dtype,
+                                                        dim=0)
+            # As of writing, sharded_quantized_batched_matmul expects scale to be
+            # a different shape order than weight
+            k_N1A_scale = k_ANH_scale.transpose(1, 2, 0)
+            v_N1H_scale = v_1NH_scale.transpose(1, 0, 2)
+        mla_layer = self.mla_layer
+        setattr(
+            mla_layer, "k_up_proj",
+            JaxEinsum(
+                einsum_str="TNH,ANH->NTA",
+                kernel_shape=(A, N, qk_nope_head_dim),
+                rngs=nnx.Rngs(0),
+                prefix=mla_layer.prefix + ".k_up_proj",
+                quant_config=self.quant_config,
+            ))
+        setattr(
+            mla_layer, "v_up_proj",
+            JaxEinsum(
+                einsum_str="NTA,ANH->TNH",
+                kernel_shape=(A, N, v_head_dim),
+                rngs=nnx.Rngs(0),
+                prefix=mla_layer.prefix + ".v_up_proj",
+                quant_config=self.quant_config,
+            ))
+        # Cannot apply anh_sharding to scales, otherwise it complains about shape mismatch.
+        mla_layer.k_up_proj.weight.value = shard_put(
+            k_ANH_weight, self.mla_layer.anh_sharding)
+        mla_layer.k_up_proj.weight_scale_inv.value = shard_put(k_N1A_scale, ())
+        mla_layer.v_up_proj.weight.value = shard_put(
+            v_ANH_weight, self.mla_layer.anh_sharding)
+        mla_layer.v_up_proj.weight_scale_inv.value = shard_put(v_N1H_scale, ())
+
+        delattr(self, 'weight')
+        delattr(self, 'weight_scale_inv')
+        delattr(self, 'quant_method')
+        return loaded_now
+
+
+@dataclass(kw_only=True)
+class MLAAttention(MLABaseAttention):
+    """Absorbed Multi-head Latent Attention (MLA)."""
+    anh_sharding: Sharding = ()
+
+    def __post_init__(self, rngs: nnx.Rngs):
+        super().__post_init__(rngs)
+
+        weight_init = _weight_init(self.random_init)
+        self.kv_b_proj = MLAEinsum(
+            mla_layer=self,
+            einsum_str="SA,AL->SL",
+            kernel_shape=(self.kv_lora_rank,
+                          self.N * (self.qk_nope_head_dim + self.v_head_dim)),
+            rngs=rngs,
+            quant_config=self.quant_config,
+            param_dtype=self.dtype,
+            kernel_init=nnx.with_partitioning(weight_init, self.ap_sharding),
+            prefix=self.prefix + ".kv_b_proj",
+        )
+
+    def compute_q_projection(
+            self, x_q_TD: jax.Array,
+            input_positions: jax.Array) -> Tuple[jax.Array, jax.Array]:
+        """
+        Computes the query projection for MLA.
+
+        Args:
+            x_q_TD: The input tensor of shape `(tokens_query, d_model)`.
+            input_positions: The input positions tensor of shape `(padded_total_num_scheduled_tokens,)`.
+
+        Returns:
+            A tuple of query tensor of shape `(tokens_query, num_query_heads, q_lora_rank)` and
+            rope tensor of shape `(tokens_query, num_query_heads, head_dim)`.
+        """
+        q_TP = self._project_q(x_q_TD)
+        q_TNH = q_TP.reshape(q_TP.shape[0], self.N, self.qk_head_dim)
+
+        q_nope_TNH = q_TNH[..., :self.qk_nope_head_dim]
+        q_rope_TNH = q_TNH[..., self.qk_nope_head_dim:]
+        if not self.use_nope:
+            q_rope_TNH = self.rope.apply_rope(input_positions, q_rope_TNH)
+
+        q_NTA = self.k_up_proj(q_nope_TNH)
+
+        q_NTA = lax.with_sharding_constraint(q_NTA, self.query_nth)
+        return (q_NTA, q_rope_TNH)
+
+    def compute_kv_projection(
+            self, x_SD: jax.Array,
+            input_positions: jax.Array) -> Tuple[jax.Array, jax.Array]:
+        """
+        Computes the key-value projection for MLA.
+
+        Args:
+            x_SD: The input tensor of shape `(tokens_kv, d_model)`.
+            input_positions: The input positions tensor of shape `(padded_total_num_scheduled_tokens,)`.
+
+        Returns:
+            A tuple of key-value tensor of shape `(tokens_kv, q_lora_rank)` and
+            rope tensor of shape `(tokens_kv, head_dim)`.
+        """
+        kv_SA = self.kv_a_proj_with_mqa(x_SD)
+
+        k_rope_SH = kv_SA[..., self.kv_lora_rank:]
+        if not self.use_nope:
+            k_rope_SNH = k_rope_SH[..., None, :]
+            k_rope_SNH = self.rope.apply_rope(input_positions, k_rope_SNH)
+            assert k_rope_SNH.shape[1] == 1
+            k_rope_SH = k_rope_SNH[:, 0, :]
+
+        kv_SA = kv_SA[..., :self.kv_lora_rank]
+        kv_SA = self.kv_a_layernorm(kv_SA)
+        kv_SA = lax.with_sharding_constraint(kv_SA, self.keyvalue_skh)
+
+        return (kv_SA, k_rope_SH)
+
+    def compute_attention(self, q_data: Tuple[jax.Array, jax.Array],
+                          kv_data: Tuple[jax.Array,
+                                         jax.Array], kv_cache: KVCache,
+                          md: AttentionMetadata) -> Tuple[KVCache, jax.Array]:
+        """
+        Computes the attention for MLA.
+
+        Args:
+            q_data: A tuple of query tensor of shape `(tokens_query, num_query_heads, q_lora_rank)` and
+                rope tensor of shape `(tokens_query, num_query_heads, head_dim)`.
+            kv_data: A tuple of key-value tensor of shape `(tokens_kv, q_lora_rank)` and
+                rope tensor of shape `(tokens_kv, head_dim)`.
+            kv_cache: The key-value cache.
+            md: The attention metadata.
+
+        Returns:
+            A tuple of key-value cache and output tensor of shape `(tokens_query, num_query_heads, q_lora_rank)`.
+        """
+
+        q_NTA, q_rope_TNH = q_data
+        k_SA, k_rope_SH = kv_data
+
+        q_scale = k_scale = None
+        if self.kv_cache_quantized_dtype:
+            k_scale = self._k_scale
+            # TODO: May need to apply quantization separately for k_c & k_pe
+            k_SA, _ = quantize_kv(self.kv_cache_quantized_dtype,
+                                  k_SA,
+                                  value=None,
+                                  k_scale=k_scale)
+            k_rope_SH, _ = quantize_kv(self.kv_cache_quantized_dtype,
+                                       k_rope_SH,
+                                       value=None,
+                                       k_scale=k_scale)
+            q_NTA = static_per_tensor_quantize_tensor(
+                self.kv_cache_quantized_dtype, q_NTA, self._q_scale)
+            q_rope_TNH = static_per_tensor_quantize_tensor(
+                self.kv_cache_quantized_dtype, q_rope_TNH, self._q_scale)
+
+        return mla_attention(q_NTA,
+                             q_rope_TNH,
+                             k_SA,
+                             k_rope_SH,
+                             kv_cache,
+                             md,
+                             self.mesh,
+                             self.num_attention_heads,
+                             self.qk_nope_head_dim,
+                             query_nth_sharding=self.query_nth,
+                             query_tnh_sharding=self.query_tnh,
+                             keyvalue_skh_sharding=self.keyvalue_skh,
+                             attn_o_nth_sharding=self.attn_o_nth,
+                             q_scale=q_scale,
+                             k_scale=k_scale,
+                             v_scale=k_scale,
+                             sm_scale=self.scale)
+
+    def process_output(self, outputs_NTA: jax.Array) -> jax.Array:
+        """
+        Processes output for MLA specifically.
+
+        Args:
+            outputs_NTA: The output tensor of shape `(num_heads, tokens_query, q_lora_rank)`.
+
+        Returns:
+            The processed output tensor of shape `(tokens_query, num_query_heads, head_dim)`.
+        """
+
+        # MLA Specific: Apply V-Up Projection after attention
+        # Outputs from MLA kernel are N-major [N, T, A]; project to T-major [T, N, H]
+        outputs_TNH = self.v_up_proj(outputs_NTA)
+        return outputs_TNH.astype(self.dtype)

--- a/tpu_inference/layers/jax/linear.py
+++ b/tpu_inference/layers/jax/linear.py
@@ -91,7 +91,16 @@ class JaxEinsum(nnx.Einsum, JaxModule):
         if self.quant_method is not None:
             return self.quant_method.apply_jax(self, inputs)
 
-        output = jax.numpy.einsum(self.einsum_str, inputs, self.weight.value)
+        # `precision` comes from nnx.Einsum's constructor (forwarded through
+        # **kwargs). It is None for every layer that does not opt in, which
+        # leaves XLA's default: on TPU an fp32 einsum is lowered to a single
+        # bf16 pass. Layers that need true fp32 arithmetic (e.g. a MoE router
+        # gate, where a bf16-rounded logit flips near-tie experts) pass
+        # `precision=jax.lax.Precision.HIGHEST`.
+        output = jax.numpy.einsum(self.einsum_str,
+                                  inputs,
+                                  self.weight.value,
+                                  precision=self.precision)
         if self.bias is not None:
             output += self.bias
         return output

--- a/tpu_inference/layers/jax/mlp.py
+++ b/tpu_inference/layers/jax/mlp.py
@@ -1,0 +1,127 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shared gated feed-forward network.
+
+Extracted from the DeepSeek-V3 model file (``DeepseekV3MLP``) so the
+MLA/MoE-family models can share one implementation. Beyond DeepSeek-V3 this
+serves the Kimi-Linear / Kimi-K3 family, which needs the ``situ`` activation
+(soft-clamps the up branch as well as the gate branch) and per-sub-module
+quantization prefixes.
+"""
+
+from dataclasses import InitVar, dataclass
+from typing import Optional
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax import lax
+from jax.sharding import PartitionSpec as P
+
+from tpu_inference.layers.jax import JaxModule
+from tpu_inference.layers.jax.activation import (SITU_BETA, SITU_LINEAR_BETA,
+                                                 apply_gated_activation)
+from tpu_inference.layers.jax.base import sharded_initializer
+from tpu_inference.layers.jax.linear import JaxEinsum
+from tpu_inference.layers.jax.quantization.configs import QuantizationConfig
+
+
+def _weight_init(random_init: bool):
+    return sharded_initializer if random_init else nnx.initializers.uniform()
+
+
+@dataclass(kw_only=True)
+class GatedMLP(JaxModule):
+    """A gated feed-forward network: ``down(act(gate(x), up(x)))``.
+
+    Attributes:
+        hidden_act: Name of the gated activation. ``situ`` uses both
+            ``situ_beta`` and ``situ_linear_beta``; every other activation is
+            unary on the gate branch.
+        prefix: Quantization prefix. Empty (the DeepSeek-V3 default) leaves the
+            sub-modules unprefixed, matching the pre-extraction behaviour.
+    """
+    dtype: jnp.dtype
+    hidden_act: str
+    hidden_size: int
+    intermediate_size: int
+    df_sharding: P = P()
+    fd_sharding: P = P()
+    activation_ffw_td: P = P()
+    random_init: bool = False
+    quant_config: Optional[QuantizationConfig] = None
+    situ_beta: float = SITU_BETA
+    situ_linear_beta: float | None = SITU_LINEAR_BETA
+    prefix: str = ""
+
+    rngs: InitVar[nnx.Rngs]
+
+    def __call__(self, x_TD):
+        """Performs the forward pass of the FFW layer.
+
+        Args:
+            x_TD: The input tensor of shape either `(sequence, d_model)`
+
+        Returns:
+            The output tensor of shape `(batch, sequence, d_model)`.
+        """
+        x_TD = jnp.asarray(x_TD, self.dtype)
+        x_TD = lax.with_sharding_constraint(x_TD, self.activation_ffw_td)
+        with jax.named_scope("wi_0"):
+            gating_TF = self.gate_proj(x_TD)
+        with jax.named_scope("wi_1"):
+            up_proj_TF = self.up_proj(x_TD)
+        fuse_TF = apply_gated_activation(self.hidden_act, gating_TF,
+                                         up_proj_TF, self.situ_beta,
+                                         self.situ_linear_beta)
+        with jax.named_scope("wo"):
+            output_TD = self.down_proj(fuse_TF)
+
+        return output_TD
+
+    def _sub_prefix(self, name: str) -> str:
+        return f"{self.prefix}.{name}" if self.prefix else ""
+
+    def __post_init__(self, rngs: nnx.Rngs):
+        D = self.hidden_size
+        F = self.intermediate_size
+        weight_init = _weight_init(self.random_init)
+
+        self.gate_proj = JaxEinsum(
+            einsum_str="TD,DF->TF",
+            kernel_shape=(D, F),
+            rngs=rngs,
+            quant_config=self.quant_config,
+            param_dtype=self.dtype,
+            kernel_init=nnx.with_partitioning(weight_init, self.df_sharding),
+            prefix=self._sub_prefix("gate_proj"),
+        )
+        self.up_proj = JaxEinsum(
+            einsum_str="TD,DF->TF",
+            kernel_shape=(D, F),
+            rngs=rngs,
+            quant_config=self.quant_config,
+            param_dtype=self.dtype,
+            kernel_init=nnx.with_partitioning(weight_init, self.df_sharding),
+            prefix=self._sub_prefix("up_proj"),
+        )
+        self.down_proj = JaxEinsum(
+            einsum_str="TF,FD->TD",
+            kernel_shape=(F, D),
+            rngs=rngs,
+            quant_config=self.quant_config,
+            param_dtype=self.dtype,
+            kernel_init=nnx.with_partitioning(weight_init, self.fd_sharding),
+            prefix=self._sub_prefix("down_proj"),
+        )

--- a/tpu_inference/layers/jax/moe/dense_moe.py
+++ b/tpu_inference/layers/jax/moe/dense_moe.py
@@ -22,13 +22,56 @@ from jaxtyping import Float
 
 from tpu_inference.layers.common.process_weights.moe_weights import \
     UnfusedMoEWeights
-from tpu_inference.layers.jax.moe.utils import modeling_flax_utils
+from tpu_inference.layers.common.quantization import dequantize_tensor
+from tpu_inference.layers.jax.activation import (SITU_BETA, SITU_LINEAR_BETA,
+                                                 apply_gated_activation)
 
 
-def dense_moe_fwd(weights: UnfusedMoEWeights, x_TD: Float,
-                  cast_dtype: jnp.dtype, activation_ffw_td: Sharding,
-                  hidden_act: str, full_weights_TE: jax.Array,
-                  mesh: Mesh) -> jax.Array:
+def dequantize_unfused_moe_weights(weights: UnfusedMoEWeights,
+                                   cast_dtype: jnp.dtype) -> UnfusedMoEWeights:
+    """Materialize block-quantized expert kernels at `cast_dtype`.
+
+    DENSE_MAT is the reference/testing backend and multiplies the expert
+    kernels with plain einsums, so quantized weights (e.g. MXFP4 experts held
+    as `float4_e2m1fn` plus per-group scales) are expanded here rather than
+    inside the matmul. Weights whose scale is None are passed through.
+
+    Each kernel is `(E, K, N)` with the contracting axis blocked, so its scale
+    is `(E, K // block, N)` and dequantization runs along axis 1.
+    """
+    if all(s is None
+           for s in (weights.w1_weight_scale, weights.w2_weight_scale,
+                     weights.w3_weight_scale)):
+        return weights
+
+    def expand(weight, scale):
+        if scale is None:
+            return weight
+        return dequantize_tensor(weight, scale, axis=1, out_dtype=cast_dtype)
+
+    return UnfusedMoEWeights(
+        w1_weight=expand(weights.w1_weight, weights.w1_weight_scale),
+        w1_weight_scale=None,
+        w1_bias=weights.w1_bias,
+        w2_weight=expand(weights.w2_weight, weights.w2_weight_scale),
+        w2_weight_scale=None,
+        w2_bias=weights.w2_bias,
+        w3_weight=expand(weights.w3_weight, weights.w3_weight_scale),
+        w3_weight_scale=None,
+        w3_bias=weights.w3_bias,
+    )
+
+
+def dense_moe_fwd(
+        weights: UnfusedMoEWeights,
+        x_TD: Float,
+        cast_dtype: jnp.dtype,
+        activation_ffw_td: Sharding,
+        hidden_act: str,
+        full_weights_TE: jax.Array,
+        mesh: Mesh,
+        situ_beta: float = SITU_BETA,
+        situ_linear_beta: float | None = SITU_LINEAR_BETA) -> jax.Array:
     """Forward pass of the dense Moe layer where we don't pre-apply the weights.
 
     TODO (jacobplatin): we probably want to support quantization at some point.
@@ -40,6 +83,9 @@ def dense_moe_fwd(weights: UnfusedMoEWeights, x_TD: Float,
         activation_ffw_td: The sharding of the activation.
         hidden_act: The activation function to use.
         full_weights_TE: The full weights of the dense Moe layer.
+        situ_beta: Gate-branch soft clamp, only used when hidden_act is "situ".
+        situ_linear_beta: Up-branch soft clamp, only used when hidden_act is
+            "situ".
 
     Returns:
         The output of the dense Moe layer.
@@ -49,11 +95,10 @@ def dense_moe_fwd(weights: UnfusedMoEWeights, x_TD: Float,
         x_TD, NamedSharding(mesh, P(*activation_ffw_td)))
     with jax.named_scope("gating"):
         gating_TEF = jnp.einsum('TD,EDF -> TEF', x_TD, weights.w1_weight)
-        activated_gating_TEF = modeling_flax_utils.ACT2FN[hidden_act](
-            gating_TEF)
     with jax.named_scope("up_projection"):
         up_proj_TEF = jnp.einsum('TD,EDF -> TEF', x_TD, weights.w2_weight)
-    fuse_TEF = activated_gating_TEF * up_proj_TEF
+    fuse_TEF = apply_gated_activation(hidden_act, gating_TEF, up_proj_TEF,
+                                      situ_beta, situ_linear_beta)
     with jax.named_scope("down_projection"):
         down_proj_TED = jnp.einsum('TEF,EFD -> TED', fuse_TEF,
                                    weights.w3_weight)
@@ -62,12 +107,16 @@ def dense_moe_fwd(weights: UnfusedMoEWeights, x_TD: Float,
     return output_TD.astype(cast_dtype)
 
 
-def dense_moe_fwd_preapply_router_weights(weights: UnfusedMoEWeights,
-                                          x_TD: Float, cast_dtype: jnp.dtype,
-                                          activation_ffw_ted: Sharding,
-                                          hidden_act: str,
-                                          full_weights_TE: jax.Array,
-                                          mesh: Mesh) -> jax.Array:
+def dense_moe_fwd_preapply_router_weights(
+        weights: UnfusedMoEWeights,
+        x_TD: Float,
+        cast_dtype: jnp.dtype,
+        activation_ffw_ted: Sharding,
+        hidden_act: str,
+        full_weights_TE: jax.Array,
+        mesh: Mesh,
+        situ_beta: float = SITU_BETA,
+        situ_linear_beta: float | None = SITU_LINEAR_BETA) -> jax.Array:
     """
     Forward pass of the dense Moe layer where we pre-apply the weights.
 
@@ -80,6 +129,9 @@ def dense_moe_fwd_preapply_router_weights(weights: UnfusedMoEWeights,
         activation_ffw_td: The sharding of the activation.
         hidden_act: The activation function to use.
         full_weights_TE: The weights of the router.
+        situ_beta: Gate-branch soft clamp, only used when hidden_act is "situ".
+        situ_linear_beta: Up-branch soft clamp, only used when hidden_act is
+            "situ".
 
     Returns:
         The output of the dense Moe layer.
@@ -93,29 +145,37 @@ def dense_moe_fwd_preapply_router_weights(weights: UnfusedMoEWeights,
 
     with jax.named_scope("gating"):
         gating_TEF = jnp.einsum('TED,EDF -> TEF', x_TED, weights.w1_weight)
-        activated_gating_TEF = modeling_flax_utils.ACT2FN[hidden_act](
-            gating_TEF)
     with jax.named_scope("up_projection"):
         up_proj_TEF = jnp.einsum('TED,EDF -> TEF', x_TED, weights.w2_weight)
 
-    fuse_TEF = activated_gating_TEF * up_proj_TEF
+    fuse_TEF = apply_gated_activation(hidden_act, gating_TEF, up_proj_TEF,
+                                      situ_beta, situ_linear_beta)
     with jax.named_scope("down_projection"):
         down_proj_TED = jnp.einsum('TEF,EFD -> TED', fuse_TEF,
                                    weights.w3_weight)
     return down_proj_TED.sum(axis=1).astype(cast_dtype)
 
 
-def dense_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
-                   gating_output: Tuple[jax.Array, jax.Array],
-                   cast_dtype: jnp.dtype, num_local_experts: int,
-                   apply_expert_weight_before_computation: bool,
-                   activation_ffw_td: Sharding, activation_ffw_ted: Sharding,
-                   hidden_act: str, mesh: Mesh) -> jax.Array:
+def dense_moe_func(
+        weights: UnfusedMoEWeights,
+        x_TD: jax.Array,
+        gating_output: Tuple[jax.Array, jax.Array],
+        cast_dtype: jnp.dtype,
+        num_local_experts: int,
+        apply_expert_weight_before_computation: bool,
+        activation_ffw_td: Sharding,
+        activation_ffw_ted: Sharding,
+        hidden_act: str,
+        mesh: Mesh,
+        situ_beta: float = SITU_BETA,
+        situ_linear_beta: float | None = SITU_LINEAR_BETA) -> jax.Array:
     """
     Forward pass of the dense MoE layer.  This is a naive implementation
     and thus should not be used in production.
 
-    TODO (jacobplatin): we probably want to support quantization at some point.
+    Block-quantized expert kernels are dequantized to `cast_dtype` up front
+    (see `dequantize_unfused_moe_weights`); the einsums below always run on
+    unquantized weights.
 
     Args:
         weights: The weights of the dense Moe layer.
@@ -129,6 +189,9 @@ def dense_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
         activation_ffw_ted: The sharding of the activation, used for the
             pre-apply weights case.
         hidden_act: The activation function to use.
+        situ_beta: Gate-branch soft clamp, only used when hidden_act is "situ".
+        situ_linear_beta: Up-branch soft clamp, only used when hidden_act is
+            "situ".
 
     Returns:
         The output of the dense Moe layer.
@@ -136,6 +199,7 @@ def dense_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
     assert isinstance(
         weights,
         UnfusedMoEWeights), "Expected unfused weights for DENSE_MAT backend"
+    weights = dequantize_unfused_moe_weights(weights, cast_dtype)
 
     weights_TX, indices_TX = gating_output
     one_hot_indices_TXE = jax.nn.one_hot(indices_TX,
@@ -154,7 +218,9 @@ def dense_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
                 activation_ffw_ted=activation_ffw_ted,
                 hidden_act=hidden_act,
                 full_weights_TE=full_weights_TE,
-                mesh=mesh)
+                mesh=mesh,
+                situ_beta=situ_beta,
+                situ_linear_beta=situ_linear_beta)
     else:
         return dense_moe_fwd(weights=weights,
                              x_TD=x_TD,
@@ -162,4 +228,6 @@ def dense_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
                              activation_ffw_td=activation_ffw_td,
                              hidden_act=hidden_act,
                              full_weights_TE=full_weights_TE,
-                             mesh=mesh)
+                             mesh=mesh,
+                             situ_beta=situ_beta,
+                             situ_linear_beta=situ_linear_beta)

--- a/tpu_inference/layers/jax/moe/sparse_moe.py
+++ b/tpu_inference/layers/jax/moe/sparse_moe.py
@@ -23,11 +23,12 @@ from vllm.model_executor.layers.fused_moe import RoutedExperts
 
 from tpu_inference.layers.common.process_weights.moe_weights import \
     UnfusedMoEWeights
+from tpu_inference.layers.jax.activation import (apply_gated_activation,
+                                                 situ_params)
 # yapf: disable
 from tpu_inference.layers.jax.moe.utils import (get_all_to_all_params_fn,
                                                 global_permute_fn, gmm_fn,
                                                 local_permute_fn,
-                                                modeling_flax_utils,
                                                 sort_activations_fn,
                                                 unpermute_fn)
 from tpu_inference.models.jax.utils.qwix.qwix_utils import \
@@ -148,32 +149,29 @@ def sparse_moe_distributed_fwd(
     with jax.named_scope("gating"):
         gating_TEF = gmm_fn(compute_inputs, kernel_gating, compute_group_sizes,
                             moe_instance.tile_size, moe_instance.moe_backend,
-                            moe_instance.dtype,
-                            moe_instance.qwix_quantized_weight_dtype)
+                            moe_instance.dtype)
         if moe_instance.edf_sharding[1] is not None:
             gating_TEF = jax.lax.psum(gating_TEF,
                                       axis_name=moe_instance.edf_sharding[1])
-        activated_gating_TEF = modeling_flax_utils.ACT2FN[
-            moe_instance.hidden_act](gating_TEF)
 
     with jax.named_scope("up_projection"):
         up_proj_TEF = gmm_fn(compute_inputs, kernel_up_proj,
                              compute_group_sizes, moe_instance.tile_size,
-                             moe_instance.moe_backend, moe_instance.dtype,
-                             moe_instance.qwix_quantized_weight_dtype)
+                             moe_instance.moe_backend, moe_instance.dtype)
         if moe_instance.edf_sharding[1] is not None:
             up_proj_TEF = jax.lax.psum(up_proj_TEF,
                                        axis_name=moe_instance.edf_sharding[1])
 
-    fuse_TEF = activated_gating_TEF * up_proj_TEF
+    situ_beta, situ_linear_beta = situ_params(moe_instance)
+    fuse_TEF = apply_gated_activation(moe_instance.hidden_act, gating_TEF,
+                                      up_proj_TEF, situ_beta, situ_linear_beta)
 
     with jax.named_scope("down_projection"):
         intermediate_output = gmm_fn(fuse_TEF, kernel_down_proj,
                                      compute_group_sizes,
                                      moe_instance.tile_size,
                                      moe_instance.moe_backend,
-                                     moe_instance.dtype,
-                                     moe_instance.qwix_quantized_weight_dtype)
+                                     moe_instance.dtype)
         if moe_instance.efd_sharding[1] is not None:
             intermediate_output = jax.lax.psum(
                 intermediate_output, axis_name=moe_instance.efd_sharding[1])
@@ -238,7 +236,13 @@ def sparse_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
     assert isinstance(
         weights, UnfusedMoEWeights), "Expected unfused weights for sparse MoE!"
     weights_TX, indices_TX = gating_output
-    if layer.qwix_quantized_weight_dtype:
+    # The expert kernels reach the GMM as a (value, scale) pair whenever they
+    # are block-quantized -- either by Qwix at load time, or by the checkpoint
+    # itself (MXFP4 experts). Both cases shard the scale like its weight.
+    quantized = bool(
+        layer.qwix_quantized_weight_dtype) or (weights.w1_weight_scale
+                                               is not None)
+    if quantized:
         gating_up_proj_spec = (PartitionSpec(*layer.edf_sharding),
                                PartitionSpec(*layer.edf_sharding))
         down_proj_spec = (PartitionSpec(*layer.efd_sharding),
@@ -264,36 +268,29 @@ def sparse_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
                              out_specs=out_specs,
                              check_rep=False)(sparse_moe_distributed_fwd)
 
-    # TODO (jacobplatin): this is needed because of issues with Qwix quantizing the `shard_map` in SpraseMatmul
-    # Basically, during the abstract pass, we need to manually quantize the weights here for Qwix, but we'll
-    # override the actual weight/scale during loading (we just need to make sure Qwix quantizes the weight
-    # in the first place).
-    kernel_gating_EDF = _process_weight_for_qwix(
-        layer.qwix_quantized_weight_dtype,
-        "kernel_gating_EDF",
-        layer.kernel_gating_EDF,
-        channelwise_axes=[0, 2],
-        tiled_axes={1: 128})
-    kernel_up_proj_EDF = _process_weight_for_qwix(
-        layer.qwix_quantized_weight_dtype,
-        "kernel_up_proj_EDF",
-        layer.kernel_up_proj_EDF,
-        channelwise_axes=[0, 2],
-        tiled_axes={1: 128})
-    kernel_down_proj_EFD = _process_weight_for_qwix(
-        layer.qwix_quantized_weight_dtype,
-        "kernel_down_proj_EFD",
-        layer.kernel_down_proj_EFD,
-        channelwise_axes=[0, 2],
-        tiled_axes={1: 128})
+    if layer.qwix_quantized_weight_dtype:
+        # TODO (jacobplatin): this is needed because of issues with Qwix quantizing the `shard_map` in SpraseMatmul
+        # Basically, during the abstract pass, we need to manually quantize the weights here for Qwix, but we'll
+        # override the actual weight/scale during loading (we just need to make sure Qwix quantizes the weight
+        # in the first place).
+        kernels = tuple(
+            _process_weight_for_qwix(layer.qwix_quantized_weight_dtype,
+                                     name,
+                                     getattr(layer, name),
+                                     channelwise_axes=[0, 2],
+                                     tiled_axes={1: 128})
+            for name in ("kernel_gating_EDF", "kernel_up_proj_EDF",
+                         "kernel_down_proj_EFD"))
+    else:
+        # Weights already carry whatever the GMM needs: a plain array, or a
+        # (value, scale) pair when the checkpoint stores them block-quantized.
+        kernels = tuple(
+            (w, s) if s is not None else w
+            for w, s in ((weights.w1_weight, weights.w1_weight_scale),
+                         (weights.w2_weight, weights.w2_weight_scale),
+                         (weights.w3_weight, weights.w3_weight_scale)))
 
-    weights.w1_weight = kernel_gating_EDF
-    weights.w2_weight = kernel_up_proj_EDF
-    weights.w3_weight = kernel_down_proj_EFD
-    # TODO (jacobplatin): support quantization
-    return mapped_moe_fwd(layer, x_TD, weights_TX, indices_TX,
-                          weights.w1_weight, weights.w2_weight,
-                          weights.w3_weight)
+    return mapped_moe_fwd(layer, x_TD, weights_TX, indices_TX, *kernels)
 
 
 def _process_weight_for_qwix(

--- a/tpu_inference/layers/jax/moe/sparse_moe.py
+++ b/tpu_inference/layers/jax/moe/sparse_moe.py
@@ -236,6 +236,18 @@ def sparse_moe_func(weights: UnfusedMoEWeights, x_TD: jax.Array,
     assert isinstance(
         weights, UnfusedMoEWeights), "Expected unfused weights for sparse MoE!"
     weights_TX, indices_TX = gating_output
+    # The (value, scale) packing below keys off w1 alone, so a partial scale
+    # set would only surface later as an opaque shard_map pytree/in_specs
+    # mismatch. Fail fast with the actual state instead.
+    scales_present = tuple(s is not None for s in (weights.w1_weight_scale,
+                                                   weights.w2_weight_scale,
+                                                   weights.w3_weight_scale))
+    assert all(scales_present) or not any(scales_present), (
+        "[moe] sparse_moe_func expects expert weight scales on all three "
+        "kernels (block-quantized checkpoint) or on none (plain weights); "
+        f"got (w1, w2, w3) scale present = {scales_present}. Each quantized "
+        "kernel is passed to shard_map as a (value, scale) pair, so a "
+        "partial set makes in_specs mismatch the argument pytree.")
     # The expert kernels reach the GMM as a (value, scale) pair whenever they
     # are block-quantized -- either by Qwix at load time, or by the checkpoint
     # itself (MXFP4 experts). Both cases shard the scale like its weight.

--- a/tpu_inference/layers/jax/moe/utils.py
+++ b/tpu_inference/layers/jax/moe/utils.py
@@ -202,16 +202,22 @@ def get_all_to_all_params_fn(all_shards_group_sizes,
     return input_offsets, send_sizes, output_offsets, recv_sizes
 
 
-def gmm_fn(inputs, kernel, group_sizes, tile_size, moe_backend, dtype,
-           quantized_dtype):
-    """Stateless Grouped Matrix Multiply."""
+def gmm_fn(inputs, kernel, group_sizes, tile_size, moe_backend, dtype):
+    """Stateless Grouped Matrix Multiply.
+
+    `kernel` is either a plain `(E, K, N)` array or, when the expert weights
+    are block-quantized, a `(qvalue, scale)` pair whose scale is
+    `(E, K // block, N)`. The pair form covers both Qwix-quantized weights and
+    checkpoint-quantized ones (e.g. MXFP4 experts), so the caller does not have
+    to say which.
+    """
     num_rows = inputs.shape[0]
     pad_amount = (tile_size[0] - num_rows % tile_size[0]) % tile_size[0]
     if pad_amount > 0:
         inputs = jnp.pad(inputs, ((0, pad_amount), (0, 0)))
 
     if moe_backend == MoEBackend.MEGABLX_GMM:
-        if quantized_dtype:
+        if isinstance(kernel, tuple):
             kernel_qvalue, kernel_scale = kernel
             kernel_scale = jnp.expand_dims(kernel_scale, 2)
         else:

--- a/tpu_inference/layers/jax/quantization/mxfp4.py
+++ b/tpu_inference/layers/jax/quantization/mxfp4.py
@@ -29,8 +29,8 @@ from tpu_inference import envs
 from tpu_inference.layers.common.moe import (FusedMoEMethodBase, MoEBackend,
                                              moe_apply)
 from tpu_inference.layers.common.process_weights.moe_weights import (
-    FusedMoEWeights, process_moe_weights, quantize_moe_weights,
-    shard_moe_weights)
+    FusedMoEWeights, UnfusedMoEWeights, process_moe_weights,
+    quantize_moe_weights, shard_moe_weights)
 from tpu_inference.layers.common.quantization import (
     MXFP4_BLOCK_SIZE, MXFP4_REQUANTIZED_BLOCK_SIZE,
     dequantize_tensor_from_mxfp4_packed, e8m0_to_fp32, u8_unpack_e2m1)
@@ -619,17 +619,25 @@ class CompressedTensorsMxfp4MoEMethod(QuantizeMethodBase, FusedMoEMethodBase):
 
     def apply_jax(self, layer: JaxMoE, x: jax.Array, *,
                   router_logits) -> jax.Array:
-        # The unfused MoE backends at this revision consume only bf16 expert
-        # kernels: DENSE_MAT einsums the raw weight arrays and MEGABLX_GMM
-        # re-reads `layer.kernel_*` itself, so the fp4 codes and the fp32
-        # group scales decoded above would be dropped on the floor and the
-        # layer would silently compute garbage. Fail loudly instead; the
-        # scale-consuming MoE backends land with the kernel layer change.
-        raise NotImplementedError(
-            f"[mxfp4-ct] {layer.prefix}: the forward pass for "
-            "compressed-tensors MXFP4 experts is not wired up at this "
-            "revision; the scale-consuming MoE backends land with the kernel "
-            "layer change.")
+        x_TD = jnp.asarray(x, layer.dtype)
+        x_TD = jax.lax.with_sharding_constraint(
+            x_TD,
+            jax.sharding.NamedSharding(layer.mesh,
+                                       P(*layer.activation_ffw_td)))
+        weights = UnfusedMoEWeights(
+            w1_weight=layer.kernel_gating_EDF.value,
+            w1_weight_scale=layer.kernel_gating_EDF_weight_scale.value,
+            w1_bias=None,
+            w2_weight=layer.kernel_up_proj_EDF.value,
+            w2_weight_scale=layer.kernel_up_proj_EDF_weight_scale.value,
+            w2_bias=None,
+            w3_weight=layer.kernel_down_proj_EFD.value,
+            w3_weight_scale=layer.kernel_down_proj_EFD_weight_scale.value,
+            w3_bias=None,
+        )
+        return moe_apply(layer, x_TD, router_logits, weights,
+                         layer.moe_backend, layer.mesh,
+                         self.extra_backend_kwargs)
 
 
 class Mxfp4Config(QuantizationConfig):

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -12,42 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
 import os
-from abc import abstractmethod
-from dataclasses import InitVar, dataclass
+from dataclasses import dataclass
 from itertools import islice
 from typing import Iterable, List, Optional, Tuple, Union
 
 import jax
 import jax.numpy as jnp
 from flax import nnx
-from flax.typing import Sharding
 from jax import lax
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Float
 from vllm.config import VllmConfig
 
-from tpu_inference import utils
 from tpu_inference.distributed.jax_parallel_state import get_pp_group
-from tpu_inference.kernels.quantized_matmul.util import quantize_tensor
 from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
     ragged_paged_attention
-from tpu_inference.layers.common.attention_interface import mla_attention
 from tpu_inference.layers.common.moe import MoEBackend
-from tpu_inference.layers.common.quantization import (
-    dequantize_tensor, quantize_kv, static_per_tensor_quantize_tensor)
+from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.common.sharding import \
     ShardingAxisNameBase as ShardingAxisName
-from tpu_inference.layers.common.utils import cpu_mesh_context
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.attention.attention import AttentionMetadata
+from tpu_inference.layers.jax.attention.mla import (MLAAttention,
+                                                    MLABaseAttention)
 from tpu_inference.layers.jax.base import _init_fn as init_fn
 from tpu_inference.layers.jax.base import create_param, sharded_initializer
 from tpu_inference.layers.jax.embed import JaxEmbed
 from tpu_inference.layers.jax.layers import FlaxUtils
 from tpu_inference.layers.jax.linear import JaxEinsum, JaxLmHead
+from tpu_inference.layers.jax.mlp import GatedMLP
 from tpu_inference.layers.jax.moe.moe import JaxMoE
 from tpu_inference.layers.jax.moe.utils import (get_expert_parallelism,
                                                 select_moe_backend)
@@ -59,8 +54,7 @@ from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
 from tpu_inference.models.jax.utils.weight_utils import (JaxAutoWeightsLoader,
-                                                         LoadableWithIterator,
-                                                         shard_put)
+                                                         LoadableWithIterator)
 
 KVCache = Tuple[jax.Array, jax.Array]
 
@@ -107,210 +101,10 @@ qk_rope_head_dim = 64
 v_head_dim = 128
 expert_axis_name = ShardingAxisName.ATTN_DATA_EXPERT
 
-
-@dataclass(kw_only=True)
-class DeepseekV3BaseAttention(JaxModule):
-    """
-    Base class containing shared logic for DeepSeek Attention mechanisms.
-    Handles initialization of common layers and defines skeleton forward pass.
-    """
-    # Core configuration
-    hidden_size: int
-    num_attention_heads: int
-    num_key_value_heads: int
-    head_dim: int
-    rope: DeepseekScalingRotaryEmbedding
-    dtype: jnp.dtype
-    kv_cache_dtype: str
-    mesh: Mesh
-
-    # Attention-specific configuration
-    q_lora_rank: int
-    kv_lora_rank: int
-    qk_nope_head_dim: int
-    qk_rope_head_dim: int
-    v_head_dim: int
-    rms_norm_eps: float
-
-    # Sharding
-    rd_sharding: P = P()
-    q_da_sharding: P = P()
-    ap_sharding: P = P()
-    kv_da_sharding: P = P()
-    activation_attention_td: P = P()
-    activation_q_td: P = P()
-    query_nth: P = P()
-    query_tnh: P = P()
-    keyvalue_skh: P = P()
-    attn_o_nth: P = P()
-    activation_attention_out_td: P = P()
-    # Weight initialization
-    random_init: bool = False
-    rope_mscale_all_dim: float = 1.0
-
-    # RNG for weight initialization
-    rngs: InitVar[nnx.Rngs]
-
-    quant_config: Optional[QuantizationConfig] = None
-
-    # Scales for Q/KV quantization (per-tensor)
-    _q_scale: float = 1
-    _k_scale: float = 1
-    _v_scale: float = 1
-
-    prefix: str = ""
-
-    def __post_init__(self, rngs: nnx.Rngs):
-        self.N = self.num_attention_heads
-        self.K = self.num_key_value_heads
-        self.D = self.hidden_size
-        self.qk_head_dim = self.qk_nope_head_dim + self.qk_rope_head_dim
-
-        if self.rope.scaling_factor <= 1.0:
-            yarn_mscale = 1.0
-        else:
-            yarn_mscale = 0.1 * self.rope_mscale_all_dim * math.log(
-                self.rope.scaling_factor) + 1.0
-
-        self.scale = self.qk_head_dim**-0.5 * yarn_mscale**2
-
-        weight_init = _weight_init(self.random_init)
-
-        self.q_a_proj = JaxEinsum(
-            einsum_str="TD,DA->TA",
-            kernel_shape=(self.D, self.q_lora_rank),
-            rngs=rngs,
-            quant_config=self.quant_config,
-            param_dtype=self.dtype,
-            kernel_init=nnx.with_partitioning(weight_init, self.q_da_sharding),
-            prefix=self.prefix + ".q_a_proj",
-        )
-
-        self.q_b_proj = JaxEinsum(
-            einsum_str="TA,AP->TP",
-            kernel_shape=(self.q_lora_rank, self.N * self.qk_head_dim),
-            rngs=rngs,
-            quant_config=self.quant_config,
-            param_dtype=self.dtype,
-            kernel_init=nnx.with_partitioning(weight_init, self.ap_sharding),
-            prefix=self.prefix + ".q_b_proj")
-
-        self.kv_a_proj_with_mqa = JaxEinsum(
-            einsum_str="SD,DA->SA",
-            kernel_shape=(self.D, self.kv_lora_rank + self.qk_rope_head_dim),
-            rngs=rngs,
-            quant_config=self.quant_config,
-            param_dtype=self.dtype,
-            kernel_init=nnx.with_partitioning(weight_init,
-                                              self.kv_da_sharding),
-            prefix=self.prefix + ".kv_a_proj_with_mqa")
-
-        self.o_proj = JaxEinsum(
-            einsum_str="TR,RD->TD",
-            kernel_shape=(self.N * self.v_head_dim, self.D),
-            rngs=rngs,
-            quant_config=self.quant_config,
-            param_dtype=self.dtype,
-            kernel_init=nnx.with_partitioning(weight_init, self.rd_sharding),
-            prefix=self.prefix + ".o_proj")
-
-        self.q_a_layernorm = JaxRmsNorm(self.q_lora_rank,
-                                        epsilon=self.rms_norm_eps,
-                                        scale_init=nnx.with_partitioning(
-                                            init_fn, (None, )),
-                                        param_dtype=self.dtype,
-                                        dtype=self.dtype,
-                                        quant_config=self.quant_config,
-                                        prefix=self.prefix + ".q_a_layernorm",
-                                        rngs=rngs)
-
-        self.kv_a_layernorm = JaxRmsNorm(
-            self.kv_lora_rank,
-            epsilon=self.rms_norm_eps,
-            scale_init=nnx.with_partitioning(init_fn, (None, )),
-            param_dtype=self.dtype,
-            dtype=self.dtype,
-            quant_config=self.quant_config,
-            prefix=self.prefix + ".kv_a_layernorm",
-            rngs=rngs)
-
-        self.kv_cache_quantized_dtype = None
-        if self.kv_cache_dtype != "auto":
-            self.kv_cache_quantized_dtype = utils.get_jax_dtype_from_str_dtype(
-                self.kv_cache_dtype)
-
-        self.kv_b_proj = JaxEinsum(
-            einsum_str="SA,AL->SL",
-            kernel_shape=(self.kv_lora_rank,
-                          self.N * (self.qk_nope_head_dim + self.v_head_dim)),
-            rngs=rngs,
-            quant_config=self.quant_config,
-            param_dtype=self.dtype,
-            kernel_init=nnx.with_partitioning(init_fn, self.ap_sharding),
-            prefix=self.prefix + ".kv_b_proj",
-        )
-
-    @abstractmethod
-    def compute_q_projection(self, *args) -> jax.Array:
-        raise NotImplementedError
-
-    @abstractmethod
-    def compute_kv_projection(self, *args) -> Tuple[jax.Array, jax.Array]:
-        raise NotImplementedError
-
-    @abstractmethod
-    def compute_attention(self, *args) -> Tuple[KVCache, jax.Array]:
-        raise NotImplementedError
-
-    def process_output(self, outputs_TNH) -> jax.Array:
-        return outputs_TNH
-
-    def __call__(
-            self, x: jax.Array, kv_cache: KVCache,
-            attention_metadata: AttentionMetadata
-    ) -> Tuple[KVCache, jax.Array]:
-        """Performs the forward pass of the attention module.  Expects that the
-        child class has implemented the `compute_q_projection`, `compute_kv_projection`,
-        and `compute_attention` methods.
-
-        Args:
-            x: The input tensor of shape `(batch_size, seq_len, d_model)`.
-            kv_cache: The key-value cache for storing past attention states.
-            attention_metadata: Metadata for attention, such as input positions.
-
-        Returns:
-            A tuple containing:
-                - The updated KV cache.
-                - The attention output tensor of shape
-                  `(batch_size, seq_len, d_model)`.
-        """
-
-        md = attention_metadata
-        x = jnp.asarray(x, self.dtype)
-        x_SD = lax.with_sharding_constraint(x, self.activation_attention_td)
-        x_q_TD = lax.with_sharding_constraint(x, self.activation_q_td)
-
-        with jax.named_scope("q_proj"):
-            q_data = self.compute_q_projection(x_q_TD, md.input_positions)
-
-        with jax.named_scope("kv_proj"):
-            kv_data = self.compute_kv_projection(x_SD, md.input_positions)
-
-        with jax.named_scope("attn_op"):
-            new_kv_cache, outputs_TNH = self.compute_attention(
-                q_data, kv_data, kv_cache, md)
-
-            outputs_TNH = self.process_output(outputs_TNH)
-
-            if outputs_TNH.shape[-1] != self.v_head_dim:
-                outputs_TNH = outputs_TNH[..., :self.v_head_dim]
-
-            with jax.named_scope("o_proj"):
-                outputs_TR = outputs_TNH.reshape(outputs_TNH.shape[0],
-                                                 self.N * self.v_head_dim)
-                o_TD = self.o_proj(outputs_TR)
-
-            return new_kv_cache, o_TD
+# MLA lives in the shared layer module so other MLA-family models can
+# reuse it; these aliases keep the DeepSeek-V3 names in place.
+DeepseekV3BaseAttention = MLABaseAttention
+DeepseekV3MLA = MLAAttention
 
 
 @dataclass(kw_only=True)
@@ -477,338 +271,9 @@ class DeepseekV3Attention(DeepseekV3BaseAttention):
         return kv_cache, output_TNH
 
 
-class MLAEinsum(JaxEinsum):
-    """Extending JaxEinsum to handle MLA.
-    
-    This class is used for MLA, where:
-    1) the weight is split into k/v parts after loading, and
-    2) modify the MLA layer to set k/v weights
-    """
-
-    def __init__(self,
-                 mla_layer,
-                 einsum_str: str,
-                 kernel_shape: tuple[int, ...],
-                 rngs,
-                 bias_shape: Optional[tuple[int, ...]] = None,
-                 quant_config: Optional[QuantizationConfig] = None,
-                 prefix: str = "",
-                 **kwargs):
-        super().__init__(einsum_str,
-                         kernel_shape,
-                         rngs,
-                         bias_shape=bias_shape,
-                         quant_config=quant_config,
-                         prefix=prefix,
-                         **kwargs)
-        self.loaded = set()
-        self.mla_layer = mla_layer
-        self.quant_config = quant_config
-
-    def named_children(self):
-        # Override, otherwise "mla_layer" will be visited, causing infinite recursion.
-        yield from []
-
-    def load_weights(self, weights):
-        named_params = dict(self.named_parameters())
-        if len(self.loaded) >= 2:
-            raise ValueError(
-                f"Expect at most 2 params to load for kv_b_proj, already got {self.loaded}, still have {[name for name, _ in weights]} coming."
-            )
-        for name, weight in weights:
-            param = named_params[name]
-            weight_loader = getattr(param, "weight_loader")
-            weight_loader(param, weight)
-            self.loaded.add(name)
-        if len(self.loaded) != len(named_params):
-            return
-        assert self.quant_config is not None
-        # After loading, split the weights into k/v
-        with cpu_mesh_context():
-            dequantized_weight = dequantize_tensor(
-                self.weight,
-                self.weight_scale_inv,
-                (0, 1),
-                block_size=None,
-            )
-            A, N, qk_nope_head_dim, v_head_dim = self.mla_layer.kv_lora_rank, self.mla_layer.N, self.mla_layer.qk_nope_head_dim, self.mla_layer.v_head_dim
-            if dequantized_weight.shape != (A, N *
-                                            (qk_nope_head_dim + v_head_dim)):
-                raise ValueError(
-                    f"Unexpected weight shape after dequantization: {dequantized_weight.shape}, expected {(A, N * (qk_nope_head_dim + v_head_dim))=}"
-                )
-            dequantized_weight = dequantized_weight.reshape(
-                A, N, qk_nope_head_dim + v_head_dim)
-            k_ANH, v_ANH = jnp.split(dequantized_weight, [qk_nope_head_dim],
-                                     axis=-1)
-            k_ANH_weight, k_ANH_scale = quantize_tensor(k_ANH,
-                                                        self.weight.dtype,
-                                                        dim=-1)
-            v_ANH_weight, v_1NH_scale = quantize_tensor(v_ANH,
-                                                        self.weight.dtype,
-                                                        dim=0)
-            # As of writing, sharded_quantized_batched_matmul expects scale to be
-            # a different shape order than weight
-            k_N1A_scale = k_ANH_scale.transpose(1, 2, 0)
-            v_N1H_scale = v_1NH_scale.transpose(1, 0, 2)
-        mla_layer = self.mla_layer
-        setattr(
-            mla_layer, "k_up_proj",
-            JaxEinsum(
-                einsum_str="TNH,ANH->NTA",
-                kernel_shape=(A, N, qk_nope_head_dim),
-                rngs=nnx.Rngs(0),
-                prefix=mla_layer.prefix + ".k_up_proj",
-                quant_config=self.quant_config,
-            ))
-        setattr(
-            mla_layer, "v_up_proj",
-            JaxEinsum(
-                einsum_str="NTA,ANH->TNH",
-                kernel_shape=(A, N, v_head_dim),
-                rngs=nnx.Rngs(0),
-                prefix=mla_layer.prefix + ".v_up_proj",
-                quant_config=self.quant_config,
-            ))
-        # Cannot apply anh_sharding to scales, otherwise it complains about shape mismatch.
-        mla_layer.k_up_proj.weight.value = shard_put(
-            k_ANH_weight, self.mla_layer.anh_sharding)
-        mla_layer.k_up_proj.weight_scale_inv.value = shard_put(k_N1A_scale, ())
-        mla_layer.v_up_proj.weight.value = shard_put(
-            v_ANH_weight, self.mla_layer.anh_sharding)
-        mla_layer.v_up_proj.weight_scale_inv.value = shard_put(v_N1H_scale, ())
-
-        delattr(self, 'weight')
-        delattr(self, 'weight_scale_inv')
-        delattr(self, 'quant_method')
-
-
-@dataclass(kw_only=True)
-class DeepseekV3MLA(DeepseekV3BaseAttention):
-    """Multi-Head Latent Attention (MLA) for DeepSeek V3."""
-    anh_sharding: Sharding = ()
-
-    def __post_init__(self, rngs: nnx.Rngs):
-        super().__post_init__(rngs)
-
-        weight_init = _weight_init(self.random_init)
-        self.kv_b_proj = MLAEinsum(
-            mla_layer=self,
-            einsum_str="SA,AL->SL",
-            kernel_shape=(self.kv_lora_rank,
-                          self.N * (self.qk_nope_head_dim + self.v_head_dim)),
-            rngs=rngs,
-            quant_config=self.quant_config,
-            param_dtype=self.dtype,
-            kernel_init=nnx.with_partitioning(weight_init, self.ap_sharding),
-            prefix=self.prefix + ".kv_b_proj",
-        )
-
-    def compute_q_projection(
-            self, x_q_TD: jax.Array,
-            input_positions: jax.Array) -> Tuple[jax.Array, jax.Array]:
-        """
-        Computes the query projection for MLA.
-
-        Args:
-            x_q_TD: The input tensor of shape `(tokens_query, d_model)`.
-            input_positions: The input positions tensor of shape `(padded_total_num_scheduled_tokens,)`.
-
-        Returns:
-            A tuple of query tensor of shape `(tokens_query, num_query_heads, q_lora_rank)` and
-            rope tensor of shape `(tokens_query, num_query_heads, head_dim)`.
-        """
-        q_TA = self.q_a_proj(x_q_TD)
-        q_TA = self.q_a_layernorm(q_TA)
-        q_TP = self.q_b_proj(q_TA)
-        q_TNH = q_TP.reshape(q_TA.shape[0], self.N, self.qk_head_dim)
-
-        q_nope_TNH = q_TNH[..., :self.qk_nope_head_dim]
-        q_rope_TNH = q_TNH[..., self.qk_nope_head_dim:]
-        q_rope_TNH = self.rope.apply_rope(input_positions, q_rope_TNH)
-
-        q_NTA = self.k_up_proj(q_nope_TNH)
-
-        q_NTA = lax.with_sharding_constraint(q_NTA, self.query_nth)
-        return (q_NTA, q_rope_TNH)
-
-    def compute_kv_projection(
-            self, x_SD: jax.Array,
-            input_positions: jax.Array) -> Tuple[jax.Array, jax.Array]:
-        """
-        Computes the key-value projection for MLA.
-
-        Args:
-            x_SD: The input tensor of shape `(tokens_kv, d_model)`.
-            input_positions: The input positions tensor of shape `(padded_total_num_scheduled_tokens,)`.
-
-        Returns:
-            A tuple of key-value tensor of shape `(tokens_kv, q_lora_rank)` and
-            rope tensor of shape `(tokens_kv, head_dim)`.
-        """
-        kv_SA = self.kv_a_proj_with_mqa(x_SD)
-
-        k_rope_SH = kv_SA[..., self.kv_lora_rank:]
-        k_rope_SNH = k_rope_SH[..., None, :]
-        k_rope_SNH = self.rope.apply_rope(input_positions, k_rope_SNH)
-        assert k_rope_SNH.shape[1] == 1
-        k_rope_SH = k_rope_SNH[:, 0, :]
-
-        kv_SA = kv_SA[..., :self.kv_lora_rank]
-        kv_SA = self.kv_a_layernorm(kv_SA)
-        kv_SA = lax.with_sharding_constraint(kv_SA, self.keyvalue_skh)
-
-        return (kv_SA, k_rope_SH)
-
-    def compute_attention(self, q_data: Tuple[jax.Array, jax.Array],
-                          kv_data: Tuple[jax.Array,
-                                         jax.Array], kv_cache: KVCache,
-                          md: AttentionMetadata) -> Tuple[KVCache, jax.Array]:
-        """
-        Computes the attention for MLA.
-
-        Args:
-            q_data: A tuple of query tensor of shape `(tokens_query, num_query_heads, q_lora_rank)` and
-                rope tensor of shape `(tokens_query, num_query_heads, head_dim)`.
-            kv_data: A tuple of key-value tensor of shape `(tokens_kv, q_lora_rank)` and
-                rope tensor of shape `(tokens_kv, head_dim)`.
-            kv_cache: The key-value cache.
-            md: The attention metadata.
-
-        Returns:
-            A tuple of key-value cache and output tensor of shape `(tokens_query, num_query_heads, q_lora_rank)`.
-        """
-
-        q_NTA, q_rope_TNH = q_data
-        k_SA, k_rope_SH = kv_data
-
-        q_scale = k_scale = None
-        if self.kv_cache_quantized_dtype:
-            k_scale = self._k_scale
-            # TODO: May need to apply quantization separately for k_c & k_pe
-            k_SA, _ = quantize_kv(self.kv_cache_quantized_dtype,
-                                  k_SA,
-                                  value=None,
-                                  k_scale=k_scale)
-            k_rope_SH, _ = quantize_kv(self.kv_cache_quantized_dtype,
-                                       k_rope_SH,
-                                       value=None,
-                                       k_scale=k_scale)
-            q_NTA = static_per_tensor_quantize_tensor(
-                self.kv_cache_quantized_dtype, q_NTA, self._q_scale)
-            q_rope_TNH = static_per_tensor_quantize_tensor(
-                self.kv_cache_quantized_dtype, q_rope_TNH, self._q_scale)
-
-        return mla_attention(q_NTA,
-                             q_rope_TNH,
-                             k_SA,
-                             k_rope_SH,
-                             kv_cache,
-                             md,
-                             self.mesh,
-                             self.num_attention_heads,
-                             self.qk_nope_head_dim,
-                             query_nth_sharding=self.query_nth,
-                             query_tnh_sharding=self.query_tnh,
-                             keyvalue_skh_sharding=self.keyvalue_skh,
-                             attn_o_nth_sharding=self.attn_o_nth,
-                             q_scale=q_scale,
-                             k_scale=k_scale,
-                             v_scale=k_scale,
-                             sm_scale=self.scale)
-
-    def process_output(self, outputs_NTA: jax.Array) -> jax.Array:
-        """
-        Processes output for MLA specifically.
-
-        Args:
-            outputs_NTA: The output tensor of shape `(num_heads, tokens_query, q_lora_rank)`.
-
-        Returns:
-            The processed output tensor of shape `(tokens_query, num_query_heads, head_dim)`.
-        """
-
-        # MLA Specific: Apply V-Up Projection after attention
-        # Outputs from MLA kernel are N-major [N, T, A]; project to T-major [T, N, H]
-        outputs_TNH = self.v_up_proj(outputs_NTA)
-        return outputs_TNH.astype(self.dtype)
-
-
-@dataclass(kw_only=True)
-class DeepseekV3MLP(JaxModule):
-    """A Gated Feed-Forward Network (FFN) layer.
-
-    This module consists of two linear projections (gating and up-projection),
-    an element-wise multiplication of the activated gating projection and the
-    up-projection, followed by a final downward projection.
-
-    Attributes:
-        sharding_cfg: The configuration for tensor sharding.
-    """
-    dtype: jnp.dtype
-    hidden_act: str
-    hidden_size: int
-    intermediate_size: int
-    df_sharding: P = P()
-    fd_sharding: P = P()
-    activation_ffw_td: P = P()
-    random_init: bool = False
-    quant_config: Optional[QuantizationConfig] = None
-
-    rngs: InitVar[nnx.Rngs]
-
-    def __call__(self, x_TD):
-        """Performs the forward pass of the FFW layer.
-
-        Args:
-            x_TD: The input tensor of shape either `(sequence, d_model)`
-
-        Returns:
-            The output tensor of shape `(batch, sequence, d_model)`.
-        """
-        x_TD = jnp.asarray(x_TD, self.dtype)
-        x_TD = lax.with_sharding_constraint(x_TD, self.activation_ffw_td)
-        with jax.named_scope("wi_0"):
-            gating_TF = self.gate_proj(x_TD)
-            activated_gating_TF = modeling_flax_utils.ACT2FN[self.hidden_act](
-                gating_TF)
-        with jax.named_scope("wi_1"):
-            up_proj_TF = self.up_proj(x_TD)
-        fuse_TF = activated_gating_TF * up_proj_TF
-        with jax.named_scope("wo"):
-            output_TD = self.down_proj(fuse_TF)
-
-        return output_TD
-
-    def __post_init__(self, rngs: nnx.Rngs):
-        D = self.hidden_size
-        F = self.intermediate_size
-        weight_init = _weight_init(self.random_init)
-
-        self.gate_proj = JaxEinsum(
-            einsum_str="TD,DF->TF",
-            kernel_shape=(D, F),
-            rngs=rngs,
-            quant_config=self.quant_config,
-            param_dtype=self.dtype,
-            kernel_init=nnx.with_partitioning(weight_init, self.df_sharding),
-        )
-        self.up_proj = JaxEinsum(
-            einsum_str="TD,DF->TF",
-            kernel_shape=(D, F),
-            rngs=rngs,
-            quant_config=self.quant_config,
-            param_dtype=self.dtype,
-            kernel_init=nnx.with_partitioning(weight_init, self.df_sharding),
-        )
-        self.down_proj = JaxEinsum(
-            einsum_str="TF,FD->TD",
-            kernel_shape=(F, D),
-            rngs=rngs,
-            quant_config=self.quant_config,
-            param_dtype=self.dtype,
-            kernel_init=nnx.with_partitioning(weight_init, self.fd_sharding),
-        )
+# The gated FFN lives in the shared layer module so other models can reuse
+# it; this keeps the DeepSeek-V3 name in place.
+DeepseekV3MLP = GatedMLP
 
 
 @dataclass(kw_only=True)
@@ -1035,6 +500,9 @@ class DeepSeekV3Router(JaxEinsum):
             quant_config=None,
             param_dtype=self.dtype,
             kernel_init=nnx.with_partitioning(weight_init, self.ed_sharding),
+            # The gate matmul runs in fp32 (see __call__); HIGHEST keeps it
+            # there on TPU instead of letting XLA drop to a bf16 pass.
+            precision=jax.lax.Precision.HIGHEST,
         )
         self.e_score_correction_bias = create_param(
             rngs,
@@ -1093,7 +561,17 @@ class DeepSeekV3Router(JaxEinsum):
 
         # Expert assignments are accumulated in high precision to preserve accuracy.
         # See: https://github.com/vllm-project/vllm/blob/e89a91d9275cd8ac086fe04476b41675a9ebbd5c/vllm/model_executor/layers/fused_moe/cpu_fused_moe.py#L59
-        logits_TE = super().__call__(x_TD).astype(jnp.float32)
+        #
+        # The reference implementations run the gate itself in fp32 --
+        # `DeepseekV3TopkRouter` / `KimiMoEGate` both do
+        # `F.linear(hidden_states.type(torch.float32), self.weight.type(torch.float32))`
+        # -- so casting only the *output* is not enough: on TPU the fp32 einsum
+        # is otherwise lowered to bf16 multiplies, and experts whose scores are
+        # within bf16 rounding of each other swap places in the top-k. Cast the
+        # activations up front and rely on `precision=HIGHEST` (set in __init__)
+        # for the multiply. The gate is [hidden, num_experts], so this costs
+        # nothing next to the expert matmuls.
+        logits_TE = super().__call__(x_TD.astype(jnp.float32))
 
         # TODO(gpolovets): add back support for DeepSeek routing.
         if self.moe_backend in MoEBackend.fused_moe_backends():

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -571,6 +571,12 @@ class DeepSeekV3Router(JaxEinsum):
         # activations up front and rely on `precision=HIGHEST` (set in __init__)
         # for the multiply. The gate is [hidden, num_experts], so this costs
         # nothing next to the expert matmuls.
+        #
+        # NOTE: this is a deliberate precision/behavior change to the existing
+        # DeepSeek-V3 path (it previously ran the gate matmul in bf16 and only
+        # cast the logits to fp32 afterwards): near-tie top-k routing decisions
+        # can differ, so DSv3 nightly baselines may shift slightly. A routing
+        # parity test pinning fp32 gate behavior lands with the K3 model.
         logits_TE = super().__call__(x_TD.astype(jnp.float32))
 
         # TODO(gpolovets): add back support for DeepSeek routing.


### PR DESCRIPTION
Piece 4 of 6 of the Kimi-K3 enablement stack. Adds the KDA attention layer (layers/common/kda_attention.py, head-sharded, on top of the split-1 kernels and split-2 metadata contract) and the shared JAX layer work the K3 model builds on: MLA and GatedMLP extracted from deepseek_v3.py into layers/jax/attention/mla.py and layers/jax/mlp.py, the SiTU gated activation (layers/jax/activation.py) wired through the dense/sparse MoE backends, quantized-expert (value, scale) kernel plumbing in the MoE GMM path, and einsum precision opt-in in linear.py — plus their tests. Depends on split 3/6 (its base branch). The full stack was validated end-to-end in #3292: CI green, gsm8k 0.976.

## Behavior change to existing DeepSeek-V3

The DeepSeek-V3 MoE router gate now computes in fp32 with `jax.lax.Precision.HIGHEST` (router `__call__` in `models/jax/deepseek_v3.py`, via the new `precision` opt-in in `layers/jax/linear.py`). Previously the gate matmul ran in bf16 and only the output logits were cast to fp32. This is a deliberate numeric change, not just an opt-in mechanism: the K3-family router picks among near-tie expert scores, and on TPU the bf16-lowered gate matmul flips top-k routing for experts whose scores are within bf16 rounding of each other — the HF reference implementations (`DeepseekV3TopkRouter`, `KimiMoEGate`) run the gate itself in fp32. A routing-parity test that pins the fp32 gate behavior arrives in split 5/6. As a result, existing DeepSeek-V3 nightly baselines may shift slightly.
