### PR TITLE
[DO NOT REVIEW] K3 split 5/6: Kimi model

### DIFF
--- a/.buildkite/scripts/fetch_k3_tiny_fixtures.sh
+++ b/.buildkite/scripts/fetch_k3_tiny_fixtures.sh
@@ -1,0 +1,54 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Fetches the Kimi-K3 test checkpoints into the persistent HF cache and exports
+# the paths the Kimi test suites read.
+#
+# SOURCE this script, do not execute it -- it only has an effect through the
+# variables it exports:
+#
+#   source .buildkite/scripts/fetch_k3_tiny_fixtures.sh
+#   .buildkite/scripts/run_in_docker.sh bash -c "python3 -m pytest ..."
+#
+# The checkpoints hold random weights on the Kimi-K3 text-stack architecture
+# plus goldens captured from the HF reference implementation; they are ~1.4 GiB
+# in total, which is why they live in GCS rather than in the repo. Every suite
+# that reads them skips when its variable is empty or points nowhere, so a
+# failed or skipped fetch degrades to the same coverage as before this script
+# existed rather than to a red build.
+#
+# Kimi-K3 needs a TPU generation with the MLA and KDA kernels, so the fetch is
+# a no-op anywhere except tpu7x and the suites skip there.
+
+K3_FIXTURES_GCS="${K3_FIXTURES_GCS:-gs://tpu-commons-ci/moonshootai/kimi/k3-tiny-fixtures}"
+# run_in_docker.sh mounts /mnt/disks/persist/models at /tmp/hf_home, so the
+# same directory has two names; the exported paths must be the container's.
+K3_FIXTURES_HOST_DIR="${K3_FIXTURES_HOST_DIR:-/mnt/disks/persist/models/k3-tiny-fixtures}"
+K3_FIXTURES_DOCKER_DIR="${K3_FIXTURES_DOCKER_DIR:-/tmp/hf_home/k3-tiny-fixtures}"
+
+if [[ "${TPU_VERSION:-tpu6e}" != "tpu7x" ]]; then
+  echo "[k3-fixtures] TPU_VERSION=${TPU_VERSION:-tpu6e}, skipping fetch"
+elif ! mkdir -p "${K3_FIXTURES_HOST_DIR}" ||
+  ! gcloud storage rsync -r "${K3_FIXTURES_GCS}" "${K3_FIXTURES_HOST_DIR}"; then
+  echo "[k3-fixtures] fetch FAILED from ${K3_FIXTURES_GCS}; the Kimi suites" \
+    "will skip. Check bucket permissions for this agent."
+else
+  export K3_TINY_CKPT="${K3_FIXTURES_DOCKER_DIR}/k3-tiny"
+  export K3_TINY_MXFP4_CKPT="${K3_FIXTURES_DOCKER_DIR}/k3-tiny-mxfp4"
+  export K3_TINY_SOFTPLUS_CKPT="${K3_FIXTURES_DOCKER_DIR}/k3-tiny-softplus"
+  export K3_KDA_GOLDENS="${K3_FIXTURES_DOCKER_DIR}/k3-tiny/kda_op_goldens.npz"
+  echo "[k3-fixtures] ready: $(du -sh "${K3_FIXTURES_HOST_DIR}" | cut -f1) at" \
+    "${K3_FIXTURES_DOCKER_DIR} (in container)"
+fi

--- a/tests/e2e/test_kimi_hybrid_e2e.py
+++ b/tests/e2e/test_kimi_hybrid_e2e.py
@@ -1,0 +1,185 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""End-to-end serving for the Kimi hybrid stack (KDA + MLA in one model).
+
+This is the first JAX-native model whose layers do not all take the same kind
+of KV cache: the KDA layers own recurrent state in the mamba pool while the
+MLA layers use the paged attention cache. The checks here are about that
+plumbing surviving a real engine step -- spec emission, per-layer slot
+mapping, slot assignment across a batch, slot reuse after a request finishes.
+
+Every assertion is structural or self-consistent; none compares tokens against
+the reference implementation. See
+`test_concurrent_requests_get_distinct_state_slots` for why a random-weight
+fixture in bf16 cannot support a token-level comparison.
+
+Set ``K3_TINY_CKPT`` to a Kimi-shaped checkpoint directory containing
+``goldens_run1.npz``; the tests skip when it is unset.
+"""
+
+import os
+
+import numpy as np
+import pytest
+from vllm import LLM, SamplingParams
+from vllm.inputs import TokensPrompt
+
+CKPT = os.environ.get("K3_TINY_CKPT", "")
+TP = int(os.environ.get("K3_E2E_TP", "1"))
+
+# Guard on the directory, not just the variable: CI points the variable at
+# a cache directory whose contents are fetched separately.
+pytestmark = pytest.mark.skipif(not CKPT or not os.path.isdir(CKPT),
+                                reason="K3_TINY_CKPT unset or not a directory")
+
+
+@pytest.fixture(scope="module")
+def goldens():
+    return np.load(os.path.join(CKPT, "goldens_run1.npz"))
+
+
+@pytest.fixture(scope="module")
+def llm():
+    engine = LLM(
+        model=CKPT,
+        trust_remote_code=True,
+        # Everything here is driven by the reference capture's token ids, and
+        # the fixture checkpoint ships no tokenizer.
+        skip_tokenizer_init=True,
+        max_model_len=256,
+        max_num_batched_tokens=256,
+        max_num_seqs=8,
+        tensor_parallel_size=TP,
+        # Prefix caching is off: recurrent state is not block-addressable, so
+        # a cache hit would skip the prefill that builds it.
+        enable_prefix_caching=False,
+        additional_config={
+            "sharding": {
+                "sharding_strategy": {
+                    "enable_dp_attention": True
+                }
+            }
+        },
+    )
+    try:
+        yield engine
+    finally:
+        engine.llm_engine.engine_core.shutdown()
+
+
+def _greedy(llm, prompt_ids, n):
+    out = llm.generate([TokensPrompt(prompt_token_ids=list(prompt_ids))],
+                       SamplingParams(temperature=0.0,
+                                      max_tokens=n,
+                                      ignore_eos=True))
+    return [int(t) for t in out[0].outputs[0].token_ids]
+
+
+def _model_runner(llm):
+    """The in-process model runner, or None when the engine runs out of
+    process (multiproc executor) and cannot be introspected directly."""
+    node = llm.llm_engine.engine_core
+    for attr in ("engine_core", "model_executor", "driver_worker",
+                 "model_runner"):
+        node = getattr(node, attr, None)
+        if node is None:
+            return None
+    return node
+
+
+def test_hybrid_cache_layout_is_per_layer(llm):
+    """The KDA layers must hold recurrent state (a tuple of arrays) and the
+    MLA layers a paged attention array -- a model-wide `use_mla` would give
+    every layer the same kind."""
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    runner = _model_runner(llm)
+    if runner is None:
+        pytest.skip("engine runs out of process; runner not introspectable")
+    spec = runner.get_kv_cache_spec()
+    mamba_layers = {n for n, s in spec.items() if isinstance(s, MambaSpec)}
+    assert mamba_layers, "no recurrent layers: hybrid spec emission is off"
+    assert len(mamba_layers) < len(spec), "every layer came out recurrent"
+
+    index = runner.layer_name_to_kvcache_index
+    assert len(index) == len(spec)
+    # Distinct arrays for distinct layers, and of the right kind each.
+    assert sorted(index.values()) == list(range(len(runner.kv_caches)))
+    for name, idx in index.items():
+        entry = runner.kv_caches[idx]
+        assert isinstance(entry, tuple) == (name in mamba_layers), (
+            f"{name} -> kv_caches[{idx}] is the wrong kind of cache")
+
+
+def test_concurrent_requests_get_distinct_state_slots(llm, goldens):
+    """Concurrent requests must each occupy their own mamba slot.
+
+    Counted structurally, from how many slots hold live recurrent state, so
+    the check does not depend on arithmetic. Nothing token-level is asserted
+    against the reference anywhere in this file: on a random-weight fixture in
+    bf16 the reference logits are near-degenerate (top-1 leads top-2 by
+    0.03-0.11 across these positions, and a bf16 forward moves them by more
+    than that), so argmax agreement flips with batch shape -- the same prompt
+    can return different tokens batched vs alone purely from padding changing
+    XLA's reduction order. The offline harness reproduces the same divergence
+    with no engine involved. Token-level fidelity is gated on the real-weight
+    model, whose margins are orders of magnitude wider.
+    """
+    from vllm.v1.kv_cache_interface import MambaSpec
+
+    runner = _model_runner(llm)
+    if runner is None:
+        pytest.skip("engine runs out of process; runner not introspectable")
+
+    prompt_ids = [int(t) for t in goldens["d32.input_ids"][0]]
+    n_req = 4
+    prompts = [
+        TokensPrompt(prompt_token_ids=prompt_ids[:16 + 4 * i])
+        for i in range(n_req)
+    ]
+    llm.generate(prompts, SamplingParams(temperature=0.0, max_tokens=1))
+
+    spec = runner.get_kv_cache_spec()
+    mamba_layers = [n for n, s in spec.items() if isinstance(s, MambaSpec)]
+    assert mamba_layers
+    for name in mamba_layers:
+        recurrent = np.asarray(
+            runner.kv_caches[runner.layer_name_to_kvcache_index[name]][-1])
+        live = [
+            slot for slot in range(recurrent.shape[0])
+            if np.abs(recurrent[slot]).max() > 0
+        ]
+        print(f"[observed] {name}: live slots {live}")
+        assert len(live) == n_req, (
+            f"{name}: {n_req} concurrent requests occupied {len(live)} "
+            f"recurrent slots ({live}) -- slots are being shared")
+        assert 0 not in live, (
+            f"{name}: slot 0 is the null block and must stay zero")
+
+
+def test_repeated_requests_reset_the_recurrent_state(llm, goldens):
+    """A finished request's slot is recycled. The same prompt run twice must
+    give the same tokens both times -- otherwise state from the previous
+    occupant leaked into the new request.
+
+    Self-consistency, so it holds at any dtype."""
+    prompt_ids = [int(t) for t in goldens["d32.input_ids"][0]]
+    n = len(goldens["d32.greedy_tokens"][0])
+    first = _greedy(llm, prompt_ids, n)
+    # Churn the slot pool with other requests in between.
+    _greedy(llm, list(reversed(prompt_ids)), n)
+    second = _greedy(llm, prompt_ids, n)
+    assert first == second, (
+        "the same prompt decoded differently after the slot was recycled: "
+        "recurrent state is not being reset on slot reuse")

--- a/tests/layers/common/test_kda_attention_dp.py
+++ b/tests/layers/common/test_kda_attention_dp.py
@@ -22,9 +22,11 @@ length nor the right values, which is why `kda_attention` runs its
 state-carrying part inside a `shard_map` over `ShardingAxisName.ATTN_DATA` —
 the same treatment `run_jax_gdn_attention` gives the GDN kernel.
 
-Slot ids in the packed metadata are GLOBAL (rank k allocates out of
-`[k * local_slots, (k + 1) * local_slots)`), so the shard_map also has to
-rebase them onto each rank's shard of the state pool.
+Slot ids in the packed metadata are rank-local: the runner rebases the
+globally allocated slot ids per DP rank (`global % local_slots` in
+`TPURunner._prepare_inputs`) before publishing
+`AttentionMetadata.mamba_state_indices`, so each rank's slice of the packed
+array indexes that rank's shard of the state pool directly.
 """
 
 import jax
@@ -96,11 +98,12 @@ def _params():
     )
 
 
-def _rank_inputs(rank, has_init_flags, global_slots):
+def _rank_inputs(rank, has_init_flags):
     """One rank's view: tokens, its shard of the state pool, its metadata.
 
-    `global_slots` selects whether the slot ids are the global ones the runner
-    publishes (`rank * BLOCKS_PER_RANK + i`) or rank-local ones.
+    Slot ids are rank-local (slots 1..REQS_PER_RANK), exactly as the runner
+    publishes them in `AttentionMetadata.mamba_state_indices` (it rebases
+    global slot ids per DP rank before publishing).
     """
     rngs = iter(jax.random.split(jax.random.key(200 + rank), 8))
     x = jax.random.normal(next(rngs), (TOKENS_PER_RANK, HIDDEN), jnp.float32)
@@ -110,7 +113,6 @@ def _rank_inputs(rank, has_init_flags, global_slots):
         s = jax.random.normal(next(rngs), shape, jnp.float32) * 0.1
         return s.at[0].set(0.0)  # null block
 
-    base = rank * BLOCKS_PER_RANK if global_slots else 0
     return dict(
         x=x,
         state=KDAState(
@@ -120,9 +122,7 @@ def _rank_inputs(rank, has_init_flags, global_slots):
             recurrent=state((BLOCKS_PER_RANK, H, D, D)),
         ),
         query_start_loc=jnp.asarray([0] + list(np.cumsum(LENGTHS)), jnp.int32),
-        state_indices=jnp.arange(base + 1,
-                                 base + REQS_PER_RANK + 1,
-                                 dtype=jnp.int32),
+        state_indices=jnp.arange(1, REQS_PER_RANK + 1, dtype=jnp.int32),
         distribution=jnp.asarray([0, 0, REQS_PER_RANK], jnp.int32),
         has_initial_state=jnp.asarray(has_init_flags, jnp.int32),
     )
@@ -163,15 +163,12 @@ def _packed_state(per_rank):
 def test_kda_attention_dp_matches_per_rank_single_device_runs(dp_mesh):
     """The sharded call over packed metadata == each rank running alone."""
     params = _params()
-    per_rank = [
-        _rank_inputs(r, FLAGS[r], global_slots=True) for r in range(DP_SIZE)
-    ]
+    per_rank = [_rank_inputs(r, FLAGS[r]) for r in range(DP_SIZE)]
 
-    # Reference: each rank alone, on rank-local slot ids (what that rank's
-    # shard of the pool is indexed by).
+    # Reference: each rank alone, on the same rank-local slot ids.
     ref = []
     for rank in range(DP_SIZE):
-        local = dict(_rank_inputs(rank, FLAGS[rank], global_slots=False))
+        local = dict(_rank_inputs(rank, FLAGS[rank]))
         new_state, out = jax.jit(lambda i, p: _call(i, p))(local, params)
         ref.append((new_state, np.asarray(out)))
 
@@ -213,10 +210,7 @@ def test_kda_attention_dp_isolates_ranks(dp_mesh):
     params = _params()
 
     def run(flags):
-        per_rank = [
-            _rank_inputs(r, flags[r], global_slots=True)
-            for r in range(DP_SIZE)
-        ]
+        per_rank = [_rank_inputs(r, flags[r]) for r in range(DP_SIZE)]
         packed = dict(
             x=_pack(per_rank, "x"),
             state=_packed_state(per_rank),
@@ -242,9 +236,7 @@ def test_kda_attention_packed_metadata_needs_the_shard_map():
     """Without the shard_map the packed layout is a shape error, not a
     silently wrong number — this pins the failure the 48B hit."""
     params = _params()
-    per_rank = [
-        _rank_inputs(r, FLAGS[r], global_slots=True) for r in range(DP_SIZE)
-    ]
+    per_rank = [_rank_inputs(r, FLAGS[r]) for r in range(DP_SIZE)]
     packed = dict(
         x=_pack(per_rank, "x"),
         state=_packed_state(per_rank),

--- a/tests/layers/jax/attention/test_mla_extraction.py
+++ b/tests/layers/jax/attention/test_mla_extraction.py
@@ -1,0 +1,379 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""No-regression checks for the shared MLA layer.
+
+`MLAAttention` was extracted from the DeepSeek-V3 model file. These tests
+pin the DeepSeek-V3 behaviour of that layer (parameter set, creation order,
+and forward numerics through the real MLA kernel) so the extraction and the
+Kimi-family feature flags cannot silently change it.
+"""
+
+import contextlib
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import torch
+from flax import nnx
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+from vllm.model_executor.models import utils as vllm_model_utils
+
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
+from tpu_inference.layers.common.sharding import ShardingAxisNameBase as Axis
+from tpu_inference.layers.jax import JaxModule
+from tpu_inference.layers.jax.attention.mla import MLAAttention
+from tpu_inference.layers.jax.rope import DeepseekScalingRotaryEmbedding
+from tpu_inference.models.jax.kimi_k3 import attach_default_weight_loaders
+from tpu_inference.models.jax.utils.weight_utils import JaxAutoWeightsLoader
+from tpu_inference.utils import align_to
+
+HIDDEN = 256
+N_HEADS = 16
+QK_NOPE, QK_ROPE, V_HEAD = 64, 32, 64
+Q_LORA, KV_LORA = 128, 64
+SEQ_LEN = 32
+ROPE_SCALING = {
+    "beta_fast": 32,
+    "beta_slow": 1,
+    "factor": 40,
+    "mscale": 1.0,
+    "mscale_all_dim": 1.0,
+    "original_max_position_embeddings": 4096,
+    "type": "yarn",
+}
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    devices = np.array(jax.devices()[:1]).reshape((1, ) * len(MESH_AXIS_NAMES))
+    return Mesh(devices, axis_names=MESH_AXIS_NAMES)
+
+
+def _rope():
+    """Same construction DeepSeek-V3 uses (deepseek_v3.py:722)."""
+    rope = DeepseekScalingRotaryEmbedding(
+        rotary_dim=QK_ROPE,
+        rope_theta=10000,
+        original_max_position_embeddings=ROPE_SCALING[
+            "original_max_position_embeddings"],
+        scaling_factor=ROPE_SCALING["factor"],
+        dtype=jnp.float32,
+        beta_fast=ROPE_SCALING["beta_fast"],
+        beta_slow=ROPE_SCALING["beta_slow"],
+        mscale_value=ROPE_SCALING["mscale"],
+        mscale_all_dim=ROPE_SCALING["mscale_all_dim"],
+    )
+    rope.initialize_cache()
+    return rope
+
+
+def _build(mesh,
+           *,
+           q_lora_rank=Q_LORA,
+           use_nope=False,
+           use_output_gate=False,
+           seed=42):
+    return MLAAttention(
+        hidden_size=HIDDEN,
+        num_attention_heads=N_HEADS,
+        num_key_value_heads=N_HEADS,
+        head_dim=V_HEAD,
+        dtype=jnp.float32,
+        kv_cache_dtype="auto",
+        mesh=mesh,
+        q_lora_rank=q_lora_rank,
+        kv_lora_rank=KV_LORA,
+        qk_nope_head_dim=QK_NOPE,
+        qk_rope_head_dim=QK_ROPE,
+        v_head_dim=V_HEAD,
+        rms_norm_eps=1e-6,
+        rope=None if use_nope else _rope(),
+        use_nope=use_nope,
+        use_output_gate=use_output_gate,
+        rngs=nnx.Rngs(seed),
+        random_init=True,
+        query_nth=P(None, Axis.MLP_TENSOR, None),
+        query_tnh=P(None, Axis.MLP_TENSOR, None),
+        keyvalue_skh=P(None, Axis.MLP_TENSOR),
+        attn_o_nth=P(None, Axis.MLP_TENSOR, None),
+        q_da_sharding=P(None, Axis.VOCAB),
+        ap_sharding=P(None, Axis.MLP_TENSOR),
+        kv_da_sharding=P(None, Axis.VOCAB),
+        rd_sharding=P(Axis.MLP_TENSOR, None),
+    )
+
+
+# Parameter set + creation order of the DeepSeek-V3 configuration. Captured
+# from the layer as it existed in the model file before the extraction, and
+# verified to be name-for-name, order-for-order, and bit-for-bit identical to
+# what the extracted layer builds from the same rngs seed.
+DSV3_PARAM_NAMES = [
+    "q_a_proj.weight",
+    "q_b_proj.weight",
+    "kv_a_proj_with_mqa.weight",
+    "o_proj.weight",
+    "q_a_layernorm.weight",
+    "kv_a_layernorm.weight",
+    "kv_b_proj.weight",
+]
+
+
+def test_dsv3_parameter_set_and_order_unchanged(mesh):
+    """The extraction must not add, drop, or reorder DeepSeek-V3 params.
+
+    Order matters beyond bookkeeping: nnx.Rngs is stateful, so a reordered
+    constructor changes every random-init weight downstream of it.
+    """
+    with jax.set_mesh(mesh):
+        layer = _build(mesh)
+    names = [n for n, _ in layer.named_parameters()]
+    assert names == DSV3_PARAM_NAMES, (
+        f"[mla] DeepSeek-V3 parameter set/order changed.\n"
+        f"  expected: {DSV3_PARAM_NAMES}\n  actual:   {names}")
+
+
+def test_dsv3_flags_default_off(mesh):
+    """DeepSeek-V3 must not pick up any Kimi-family behaviour by default."""
+    with jax.set_mesh(mesh):
+        layer = _build(mesh)
+    assert layer.use_nope is False
+    assert layer.use_output_gate is False
+    assert not hasattr(layer, "g_proj")
+    assert hasattr(layer, "q_a_proj") and not hasattr(layer, "q_proj")
+    # YaRN mscale correction is applied for the rope path.
+    assert layer.scale != (QK_NOPE + QK_ROPE)**-0.5
+
+
+def test_nope_uses_plain_scale_and_no_rope(mesh):
+    with jax.set_mesh(mesh):
+        layer = _build(mesh, use_nope=True)
+    assert layer.rope is None
+    assert layer.scale == pytest.approx((QK_NOPE + QK_ROPE)**-0.5)
+
+
+def test_no_q_lora_uses_fused_q_proj(mesh):
+    """Kimi-Linear-48B has q_lora_rank=null."""
+    with jax.set_mesh(mesh):
+        layer = _build(mesh, q_lora_rank=None)
+    names = [n for n, _ in layer.named_parameters()]
+    assert "q_proj.weight" in names
+    assert not any(n.startswith("q_a_") or n.startswith("q_b_") for n in names)
+
+
+def test_output_gate_adds_only_g_proj(mesh):
+    with jax.set_mesh(mesh):
+        base = _build(mesh)
+        gated = _build(mesh, use_output_gate=True)
+    base_names = {n for n, _ in base.named_parameters()}
+    gated_names = {n for n, _ in gated.named_parameters()}
+    assert gated_names - base_names == {"g_proj.weight"}
+    assert base_names - gated_names == set()
+
+
+def _kv_b_split(layer):
+    """Run the unquantized kv_b_proj -> k_up/v_up split (normally driven by
+    the weight loader) so the absorbed forward can run."""
+    layer.kv_b_proj.loaded.add("weight")
+    layer.kv_b_proj._split_unquantized()
+
+
+def _metadata(seq_len, pages=8):
+    return AttentionMetadata(
+        input_positions=jnp.arange(seq_len, dtype=jnp.int32),
+        block_tables=jnp.arange(pages, dtype=jnp.int32),
+        seq_lens=jnp.array([seq_len], dtype=jnp.int32),
+        query_start_loc=jnp.array([0, seq_len], dtype=jnp.int32),
+        request_distribution=jnp.array([0, 0, 1], dtype=jnp.int32),
+        padded_num_reqs=1,
+    )
+
+
+@pytest.mark.parametrize("use_nope,use_output_gate", [
+    (False, False),
+    (True, False),
+    (True, True),
+])
+def test_forward_runs_and_is_deterministic(mesh, use_nope, use_output_gate):
+    """Forward through the real MLA kernel, for the DeepSeek-V3 config and
+    the Kimi-family flag combinations."""
+    import tpu_inference.kernels.mla.v1.kernel as mla_kernel
+    with jax.set_mesh(mesh):
+        layer = _build(mesh,
+                       use_nope=use_nope,
+                       use_output_gate=use_output_gate)
+        _kv_b_split(layer)
+
+        num_blocks, block_size = 8, 16
+        # The MLA cache lays out the latent and the shared ("rope") dims
+        # each padded to 128, so its width is the sum of the aligned dims,
+        # not the sum of the raw ones (kv_cache_manager.py:469-478).
+        kv_dim = align_to(KV_LORA, 128) + align_to(QK_ROPE, 128)
+        cache_shape = mla_kernel.get_kv_cache_shape(num_blocks, block_size,
+                                                    kv_dim, jnp.float32)
+        kv_cache = jnp.zeros(cache_shape, dtype=jnp.float32)
+        x = jax.random.normal(jax.random.PRNGKey(0), (SEQ_LEN, HIDDEN),
+                              dtype=jnp.float32) * 0.05
+
+        _, out_a = layer(x, kv_cache, _metadata(SEQ_LEN))
+        _, out_b = layer(x, jnp.zeros_like(kv_cache), _metadata(SEQ_LEN))
+
+    assert out_a.shape == (SEQ_LEN, HIDDEN)
+    assert jnp.isfinite(out_a).all(), "[mla] non-finite attention output"
+    np.testing.assert_array_equal(np.asarray(out_a), np.asarray(out_b))
+
+
+def test_output_gate_scales_output(mesh):
+    """The K3 output gate must actually multiply the attention output by
+    sigmoid(g_proj(x)) -- i.e. shrink it, since sigmoid < 1."""
+    import tpu_inference.kernels.mla.v1.kernel as mla_kernel
+    with jax.set_mesh(mesh):
+        plain = _build(mesh, use_nope=True, use_output_gate=False, seed=7)
+        gated = _build(mesh, use_nope=True, use_output_gate=True, seed=7)
+        # Copy the shared weights so the only difference is the gate.
+        gated_params = dict(gated.named_parameters())
+        for name, param in plain.named_parameters():
+            gated_params[name].value = param.value
+        _kv_b_split(plain)
+        _kv_b_split(gated)
+        # k_up/v_up are derived after the copy, so redo them for `gated`.
+        num_blocks, block_size = 8, 16
+        # The MLA cache lays out the latent and the shared ("rope") dims
+        # each padded to 128, so its width is the sum of the aligned dims,
+        # not the sum of the raw ones (kv_cache_manager.py:469-478).
+        kv_dim = align_to(KV_LORA, 128) + align_to(QK_ROPE, 128)
+        cache_shape = mla_kernel.get_kv_cache_shape(num_blocks, block_size,
+                                                    kv_dim, jnp.float32)
+        kv_cache = jnp.zeros(cache_shape, dtype=jnp.float32)
+        x = jax.random.normal(jax.random.PRNGKey(1), (SEQ_LEN, HIDDEN),
+                              dtype=jnp.float32) * 0.05
+        _, out_plain = plain(x, kv_cache, _metadata(SEQ_LEN))
+        _, out_gated = gated(x, jnp.zeros_like(kv_cache), _metadata(SEQ_LEN))
+
+    assert not np.allclose(np.asarray(out_plain), np.asarray(out_gated)), (
+        "[mla] use_output_gate=True produced identical output to the "
+        "ungated layer; the gate is not being applied")
+
+
+class _SingleLayerModel(JaxModule):
+    """Smallest model shape the recursive auto-loader will walk into.
+
+    `AutoWeightsLoader` never calls `load_weights` on the root module (that is
+    how it avoids recursing into itself), so reaching `MLAEinsum.load_weights`
+    the way a real load does requires the layer to sit under a parent.
+    """
+
+    def __init__(self, attention):
+        super().__init__()
+        self.self_attn = attention
+
+
+_KV_B_PROJ_WEIGHT = "self_attn.kv_b_proj.weight"
+_UNCOLLECTED_WARNING = "Unable to collect loaded parameters"
+
+
+def _loadable_model(mesh):
+    """An MLA layer under a parent, wired the way a Kimi model wires it.
+
+    `attach_default_weight_loaders` is what the model does before handing
+    itself to the auto-loader; without it the loader would try to infer a
+    3-D MHA layout for the 2-D `o_proj`.
+    """
+    model = _SingleLayerModel(_build(mesh))
+    attach_default_weight_loaders(model)
+    return model
+
+
+def _kv_b_proj_checkpoint_weight(layer):
+    """The one checkpoint tensor `MLAEinsum` consumes.
+
+    Built in the checkpoint's `[out, in]` orientation, which the loader
+    transposes into the layer's `[in, out]` kernel.
+    """
+    rows, cols = layer.kv_b_proj.weight.get_value().shape
+    return torch.arange(rows * cols, dtype=torch.float32).reshape(cols,
+                                                                  rows) * 1e-4
+
+
+@contextlib.contextmanager
+def _captured_auto_loader_logs(caplog):
+    """Capture the auto-loader's own logger.
+
+    vLLM configures the `vllm` logger with `propagate=False`, so its records
+    never reach the root logger `caplog` installs on; attach caplog's handler
+    to the emitting logger directly.
+    """
+    logger = vllm_model_utils.logger
+    logger.addHandler(caplog.handler)
+    try:
+        yield
+    finally:
+        logger.removeHandler(caplog.handler)
+
+
+def test_kv_b_proj_load_weights_reports_the_names_it_loaded(mesh, caplog):
+    """`load_weights` must return its loaded names, not None.
+
+    vLLM's `AutoWeightsLoader._load_module` treats a None return from a child
+    module's `load_weights` as "this module cannot report what it loaded" and
+    logs a WARNING that interpolates the module's entire repr -- for an nnx
+    module that is the whole parameter tree, once per MLA layer, on every load
+    that goes through the auto-loader. The names are module-local; the caller
+    qualifies them with the module prefix.
+    """
+    with jax.set_mesh(mesh):
+        model = _loadable_model(mesh)
+        weight = _kv_b_proj_checkpoint_weight(model.self_attn)
+        loader = JaxAutoWeightsLoader(model)
+        with _captured_auto_loader_logs(caplog):
+            loaded = loader.load_weights([(_KV_B_PROJ_WEIGHT, weight)])
+
+    assert loaded == {_KV_B_PROJ_WEIGHT
+                      }, (f"[mla] auto-loader collected {loaded}, expected "
+                          f"{{{_KV_B_PROJ_WEIGHT!r}}}")
+    uncollected = [
+        record for record in caplog.records
+        if _UNCOLLECTED_WARNING in record.getMessage()
+    ]
+    assert not uncollected, (
+        "[mla] the auto-loader still could not collect kv_b_proj's loaded "
+        "parameters:\n" + "\n".join(r.getMessage() for r in uncollected))
+
+
+def test_kv_b_proj_load_weights_still_loads_and_splits(mesh):
+    """The bookkeeping fix must not disturb the load itself.
+
+    Same drive as above, checking the parts that were already working: the
+    checkpoint tensor lands in `kv_b_proj`, the fused weight is split into the
+    absorbed `k_up_proj`/`v_up_proj` the forward runs on, and the fused
+    parameter is released.
+    """
+    with jax.set_mesh(mesh):
+        model = _loadable_model(mesh)
+        attention = model.self_attn
+        weight = _kv_b_proj_checkpoint_weight(attention)
+        JaxAutoWeightsLoader(model).load_weights([(_KV_B_PROJ_WEIGHT, weight)])
+
+    assert not hasattr(attention.kv_b_proj, "weight"), (
+        "[mla] kv_b_proj.weight should be released once it is split")
+    k_up = np.asarray(attention.k_up_proj.weight.get_value())
+    v_up = np.asarray(attention.v_up_proj.weight.get_value())
+    assert k_up.shape == (KV_LORA, N_HEADS, QK_NOPE)
+    assert v_up.shape == (KV_LORA, N_HEADS, V_HEAD)
+
+    fused = weight.numpy().T.reshape(KV_LORA, N_HEADS, QK_NOPE + V_HEAD)
+    np.testing.assert_array_equal(k_up, fused[..., :QK_NOPE])
+    np.testing.assert_array_equal(v_up, fused[..., QK_NOPE:])

--- a/tests/models/common/test_model_loader.py
+++ b/tests/models/common/test_model_loader.py
@@ -34,6 +34,7 @@ from tpu_inference.distributed.jax_parallel_state import \
     init_pp_distributed_environment
 from tpu_inference.models.common import model_loader
 from tpu_inference.models.jax.qwen3 import Qwen3ForCausalLM
+from tpu_inference.models.jax.utils.weight_utils import LoadableWithIterator
 
 
 class MockModelA:
@@ -540,3 +541,122 @@ class TestGetModel:
         mock_get_vllm.assert_called_once_with(vllm_config, rng, mesh, False,
                                               None)
         assert result == "vllm_model_sentinel"
+
+
+class TestResolveModelArchitectureWithRunaiStreamer:
+    """`--load-format runai_streamer` must not silently change implementation.
+
+    Under `MODEL_IMPL_TYPE=auto` the streamer check decides whether a model is
+    served by its flax_nnx implementation or by vLLM's. Getting it wrong is not
+    an error, it is a different model implementation running than the one the
+    architecture registers, so each capability the loader actually supports is
+    pinned here.
+    """
+
+    @staticmethod
+    def _config(architecture: str, load_format: str) -> MagicMock:
+        config = MagicMock(spec=VllmConfig)
+        config.model_config = MagicMock()
+        config.model_config.hf_config = PretrainedConfig(
+            architectures=[architecture])
+        config.load_config = MagicMock()
+        config.load_config.load_format = load_format
+        return config
+
+    @pytest.mark.parametrize("architecture", [
+        "DeepseekV3ForCausalLM",
+        "KimiK3ForConditionalGeneration",
+        "Qwen3ForCausalLM",
+    ])
+    def test_every_other_iterator_loadable_architecture_moves_too(
+            self, architecture):
+        """The registry's other `WeightLoader`-less models, listed explicitly.
+
+        These are the architectures whose resolution this widening changes,
+        so the set is written down rather than left to be discovered: each
+        used to resolve to "vllm" under the streamer and now resolves to its
+        own implementation. No configuration in this repository reaches the
+        change, because every caller that passes `--load-format
+        runai_streamer` also pins MODEL_IMPL_TYPE.
+        """
+        config = self._config(architecture, "runai_streamer")
+        assert model_loader.resolve_model_architecture(config, False) \
+            == "flax_nnx"
+
+    def test_loadable_with_iterator_model_stays_on_flax(self):
+        """A model that loads through `LoadableWithIterator` streams fine.
+
+        KimiLinearForCausalLM has no `WeightLoader`; it takes the weights
+        iterator through the mixin, which is how most flax_nnx models load.
+        Requiring `WeightLoader` sent it to the vLLM implementation instead.
+        """
+        assert issubclass(
+            model_loader._get_model_architecture(
+                PretrainedConfig(architectures=["KimiLinearForCausalLM"])),
+            LoadableWithIterator)
+
+        config = self._config("KimiLinearForCausalLM", "runai_streamer")
+        assert model_loader.resolve_model_architecture(config, False) \
+            == "flax_nnx"
+
+    def test_weight_loader_model_stays_on_flax(self):
+        """The other supported way in: a `BaseWeightLoader` subclass."""
+        config = self._config("Gemma4ForCausalLM", "runai_streamer")
+        assert model_loader.resolve_model_architecture(config, False) \
+            == "flax_nnx"
+
+    def test_model_supporting_neither_falls_back_to_vllm(self):
+        """The guard the check exists for is still in force."""
+
+        class NotStreamable:
+            pass
+
+        config = self._config("Qwen3ForCausalLM", "runai_streamer")
+        with patch.object(model_loader,
+                          "_get_model_architecture",
+                          return_value=NotStreamable):
+            assert model_loader.resolve_model_architecture(config, False) \
+                == "vllm"
+
+    def test_non_streaming_load_format_ignores_the_capability(self):
+        """Without the streamer the capability is irrelevant to the choice."""
+
+        class NotStreamable:
+            pass
+
+        config = self._config("Qwen3ForCausalLM", "auto")
+        with patch.object(model_loader,
+                          "_get_model_architecture",
+                          return_value=NotStreamable):
+            assert model_loader.resolve_model_architecture(config, False) \
+                == "flax_nnx"
+
+    def test_vllm_preferred_architecture_still_wins(self):
+        """Streamable or not, a vLLM-preferred architecture resolves to vLLM."""
+        config = self._config("Qwen3MoeForCausalLM", "runai_streamer")
+        assert model_loader.resolve_model_architecture(config, False) == "vllm"
+
+    @patch.dict(os.environ, {"MODEL_IMPL_TYPE": "auto"}, clear=True)
+    @patch("tpu_inference.models.common.model_loader.get_vllm_model")
+    @patch("tpu_inference.models.common.model_loader.get_flax_model")
+    def test_streamed_kimi_k3_serve_dispatches_to_flax(self, mock_get_flax,
+                                                       mock_get_vllm,
+                                                       vllm_config, rng, mesh):
+        """The reported configuration, end to end through `get_model`.
+
+        Serving Kimi-K3 from object-storage weights means `--load-format
+        runai_streamer` with `MODEL_IMPL_TYPE` left at its `auto` default; the
+        resolution above only matters because `get_model` acts on it, so pin
+        the dispatch rather than the returned string.
+        """
+        vllm_config.model_config.hf_config.architectures = [
+            "KimiK3ForConditionalGeneration"
+        ]
+        vllm_config.load_config.load_format = "runai_streamer"
+        mock_get_flax.return_value = "flax_model_sentinel"
+
+        result = model_loader.get_model(vllm_config, rng, mesh)
+
+        mock_get_flax.assert_called_once_with(vllm_config, rng, mesh, False)
+        mock_get_vllm.assert_not_called()
+        assert result == "flax_model_sentinel"

--- a/tests/models/jax/test_kimi_k3.py
+++ b/tests/models/jax/test_kimi_k3.py
@@ -1,0 +1,779 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Kimi-Linear / Kimi-K3 model parity against HF-reference goldens.
+
+The config/AttnRes tests run anywhere. The parity tests need a K3-tiny
+checkpoint directory (``config.json`` + ``model.safetensors`` +
+``goldens_run1.npz``, produced by the golden harness from the HF reference in
+``moonshotai/Kimi-K3``) and a TPU for the MLA kernel; point
+``K3_TINY_CKPT`` / ``K3_TINY_SOFTPLUS_CKPT`` at them, otherwise they skip.
+
+The two checkpoints cover both configurations of every family-level flag that
+K3-tiny can express: ``K3_TINY_CKPT`` is the Kimi-K3 form (sigmoid
+lower-bound KDA gate, full-rank output gate) and ``K3_TINY_SOFTPLUS_CKPT`` is
+the Kimi-Linear-48B form (softplus gate, low-rank ``g_a``/``g_b``).
+
+Everything is compared at ``jax.default_matmul_precision("highest")``: the
+goldens come from a torch fp32 CPU forward, while TPU einsums default to a
+reduced-precision fp32 algorithm that costs ~3 orders of magnitude of
+agreement in a 9-layer stack. These tests check the model's math, not the
+matmul default.
+"""
+
+import dataclasses
+import json
+import os
+import types
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+from jax.sharding import Mesh
+
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.common.kda_attention import KDAState
+from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
+from tpu_inference.models.jax.kimi_k3 import (KimiConfig,
+                                              KimiK3ForConditionalGeneration,
+                                              KimiLinearForCausalLM,
+                                              adapt_wrapper_checkpoint,
+                                              apply_attn_res)
+from tpu_inference.utils import align_to
+
+CKPTS = {
+    "sigmoid_fullrank": os.environ.get("K3_TINY_CKPT", ""),
+    "softplus_lowrank": os.environ.get("K3_TINY_SOFTPLUS_CKPT", ""),
+}
+
+# Gates. The observed maxima are ~1.5e-4 on activations of magnitude ~5 and
+# ~1e-4 on logits of magnitude ~3, i.e. ~3e-5 relative.
+ACT_ATOL = 2e-3
+LOGIT_ATOL = 2e-3
+
+NUM_BLOCKS, BLOCK_SIZE = 8, 64
+
+
+def _skip_if_missing(ckpt):
+    if not ckpt or not os.path.isdir(ckpt):
+        pytest.skip("K3-tiny checkpoint not available (set K3_TINY_CKPT / "
+                    "K3_TINY_SOFTPLUS_CKPT)")
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    devices = np.array(jax.devices()[:1]).reshape((1, ) * len(MESH_AXIS_NAMES))
+    return Mesh(devices, axis_names=MESH_AXIS_NAMES)
+
+
+def _kimi_config(ckpt) -> KimiConfig:
+    with open(os.path.join(ckpt, "config.json")) as f:
+        return KimiConfig(types.SimpleNamespace(**json.load(f)))
+
+
+def _vllm_config_double(ckpt):
+    """The slice of VllmConfig the model reads, without an engine."""
+    with open(os.path.join(ckpt, "config.json")) as f:
+        hf = types.SimpleNamespace(**json.load(f))
+    from tpu_inference.layers.jax.quantization.unquantized import \
+        UnquantizedConfig
+    return types.SimpleNamespace(
+        model_config=types.SimpleNamespace(
+            hf_config=hf,
+            dtype=jnp.float32,
+            get_vocab_size=lambda: hf.vocab_size),
+        quant_config=UnquantizedConfig({}),
+        cache_config=types.SimpleNamespace(cache_dtype="auto"))
+
+
+def _checkpoint_weights(ckpt):
+    from safetensors import safe_open
+    f = safe_open(os.path.join(ckpt, "model.safetensors"), "pt")
+    for name in f.keys():
+        yield name, f.get_tensor(name)
+
+
+def _build_loaded_model(ckpt, mesh):
+    with jax.set_mesh(mesh):
+        model = KimiLinearForCausalLM(_vllm_config_double(ckpt),
+                                      jax.random.PRNGKey(0), mesh)
+        loaded = model.load_weights(_checkpoint_weights(ckpt))
+    return model, loaded
+
+
+# The vision tensors the released Kimi-K3 checkpoint carries next to its text
+# stack, one of each kind, at the names it uses.
+WRAPPER_VISION_TENSORS = (
+    "vision_tower.patch_embed.proj.weight",
+    "vision_tower.encoder.blocks.0.wqkv.weight",
+    "mm_projector.post_norm.weight",
+)
+
+
+def _wrapper_layout_weights(ckpt):
+    """The tiny checkpoint presented the way the released K3 stores itself.
+
+    That checkpoint is the ``KimiK3ForConditionalGeneration`` multimodal
+    wrapper: the whole text stack sits under ``language_model.`` and the vision
+    tensors sit beside it. Building that view over the text-only fixture keeps
+    the two layouts in lockstep, where a second staged copy of every tensor
+    would drift.
+
+    One vision tensor is yielded first and the rest last, so a loader that only
+    drops them at one end of the stream still fails.
+    """
+    import torch
+    vision = [(n, torch.zeros(2, 2, dtype=torch.bfloat16))
+              for n in WRAPPER_VISION_TENSORS]
+    yield vision[0]
+    for name, tensor in _checkpoint_weights(ckpt):
+        yield f"language_model.{name}", tensor
+    yield from vision[1:]
+
+
+def _wrapper_vllm_config_double(ckpt):
+    """`_vllm_config_double`, with the text config nested as K3 nests it."""
+    double = _vllm_config_double(ckpt)
+    text = double.model_config.hf_config
+    double.model_config.hf_config = types.SimpleNamespace(
+        architectures=["KimiK3ForConditionalGeneration"],
+        model_type="kimi_k3",
+        text_config=text,
+        vision_config=types.SimpleNamespace(vt_hidden_size=8))
+    return double
+
+
+def _fresh_caches(config):
+    """Manually allocated per-layer state (hybrid cache wiring is Phase 3)."""
+    import tpu_inference.kernels.mla.v1.kernel as mla_kernel
+    hp = config.kda_num_heads * config.kda_head_dim
+    w = config.kda_conv_kernel_size
+    # The MLA cache pads the latent and the shared ("rope") dims to 128 each,
+    # so its width is the sum of the aligned dims, not of the raw ones.
+    kv_dim = align_to(config.kv_lora_rank, 128) + align_to(
+        config.qk_rope_head_dim, 128)
+    caches = []
+    for i in range(config.num_hidden_layers):
+        if config.is_kda_layer(i):
+            # Slot 0 is the null block; the tests use slot 1.
+            # Allocated as a plain tuple, the way the KV-cache manager
+            # hands a `MambaSpec` layer's slot to the model.
+            caches.append(
+                tuple(
+                    KDAState(conv_q=jnp.zeros((4, w - 1, hp), jnp.float32),
+                             conv_k=jnp.zeros((4, w - 1, hp), jnp.float32),
+                             conv_v=jnp.zeros((4, w - 1, hp), jnp.float32),
+                             recurrent=jnp.zeros(
+                                 (4, config.kda_num_heads, config.kda_head_dim,
+                                  config.kda_head_dim), jnp.float32))))
+        else:
+            caches.append(
+                jnp.zeros(
+                    mla_kernel.get_kv_cache_shape(NUM_BLOCKS, BLOCK_SIZE,
+                                                  kv_dim, jnp.float32),
+                    jnp.float32))
+    return caches
+
+
+def _metadata(num_tokens, positions, seq_len, *, decode):
+    return AttentionMetadata(
+        input_positions=jnp.asarray(positions, jnp.int32),
+        block_tables=jnp.arange(NUM_BLOCKS, dtype=jnp.int32),
+        seq_lens=jnp.array([seq_len], jnp.int32),
+        query_start_loc=jnp.array([0, num_tokens], jnp.int32),
+        # (decode_end, prefill_end, mixed_end); decode-only is
+        # distribution[0] == distribution[2].
+        request_distribution=jnp.array([1, 1, 1] if decode else [0, 0, 1],
+                                       jnp.int32),
+        mamba_state_indices=jnp.array([1], jnp.int32),
+        # `seq_len > num_tokens` means the request already has state in its
+        # slot -- what the runner publishes as `has_initial_state`.
+        has_initial_state=jnp.array([int(seq_len > num_tokens)], jnp.int32),
+        padded_num_reqs=1)
+
+
+@nnx.jit
+def _forward(model, caches, input_ids, md):
+    caches, hidden, _, _ = model(caches, input_ids, md)
+    return caches, hidden, model.compute_logits(hidden)
+
+
+# --------------------------------------------------------------------------
+# Config / structure (no checkpoint required)
+# --------------------------------------------------------------------------
+
+
+def _config_from(**overrides):
+    base = dict(hidden_size=8,
+                intermediate_size=16,
+                num_hidden_layers=4,
+                vocab_size=32,
+                rms_norm_eps=1e-5,
+                hidden_act="silu",
+                num_attention_heads=2,
+                num_key_value_heads=2,
+                kv_lora_rank=4,
+                qk_nope_head_dim=4,
+                qk_rope_head_dim=2,
+                v_head_dim=4)
+    base.update(overrides)
+    return KimiConfig(types.SimpleNamespace(**base))
+
+
+def test_config_defaults_to_kimi_linear_48b_behaviour():
+    """Every K3-only feature is off when its config field is absent."""
+    c = _config_from()
+    assert not c.use_attn_residuals
+    assert c.routed_expert_hidden_size is None
+    assert c.moe_hidden_size == c.hidden_size
+    assert c.kda_gate_lower_bound is None  # softplus decay form
+    assert not c.kda_use_full_rank_gate  # low-rank g_a/g_b
+    assert not c.mla_use_output_gate
+    assert c.q_lora_rank is None
+
+
+def test_kda_layers_are_one_indexed_in_the_config():
+    c = _config_from(linear_attn_config={"kda_layers": [1, 2, 4]})
+    assert [i for i in range(4) if c.is_kda_layer(i)] == [0, 1, 3]
+
+
+def test_moe_and_dense_layer_split():
+    c = _config_from(num_experts=8, first_k_dense_replace=1)
+    assert not c.is_moe_layer(0)
+    assert all(c.is_moe_layer(i) for i in range(1, 4))
+
+
+def test_attn_res_checkpoint_layers():
+    c = _config_from(attn_res_block_size=2, num_hidden_layers=6)
+    assert [i for i in range(6) if c.is_attn_res_checkpoint(i)] == [0, 2, 4]
+
+
+def _apply_attn_res_numpy(prefix_sum, blocks, proj_w, norm_w, eps):
+    """fp64 transcription of modeling_kimi_linear.py::_apply_attn_res."""
+    v = np.concatenate([
+        np.asarray(blocks, np.float64).transpose(1, 0, 2),
+        prefix_sum[:, None, :].astype(np.float64)
+    ],
+                       axis=1)
+    k = v / np.sqrt(np.mean(v * v, axis=-1, keepdims=True) + eps)
+    score_weight = norm_w.astype(np.float64) * proj_w.reshape(-1).astype(
+        np.float64)
+    scores = (k * score_weight).sum(-1)
+    probs = np.exp(scores - scores.max(-1, keepdims=True))
+    probs /= probs.sum(-1, keepdims=True)
+    return np.einsum('tb,tbd->td', probs, v)
+
+
+def test_apply_attn_res_matches_reference():
+    rng = np.random.default_rng(0)
+    t, d, nb = 7, 16, 3
+    prefix_sum = rng.standard_normal((t, d), dtype=np.float32)
+    blocks = [rng.standard_normal((t, d), dtype=np.float32) for _ in range(nb)]
+    proj_w = rng.standard_normal((d, 1), dtype=np.float32)
+    norm_w = rng.standard_normal((d, ), dtype=np.float32)
+
+    got = np.asarray(
+        apply_attn_res(jnp.asarray(prefix_sum),
+                       [jnp.asarray(b) for b in blocks], jnp.asarray(proj_w),
+                       jnp.asarray(norm_w), 1e-5))
+    ref = _apply_attn_res_numpy(prefix_sum, blocks, proj_w, norm_w, 1e-5)
+    err = np.abs(got - ref).max()
+    print(f"[observed] apply_attn_res max_abs={err:.3e}")
+    np.testing.assert_allclose(got, ref, atol=1e-4, rtol=1e-4)
+
+
+def test_apply_attn_res_is_a_convex_mix_of_its_candidates():
+    """Anti-vacuity: the output must lie inside the candidates' hull, so a
+    mix that silently ignored `block_residual` would be visible."""
+    rng = np.random.default_rng(1)
+    t, d = 5, 8
+    prefix_sum = jnp.asarray(rng.standard_normal((t, d), dtype=np.float32))
+    blocks = [
+        jnp.asarray(rng.standard_normal((t, d), dtype=np.float32))
+        for _ in range(2)
+    ]
+    proj_w = jnp.asarray(rng.standard_normal((d, 1), dtype=np.float32))
+    norm_w = jnp.asarray(rng.standard_normal((d, ), dtype=np.float32))
+    out = np.asarray(apply_attn_res(prefix_sum, blocks, proj_w, norm_w, 1e-5))
+    stack = np.stack([np.asarray(b)
+                      for b in blocks] + [np.asarray(prefix_sum)])
+    assert (out <= stack.max(0) + 1e-5).all()
+    assert (out >= stack.min(0) - 1e-5).all()
+    # ...and it is not simply the prefix sum passed through.
+    assert np.abs(out - np.asarray(prefix_sum)).max() > 1e-3
+
+
+def test_moe_layer_split_respects_first_k_dense_replace():
+    c = _config_from(num_experts=8, first_k_dense_replace=2)
+    assert [i for i in range(4) if c.is_moe_layer(i)] == [2, 3]
+
+
+# --------------------------------------------------------------------------
+# Kimi-Linear-48B-shaped config: the paths K3-tiny cannot reach
+# --------------------------------------------------------------------------
+
+# Both tiny checkpoints have attention residuals, a latent MoE, situ, and
+# routed_scaling_factor 1.0, so the golden tests above never exercise the
+# plain residual stream, the full-width MoE, or the routed scaling. This is
+# the Kimi-Linear-48B shape (attn_res / routed_expert_hidden_size / situ /
+# q_lora_rank all absent) at tiny dimensions.
+_48B_SHAPED = dict(
+    hidden_size=32,
+    intermediate_size=64,
+    num_hidden_layers=2,
+    vocab_size=64,
+    hidden_act="silu",
+    num_attention_heads=2,
+    num_key_value_heads=2,
+    q_lora_rank=None,
+    kv_lora_rank=16,
+    qk_nope_head_dim=16,
+    qk_rope_head_dim=8,
+    v_head_dim=16,
+    mla_use_nope=True,
+    num_experts=8,
+    num_experts_per_token=2,
+    moe_intermediate_size=16,
+    num_shared_experts=1,
+    first_k_dense_replace=1,
+    routed_scaling_factor=2.446,
+    linear_attn_config={
+        # 1-indexed: layer 0 is MLA (+ dense MLP), layer 1 KDA.
+        "kda_layers": [2],
+        "num_heads": 2,
+        "head_dim": 16,
+        "short_conv_kernel_size": 4,
+    })
+
+
+def _build_48b_shaped(mesh, **overrides):
+    from tpu_inference.layers.jax.quantization.unquantized import \
+        UnquantizedConfig
+    from tpu_inference.models.jax.kimi_k3 import KimiLinearModel
+    config = _config_from(**{**_48B_SHAPED, **overrides})
+    with jax.set_mesh(mesh):
+        model = KimiLinearModel(config=config,
+                                rngs=nnx.Rngs(0),
+                                mesh=mesh,
+                                dtype=jnp.float32,
+                                quant_config=UnquantizedConfig({}),
+                                random_init=True)
+    return config, model
+
+
+def test_48b_shaped_model_omits_k3_only_parameters(mesh):
+    """No attention-residual or latent-MoE weights when the flags are absent."""
+    config, model = _build_48b_shaped(mesh)
+    names = {n for n, _ in model.named_parameters()}
+    assert not config.use_attn_residuals
+    assert not [n for n in names if "_res_proj" in n or "_res_norm" in n]
+    assert not [n for n in names if "routed_expert_" in n]
+    # q_lora_rank=None selects the single fused q_proj.
+    assert any(n.endswith("layers.0.self_attn.q_proj.weight") for n in names)
+    assert not [n for n in names if "q_a_proj" in n or "q_b_proj" in n]
+    # ...while the KDA layer keeps the low-rank output gate.
+    assert any("layers.1.self_attn.g_a_proj" in n for n in names)
+    assert not [n for n in names if "layers.1.self_attn.g_proj" in n]
+
+
+def test_48b_shaped_moe_runs_experts_at_full_hidden_width(mesh):
+    config, model = _build_48b_shaped(mesh)
+    moe = model.layers[1].block_sparse_moe
+    assert not moe.use_latent_moe
+    assert moe.experts.hidden_size == config.hidden_size
+
+
+@nnx.jit
+def _moe_block_fwd(model, x):
+    return model.layers[1].block_sparse_moe(x)
+
+
+def test_routed_scaling_factor_scales_the_routed_contribution(mesh):
+    """The reference applies it to the top-k weights inside the gate, so the
+    routed path -- and only the routed path -- scales with it."""
+    x = jax.random.normal(jax.random.PRNGKey(0),
+                          (4, _48B_SHAPED["hidden_size"]),
+                          dtype=jnp.float32)
+
+    def routed_only(factor):
+        _, model = _build_48b_shaped(mesh,
+                                     routed_scaling_factor=factor,
+                                     num_shared_experts=None)
+        with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
+            return np.asarray(_moe_block_fwd(model, x), np.float32)
+
+    one = routed_only(1.0)
+    scaled = routed_only(2.446)
+    err = np.abs(scaled - one * 2.446).max()
+    print(f"[observed] routed_scaling_factor linearity max_abs={err:.3e}")
+    np.testing.assert_allclose(scaled, one * 2.446, rtol=2e-5, atol=2e-5)
+    # Anti-vacuity: the scaling actually changed the output.
+    assert np.abs(scaled - one).max() > 1e-3
+
+
+@nnx.jit
+def _plain_residual_probe(model, caches, x, md):
+    """The layer's own output alongside an explicit x + attn + mlp."""
+    layer = model.layers[1]  # KDA layer: no MLA kernel needed
+    _, got, block_residual = layer(x,
+                                   kv_cache=caches[1],
+                                   attention_metadata=md,
+                                   block_residual=[])
+    _, attn_out = layer.self_attn(layer.input_layernorm(x), caches[1], md)
+    h = x + attn_out
+    expect = h + layer._mlp()(layer.post_attention_layernorm(h))
+    return got, expect, block_residual
+
+
+def test_48b_shaped_decoder_uses_the_plain_residual_stream(mesh):
+    """Without attention residuals the layer must be x + attn + mlp."""
+    config, model = _build_48b_shaped(mesh)
+    md = _metadata(4, np.arange(4), 4, decode=False)
+    x = jax.random.normal(jax.random.PRNGKey(1), (4, config.hidden_size),
+                          dtype=jnp.float32) * 0.1
+
+    with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
+        got, expect, block_residual = _plain_residual_probe(
+            model, _fresh_caches(config), x, md)
+
+    assert block_residual == []
+    err = np.abs(np.asarray(got, np.float32) -
+                 np.asarray(expect, np.float32)).max()
+    print(f"[observed] plain residual stream max_abs={err:.3e}")
+    np.testing.assert_allclose(np.asarray(got), np.asarray(expect), atol=1e-5)
+
+
+def test_kda_layer_rejects_missing_has_initial_state(mesh):
+    """The state-resumption flag comes from the runner, not from a local
+    derivation off `query_start_loc` -- which would be wrong under attention
+    DP. If the field is absent the layer must say so rather than guess."""
+    config, model = _build_48b_shaped(mesh)
+    md = dataclasses.replace(_metadata(4, np.arange(4), 4, decode=False),
+                             has_initial_state=None)
+    x = jax.random.normal(jax.random.PRNGKey(1), (4, config.hidden_size),
+                          dtype=jnp.float32) * 0.1
+    kda_layer = model.layers[1].self_attn
+    caches = _fresh_caches(config)
+
+    with jax.set_mesh(mesh):
+        with pytest.raises(ValueError, match="has_initial_state is None"):
+            kda_layer(x, caches[1], md)
+
+
+def _expert_parallel_mesh(ep_size):
+    """A mesh whose only nontrivial axis is the expert axis."""
+    if len(jax.devices()) < ep_size:
+        pytest.skip(f"needs >= {ep_size} devices")
+    shape = tuple(ep_size if name == "attn_dp_expert" else 1
+                  for name in MESH_AXIS_NAMES)
+    devices = np.array(jax.devices()[:ep_size]).reshape(shape)
+    return Mesh(devices, axis_names=MESH_AXIS_NAMES)
+
+
+@pytest.mark.parametrize("ep_size,expected", [
+    (1, "dense_mat"),
+    (2, "megablox_gmm"),
+])
+def test_moe_backend_follows_expert_parallelism(ep_size, expected):
+    """DENSE_MAT evaluates every expert on every device, so it only works
+    while the experts are replicated; once they are sharded the model has to
+    pick the dispatching backend, or the all-gather of the expert weights
+    alone exceeds HBM (Kimi-Linear-48B: 722 GiB across 8 chips)."""
+    from tpu_inference.layers.jax.quantization.unquantized import \
+        UnquantizedConfig
+    ep_mesh = _expert_parallel_mesh(ep_size)
+    hf = types.SimpleNamespace(**{
+        **_config_from().hf_config.__dict__,
+        **_48B_SHAPED
+    })
+    vllm_config = types.SimpleNamespace(
+        model_config=types.SimpleNamespace(
+            hf_config=hf,
+            dtype=jnp.float32,
+            get_vocab_size=lambda: _48B_SHAPED["vocab_size"]),
+        quant_config=UnquantizedConfig({}),
+        cache_config=types.SimpleNamespace(cache_dtype="auto"))
+
+    with jax.set_mesh(ep_mesh):
+        model = KimiLinearForCausalLM(vllm_config,
+                                      jax.random.PRNGKey(0),
+                                      ep_mesh,
+                                      random_init=True)
+
+    assert model.num_expert_parallelism == ep_size
+    assert model.model.moe_backend.value == expected
+    experts = model.model.layers[1].block_sparse_moe.experts
+    assert experts.num_expert_parallelism == ep_size
+    assert experts.use_ep == (ep_size > 1)
+
+
+# --------------------------------------------------------------------------
+# Released-checkpoint layout (no checkpoint needed)
+# --------------------------------------------------------------------------
+
+
+def test_wrapper_checkpoint_is_mapped_onto_the_text_stack():
+    """`language_model.` off the text tensors, vision tensors dropped."""
+    src = [
+        ("vision_tower.patch_embed.proj.weight", 1),
+        ("language_model.model.layers.0.self_attn.q_proj.weight", 2),
+        ("mm_projector.post_norm.weight", 3),
+        ("language_model.lm_head.weight", 4),
+    ]
+    assert list(adapt_wrapper_checkpoint(src)) == [
+        ("model.layers.0.self_attn.q_proj.weight", 2),
+        ("lm_head.weight", 4),
+    ]
+
+
+def test_text_only_checkpoint_passes_through_unchanged():
+    """Kimi-Linear-48B stores the same stack without the wrapper."""
+    src = [("model.layers.0.self_attn.q_proj.weight", 1),
+           ("lm_head.weight", 2)]
+    assert list(adapt_wrapper_checkpoint(src)) == src
+
+
+def test_an_unknown_tensor_still_reaches_the_loader():
+    """Only the listed prefixes are dropped, so surprises fail loudly."""
+    src = [("audio_tower.encoder.weight", 1)]
+    assert list(adapt_wrapper_checkpoint(src)) == src
+
+
+# --------------------------------------------------------------------------
+# Golden parity (needs a checkpoint + TPU)
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("variant", sorted(CKPTS))
+def test_every_checkpoint_tensor_is_loaded(variant, mesh):
+    """The loader must consume the whole checkpoint, not a subset."""
+    from safetensors import safe_open
+    ckpt = CKPTS[variant]
+    _skip_if_missing(ckpt)
+    model, loaded = _build_loaded_model(ckpt, mesh)
+
+    with safe_open(os.path.join(ckpt, "model.safetensors"), "np") as f:
+        ckpt_names = set(f.keys())
+    model_names = {n for n, _ in model.named_parameters()}
+    # Routed experts are fused into `kernel_*` params, and the absorbed-MLA
+    # k_up/v_up are derived from kv_b_proj during load; neither has a 1:1
+    # checkpoint name.
+    unloaded = {
+        n
+        for n in model_names - set(loaded)
+        if "_up_proj" not in n and ".experts." not in n
+    }
+    assert not unloaded, f"[kimi-k3] params never loaded: {sorted(unloaded)}"
+
+    # ...and no checkpoint tensor is silently dropped. The two exempt groups
+    # are consumed by a module-level `load_weights` that reports no name:
+    # the routed experts (fused into the `kernel_*` params) and kv_b_proj
+    # (split into k_up_proj / v_up_proj).
+    unconsumed = {
+        n
+        for n in ckpt_names - set(loaded)
+        if ".experts." not in n and not n.endswith("kv_b_proj.weight")
+    }
+    assert not unconsumed, (
+        f"[kimi-k3] checkpoint tensors ignored by the loader: "
+        f"{sorted(unconsumed)}")
+
+
+def test_conditional_generation_layout_loads_the_same_model(mesh):
+    """The released K3 layout must load, and load to the same weights.
+
+    The fixtures are text-only, so every earlier phase validated a layout the
+    released checkpoint does not use: it is the multimodal wrapper, with the
+    text stack under ``language_model.`` and 168 vision tensors beside it.
+    """
+    ckpt = CKPTS["sigmoid_fullrank"]
+    _skip_if_missing(ckpt)
+
+    with jax.set_mesh(mesh):
+        model = KimiK3ForConditionalGeneration(
+            _wrapper_vllm_config_double(ckpt), jax.random.PRNGKey(0), mesh)
+        loaded = model.load_weights(_wrapper_layout_weights(ckpt))
+
+    # Anti-vacuity: the vision tensors really were offered to the loader, and
+    # the text ones really did arrive wrapped.
+    offered = [n for n, _ in _wrapper_layout_weights(ckpt)]
+    assert set(WRAPPER_VISION_TENSORS) <= set(offered)
+    assert all(
+        n.startswith("language_model.") for n in offered
+        if n not in WRAPPER_VISION_TENSORS)
+
+    # Nothing is loaded under a wrapped name, and no vision weight created a
+    # parameter.
+    assert not [n for n in loaded if n.startswith("language_model.")]
+    assert not [
+        n for n, _ in model.named_parameters()
+        if "vision" in n or "mm_projector" in n
+    ]
+
+    # Same weights as the text-only layout, param for param.
+    reference, reference_loaded = _build_loaded_model(ckpt, mesh)
+    assert loaded == reference_loaded
+    wrapped_params = dict(model.named_parameters())
+    for name, param in reference.named_parameters():
+        np.testing.assert_array_equal(
+            np.asarray(wrapped_params[name].get_value()),
+            np.asarray(param.get_value()),
+            err_msg=f"[kimi-k3] {name} differs between checkpoint layouts")
+
+
+@pytest.mark.parametrize("variant", sorted(CKPTS))
+@pytest.mark.parametrize("tag,seq_len", [("p48", 48), ("p64", 64)])
+def test_prefill_logits_match_goldens(variant, tag, seq_len, mesh):
+    ckpt = CKPTS[variant]
+    _skip_if_missing(ckpt)
+    g = np.load(os.path.join(ckpt, "goldens_run1.npz"))
+    model, _ = _build_loaded_model(ckpt, mesh)
+
+    input_ids = jnp.asarray(g[f"{tag}.input_ids"][0], jnp.int32)
+    md = _metadata(seq_len, np.arange(seq_len), seq_len, decode=False)
+    with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
+        _, hidden, logits = _forward(model, _fresh_caches(model.config),
+                                     input_ids, md)
+
+    ref_hidden = g[f"{tag}.final_norm.out"][0]
+    ref_logits = g[f"{tag}.logits"][0]
+    got_hidden = np.asarray(hidden, np.float32)
+    got_logits = np.asarray(logits, np.float32)
+    print(f"[observed] {variant} {tag} hidden max_abs="
+          f"{np.abs(got_hidden - ref_hidden).max():.3e} logits max_abs="
+          f"{np.abs(got_logits - ref_logits).max():.3e} "
+          f"(logit scale {np.abs(ref_logits).max():.3e})")
+    np.testing.assert_allclose(got_hidden, ref_hidden, atol=ACT_ATOL)
+    np.testing.assert_allclose(got_logits, ref_logits, atol=LOGIT_ATOL)
+    np.testing.assert_array_equal(got_logits.argmax(-1), ref_logits.argmax(-1))
+
+
+@pytest.mark.parametrize("variant", sorted(CKPTS))
+def test_greedy_decode_reproduces_golden_tokens(variant, mesh):
+    """Prefill 32 tokens, then 8 greedy steps through the recurrent state."""
+    ckpt = CKPTS[variant]
+    _skip_if_missing(ckpt)
+    g = np.load(os.path.join(ckpt, "goldens_run1.npz"))
+    model, _ = _build_loaded_model(ckpt, mesh)
+    config = model.config
+
+    input_ids = jnp.asarray(g["d32.input_ids"][0], jnp.int32)
+    prompt_len = input_ids.shape[0]
+    worst_logit_err = 0.0
+    with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
+        caches, _, logits = _forward(
+            model, _fresh_caches(config), input_ids,
+            _metadata(prompt_len,
+                      np.arange(prompt_len),
+                      prompt_len,
+                      decode=False))
+        ref = g["d32.prefill_logits"][0]
+        got = np.asarray(logits, np.float32)
+        worst_logit_err = max(worst_logit_err, np.abs(got - ref).max())
+        np.testing.assert_allclose(got, ref, atol=LOGIT_ATOL)
+
+        # The recurrent state carried into decode must match the reference's.
+        worst_state_err = 0.0
+        for i in range(config.num_hidden_layers):
+            if not config.is_kda_layer(i):
+                continue
+            ref_state = g[f"d32.layers.{i}.recurrent_state"][0]
+            got_state = np.asarray(
+                KDAState(*caches[i]).recurrent[1], np.float32)
+            worst_state_err = max(worst_state_err,
+                                  np.abs(got_state - ref_state).max())
+            np.testing.assert_allclose(got_state, ref_state, atol=ACT_ATOL)
+
+        tokens = [int(np.asarray(logits)[-1].argmax())]
+        for step in range(8):
+            position = prompt_len + step
+            caches, _, logits = _forward(
+                model, caches, jnp.asarray([tokens[-1]], jnp.int32),
+                _metadata(1, [position], position + 1, decode=True))
+            got = np.asarray(logits, np.float32)
+            ref = g[f"d32.step{step}.logits"][0]
+            worst_logit_err = max(worst_logit_err, np.abs(got - ref).max())
+            tokens.append(int(got[-1].argmax()))
+
+    print(f"[observed] {variant} d32 worst logit max_abs={worst_logit_err:.3e}"
+          f" worst recurrent-state max_abs={worst_state_err:.3e}")
+    np.testing.assert_array_equal(np.array(tokens), g["d32.greedy_tokens"][0])
+
+
+@pytest.mark.parametrize("variant", sorted(CKPTS))
+def test_per_layer_parity(variant, mesh):
+    """Per-site parity through the whole stack.
+
+    Checks every mix point the AttnRes threading touches, so a residual-stream
+    bug is localized to a layer rather than only showing up in the logits.
+    """
+    ckpt = CKPTS[variant]
+    _skip_if_missing(ckpt)
+    g = np.load(os.path.join(ckpt, "goldens_run1.npz"))
+    model, _ = _build_loaded_model(ckpt, mesh)
+    config = model.config
+
+    @nnx.jit
+    def capture(model, caches, input_ids, md):
+        out = {}
+        m = model.model
+        x = m.embed_tokens(input_ids)
+        block_residual = []
+        for i, layer in enumerate(m.layers):
+            prefix_sum = x
+            hidden = x
+            if block_residual:
+                hidden = layer._mix(layer.self_attention_res_proj,
+                                    layer.self_attention_res_norm, prefix_sum,
+                                    block_residual)
+            out[f"{i}.input_layernorm.in"] = hidden
+            if m.config.is_attn_res_checkpoint(i):
+                block_residual = list(block_residual) + [prefix_sum]
+                prefix_sum = None
+            hidden = layer.input_layernorm(hidden)
+            out[f"{i}.self_attn.in"] = hidden
+            caches[i], attn_out = layer.self_attn(hidden, caches[i], md)
+            out[f"{i}.self_attn.out"] = attn_out
+            prefix_sum = (attn_out if prefix_sum is None else prefix_sum +
+                          attn_out)
+            hidden = layer._mix(layer.mlp_res_proj, layer.mlp_res_norm,
+                                prefix_sum, block_residual)
+            out[f"{i}.post_attention_layernorm.in"] = hidden
+            hidden = layer.post_attention_layernorm(hidden)
+            mlp_name = layer.mlp_attr
+            out[f"{i}.{mlp_name}.in"] = hidden
+            mlp_out = layer._mlp()(hidden)
+            out[f"{i}.{mlp_name}.out"] = mlp_out
+            prefix_sum = prefix_sum + mlp_out
+            out[f"{i}.out"] = prefix_sum
+            x = prefix_sum
+        return out
+
+    seq_len = 48
+    input_ids = jnp.asarray(g["p48.input_ids"][0], jnp.int32)
+    md = _metadata(seq_len, np.arange(seq_len), seq_len, decode=False)
+    with jax.set_mesh(mesh), jax.default_matmul_precision("highest"):
+        captured = capture(model, _fresh_caches(config), input_ids, md)
+
+    worst, worst_key = 0.0, ""
+    for key, value in captured.items():
+        golden_key = f"p48.layers.{key}"
+        assert golden_key in g, f"[kimi-k3] no golden for {golden_key}"
+        err = np.abs(np.asarray(value, np.float32) - g[golden_key][0]).max()
+        if err > worst:
+            worst, worst_key = err, golden_key
+        assert err < ACT_ATOL, f"[kimi-k3] {golden_key} off by {err:.3e}"
+    print(f"[observed] {variant} per-layer worst max_abs={worst:.3e} "
+          f"at {worst_key} ({len(captured)} sites)")

--- a/tests/models/jax/test_kimi_k3.py
+++ b/tests/models/jax/test_kimi_k3.py
@@ -320,6 +320,44 @@ def test_moe_layer_split_respects_first_k_dense_replace():
     assert [i for i in range(4) if c.is_moe_layer(i)] == [2, 3]
 
 
+def test_moe_layer_split_matches_reference_rule_at_freq_2():
+    """The reference (modeling_kimi_linear.py::KimiDecoderLayer) gates MoE on
+    `layer_idx % moe_layer_freq == 0` -- so at freq=2 the even layers past
+    the dense prefix are MoE, not the odd ones a `(layer_idx + 1) % freq`
+    form would pick."""
+    c = _config_from(num_experts=8,
+                     first_k_dense_replace=1,
+                     moe_layer_freq=2,
+                     num_hidden_layers=6)
+    assert [i for i in range(6) if c.is_moe_layer(i)] == [2, 4]
+
+
+def _mesh_with_model_ways(ways):
+    """A mesh whose only nontrivial axis is `model` (a KDA head-split axis)."""
+    if len(jax.devices()) < ways:
+        pytest.skip(f"needs >= {ways} devices")
+    shape = tuple(ways if name == "model" else 1 for name in MESH_AXIS_NAMES)
+    devices = np.array(jax.devices()[:ways]).reshape(shape)
+    return Mesh(devices, axis_names=MESH_AXIS_NAMES)
+
+
+def test_validate_kda_head_sharding_accepts_a_dividing_head_count():
+    from tpu_inference.models.jax.kimi_k3 import validate_kda_head_sharding
+    mesh = _mesh_with_model_ways(4)
+    assert validate_kda_head_sharding(8, mesh, prefix="self_attn") == 4
+    # No mesh means no split.
+    assert validate_kda_head_sharding(96, None) == 1
+
+
+def test_validate_kda_head_sharding_refuses_a_torn_head():
+    """6 heads on a 4-way head axis: 6*head_dim may divide, the heads do
+    not -- the check must name the head count and the mesh."""
+    from tpu_inference.models.jax.kimi_k3 import validate_kda_head_sharding
+    mesh = _mesh_with_model_ways(4)
+    with pytest.raises(ValueError, match=r"\[kda\] 'self_attn': 6 KDA heads"):
+        validate_kda_head_sharding(6, mesh, prefix="self_attn")
+
+
 # --------------------------------------------------------------------------
 # Kimi-Linear-48B-shaped config: the paths K3-tiny cannot reach
 # --------------------------------------------------------------------------
@@ -371,6 +409,14 @@ def _build_48b_shaped(mesh, **overrides):
                                 quant_config=UnquantizedConfig({}),
                                 random_init=True)
     return config, model
+
+
+def test_mla_layer_without_nope_is_refused_at_construction(mesh):
+    """The port never builds a rope module, so a config with an MLA layer and
+    mla_use_nope unset must fail loudly at construction, not at forward."""
+    with pytest.raises(NotImplementedError,
+                       match=r"\[kimi\] layer 0: MLA with rotary"):
+        _build_48b_shaped(mesh, mla_use_nope=False)
 
 
 def test_48b_shaped_model_omits_k3_only_parameters(mesh):

--- a/tests/models/jax/test_kimi_k3_expert_sharding.py
+++ b/tests/models/jax/test_kimi_k3_expert_sharding.py
@@ -1,0 +1,303 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Routed-expert sharding: the expert axis and the tensor axis compose.
+
+Kimi-K3's routed experts are ~1.4 TB and its non-expert stack ~113 GB. Split
+only along the expert axis, a fixed device budget has to choose between them:
+devices spent on ``model`` (which the non-expert stack needs) are devices not
+spent on the expert axis, so the experts end up replicated. Splitting ``E``
+over the expert axis *and* ``F`` over ``model`` removes the choice.
+
+The tests below cover the three things that can go wrong independently: the
+declared specs, the guard that refuses a mesh which would replicate the
+experts anyway, and the numerics of the composed layout (the down projection
+now contracts a sharded dimension, so its result is a partial sum that has to
+be reduced).
+"""
+
+import types
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+
+from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
+                                                  ShardingAxisNameBase)
+from tpu_inference.models.jax.kimi_k3 import (experts_are_block_quantized,
+                                              routed_expert_sharding_ways,
+                                              routed_expert_shardings,
+                                              validate_routed_expert_sharding)
+
+E_AXES = ShardingAxisNameBase.ATTN_DATA_EXPERT
+F_AXIS = ShardingAxisNameBase.MODEL
+
+
+def _mesh(**axis_sizes):
+    """A mesh with the named axes set and every other axis at 1."""
+    need = int(np.prod(list(axis_sizes.values())))
+    if len(jax.devices()) < need:
+        pytest.skip(f"needs >= {need} devices, have {len(jax.devices())}")
+    shape = tuple(axis_sizes.get(name, 1) for name in MESH_AXIS_NAMES)
+    return Mesh(np.array(jax.devices()[:need]).reshape(shape),
+                axis_names=MESH_AXIS_NAMES)
+
+
+def _config(num_experts=32, moe_intermediate_size=384, moe_hidden_size=512):
+    return types.SimpleNamespace(num_experts=num_experts,
+                                 moe_intermediate_size=moe_intermediate_size,
+                                 moe_hidden_size=moe_hidden_size)
+
+
+# --------------------------------------------------------------------------
+# The specs themselves
+# --------------------------------------------------------------------------
+
+
+def test_both_axes_are_sharded():
+    """The point of the change: E and F are both split, over disjoint axes.
+
+    This is the assertion that fails if F goes back to being replicated.
+    """
+    edf, efd = routed_expert_shardings()
+    assert edf == P(E_AXES, None, F_AXIS)
+    assert efd == P(E_AXES, F_AXIS, None)
+    # Disjoint, or the two splits would collide instead of multiplying.
+    assert F_AXIS not in E_AXES
+
+
+def test_the_contracted_dimension_decides_the_reduction():
+    """`sparse_moe_distributed_fwd` reduces over ``<spec>[1]`` of each kernel
+    spec. That has to line up with which contraction is split:
+
+      * gate/up contract D, replicated in `edf` -> spec[1] is None, no psum;
+      * down contracts F, split in `efd` -> spec[1] is the tensor axis, psum.
+
+    Getting this backwards is silently wrong rather than loud, so it is
+    asserted directly.
+    """
+    edf, efd = routed_expert_shardings()
+    assert edf[1] is None, ("gate/up contract a replicated D; a reduction "
+                            "here would double-count")
+    assert efd[1] == F_AXIS, ("down contracts a split F; without this the "
+                              "partial sums are never added")
+
+
+def test_sharding_ways_multiply():
+    mesh = _mesh(attn_dp_expert=2, model=4)
+    assert routed_expert_sharding_ways(mesh) == (2, 4)
+
+
+# --------------------------------------------------------------------------
+# The guard
+# --------------------------------------------------------------------------
+
+
+def test_per_device_expert_share_drops_by_the_product():
+    """The memory claim, as arithmetic: composing the two axes divides the
+    per-device expert bytes by their product, not by either one alone."""
+    cfg = _config()
+    total = cfg.num_experts * 3 * cfg.moe_hidden_size * cfg.moe_intermediate_size
+
+    e_only, f_only = routed_expert_sharding_ways(_mesh(attn_dp_expert=8))
+    assert (e_only, f_only) == (8, 1)
+    composed_e, composed_f = routed_expert_sharding_ways(
+        _mesh(attn_dp_expert=2, model=4))
+
+    # Same 8 devices either way, but only the composed layout can also give
+    # `model` to the non-expert stack.
+    assert e_only * f_only == composed_e * composed_f == 8
+    assert total // (composed_e * composed_f) < total
+
+
+def test_replicated_experts_are_refused():
+    """A multi-device mesh with neither axis split: the failure that showed up
+    as an out-of-memory part-way through loading."""
+    mesh = _mesh(attn_dp=4)
+    with pytest.raises(ValueError, match="would be replicated"):
+        validate_routed_expert_sharding(_config(), mesh, block_quantized=False)
+
+
+def test_single_device_replication_is_allowed():
+    """The same condition is normal on one device, and must not raise."""
+    ways = validate_routed_expert_sharding(_config(),
+                                           _mesh(),
+                                           block_quantized=False)
+    assert ways == (1, 1)
+
+
+def test_indivisible_expert_count_is_refused():
+    mesh = _mesh(attn_dp_expert=4)
+    with pytest.raises(ValueError, match="num_experts=6 is not divisible"):
+        validate_routed_expert_sharding(_config(num_experts=6),
+                                        mesh,
+                                        block_quantized=False)
+
+
+def test_indivisible_intermediate_size_is_refused():
+    mesh = _mesh(model=4)
+    with pytest.raises(ValueError, match="moe_intermediate_size=6 is not"):
+        validate_routed_expert_sharding(_config(moe_intermediate_size=6),
+                                        mesh,
+                                        block_quantized=False)
+
+
+def test_unquantized_config_is_not_treated_as_block_quantized():
+    """The unquantized path supplies an `UnquantizedConfig`, not `None`, and
+    its weights carry no block scales -- so the tiling rule must not apply to
+    it. Treating "quant_config is not None" as "quantized" wrongly refused
+    meshes that had no F sharding at all."""
+    from tpu_inference.layers.jax.quantization.unquantized import \
+        UnquantizedConfig
+    assert not experts_are_block_quantized(None)
+    assert not experts_are_block_quantized(UnquantizedConfig({}))
+
+
+def test_real_k3_dimensions_divide_on_the_target_mesh():
+    """The 32-device layout this change exists to enable: E over 4, F over 8."""
+    mesh = _mesh(attn_dp_expert=4, model=8)
+    cfg = _config(num_experts=896,
+                  moe_intermediate_size=3072,
+                  moe_hidden_size=3584)
+    assert validate_routed_expert_sharding(cfg, mesh,
+                                           block_quantized=True) == (4, 8)
+
+
+# --------------------------------------------------------------------------
+# Numerics: the down projection now contracts a split dimension
+# --------------------------------------------------------------------------
+
+
+def _routed_experts(ckpt, mesh, *, quantized):
+    from tests.models.jax.test_kimi_k3_mxfp4 import (_build_loaded_model,
+                                                     _moe_block)
+    return _moe_block(_build_loaded_model(ckpt, mesh,
+                                          quantized=quantized)).experts
+
+
+def _apply(experts, x, weights_TX, indices_TX, mesh):
+    with jax.set_mesh(mesh):
+        return np.asarray(
+            experts.quant_method.apply_jax(experts,
+                                           x,
+                                           router_logits=(weights_TX,
+                                                          indices_TX)))
+
+
+def _expert_inputs(experts, num_tokens=16, seed=0):
+    rng = np.random.default_rng(seed)
+    x = jnp.asarray(rng.standard_normal((num_tokens, experts.hidden_size)),
+                    dtype=jnp.float32)
+    indices_TX = jnp.asarray(rng.integers(0,
+                                          experts.num_local_experts,
+                                          size=(num_tokens, experts.top_k)),
+                             dtype=jnp.int32)
+    weights_TX = jnp.full((num_tokens, experts.top_k),
+                          1.0 / experts.top_k,
+                          dtype=jnp.float32)
+    return x, weights_TX, indices_TX
+
+
+@pytest.fixture(scope="module")
+def wide_f_checkpoints(tmp_path_factory):
+    """K3-tiny with a wider ``moe_intermediate_size``.
+
+    The shipped fixture has F=384, whose only splits are 192 and 96 -- neither
+    a multiple of 128, which the block-quantized grouped matmul requires (see
+    `test_indivisible_per_shard_intermediate_is_refused`). F=1024 splits into
+    512 and 256, so the composed layout can actually be exercised. Built here
+    rather than shipped: it is random weights compared against themselves, so
+    it needs no goldens.
+    """
+    import json
+
+    from tests.models.jax.utils.k3_tiny_generator import (TINY_TEXT_CONFIG,
+                                                          build_state_dicts,
+                                                          write_checkpoint)
+    cfg = json.loads(json.dumps(TINY_TEXT_CONFIG))
+    cfg["moe_intermediate_size"] = 1024
+    cfg["num_experts"] = 8
+    bf16, mxfp4 = build_state_dicts(42, cfg=cfg)
+    root = tmp_path_factory.mktemp("k3-wide-f")
+    write_checkpoint(str(root / "bf16"), bf16, False, None, cfg=cfg)
+    write_checkpoint(str(root / "mxfp4"), mxfp4, True, None, cfg=cfg)
+    return {"bf16": str(root / "bf16"), "mxfp4": str(root / "mxfp4")}
+
+
+@pytest.mark.parametrize("ckpt_kind", ["bf16", "mxfp4"])
+def test_composed_sharding_matches_expert_only_sharding(
+        ckpt_kind, wide_f_checkpoints):
+    """Splitting F as well as E must not change the answer.
+
+    Held against the expert-only layout rather than a single device: same
+    backend (MEGABLX_GMM), same expert-axis width, same weights. The only
+    difference is that F is split 4 ways, which makes the down projection
+    contract a sharded dimension -- so if its partial sums were not reduced,
+    or reduced over the wrong axis, this is where it shows.
+    """
+    quantized = ckpt_kind == "mxfp4"
+    ckpt = wide_f_checkpoints[ckpt_kind]
+
+    expert_only = _mesh(attn_dp_expert=2)
+    composed = _mesh(attn_dp_expert=2, model=4)
+    assert routed_expert_sharding_ways(expert_only) == (2, 1)
+    assert routed_expert_sharding_ways(composed) == (2, 4)
+
+    ref_experts = _routed_experts(ckpt, expert_only, quantized=quantized)
+    new_experts = _routed_experts(ckpt, composed, quantized=quantized)
+    for experts in (ref_experts, new_experts):
+        assert experts.moe_backend.value == "megablox_gmm"
+
+    # The composed layout really did split F on device, not just in the spec.
+    down = new_experts.kernel_down_proj_EFD.value
+    assert down.sharding.spec == P(E_AXES, F_AXIS, None)
+    assert down.addressable_shards[0].data.shape[1] == down.shape[1] // 4
+
+    x, weights_TX, indices_TX = _expert_inputs(ref_experts)
+    ref = _apply(ref_experts, x, weights_TX, indices_TX, expert_only)
+    got = _apply(new_experts, x, weights_TX, indices_TX, composed)
+
+    scale = float(np.abs(ref).max())
+    assert scale > 0, "reference output is all zeros; the comparison is vacuous"
+    assert not np.isnan(got).any(), "composed layout produced NaNs"
+    np.testing.assert_allclose(got, ref, rtol=1e-5, atol=1e-6 * scale)
+
+
+def test_indivisible_per_shard_intermediate_is_refused():
+    """F can divide evenly and still leave a per-shard width the quantized
+    grouped matmul mishandles.
+
+    Measured: F=384 split 4 ways gives 96, and the block-quantized path then
+    returns 9 NaNs out of 8192 output entries while the rest stay correct to
+    ~1e-8 -- a silent corruption, so it is refused up front. The same width is
+    clean for bf16 weights, hence the `block_quantized` gate.
+    """
+    mesh = _mesh(attn_dp_expert=2, model=4)
+    cfg = _config(moe_intermediate_size=384)  # 384/4 = 96, 96 % 128 != 0
+    validate_routed_expert_sharding(cfg, mesh, block_quantized=False)
+    with pytest.raises(ValueError, match="not a multiple of 128"):
+        validate_routed_expert_sharding(cfg, mesh, block_quantized=True)
+
+
+def test_real_k3_per_shard_intermediate_is_a_multiple_of_128():
+    """K3's F=3072 over the intended 8-way tensor axis gives 384."""
+    mesh = _mesh(attn_dp_expert=4, model=8)
+    cfg = _config(num_experts=896,
+                  moe_intermediate_size=3072,
+                  moe_hidden_size=3584)
+    assert validate_routed_expert_sharding(cfg, mesh,
+                                           block_quantized=True) == (4, 8)
+    assert (3072 // 8) % 128 == 0

--- a/tests/models/jax/test_kimi_k3_mxfp4.py
+++ b/tests/models/jax/test_kimi_k3_mxfp4.py
@@ -1,0 +1,374 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Kimi routed experts stored as compressed-tensors ``mxfp4-pack-quantized``.
+
+The fixture pair these tests need is a bf16 checkpoint and an MXFP4 twin whose
+expert weights were drawn *on* the fp4 grid, so ``dequantize(mxfp4) == bf16``
+holds exactly and any difference between the two models is a loader bug rather
+than quantization error. Point ``K3_TINY_CKPT`` and ``K3_TINY_MXFP4_CKPT`` at
+them, otherwise these tests skip.
+
+What is gated here:
+  * the checkpoint's fp4 codes and E8M0 scales survive loading unchanged (the
+    model is quantization-aware-trained, so re-deriving scales would move the
+    weights off the values training converged on);
+  * expert weights stay 4-bit on device;
+  * a layer the config's target list claims is quantized but the checkpoint
+    stores as plain bf16 still loads (the config ignore list is not a
+    trustworthy statement of what is compressed -- the checkpoint is).
+"""
+
+import json
+import os
+import types
+from types import MappingProxyType
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.sharding import Mesh
+from safetensors import safe_open
+from vllm.model_executor.layers.quantization.compressed_tensors.utils import \
+    should_ignore_layer
+
+from tpu_inference.layers.common.quantization import (e8m0_to_fp32,
+                                                      u8_unpack_e2m1)
+from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
+from tpu_inference.layers.jax.quantization.compressed_tensors import \
+    CompressedTensorsConfig
+from tpu_inference.layers.jax.quantization.mxfp4 import \
+    CompressedTensorsMxfp4MoEMethod
+from tpu_inference.layers.jax.quantization.unquantized import UnquantizedConfig
+from tpu_inference.models.jax.kimi_k3 import KimiLinearForCausalLM
+
+BF16_CKPT = os.environ.get("K3_TINY_CKPT", "")
+MXFP4_CKPT = os.environ.get("K3_TINY_MXFP4_CKPT", "")
+
+# A quantized expert projection, and the layer it lives in. Layer 1 is the
+# first MoE layer (layer 0 is the dense MLP).
+MOE_LAYER = 1
+
+# Module paths the config's target/ignore lists claim are quantized while the
+# checkpoint stores them as plain bf16 -- the Kimi-K3 hazard this loader has to
+# resolve from the checkpoint rather than the config.
+_AMBIGUOUS_PREFIXES = (
+    f"model.layers.{MOE_LAYER}.block_sparse_moe.routed_expert_down_proj",
+    f"model.layers.{MOE_LAYER}.block_sparse_moe.routed_expert_up_proj",
+    f"model.layers.{MOE_LAYER}.mlp_res_proj",
+)
+
+
+def _skip_if_missing():
+    for ckpt, var in ((BF16_CKPT, "K3_TINY_CKPT"), (MXFP4_CKPT,
+                                                    "K3_TINY_MXFP4_CKPT")):
+        if not ckpt or not os.path.isdir(ckpt):
+            pytest.skip(f"K3-tiny checkpoint not available (set {var})")
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    devices = np.array(jax.devices()[:1]).reshape((1, ) * len(MESH_AXIS_NAMES))
+    return Mesh(devices, axis_names=MESH_AXIS_NAMES)
+
+
+def _hf_config(ckpt):
+    with open(os.path.join(ckpt, "config.json")) as f:
+        return types.SimpleNamespace(**json.load(f))
+
+
+def _vllm_config_double(ckpt, *, quantized):
+    """The slice of VllmConfig the model reads, without an engine."""
+    hf = _hf_config(ckpt)
+    if quantized:
+        quant_config = CompressedTensorsConfig(hf.quantization_config,
+                                               model_name_or_path=ckpt)
+    else:
+        quant_config = UnquantizedConfig({})
+    return types.SimpleNamespace(
+        model_config=types.SimpleNamespace(
+            hf_config=hf,
+            dtype=jnp.float32,
+            get_vocab_size=lambda: hf.vocab_size),
+        quant_config=quant_config,
+        cache_config=types.SimpleNamespace(cache_dtype="auto"))
+
+
+def _checkpoint_weights(ckpt):
+    f = safe_open(os.path.join(ckpt, "model.safetensors"), "pt")
+    for name in f.keys():
+        yield name, f.get_tensor(name)
+
+
+def _build_loaded_model(ckpt, mesh, *, quantized):
+    with jax.set_mesh(mesh):
+        model = KimiLinearForCausalLM(
+            _vllm_config_double(ckpt, quantized=quantized),
+            jax.random.PRNGKey(0), mesh)
+        model.load_weights(_checkpoint_weights(ckpt))
+    return model
+
+
+@pytest.fixture(scope="module")
+def mxfp4_model(mesh):
+    _skip_if_missing()
+    return _build_loaded_model(MXFP4_CKPT, mesh, quantized=True)
+
+
+def _moe_block(model, layer_idx=MOE_LAYER):
+    return model.model.layers[layer_idx].block_sparse_moe
+
+
+def _checkpoint_tensor(ckpt, name):
+    with safe_open(os.path.join(ckpt, "model.safetensors"),
+                   framework="numpy") as f:
+        return jnp.asarray(f.get_tensor(name))
+
+
+def _expert_prefix(layer_idx=MOE_LAYER):
+    return f"model.layers.{layer_idx}.block_sparse_moe.experts"
+
+
+def test_expert_weights_stay_four_bit_on_device(mxfp4_model):
+    """4-bit residency: the decode must not expand the experts to bf16."""
+    experts = _moe_block(mxfp4_model).experts
+    for name in ("kernel_gating_EDF", "kernel_up_proj_EDF",
+                 "kernel_down_proj_EFD"):
+        param = getattr(experts, name)
+        assert param.value.dtype == jnp.float4_e2m1fn, (
+            f"{name} was materialized as {param.value.dtype}, expected "
+            "float4_e2m1fn")
+        scale = getattr(experts, f"{name}_weight_scale")
+        assert scale.value.dtype == jnp.float32
+
+
+def test_expert_codes_are_the_checkpoint_nibbles(mxfp4_model):
+    """Lossless values: every loaded fp4 code equals the checkpoint's."""
+    experts = _moe_block(mxfp4_model).experts
+    num_experts = experts.num_local_experts
+    for suffix, param_name in (("w1", "kernel_gating_EDF"),
+                               ("w3", "kernel_up_proj_EDF"),
+                               ("w2", "kernel_down_proj_EFD")):
+        loaded = getattr(experts, param_name).value
+        for expert_id in (0, num_experts - 1):
+            packed = _checkpoint_tensor(
+                MXFP4_CKPT,
+                f"{_expert_prefix()}.{expert_id}.{suffix}.weight_packed")
+            # Checkpoint is [out, in] with `in` packed; the kernel is (E,in,out).
+            expected = jnp.swapaxes(u8_unpack_e2m1(packed), 0, 1)
+            got = loaded[expert_id]
+            assert got.shape == expected.shape
+            assert jnp.array_equal(got.astype(
+                jnp.float32), expected.astype(
+                    jnp.float32)), (f"expert {expert_id} {suffix} codes "
+                                    "differ from the checkpoint")
+
+
+def test_checkpoint_scales_are_passed_through_exactly(mxfp4_model):
+    """Lossless scales: no requantization, no recomputed exponents.
+
+    The loaded scale must re-encode to the checkpoint's E8M0 bytes exactly.
+    """
+    experts = _moe_block(mxfp4_model).experts
+    num_experts = experts.num_local_experts
+    for suffix, param_name in (("w1", "kernel_gating_EDF"),
+                               ("w3", "kernel_up_proj_EDF"),
+                               ("w2", "kernel_down_proj_EFD")):
+        loaded = getattr(experts, f"{param_name}_weight_scale").value
+        for expert_id in (0, num_experts - 1):
+            raw_u8 = _checkpoint_tensor(
+                MXFP4_CKPT,
+                f"{_expert_prefix()}.{expert_id}.{suffix}.weight_scale")
+            expected = jnp.swapaxes(e8m0_to_fp32(raw_u8), 0, 1)
+            got = loaded[expert_id]
+            assert got.shape == expected.shape
+            assert jnp.array_equal(got, expected), (
+                f"expert {expert_id} {suffix} scales are not the checkpoint's")
+            # Every scale is an exact power of two, i.e. nothing was averaged
+            # or re-fit over a larger block.
+            _, exponent = jnp.frexp(got)
+            assert jnp.array_equal(
+                jnp.ldexp(jnp.full_like(got, 0.5), exponent), got)
+
+
+def test_scale_group_size_matches_the_checkpoint(mxfp4_model):
+    """One scale per 32 input elements, as `group_size` in the config says."""
+    experts = _moe_block(mxfp4_model).experts
+    group_size = _hf_config(MXFP4_CKPT).quantization_config["config_groups"][
+        "group_0"]["weights"]["group_size"]
+    for param_name in ("kernel_gating_EDF", "kernel_up_proj_EDF",
+                       "kernel_down_proj_EFD"):
+        weight = getattr(experts, param_name).value
+        scale = getattr(experts, f"{param_name}_weight_scale").value
+        assert weight.shape[1] == scale.shape[1] * group_size
+        assert weight.shape[2] == scale.shape[2]
+
+
+def test_uncompressed_targets_are_read_off_the_checkpoint_not_the_config():
+    """Trust the checkpoint's tensor names, not the config's ignore list.
+
+    K3 targets every ``Linear`` and its ignore list does not mention the MoE
+    latent projections or the attention-residual projections, yet the
+    checkpoint stores those as plain bf16. A config-only decision calls them
+    quantized and the load then fails looking for a `weight_packed` that isn't
+    there.
+    """
+    _skip_if_missing()
+    hf = _hf_config(MXFP4_CKPT)
+    config = CompressedTensorsConfig(hf.quantization_config,
+                                     model_name_or_path=MXFP4_CKPT)
+    assert config._compressed_modules is not None, (
+        "checkpoint scan failed; the rest of this test would pass vacuously")
+
+    # Every Linear is a target, so the config alone offers no way out.
+    assert "Linear" in config._target_scheme_map
+
+    for prefix in _AMBIGUOUS_PREFIXES:
+        # The hazard is real: nothing in the ignore list covers these...
+        assert not should_ignore_layer(prefix,
+                                       ignore=config._ct.ignore,
+                                       fused_mapping=MappingProxyType({}))
+        # ...but the checkpoint does not store them compressed.
+        assert not config._is_compressed_in_checkpoint(prefix)
+
+    # The experts, which the checkpoint really does compress, are selected.
+    assert config._is_compressed_in_checkpoint(_expert_prefix())
+
+
+def test_moe_layer_gets_the_mxfp4_method(mxfp4_model):
+    assert isinstance(
+        _moe_block(mxfp4_model).experts.quant_method,
+        CompressedTensorsMxfp4MoEMethod)
+
+
+def test_uncompressed_moe_falls_back_to_the_unquantized_method():
+    """A checkpoint that targets the experts but stores them plain bf16."""
+    _skip_if_missing()
+    hf = _hf_config(MXFP4_CKPT)
+    config = CompressedTensorsConfig(hf.quantization_config,
+                                     model_name_or_path=BF16_CKPT)
+    assert config._compressed_modules == set()
+    assert not config._is_compressed_in_checkpoint(_expert_prefix())
+
+
+def test_fused_backend_is_rejected(mesh):
+    """The fused GMM backends drop the router bias and have no situ branch."""
+    _skip_if_missing()
+    from tpu_inference.layers.common.moe import MoEBackend
+
+    layer = types.SimpleNamespace(moe_backend=MoEBackend.GMM_TP,
+                                  prefix="experts")
+    with pytest.raises(NotImplementedError, match="unfused MoE backends"):
+        CompressedTensorsMxfp4MoEMethod(layer)
+
+
+def _logits(model, mesh, ckpt):
+    """Prefill logits for a fixed prompt, with hand-allocated state."""
+    from tests.models.jax.test_kimi_k3 import (_forward, _fresh_caches,
+                                               _kimi_config, _metadata)
+    config = _kimi_config(ckpt)
+    seq_len = 32
+    rng = np.random.default_rng(0)
+    input_ids = jnp.asarray(rng.integers(0, config.vocab_size, size=seq_len),
+                            dtype=jnp.int32)
+    caches = _fresh_caches(config)
+    md = _metadata(seq_len,
+                   jnp.arange(seq_len, dtype=jnp.int32),
+                   seq_len,
+                   decode=False)
+    with jax.set_mesh(mesh):
+        _, _, logits = _forward(model, caches, input_ids, md)
+    return logits
+
+
+def test_mxfp4_logits_equal_the_bf16_twin(mxfp4_model, mesh):
+    """The fixture's fp4 codes dequantize exactly, so the models must agree."""
+    bf16_model = _build_loaded_model(BF16_CKPT, mesh, quantized=False)
+    ref = _logits(bf16_model, mesh, BF16_CKPT)
+    got = _logits(mxfp4_model, mesh, MXFP4_CKPT)
+    max_abs = float(jnp.max(jnp.abs(got - ref)))
+    assert max_abs == 0.0, (
+        f"MXFP4 logits differ from the bf16 twin by {max_abs} (both "
+        "checkpoints hold the same values; any difference is a loader bug)")
+
+    # Anti-vacuity: the comparison has to be able to fail. Bumping one expert
+    # group's scale by a single E8M0 step must move the logits.
+    experts = _moe_block(mxfp4_model).experts
+    original = experts.kernel_gating_EDF_weight_scale.value
+    experts.kernel_gating_EDF_weight_scale.value = original.at[0, 0,
+                                                               0].multiply(2.0)
+    try:
+        perturbed = _logits(mxfp4_model, mesh, MXFP4_CKPT)
+    finally:
+        experts.kernel_gating_EDF_weight_scale.value = original
+    assert float(jnp.max(jnp.abs(perturbed - ref))) > 0.0
+
+
+def _routed_expert_output(experts, x, weights_TX, indices_TX, mesh):
+    with jax.set_mesh(mesh):
+        return np.asarray(
+            experts.quant_method.apply_jax(experts,
+                                           x,
+                                           router_logits=(weights_TX,
+                                                          indices_TX)))
+
+
+def test_expert_parallel_gmm_matches_the_bf16_twin(mesh):
+    """The sharded MEGABLX_GMM path is what the real model runs on.
+
+    DENSE_MAT evaluates every expert on every device and only works while the
+    experts are replicated; once they shard, K3 dispatches through the
+    grouped-matmul kernel, which consumes the fp4 codes and their per-group
+    scales directly rather than a dequantized copy.
+
+    Driven at the MoE layer rather than the whole model: the two must differ
+    only in quantization, and a whole-model comparison across meshes cannot
+    give that (the fixture's hand-allocated caches make expert-parallel and
+    replicated whole-model runs disagree by ~1.7 in logits for *unquantized*
+    weights too, so it would not isolate the variable).
+    """
+    _skip_if_missing()
+    from tests.models.jax.test_kimi_k3 import _expert_parallel_mesh
+    ep_mesh = _expert_parallel_mesh(2)
+
+    bf16_experts = _moe_block(
+        _build_loaded_model(BF16_CKPT, ep_mesh, quantized=False)).experts
+    mxfp4_experts = _moe_block(
+        _build_loaded_model(MXFP4_CKPT, ep_mesh, quantized=True)).experts
+    for experts in (bf16_experts, mxfp4_experts):
+        assert experts.moe_backend.value == "megablox_gmm"
+
+    rng = np.random.default_rng(0)
+    num_tokens = 16
+    x = jnp.asarray(rng.standard_normal(
+        (num_tokens, bf16_experts.hidden_size)),
+                    dtype=jnp.float32)
+    top_k = bf16_experts.top_k
+    indices_TX = jnp.asarray(rng.integers(0,
+                                          bf16_experts.num_local_experts,
+                                          size=(num_tokens, top_k)),
+                             dtype=jnp.int32)
+    weights_TX = jnp.full((num_tokens, top_k), 1.0 / top_k, dtype=jnp.float32)
+
+    ref = _routed_expert_output(bf16_experts, x, weights_TX, indices_TX,
+                                ep_mesh)
+    got = _routed_expert_output(mxfp4_experts, x, weights_TX, indices_TX,
+                                ep_mesh)
+
+    assert not np.isnan(got).any()
+    max_abs = float(np.max(np.abs(got - ref)))
+    scale = float(np.max(np.abs(ref)))
+    assert max_abs < 5e-3 * max(scale, 1.0), (
+        f"expert-parallel MXFP4 expert output differs from the bf16 twin by "
+        f"{max_abs} (output scale {scale})")

--- a/tests/models/jax/test_kimi_k3_mxfp4_real_layer.py
+++ b/tests/models/jax/test_kimi_k3_mxfp4_real_layer.py
@@ -1,0 +1,292 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""One real Kimi-K3 MoE layer's experts, loaded from the real checkpoint.
+
+The tiny fixture pins the loader's *logic*; this pins it against the bytes the
+released checkpoint actually ships -- real expert count and widths, real E8M0
+scale distribution, the `language_model.` prefix the multimodal wrapper adds.
+
+Point ``K3_REAL_SHARD`` at a directory holding the shard that contains a whole
+MoE layer (in the released 96-shard checkpoint, layer 1 lives entirely in
+`model-00002-of-000096.safetensors`) plus that checkpoint's `config.json`,
+otherwise these tests skip.
+
+The reference is deliberately independent of the loader: nibbles are pulled
+out of the uint8 words with numpy shifts and masks and mapped through the
+E2M1 value table by hand, and the scales are read as raw exponents.
+"""
+
+import json
+import os
+from types import SimpleNamespace
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.sharding import Mesh
+from safetensors import safe_open
+
+from tpu_inference.layers.common.moe import MoEBackend
+from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
+from tpu_inference.layers.jax.quantization.compressed_tensors import \
+    CompressedTensorsConfig
+
+REAL_SHARD_DIR = os.environ.get("K3_REAL_SHARD", "")
+LAYER = int(os.environ.get("K3_REAL_SHARD_LAYER", "1"))
+# Loading every expert of a real layer is ~15 GB of packed weights; the byte
+# comparisons run over all of them, the forward-parity check over this many.
+NUM_EXPERTS_FOR_FORWARD = int(os.environ.get("K3_REAL_FORWARD_EXPERTS", "8"))
+
+# The eight magnitudes an e2m1 code can denote, indexed by its low 3 bits.
+E2M1_MAGNITUDES = np.array([0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0],
+                           dtype=np.float64)
+
+PROJECTIONS = (("w1", "kernel_gating_EDF"), ("w3", "kernel_up_proj_EDF"),
+               ("w2", "kernel_down_proj_EFD"))
+
+
+def _skip_if_missing():
+    if not REAL_SHARD_DIR or not os.path.isdir(REAL_SHARD_DIR):
+        pytest.skip("real Kimi-K3 shard not available (set K3_REAL_SHARD)")
+
+
+def _shard_path():
+    shards = [
+        f for f in sorted(os.listdir(REAL_SHARD_DIR))
+        if f.endswith(".safetensors")
+    ]
+    if len(shards) != 1:
+        pytest.skip(f"expected exactly one shard in {REAL_SHARD_DIR}, "
+                    f"found {len(shards)}")
+    return os.path.join(REAL_SHARD_DIR, shards[0])
+
+
+def _text_config():
+    with open(os.path.join(REAL_SHARD_DIR, "config.json")) as f:
+        config = json.load(f)
+    return config.get("text_config", config), config
+
+
+def _reference_dequantize(packed: np.ndarray,
+                          scale_u8: np.ndarray) -> np.ndarray:
+    """Independent fp64 dequantization of one `[out, in]` expert projection."""
+    low = packed & 0x0F
+    high = packed >> 4
+    # compressed-tensors packs the even-indexed value in the low nibble.
+    codes = np.empty((packed.shape[0], packed.shape[1] * 2), dtype=np.uint8)
+    codes[:, 0::2] = low
+    codes[:, 1::2] = high
+    magnitude = E2M1_MAGNITUDES[codes & 0x07]
+    sign = np.where(codes & 0x08, -1.0, 1.0)
+    values = sign * magnitude
+    # E8M0: the stored byte is the exponent biased by 127.
+    scale = np.ldexp(1.0, scale_u8.astype(np.int32) - 127).astype(np.float64)
+    group = values.shape[1] // scale.shape[1]
+    return (values.reshape(values.shape[0], scale.shape[1], group) *
+            scale[:, :, None]).reshape(values.shape)
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    devices = np.array(jax.devices()[:1]).reshape((1, ) * len(MESH_AXIS_NAMES))
+    return Mesh(devices, axis_names=MESH_AXIS_NAMES)
+
+
+@pytest.fixture(scope="module")
+def expert_prefix():
+    _skip_if_missing()
+    with safe_open(_shard_path(), framework="numpy") as f:
+        names = [
+            n for n in f.keys() if f".layers.{LAYER}." in n
+            and ".experts." in n and n.endswith(".weight_packed")
+        ]
+    if not names:
+        pytest.skip(f"shard holds no packed experts for layer {LAYER}")
+    # ".../experts.<id>.<proj>.weight_packed" -> ".../experts"
+    return names[0].rsplit(".", 3)[0]
+
+
+@pytest.fixture(scope="module")
+def loaded_experts(mesh, expert_prefix):
+    """A real-width KimiRoutedExperts holding the checkpoint's own bytes."""
+    from flax import nnx
+    from jax.sharding import PartitionSpec as P
+
+    from tpu_inference.models.jax.kimi_k3 import (WRAPPER_TEXT_PREFIX,
+                                                  KimiRoutedExperts)
+
+    # The released checkpoint stores the text stack under `language_model.`;
+    # the model's module paths do not carry it, and neither does the prefix the
+    # quant config is asked about. Keep the two apart here for the same reason
+    # the loader does: `expert_prefix` names checkpoint tensors,
+    # `module_prefix` names a module.
+    module_prefix = expert_prefix.removeprefix(WRAPPER_TEXT_PREFIX)
+
+    # Spelled out rather than taken from `ShardingAxisName`: that resolves
+    # lazily against whichever mesh layout the process configured first, and
+    # this test builds its mesh directly instead of going through the model.
+    expert_axis = ("attn_dp_expert", "expert")
+    data_axis = "data"
+
+    text_config, full_config = _text_config()
+    quant_config = CompressedTensorsConfig(
+        full_config.get("quantization_config")
+        or text_config["quantization_config"],
+        model_name_or_path=REAL_SHARD_DIR)
+
+    with safe_open(_shard_path(), framework="pt") as f:
+        names = sorted(n for n in f.keys()
+                       if n.startswith(expert_prefix + "."))
+        num_experts = 1 + max(
+            int(n[len(expert_prefix) + 1:].split(".")[0]) for n in names)
+        assert num_experts == text_config["num_experts"], (
+            f"shard holds {num_experts} experts, config says "
+            f"{text_config['num_experts']}")
+
+        with jax.set_mesh(mesh):
+            experts = KimiRoutedExperts(
+                dtype=jnp.bfloat16,
+                num_local_experts=num_experts,
+                apply_expert_weight_before_computation=False,
+                expert_axis_name=expert_axis,
+                num_expert_parallelism=1,
+                hidden_size=text_config["routed_expert_hidden_size"],
+                intermediate_size_moe=text_config["moe_intermediate_size"],
+                num_experts_per_tok=text_config["num_experts_per_token"],
+                mesh=mesh,
+                hidden_act=text_config["hidden_act"],
+                rngs=nnx.Rngs(0),
+                random_init=False,
+                quant_config=quant_config,
+                activation_ffw_td=P(data_axis, None),
+                activation_ffw_ted=P(data_axis, None, None),
+                edf_sharding=P(expert_axis, None, None),
+                efd_sharding=P(expert_axis, None, None),
+                moe_backend=MoEBackend.DENSE_MAT,
+                qwix_quantized_weight_dtype=None,
+                prefix=module_prefix,
+                # Only `num_experts_per_tok` is read during construction; the
+                # tests below drive the expert kernels directly, not routing.
+                router=SimpleNamespace(
+                    num_experts_per_tok=text_config["num_experts_per_token"]),
+                scoring_func="sigmoid",
+                renormalize=True)
+            experts.load_weights(
+                (n.removeprefix(WRAPPER_TEXT_PREFIX), f.get_tensor(n))
+                for n in names)
+            assert experts.quant_method.process_weights_after_loading(experts)
+    return experts
+
+
+def _checkpoint(name):
+    with safe_open(_shard_path(), framework="numpy") as f:
+        return f.get_tensor(name)
+
+
+def test_real_layer_scales_are_byte_identical(loaded_experts, expert_prefix):
+    """QAT fidelity: the loaded scales re-encode to the checkpoint's bytes.
+
+    Runs over every expert in the layer, so a scale recomputed anywhere -- for
+    one projection, one expert, one group -- fails.
+    """
+    checked = 0
+    for suffix, param_name in PROJECTIONS:
+        loaded = np.asarray(
+            getattr(loaded_experts, f"{param_name}_weight_scale").value)
+        for expert_id in range(loaded_experts.num_local_experts):
+            raw = _checkpoint(
+                f"{expert_prefix}.{expert_id}.{suffix}.weight_scale")
+            _, exponent = np.frexp(loaded[expert_id].T)
+            reencoded = (exponent - 1 + 127).astype(np.uint8)
+            assert np.array_equal(reencoded, raw), (
+                f"expert {expert_id} {suffix}: loaded scales do not re-encode "
+                "to the checkpoint's E8M0 bytes")
+            checked += 1
+    assert checked == 3 * loaded_experts.num_local_experts
+
+
+def test_real_layer_codes_match_an_independent_decode(loaded_experts,
+                                                      expert_prefix):
+    """Lossless values, checked against a hand-written nibble decode."""
+    for suffix, param_name in PROJECTIONS:
+        loaded = getattr(loaded_experts, param_name).value
+        for expert_id in (0, loaded_experts.num_local_experts - 1):
+            packed = _checkpoint(
+                f"{expert_prefix}.{expert_id}.{suffix}.weight_packed")
+            scale = _checkpoint(
+                f"{expert_prefix}.{expert_id}.{suffix}.weight_scale")
+            expected = _reference_dequantize(packed, scale).T
+            scales = np.asarray(
+                getattr(loaded_experts,
+                        f"{param_name}_weight_scale").value)[expert_id]
+            group = expected.shape[0] // scales.shape[0]
+            got = (np.asarray(loaded[expert_id], dtype=np.float64).reshape(
+                scales.shape[0], group, -1) * scales[:, None, :]).reshape(
+                    expected.shape)
+            assert np.array_equal(got, expected), (
+                f"expert {expert_id} {suffix}: dequantized weights differ "
+                "from the independent reference")
+
+
+def test_real_layer_forward_matches_a_cpu_dequant_reference(
+        loaded_experts, expert_prefix, mesh):
+    """The device path's expert matmul, against an fp64 CPU reference."""
+    from tpu_inference.layers.common.process_weights.moe_weights import \
+        UnfusedMoEWeights
+    from tpu_inference.layers.jax.moe.dense_moe import \
+        dequantize_unfused_moe_weights
+
+    n = min(NUM_EXPERTS_FOR_FORWARD, loaded_experts.num_local_experts)
+    latent = loaded_experts.hidden_size
+    rng = np.random.default_rng(0)
+    x = rng.standard_normal((4, latent)).astype(np.float32)
+
+    weights = UnfusedMoEWeights(
+        w1_weight=loaded_experts.kernel_gating_EDF.value[:n],
+        w1_weight_scale=loaded_experts.kernel_gating_EDF_weight_scale.
+        value[:n],
+        w1_bias=None,
+        w2_weight=loaded_experts.kernel_up_proj_EDF.value[:n],
+        w2_weight_scale=loaded_experts.kernel_up_proj_EDF_weight_scale.
+        value[:n],
+        w2_bias=None,
+        w3_weight=loaded_experts.kernel_down_proj_EFD.value[:n],
+        w3_weight_scale=loaded_experts.kernel_down_proj_EFD_weight_scale.
+        value[:n],
+        w3_bias=None,
+    )
+    with jax.set_mesh(mesh):
+        expanded = dequantize_unfused_moe_weights(weights, jnp.float32)
+        # HIGHEST precision so the tolerance below is testing the loaded
+        # weights, not XLA:TPU's default bf16-passes fp32 matmul (which alone
+        # costs ~2e-3 relative over this 3584-long contraction).
+        gate = np.asarray(
+            jnp.einsum("TD,EDF->TEF",
+                       jnp.asarray(x),
+                       expanded.w1_weight,
+                       precision=jax.lax.Precision.HIGHEST))
+
+    reference = np.empty_like(gate, dtype=np.float64)
+    for expert_id in range(n):
+        packed = _checkpoint(f"{expert_prefix}.{expert_id}.w1.weight_packed")
+        scale = _checkpoint(f"{expert_prefix}.{expert_id}.w1.weight_scale")
+        w = _reference_dequantize(packed, scale)  # [F, D]
+        reference[:, expert_id, :] = x.astype(np.float64) @ w.T
+
+    max_abs = float(np.max(np.abs(gate.astype(np.float64) - reference)))
+    scale_of = float(np.max(np.abs(reference)))
+    assert max_abs < 1e-3 * max(scale_of, 1.0), (
+        f"real-layer gate projection differs from the fp64 reference by "
+        f"{max_abs} (output scale {scale_of})")

--- a/tests/models/jax/test_kimi_k3_mxfp4_shard_decode.py
+++ b/tests/models/jax/test_kimi_k3_mxfp4_shard_decode.py
@@ -1,0 +1,237 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shard-then-decode MXFP4 experts produce the host decode's exact bytes.
+
+Decoding each device's shard on that device instead of decoding a whole layer
+on the host is only sound because the fp4 unpack and the E8M0 expansion are
+elementwise along the packed axis, so every shard boundary falls on a whole
+uint8 word. That is an argument about the sharding arithmetic, so these tests
+compare the two paths *bit for bit* -- `.view(uint8)` / `.view(uint32)`, not
+`==`, so a `-0.0` that should be `+0.0` cannot pass -- over the mesh shapes
+Kimi-K3 actually uses, and check that a shard which would split a packed word
+is refused rather than silently mis-decoded.
+
+Needs at least 8 devices for the interesting mesh shapes. On a host without
+them, run with
+``XLA_FLAGS=--xla_force_host_platform_device_count=8 JAX_PLATFORMS=cpu``.
+
+`K3_TINY_MXFP4_CKPT` and `K3_REAL_SHARD` (see the sibling MXFP4 tests) add the
+same comparison over real checkpoint bytes.
+"""
+
+import glob
+import os
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+from safetensors import safe_open
+
+from tpu_inference.layers.common.quantization import (e8m0_to_fp32,
+                                                      u8_unpack_e2m1)
+from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
+from tpu_inference.layers.jax.quantization.mxfp4 import (
+    CompressedTensorsMxfp4MoEMethod, _decode_sharded)
+
+TINY_MXFP4_CKPT = os.environ.get("K3_TINY_MXFP4_CKPT", "")
+REAL_SHARD_DIR = os.environ.get("K3_REAL_SHARD", "")
+REAL_SHARD_LAYER = int(os.environ.get("K3_REAL_SHARD_LAYER", "1"))
+
+# `(expert axis, model axis)` device counts. K3 runs `E` over
+# `ShardingAxisName.ATTN_DATA_EXPERT` and `F` over `ShardingAxisName.MODEL`;
+# the pairs below are the composed mesh the sliced-checkpoint rig uses (2x4),
+# plus each axis carrying the whole split on its own.
+MESH_SHAPES = ((2, 4), (1, 8), (8, 1), (4, 2))
+
+EXPERT_AXIS = "attn_dp_expert"
+MODEL_AXIS = "model"
+
+
+def _mesh(num_expert: int, num_model: int, num_data: int = 1) -> Mesh:
+    needed = num_expert * num_model * num_data
+    devices = jax.devices()
+    if len(devices) < needed:
+        pytest.skip(f"needs {needed} devices, have {len(devices)}")
+    sizes = {EXPERT_AXIS: num_expert, MODEL_AXIS: num_model, "data": num_data}
+    shape = tuple(sizes.get(name, 1) for name in MESH_AXIS_NAMES)
+    grid = np.array(devices[:needed]).reshape(shape)
+    return Mesh(grid, axis_names=MESH_AXIS_NAMES)
+
+
+def _specs():
+    """`(edf, efd)` in the spelling `routed_expert_shardings` produces."""
+    return (P(EXPERT_AXIS, None, MODEL_AXIS), P(EXPERT_AXIS, MODEL_AXIS, None))
+
+
+def _stage(rng, num_experts, out, packed_in, group):
+    """Per-expert `[1, out, in]` staging tensors, as `load_weights` builds."""
+    packed = [
+        jnp.asarray(rng.integers(0, 256, (1, out, packed_in), dtype=np.uint8))
+        for _ in range(num_experts)
+    ]
+    scale = [
+        jnp.asarray(
+            rng.integers(0,
+                         256, (1, out, packed_in * 2 // group),
+                         dtype=np.uint8)) for _ in range(num_experts)
+    ]
+    return packed, scale
+
+
+def _assert_bit_identical(new, old, what):
+    assert new.shape == old.shape, f"{what}: {new.shape} != {old.shape}"
+    assert new.dtype == old.dtype, f"{what}: {new.dtype} != {old.dtype}"
+    assert new.sharding == old.sharding, (
+        f"{what}: {new.sharding} != {old.sharding}")
+    raw = np.uint8 if old.dtype.itemsize == 1 else np.uint32
+    got = np.asarray(new).view(raw)
+    want = np.asarray(old).view(raw)
+    mismatch = int(np.count_nonzero(got != want))
+    assert mismatch == 0, (f"{what}: {mismatch} of {got.size} raw words "
+                           "differ from the host decode")
+
+
+def _compare_paths(packed, scale, spec, mesh):
+    """Both decode paths over the same staged tensors, compared bitwise."""
+    host_values, host_scale = CompressedTensorsMxfp4MoEMethod._decode_on_host(
+        packed, scale, spec, mesh)
+    sharded_values = _decode_sharded(packed, u8_unpack_e2m1, 2, spec, mesh)
+    sharded_scale = _decode_sharded(scale, e8m0_to_fp32, 1, spec, mesh)
+    _assert_bit_identical(sharded_values, host_values, f"values {spec}")
+    _assert_bit_identical(sharded_scale, host_scale, f"scales {spec}")
+
+
+@pytest.mark.parametrize("num_expert,num_model", MESH_SHAPES)
+def test_shard_then_decode_is_bit_identical_to_the_host_decode(
+        num_expert, num_model):
+    """Every K3 mesh shape, both expert-kernel orientations."""
+    mesh = _mesh(num_expert, num_model)
+    rng = np.random.default_rng(0)
+    edf, efd = _specs()
+    # `[E, out, in//2]`: gate/up are `[F, D]`, down is `[D, F]`. Both widths
+    # divide by 8 the way K3's do (D=3584, F=3072, 32-wide groups), including
+    # the scales' `in//group` axis, which `efd` shards.
+    for spec in (edf, efd):
+        packed, scale = _stage(rng, 16, out=64, packed_in=128, group=32)
+        _compare_paths(packed, scale, spec, mesh)
+
+
+def test_replicated_mesh_axes_get_the_same_shard():
+    """A mesh axis the spec does not name replicates rather than splits.
+
+    The expert kernels' specs name only the expert and tensor axes, so on a
+    mesh with any other axis larger than one every device on that axis holds
+    the same shard -- and the decode has to hand each of them a copy, not a
+    slice of one.
+    """
+    mesh = _mesh(2, 2, num_data=2)
+    rng = np.random.default_rng(3)
+    for spec in _specs():
+        packed, scale = _stage(rng, 16, out=64, packed_in=128, group=32)
+        _compare_paths(packed, scale, spec, mesh)
+
+
+def test_decode_survives_the_loader_context():
+    """As the loader calls it: inside a mesh context, caches cleared between
+    layers.
+
+    `_load_module` runs `jax.clear_caches()` after every module's
+    `process_weights_after_loading`, which drops `jax.jit`'s trace and lowering
+    caches -- so the per-shard decode is held as a compiled executable, and
+    this checks that the second "layer" reuses it instead of compiling again
+    (93 layers x 6 shard shapes of needless compiles otherwise) and still
+    produces the host decode's bytes.
+    """
+    from tpu_inference.layers.jax.quantization import mxfp4
+
+    mesh = _mesh(2, 4)
+    rng = np.random.default_rng(2)
+    spec = _specs()[1]
+    packed, scale = _stage(rng, 16, out=64, packed_in=128, group=32)
+    mxfp4._DECODE_EXECUTABLES.clear()
+    with jax.set_mesh(mesh):
+        _compare_paths(packed, scale, spec, mesh)
+        compiled_after_first = len(mxfp4._DECODE_EXECUTABLES)
+        jax.clear_caches()
+        _compare_paths(packed, scale, spec, mesh)
+    assert compiled_after_first > 0
+    assert len(mxfp4._DECODE_EXECUTABLES) == compiled_after_first, (
+        "a second layer of the same shape re-compiled its per-shard decode")
+
+
+def test_a_shard_that_splits_a_packed_word_is_refused():
+    """The nibble-alignment guard, not a silently wrong decode."""
+    mesh = _mesh(1, 4)
+    rng = np.random.default_rng(1)
+    # `in//2 = 2` packed words -> 4 fp4 values over 4 model shards, so every
+    # shard but the first starts on a half-word.
+    packed, _ = _stage(rng, 1, 1, 2, group=4)
+    with pytest.raises(ValueError, match="splits a packed uint8 word"):
+        _decode_sharded(packed, u8_unpack_e2m1, 2,
+                        P(EXPERT_AXIS, MODEL_AXIS, None), mesh)
+
+
+def _checkpoint_experts(path, layer, prefix, projection, limit=None):
+    """`(packed, scale)` staging lists for one layer's expert projection."""
+    with safe_open(path, framework="numpy") as f:
+        base = f"{prefix}.layers.{layer}.block_sparse_moe.experts"
+        ids = sorted(
+            int(n[len(base) + 1:].split(".")[0]) for n in f.keys()
+            if n.startswith(base + ".")
+            and n.endswith(f".{projection}.weight_packed"))
+        if limit:
+            ids = ids[:limit]
+        if not ids:
+            pytest.skip(f"no {projection} experts for layer {layer}")
+        staged = []
+        for kind in ("weight_packed", "weight_scale"):
+            staged.append([
+                jnp.asarray(
+                    f.get_tensor(f"{base}.{i}.{projection}.{kind}")[None])
+                for i in ids
+            ])
+    return staged[0], staged[1]
+
+
+@pytest.mark.parametrize("projection", ("w1", "w2"))
+def test_tiny_checkpoint_bytes_decode_identically(projection):
+    """Real MXFP4 bytes, small enough to run everywhere."""
+    if not TINY_MXFP4_CKPT or not os.path.isdir(TINY_MXFP4_CKPT):
+        pytest.skip("set K3_TINY_MXFP4_CKPT")
+    mesh = _mesh(2, 4)
+    shard = os.path.join(TINY_MXFP4_CKPT, "model.safetensors")
+    packed, scale = _checkpoint_experts(shard, 1, "model", projection)
+    edf, efd = _specs()
+    _compare_paths(packed, scale, efd if projection == "w2" else edf, mesh)
+
+
+@pytest.mark.parametrize("projection", ("w1", "w2"))
+def test_real_shard_bytes_decode_identically(projection):
+    """The released checkpoint's own bytes: every expert of a real layer."""
+    if not REAL_SHARD_DIR or not os.path.isdir(REAL_SHARD_DIR):
+        pytest.skip("set K3_REAL_SHARD")
+    shards = glob.glob(os.path.join(REAL_SHARD_DIR, "*.safetensors"))
+    if len(shards) != 1:
+        pytest.skip(f"expected one shard in {REAL_SHARD_DIR}, "
+                    f"found {len(shards)}")
+    mesh = _mesh(2, 4)
+    limit = int(os.environ.get("K3_REAL_DECODE_EXPERTS", "0")) or None
+    packed, scale = _checkpoint_experts(shards[0], REAL_SHARD_LAYER,
+                                        "language_model.model", projection,
+                                        limit)
+    edf, efd = _specs()
+    _compare_paths(packed, scale, efd if projection == "w2" else edf, mesh)

--- a/tests/models/jax/test_kimi_k3_real_shapes.py
+++ b/tests/models/jax/test_kimi_k3_real_shapes.py
@@ -1,0 +1,538 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Every tensor of the RELEASED Kimi-K3 checkpoint, against the parameters the
+model actually builds at the real config.
+
+Why this exists: the K3-tiny fixtures were written to the shapes our model
+expects, so they agree with it by construction and cannot catch a checkpoint
+that disagrees. This test takes the other side -- the shapes below are
+transcribed from the released artifacts, not from this repo:
+
+  * ``REAL_K3_TEXT_CONFIG``: ``text_config`` of ``moonshotai/Kimi-K3``'s
+    ``config.json``.
+  * ``RELEASED_TENSORS``: ``{name pattern: (shape, tensor count)}`` reduced
+    from ``HfApi.get_safetensors_metadata("moonshotai/Kimi-K3")`` (497,052 text
+    tensors over 96 shards, after the wrapper prefix is stripped and the 168
+    vision/projector tensors are dropped) by replacing every ``.<digits>.``
+    with ``.N.``. The counts are part of the assertion: they pin the layer
+    classification (69 KDA / 24 MLA / 92 MoE / 1 dense) and the expert count,
+    not just the widths.
+
+The model is built with ``nnx.eval_shape``, so the full 93-layer / 896-expert /
+163,840-vocab parameter tree costs no memory and needs no accelerator.
+"""
+
+import re
+import types
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import torch
+from flax import nnx
+from jax.sharding import Mesh
+
+from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
+from tpu_inference.layers.jax import JaxModule
+from tpu_inference.models.jax.kimi_k3 import (KimiDeltaAttention,
+                                              KimiLinearForCausalLM,
+                                              attach_default_weight_loaders,
+                                              load_kda_a_log)
+
+# `full_attn_layers` is every 4th layer plus a second one at the end (1-indexed
+# in the config); the remaining 69 are KDA.
+_FULL_ATTN_LAYERS = list(range(4, 93, 4)) + [93]
+
+REAL_K3_TEXT_CONFIG = {
+    "hidden_size": 7168,
+    "intermediate_size": 33792,
+    "num_hidden_layers": 93,
+    "vocab_size": 163840,
+    "rms_norm_eps": 1e-05,
+    "hidden_act": "situ",
+    "activation_situ_beta": 4.0,
+    "activation_situ_linear_beta": 25.0,
+    "num_attention_heads": 96,
+    "num_key_value_heads": 96,
+    "q_lora_rank": 1536,
+    "kv_lora_rank": 512,
+    "qk_nope_head_dim": 128,
+    "qk_rope_head_dim": 64,
+    "v_head_dim": 128,
+    "mla_use_nope": True,
+    "mla_use_output_gate": True,
+    "num_experts": 896,
+    "num_experts_per_token": 16,
+    "moe_intermediate_size": 3072,
+    "num_shared_experts": 2,
+    "first_k_dense_replace": 1,
+    "moe_layer_freq": 1,
+    "moe_renormalize": True,
+    "moe_router_activation_func": "sigmoid",
+    "num_expert_group": 1,
+    "topk_group": 1,
+    "topk_method": "noaux_tc",
+    "use_grouped_topk": True,
+    "routed_scaling_factor": 1.0,
+    "routed_expert_hidden_size": 3584,
+    "latent_moe_use_norm": True,
+    "attn_res_block_size": 12,
+    "tie_word_embeddings": False,
+    "linear_attn_config": {
+        "full_attn_layers": _FULL_ATTN_LAYERS,
+        "kda_layers":
+        [i for i in range(1, 94) if i not in set(_FULL_ATTN_LAYERS)],
+        "head_dim": 128,
+        "num_heads": 96,
+        "short_conv_kernel_size": 4,
+        "gate_lower_bound": -5.0,
+        "use_full_rank_gate": True,
+    },
+}
+
+# {checkpoint name pattern: (shape, number of tensors)}.
+RELEASED_TENSORS = {
+    "model.embed_tokens.weight": ([163840, 7168], 1),
+    "lm_head.weight": ([163840, 7168], 1),
+    "model.norm.weight": ([7168], 1),
+    "model.output_attn_res_norm.weight": ([7168], 1),
+    "model.output_attn_res_proj.weight": ([1, 7168], 1),
+    "model.layers.N.input_layernorm.weight": ([7168], 93),
+    "model.layers.N.post_attention_layernorm.weight": ([7168], 93),
+    "model.layers.N.self_attention_res_norm.weight": ([7168], 93),
+    "model.layers.N.self_attention_res_proj.weight": ([1, 7168], 93),
+    "model.layers.N.mlp_res_norm.weight": ([7168], 93),
+    "model.layers.N.mlp_res_proj.weight": ([1, 7168], 93),
+    # Dense MLP, layer 0 only (`first_k_dense_replace=1`).
+    "model.layers.N.mlp.gate_proj.weight": ([33792, 7168], 1),
+    "model.layers.N.mlp.up_proj.weight": ([33792, 7168], 1),
+    "model.layers.N.mlp.down_proj.weight": ([7168, 33792], 1),
+    # KDA layers (69).
+    "model.layers.N.self_attn.q_proj.weight": ([12288, 7168], 69),
+    "model.layers.N.self_attn.k_proj.weight": ([12288, 7168], 69),
+    "model.layers.N.self_attn.v_proj.weight": ([12288, 7168], 69),
+    "model.layers.N.self_attn.q_conv1d.weight": ([12288, 1, 4], 69),
+    "model.layers.N.self_attn.k_conv1d.weight": ([12288, 1, 4], 69),
+    "model.layers.N.self_attn.v_conv1d.weight": ([12288, 1, 4], 69),
+    # 96 heads, but stored in a head_dim-wide buffer -- see
+    # `test_a_log_is_stored_one_scalar_per_head_zero_padded`.
+    "model.layers.N.self_attn.A_log": ([128], 69),
+    "model.layers.N.self_attn.dt_bias": ([12288], 69),
+    "model.layers.N.self_attn.f_a_proj.weight": ([128, 7168], 69),
+    "model.layers.N.self_attn.f_b_proj.weight": ([12288, 128], 69),
+    "model.layers.N.self_attn.b_proj.weight": ([96, 7168], 69),
+    "model.layers.N.self_attn.o_norm.weight": ([128], 69),
+    # MLA layers (24).
+    "model.layers.N.self_attn.q_a_proj.weight": ([1536, 7168], 24),
+    "model.layers.N.self_attn.q_a_layernorm.weight": ([1536], 24),
+    "model.layers.N.self_attn.q_b_proj.weight": ([18432, 1536], 24),
+    "model.layers.N.self_attn.kv_a_proj_with_mqa.weight": ([576, 7168], 24),
+    "model.layers.N.self_attn.kv_a_layernorm.weight": ([512], 24),
+    "model.layers.N.self_attn.kv_b_proj.weight": ([24576, 512], 24),
+    # Output gate and o_proj exist on both attention kinds (93).
+    "model.layers.N.self_attn.g_proj.weight": ([12288, 7168], 93),
+    "model.layers.N.self_attn.o_proj.weight": ([7168, 12288], 93),
+    # MoE layers (92).
+    "model.layers.N.block_sparse_moe.gate.weight": ([896, 7168], 92),
+    "model.layers.N.block_sparse_moe.gate.e_score_correction_bias":
+    ([896], 92),
+    "model.layers.N.block_sparse_moe.routed_expert_down_proj.weight":
+    ([3584, 7168], 92),
+    "model.layers.N.block_sparse_moe.routed_expert_up_proj.weight":
+    ([7168, 3584], 92),
+    "model.layers.N.block_sparse_moe.routed_expert_norm.weight": ([3584], 92),
+    "model.layers.N.block_sparse_moe.shared_experts.gate_proj.weight":
+    ([6144, 7168], 92),
+    "model.layers.N.block_sparse_moe.shared_experts.up_proj.weight":
+    ([6144, 7168], 92),
+    "model.layers.N.block_sparse_moe.shared_experts.down_proj.weight":
+    ([7168, 6144], 92),
+    # Routed experts, MXFP4: 2 fp4 codes per byte, one E8M0 scale per 32.
+    # 82,432 = 92 MoE layers x 896 experts.
+    "model.layers.N.block_sparse_moe.experts.N.w1.weight_packed":
+    ([3072, 1792], 82432),
+    "model.layers.N.block_sparse_moe.experts.N.w1.weight_scale": ([3072, 112],
+                                                                  82432),
+    "model.layers.N.block_sparse_moe.experts.N.w2.weight_packed":
+    ([3584, 1536], 82432),
+    "model.layers.N.block_sparse_moe.experts.N.w2.weight_scale": ([3584,
+                                                                   96], 82432),
+    "model.layers.N.block_sparse_moe.experts.N.w3.weight_packed":
+    ([3072, 1792], 82432),
+    "model.layers.N.block_sparse_moe.experts.N.w3.weight_scale": ([3072, 112],
+                                                                  82432),
+}
+
+# The tensors Kimi-K3 checkpoints in fp32 while Kimi-Linear-48B checkpoints
+# them in bf16 (dtypes read from the same safetensors metadata). They are the
+# recurrent-state and router-selection tensors, i.e. exactly the ones where
+# rounding to bf16 is not obviously harmless: the short-conv weights and the
+# gated-RMSNorm scale feed the KDA recurrence, and `e_score_correction_bias`
+# decides the top-16 expert cut. Loading them into a bf16 parameter would
+# discard that precision before any compute dtype gets a say.
+RELEASED_FP32_TENSORS = (
+    "model.layers.N.self_attn.A_log",
+    "model.layers.N.self_attn.dt_bias",
+    "model.layers.N.self_attn.q_conv1d.weight",
+    "model.layers.N.self_attn.k_conv1d.weight",
+    "model.layers.N.self_attn.v_conv1d.weight",
+    "model.layers.N.self_attn.o_norm.weight",
+    "model.layers.N.block_sparse_moe.gate.e_score_correction_bias",
+)
+
+# The routed experts are stacked on a leading expert axis in this model, so one
+# fused parameter answers for all 896 of a layer's checkpoint tensors.
+_EXPERT_PARAM = {
+    "w1": "kernel_gating_EDF",
+    "w2": "kernel_down_proj_EFD",
+    "w3": "kernel_up_proj_EDF",
+}
+
+
+@pytest.fixture(scope="module")
+def real_config_params():
+    """``{parameter name: (shape, dtype)}`` for the full real Kimi-K3 config.
+
+    ``nnx.eval_shape`` builds the parameter tree abstractly, so this is the
+    real 93-layer / 896-expert / 163,840-vocab model at no memory cost.
+    """
+    from tpu_inference.layers.jax.quantization.unquantized import \
+        UnquantizedConfig
+    hf = types.SimpleNamespace(**REAL_K3_TEXT_CONFIG)
+    vllm_config = types.SimpleNamespace(
+        model_config=types.SimpleNamespace(
+            hf_config=hf,
+            dtype=jnp.bfloat16,
+            get_vocab_size=lambda: REAL_K3_TEXT_CONFIG["vocab_size"]),
+        quant_config=UnquantizedConfig({}),
+        cache_config=types.SimpleNamespace(cache_dtype="auto"))
+    devices = np.array(jax.devices()[:1]).reshape((1, ) * len(MESH_AXIS_NAMES))
+    mesh = Mesh(devices, axis_names=MESH_AXIS_NAMES)
+    with jax.set_mesh(mesh):
+        model = nnx.eval_shape(lambda: KimiLinearForCausalLM(
+            vllm_config, jax.random.PRNGKey(0), mesh))
+    return {
+        n: (tuple(p.get_value().shape), p.get_value().dtype)
+        for n, p in model.named_parameters()
+    }
+
+
+@pytest.fixture(scope="module")
+def real_config_param_shapes(real_config_params):
+    """``{parameter name pattern: shape}``, reduced the same way the released
+    tensor names are. Every parameter sharing a pattern must share a shape --
+    otherwise one released shape could not answer for all of them."""
+    by_pattern = {}
+    for name, (shape, _dtype) in real_config_params.items():
+        seen = by_pattern.setdefault(_pattern(name), shape)
+        assert seen == shape, (
+            f"{_pattern(name)} covers parameters of differing shapes: "
+            f"{seen} and {shape}")
+    return by_pattern
+
+
+def _pattern(name):
+    return re.sub(r"\.\d+\.", ".N.", name)
+
+
+def _wanted_checkpoint_shape(pattern, param_shape):
+    """The checkpoint shape this parameter can be loaded from.
+
+    Inverts what ``kimi_k3.attach_default_weight_loaders`` declares: the
+    embedding and the depthwise conv keep their checkpoint layout, ``A_log``
+    is read out of a flat buffer, everything 2-D is stored transposed
+    (``[out, in]``) and everything 1-D is stored as is.
+    """
+    if pattern.endswith(("embed_tokens.weight", "conv1d.weight")):
+        return param_shape
+    if pattern.endswith("self_attn.A_log"):
+        # One scalar per head, stored in a head_dim-wide zero-padded buffer.
+        # The released width alone says nothing about the head count, so hold
+        # the parameter to the config's `num_heads` and only then accept the
+        # wider buffer it is stored in.
+        lac = REAL_K3_TEXT_CONFIG["linear_attn_config"]
+        if param_shape != (lac["num_heads"], ):
+            return param_shape
+        return (lac["head_dim"], )
+    if len(param_shape) == 2:
+        return param_shape[::-1]
+    return param_shape
+
+
+def _resolve(pattern, param_shapes):
+    """(model parameter pattern, checkpoint shape it accepts) for a released
+    tensor pattern. The shape is ``None`` when the model has no such
+    parameter, so the coverage test can report it instead of raising."""
+    if ".experts.N.w" in pattern:
+        head, tail = pattern.split(".experts.N.")
+        w, kind = tail.split(".")
+        name = f"{head}.experts.{_EXPERT_PARAM[w]}"
+        if name not in param_shapes:
+            return name, None
+        # Drop the stacked expert axis, then un-transpose to [out, in].
+        out_dim, in_dim = param_shapes[name][1:][::-1]
+        if kind == "weight_packed":
+            return name, (out_dim, in_dim // 2)
+        return name, (out_dim, in_dim // 32)
+    if pattern not in param_shapes:
+        return pattern, None
+    return pattern, _wanted_checkpoint_shape(pattern, param_shapes[pattern])
+
+
+def _released_vs_model(param_shapes):
+    """[(pattern, checkpoint shape, shape the model accepts)] for mismatches."""
+    bad = []
+    for pattern, (shape, _count) in RELEASED_TENSORS.items():
+        _name, wanted = _resolve(pattern, param_shapes)
+        if wanted is None:
+            bad.append((pattern, tuple(shape), "no such parameter"))
+        elif tuple(shape) != tuple(wanted):
+            bad.append((pattern, tuple(shape), tuple(wanted)))
+    return bad
+
+
+def test_model_has_a_parameter_for_every_released_tensor(
+        real_config_param_shapes):
+    """No released tensor lands on a parameter that does not exist."""
+    missing = [
+        p for p in RELEASED_TENSORS
+        if _resolve(p, real_config_param_shapes)[1] is None
+    ]
+    assert not missing, f"released tensors with no parameter: {missing}"
+
+
+def test_every_released_tensor_matches_the_parameter_shape(
+        real_config_param_shapes):
+    """The whole-checkpoint load, checked without a multi-host pod.
+
+    ``A_log`` is the tensor a full-checkpoint serve first failed on
+    (checkpoint ``[128]`` vs a ``[96]`` parameter); this asserts all 48
+    patterns at once so the next one does not have to be found the same way.
+    """
+    bad = _released_vs_model(real_config_param_shapes)
+    assert not bad, "released checkpoint disagrees with the model:\n" + "\n".join(
+        f"  {p}: checkpoint {list(c)} vs model accepts {m}" for p, c, m in bad)
+
+
+def test_the_shape_check_is_not_vacuous(real_config_param_shapes):
+    """Perturbing one parameter must be caught -- otherwise the test above
+    proves nothing about the shapes it enumerates."""
+    for pattern in (
+            "model.layers.N.self_attn.A_log",
+            "model.layers.N.self_attn.q_proj.weight",
+            "model.layers.N.block_sparse_moe.experts.kernel_gating_EDF"):
+        perturbed = dict(real_config_param_shapes)
+        shape = list(perturbed[pattern])
+        shape[-1] += 1
+        perturbed[pattern] = tuple(shape)
+        assert _released_vs_model(perturbed), (
+            f"perturbing {pattern} went undetected")
+
+
+def test_released_tensor_counts_match_the_layer_classification(
+        real_config_params, real_config_param_shapes):
+    """The per-pattern tensor counts pin the layer stack, not just the widths:
+    69 KDA + 24 MLA layers, 92 MoE + 1 dense, 896 experts each."""
+    counts = {}
+    for name in real_config_params:
+        counts[_pattern(name)] = counts.get(_pattern(name), 0) + 1
+    experts_per_layer = REAL_K3_TEXT_CONFIG["num_experts"]
+    for pattern, (_shape, released_count) in RELEASED_TENSORS.items():
+        param_pattern, _ = _resolve(pattern, real_config_param_shapes)
+        built = counts[param_pattern]
+        expected = (released_count // experts_per_layer
+                    if ".experts.N.w" in pattern else released_count)
+        assert built == expected, (
+            f"{pattern}: checkpoint has {released_count} tensors "
+            f"(=> {expected} parameters) but the model builds {built}")
+
+
+def test_every_parameter_is_filled_by_a_released_tensor(
+        real_config_param_shapes):
+    """The other direction: nothing the model builds is left uninitialized."""
+    filled = {
+        _resolve(p, real_config_param_shapes)[0]
+        for p in RELEASED_TENSORS
+    }
+    unfilled = sorted(set(real_config_param_shapes) - filled)
+    assert not unfilled, f"parameters no released tensor fills: {unfilled[:20]}"
+
+
+def test_fp32_released_tensors_get_fp32_parameters(real_config_params):
+    """Kimi-K3 stores its recurrent-state and router-selection tensors in fp32
+    where Kimi-Linear-48B stores them in bf16, and these are the tensors where
+    rounding is least obviously harmless.
+
+    This is the *declared* parameter dtype. It is not what stops the load from
+    narrowing -- `weight_utils.jax_array_from_reshaped_torch` converts with
+    `t2j`, which keeps the checkpoint's dtype, and `assign_and_shard_param`
+    assigns it as is -- but it is what a dummy/random-init load produces, and
+    a bf16 declaration here would say the model intends bf16 for them.
+    `test_kda_params_keep_fp32_where_the_math_is_fp32` covers the value that
+    actually reaches the math.
+    """
+    by_pattern = {}
+    for name, (_shape, dtype) in real_config_params.items():
+        by_pattern.setdefault(_pattern(name), dtype)
+    narrowed = {
+        p: str(by_pattern[p])
+        for p in RELEASED_FP32_TENSORS if by_pattern[p] != jnp.float32
+    }
+    assert not narrowed, (
+        "released fp32 tensors declared narrower than fp32: " +
+        ", ".join(f"{p} -> {d}" for p, d in narrowed.items()))
+
+
+def test_kda_params_keep_fp32_where_the_math_is_fp32():
+    """An fp32 checkpoint value must still be fp32 when the KDA math sees it.
+
+    The load preserves the checkpoint dtype, so the only place precision can
+    be dropped is `KimiDeltaAttention._params`. Two of the three fp32 KDA
+    tensors must survive it, and the third must not:
+
+      * `A_log`, `dt_bias`, `o_norm.weight` -> fp32. The decay and the gated
+        RMSNorm both compute in fp32, so narrowing them buys nothing.
+      * the short-conv weights -> the model dtype. The ragged conv's prefill
+        branch is a `lax.conv_general_dilated`, which rejects mixed dtypes, so
+        the weight has to meet bf16 activations. Asserted rather than left
+        implicit: this is the one documented place K3's extra conv precision
+        is dropped.
+    """
+    num_heads, head_dim, hidden = 2, 8, 16
+    devices = np.array(jax.devices()[:1]).reshape((1, ) * len(MESH_AXIS_NAMES))
+    mesh = Mesh(devices, axis_names=MESH_AXIS_NAMES)
+    with jax.set_mesh(mesh):
+        layer = KimiDeltaAttention(hidden_size=hidden,
+                                   num_heads=num_heads,
+                                   head_dim=head_dim,
+                                   conv_kernel_size=4,
+                                   rms_norm_eps=1e-5,
+                                   dtype=jnp.bfloat16,
+                                   use_full_rank_gate=True,
+                                   mesh=mesh,
+                                   gate_lower_bound=-5.0,
+                                   rngs=nnx.Rngs(params=0))
+        # Stand in for a load from an fp32 checkpoint.
+        layer.A_log.set_value(jnp.ones((num_heads, ), jnp.float32))
+        layer.dt_bias.set_value(jnp.ones((num_heads * head_dim, ),
+                                         jnp.float32))
+        layer.o_norm.weight.set_value(jnp.ones((head_dim, ), jnp.float32))
+        layer.q_conv1d.weight.set_value(
+            jnp.ones((num_heads * head_dim, 1, 4), jnp.float32))
+        params = layer._params()
+    assert params.A_log.dtype == jnp.float32
+    assert params.dt_bias.dtype == jnp.float32
+    assert params.o_norm_weight.dtype == jnp.float32, (
+        "o_norm.weight was narrowed even though the gated RMSNorm is fp32")
+    assert params.q_conv_weight.dtype == jnp.bfloat16, (
+        "the short-conv weight must reach lax.conv_general_dilated at the "
+        "activation dtype")
+
+
+# --------------------------------------------------------------------------
+# A_log: one scalar per head, stored padded -- the tensor a full-checkpoint
+# serve first failed to load.
+# --------------------------------------------------------------------------
+
+
+def _a_log_param(num_heads=4):
+    return nnx.Param(jnp.zeros((num_heads, ), jnp.float32))
+
+
+def test_a_log_is_stored_one_scalar_per_head_zero_padded():
+    """Kimi-K3's layout: a head_dim-wide buffer, `num_heads` values then zeros.
+
+    Measured over the released checkpoint: every one of the 69 KDA layers
+    stores `[128]` with entries 0..95 non-zero and 96..127 exactly 0.0, at
+    `num_heads=96` / `head_dim=128`.
+    """
+    values = torch.tensor([0.5, -1.25, 2.0, 0.125], dtype=torch.float32)
+    padded = torch.zeros(128, dtype=torch.float32)
+    padded[:4] = values
+    param = _a_log_param()
+    load_kda_a_log(param, padded, param_name="test.A_log")
+    np.testing.assert_array_equal(np.asarray(param.get_value()),
+                                  values.numpy())
+
+
+def test_a_log_accepts_the_kimi_linear_48b_layout():
+    """Kimi-Linear-48B stores the same vector as `[1, 1, num_heads, 1]`."""
+    values = torch.tensor([0.5, -1.25, 2.0, 0.125], dtype=torch.float32)
+    param = _a_log_param()
+    load_kda_a_log(param, values.reshape(1, 1, 4, 1), param_name="test.A_log")
+    np.testing.assert_array_equal(np.asarray(param.get_value()),
+                                  values.numpy())
+
+
+def test_a_log_refuses_to_truncate_a_non_zero_tail():
+    """A non-zero tail is not padding, so dropping it would silently change
+    every head's decay -- the failure mode this loader exists to prevent."""
+    padded = torch.zeros(128, dtype=torch.float32)
+    padded[:4] = torch.tensor([0.5, -1.25, 2.0, 0.125])
+    padded[7] = 0.75
+    with pytest.raises(ValueError, match="not zero padding"):
+        load_kda_a_log(_a_log_param(), padded, param_name="test.A_log")
+
+
+def test_a_log_rejects_a_checkpoint_with_too_few_heads():
+    with pytest.raises(ValueError, match="cannot fill it"):
+        load_kda_a_log(_a_log_param(num_heads=8),
+                       torch.zeros(4, dtype=torch.float32),
+                       param_name="test.A_log")
+
+
+def test_the_attached_loader_reads_the_released_a_log_layout():
+    """End-to-end through `attach_default_weight_loaders`, not by calling
+    `load_kda_a_log` directly.
+
+    The shape table above compares the released shapes against the parameters,
+    but it does not run the loader; only this does. Drop the `A_log` entry from
+    `_LOADER_FN_OVERRIDES` and the generic loader takes the tensor instead and
+    raises `Shape mismatch in non-vocab layer ... torch (128,) vs jax (96,)` --
+    the failure the first full-checkpoint serve hit.
+    """
+
+    class _DecoderLayer(JaxModule):
+        """Minimal stand-in for the decoder layer, so the KDA parameters carry
+        the `self_attn.` path the loader overrides are keyed on."""
+
+        def __init__(self, kda):
+            self.self_attn = kda
+
+    num_heads, head_dim, hidden = 4, 8, 16
+    devices = np.array(jax.devices()[:1]).reshape((1, ) * len(MESH_AXIS_NAMES))
+    mesh = Mesh(devices, axis_names=MESH_AXIS_NAMES)
+    values = torch.tensor([0.5, -1.25, 2.0, 0.125], dtype=torch.float32)
+    padded = torch.zeros(head_dim, dtype=torch.float32)
+    padded[:num_heads] = values
+    with jax.set_mesh(mesh):
+        layer = _DecoderLayer(
+            KimiDeltaAttention(hidden_size=hidden,
+                               num_heads=num_heads,
+                               head_dim=head_dim,
+                               conv_kernel_size=4,
+                               rms_norm_eps=1e-5,
+                               dtype=jnp.bfloat16,
+                               use_full_rank_gate=True,
+                               mesh=mesh,
+                               gate_lower_bound=-5.0,
+                               rngs=nnx.Rngs(params=0)))
+        attach_default_weight_loaders(layer)
+        names = dict(layer.named_parameters())
+        assert "self_attn.A_log" in names, sorted(names)
+        param = names["self_attn.A_log"]
+        param.weight_loader(param, padded)
+    np.testing.assert_array_equal(np.asarray(param.get_value()),
+                                  values.numpy())

--- a/tests/models/jax/test_kimi_k3_router.py
+++ b/tests/models/jax/test_kimi_k3_router.py
@@ -1,0 +1,263 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Kimi-K3 MoE routing parity against the reference gate.
+
+Kimi-K3 routes with the DeepSeek-style noaux_tc gate but a single expert
+group (`num_expert_group=1`), sigmoid scoring, renormalized top-16 weights and
+`routed_scaling_factor=1.0` (HF `moonshotai/Kimi-K3` config + the
+`KimiMoEGate` implementation in its modeling_kimi_linear.py).
+
+The reference gate is transcribed here in numpy; the tests check the shared
+router reproduces both WHICH experts are selected and the weights they get,
+using a real K3-shaped checkpoint and the golden activations captured from
+the reference implementation when available.
+
+Set `K3_TINY_CKPT` to a K3-tiny checkpoint directory (with goldens_run1.npz)
+to run the checkpoint-backed cases; they skip when it is unset.
+"""
+
+import os
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+
+from tpu_inference.layers.common.moe import MoEBackend
+from tpu_inference.layers.common.sharding import MESH_AXIS_NAMES
+from tpu_inference.layers.jax.linear import JaxEinsum
+from tpu_inference.models.jax.deepseek_v3 import DeepSeekV3Router
+
+CKPT = os.environ.get("K3_TINY_CKPT", "")
+# The suites skip when the checkpoint is merely *named*, not just when the
+# variable is unset: CI points the variable at a cache directory whose
+# contents are fetched separately, so it can exist as a path and not as a
+# checkpoint.
+HAVE_CKPT = bool(CKPT) and os.path.isdir(CKPT)
+# K3-tiny routed-MoE config (mirrors Kimi-K3 with smaller dims).
+NUM_EXPERTS, TOPK, HIDDEN = 32, 4, 1024
+ROUTED_SCALING = 1.0
+
+
+def reference_gate(x,
+                   weight,
+                   bias,
+                   topk=TOPK,
+                   renormalize=True,
+                   routed_scaling_factor=ROUTED_SCALING):
+    """KimiMoEGate from HF moonshotai/Kimi-K3, n_group == 1 path, fp32.
+
+    Selection uses scores + bias; the returned weights come from the
+    *un-biased* scores and are renormalized to sum to 1.
+    """
+    logits = x.astype(np.float32) @ weight.astype(np.float32).T
+    scores = 1.0 / (1.0 + np.exp(-logits))
+    scores_for_choice = scores + bias.astype(np.float32)[None, :]
+    # num_expert_group == 1 -> no group masking, plain top-k.
+    topk_idx = np.argsort(-scores_for_choice, axis=-1, kind="stable")[:, :topk]
+    topk_weight = np.take_along_axis(scores, topk_idx, axis=-1)
+    if topk > 1 and renormalize:
+        topk_weight = topk_weight / (topk_weight.sum(-1, keepdims=True) +
+                                     1e-20)
+    return topk_idx, topk_weight * routed_scaling_factor
+
+
+@pytest.fixture(scope="module")
+def mesh():
+    devices = np.array(jax.devices()[:1]).reshape((1, ) * len(MESH_AXIS_NAMES))
+    return Mesh(devices, axis_names=MESH_AXIS_NAMES)
+
+
+def _build_router(mesh, num_experts=NUM_EXPERTS, hidden=HIDDEN, topk=TOPK):
+    """K3's routing config on the shared DeepSeek-style router.
+
+    `moe_backend` is deliberately an unfused backend: the fused backends take
+    raw logits and do selection themselves, which is where the noaux_tc bias
+    gets dropped. K3 keeps routing eager so the bias is applied here.
+    """
+    return DeepSeekV3Router(
+        hidden_size=hidden,
+        num_experts=num_experts,
+        num_experts_per_tok=topk,
+        n_groups=1,
+        topk_groups=1,
+        norm_topk_prob=True,
+        routed_scaling_factor=ROUTED_SCALING,
+        dtype=jnp.float32,
+        rngs=nnx.Rngs(0),
+        activation_ffw_td=P(),
+        ed_sharding=P(),
+        e_sharding=P(),
+        scoring_func="sigmoid",
+        moe_backend=MoEBackend.DENSE_MAT,
+    )
+
+
+def _load_gate_weights(layer=1):
+    from safetensors import safe_open
+    pre = f"model.layers.{layer}.block_sparse_moe.gate."
+    with safe_open(os.path.join(CKPT, "model.safetensors"), "np") as f:
+        w = f.get_tensor(pre + "weight").astype(np.float32)
+        b = f.get_tensor(pre + "e_score_correction_bias").astype(np.float32)
+    return w, b
+
+
+def _run_router(mesh, router, x):
+    # The router constrains its input's sharding, which requires an
+    # explicitly-placed array rather than a bare device array.
+    with jax.set_mesh(mesh):
+        x_dev = jax.device_put(jnp.asarray(x, jnp.float32),
+                               NamedSharding(mesh, P()))
+        weights, idx = router(x_dev)
+    return np.asarray(idx), np.asarray(weights)
+
+
+def _assert_matches(idx_jax, w_jax, idx_ref, w_ref, label):
+    """Expert *sets* must match exactly; weights must match numerically.
+
+    Top-k tie ordering is unspecified, so compare sorted sets and compare
+    weights after sorting each row by expert id.
+    """
+    np.testing.assert_array_equal(np.sort(idx_jax, -1), np.sort(idx_ref, -1))
+    order_jax = np.argsort(idx_jax, -1)
+    order_ref = np.argsort(idx_ref, -1)
+    w_jax_sorted = np.take_along_axis(w_jax, order_jax, -1)
+    w_ref_sorted = np.take_along_axis(w_ref, order_ref, -1)
+    err = np.abs(w_jax_sorted - w_ref_sorted).max()
+    print(f"[observed] {label}: weight max_abs={err:.3e}")
+    np.testing.assert_allclose(w_jax_sorted,
+                               w_ref_sorted,
+                               atol=1e-5,
+                               rtol=1e-5)
+
+
+def test_router_matches_reference_gate_random_inputs(mesh):
+    """Random weights/inputs: selection and weights must match the
+    reference gate, with a bias large enough that ignoring it would show."""
+    rng = np.random.default_rng(0)
+    router = _build_router(mesh)
+    weight = rng.standard_normal(
+        (NUM_EXPERTS, HIDDEN), dtype=np.float32) * 0.05
+    bias = rng.standard_normal(NUM_EXPERTS, dtype=np.float32) * 0.1
+    with jax.set_mesh(mesh):
+        router.weight.value = jnp.asarray(weight.T)
+        router.e_score_correction_bias.value = jnp.asarray(bias)
+    x = rng.standard_normal((64, HIDDEN), dtype=np.float32) * 0.1
+
+    idx_ref, w_ref = reference_gate(x, weight, bias)
+    idx_jax, w_jax = _run_router(mesh, router, x)
+    _assert_matches(idx_jax, w_jax, idx_ref, w_ref, "random")
+
+
+def test_gate_logits_are_computed_in_full_precision(mesh):
+    """The gate matmul itself must run in fp32, not a bf16 pass.
+
+    The reference casts both operands to fp32 before the linear. On TPU an
+    fp32 einsum at XLA's default precision is lowered to a single bf16
+    multiply, which costs ~4 decimal digits on the logits -- enough to
+    reorder experts whose scores are within that of each other, which shows
+    up as an expert-set mismatch in the parity tests above. Assert the
+    logits directly so the cause is readable when it regresses.
+    """
+    rng = np.random.default_rng(2)
+    router = _build_router(mesh)
+    weight = rng.standard_normal(
+        (NUM_EXPERTS, HIDDEN), dtype=np.float32) * 0.05
+    with jax.set_mesh(mesh):
+        router.weight.value = jnp.asarray(weight.T)
+    x = rng.standard_normal((64, HIDDEN), dtype=np.float32) * 0.1
+
+    with jax.set_mesh(mesh):
+        x_dev = jax.device_put(jnp.asarray(x, jnp.float32),
+                               NamedSharding(mesh, P()))
+        # The gate matmul on its own, before sigmoid/top-k.
+        logits = np.asarray(JaxEinsum.__call__(router, x_dev))
+    # fp64 reference for the same contraction.
+    ref = x.astype(np.float64) @ weight.astype(np.float64).T
+    err = np.abs(logits - ref).max()
+    print(f"[observed] gate logit max_abs vs fp64: {err:.3e}")
+    # A bf16-rounded contraction over 1024 terms lands around 1e-3 here;
+    # fp32 lands near 1e-6. The gate sits between them by a wide margin.
+    assert err < 1e-5, (
+        f"router gate logits are off by {err:.3e} -- the gate matmul is not "
+        "running in fp32 (check `precision` on DeepSeekV3Router)")
+
+
+def test_ignoring_the_bias_would_fail_this_test(mesh):
+    """Guard against a vacuous parity test: the same comparison against a
+    reference computed WITHOUT the bias must disagree."""
+    rng = np.random.default_rng(1)
+    router = _build_router(mesh)
+    weight = rng.standard_normal(
+        (NUM_EXPERTS, HIDDEN), dtype=np.float32) * 0.05
+    bias = rng.standard_normal(NUM_EXPERTS, dtype=np.float32) * 0.1
+    with jax.set_mesh(mesh):
+        router.weight.value = jnp.asarray(weight.T)
+        router.e_score_correction_bias.value = jnp.asarray(bias)
+    x = rng.standard_normal((64, HIDDEN), dtype=np.float32) * 0.1
+
+    idx_jax, _ = _run_router(mesh, router, x)
+    idx_nobias, _ = reference_gate(x, weight, np.zeros_like(bias))
+    changed = (np.sort(idx_jax, -1) != np.sort(idx_nobias, -1)).any(-1)
+    print(f"[observed] tokens whose selection depends on the bias: "
+          f"{changed.mean():.1%}")
+    assert changed.any(), (
+        "bias had no observable effect, so the parity test above would pass "
+        "even with the bias dropped")
+
+
+@pytest.mark.skipif(not HAVE_CKPT,
+                    reason="K3_TINY_CKPT unset "
+                    "or not a directory")
+@pytest.mark.parametrize("layer", [1, 4, 8])
+def test_router_matches_reference_on_checkpoint_and_golden_inputs(mesh, layer):
+    """Real K3-shaped gate weights, driven by the activations the reference
+    implementation actually saw at that layer."""
+    z = np.load(os.path.join(CKPT, "goldens_run1.npz"))
+    weight, bias = _load_gate_weights(layer)
+    # Input to the MoE block, captured from the reference forward.
+    x = z[f"p48.layers.{layer}.block_sparse_moe.in"][0].astype(np.float32)
+
+    router = _build_router(mesh)
+    with jax.set_mesh(mesh):
+        router.weight.value = jnp.asarray(weight.T)
+        router.e_score_correction_bias.value = jnp.asarray(bias)
+
+    idx_ref, w_ref = reference_gate(x, weight, bias)
+    idx_jax, w_jax = _run_router(mesh, router, x)
+    _assert_matches(idx_jax, w_jax, idx_ref, w_ref, f"ckpt L{layer}")
+    assert idx_jax.shape == (x.shape[0], TOPK)
+
+
+@pytest.mark.skipif(not HAVE_CKPT,
+                    reason="K3_TINY_CKPT unset "
+                    "or not a directory")
+def test_weights_sum_to_one_and_scaling_is_identity(mesh):
+    """K3 renormalizes the top-k weights and uses routed_scaling_factor=1.0,
+    so each token's routing weights sum to 1."""
+    z = np.load(os.path.join(CKPT, "goldens_run1.npz"))
+    weight, bias = _load_gate_weights(1)
+    x = z["p48.layers.1.block_sparse_moe.in"][0].astype(np.float32)
+    router = _build_router(mesh)
+    with jax.set_mesh(mesh):
+        router.weight.value = jnp.asarray(weight.T)
+        router.e_score_correction_bias.value = jnp.asarray(bias)
+    _, w_jax = _run_router(mesh, router, x)
+    sums = w_jax.sum(-1)
+    print(f"[observed] weight-sum deviation from 1: "
+          f"{np.abs(sums - 1).max():.3e}")
+    np.testing.assert_allclose(sums, 1.0, atol=1e-5)

--- a/tests/models/jax/utils/k3_tiny_generator.py
+++ b/tests/models/jax/utils/k3_tiny_generator.py
@@ -1,0 +1,448 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Generator for K3-tiny: a small random-weight checkpoint with the Kimi-K3
+text-stack architecture (HF `moonshotai/Kimi-K3`, `model_type=kimi_linear`).
+
+Produces two variants that represent the exact same function:
+  * bf16:   all weights bf16 (`k3-tiny/`)
+  * mxfp4:  routed-expert weights packed in the compressed-tensors
+            `mxfp4-pack-quantized` format (`k3-tiny-mxfp4/`), everything else
+            identical to the bf16 variant.
+
+The routed-expert weights are drawn directly on the MXFP4 grid (random E2M1
+codes x power-of-two E8M0 group scales), so `dequantize(mxfp4 variant) ==
+bf16 variant` holds bit-exactly by construction. Packing/unpacking uses
+`compressed_tensors`' own helpers so the byte format is canonical.
+
+Topology (scaled-down but architecture-faithful to Kimi-K3):
+  * 9 layers: 6 KDA + 3 MLA; 1-indexed `kda_layers=[1,2,3,5,6,7]`,
+    `full_attn_layers=[4,8,9]` - the 3:1 KDA:MLA pattern with K3's extra
+    final MLA layer (two consecutive MLA at the end, like K3's layers 92/93).
+  * Layer 0 dense MLP, layers 1..8 MoE (`first_k_dense_replace=1`).
+  * hidden 1024, 8 heads x head_dim 128 (KDA); MLA q/kv-lora with
+    qk_nope 128 / qk_rope 64 / v 128 (NoPE + sigmoid output gate).
+  * LatentMoE: 32 routed experts, top-4, 1 shared expert, latent dim 512,
+    expert intermediate 384, latent RMSNorm; SiTU activation.
+  * AttnRes with `attn_res_block_size=4` (depth checkpoints at layers 0/4/8).
+  * Full-rank KDA output gate; `gate_lower_bound=-5.0`.
+
+Weight names/shapes follow the HF reference implementation in
+`moonshotai/Kimi-K3` (`modeling_kimi_linear.py`); the quantization_config
+mirrors the real K3 `config.json` (same ignore regexes, group_size 32).
+Where a released checkpoint's *storage* layout differs from the reference's
+parameter shape, the checkpoint wins -- see `store_a_log`, which reproduces
+Kimi-K3's zero-padded `A_log` buffer and Kimi-Linear-48B's `[1, 1, H, 1]`.
+
+Usage:
+    python tests/models/jax/utils/k3_tiny_generator.py \
+        --output-root /mnt/disks/persist/models --seed 42
+"""
+
+import argparse
+import json
+import os
+import shutil
+
+import torch
+from safetensors.torch import save_file
+
+TINY_TEXT_CONFIG = {
+    "architectures": ["KimiLinearForCausalLM"],
+    "auto_map": {
+        "AutoConfig": "configuration_kimi_k3.KimiLinearConfig",
+        "AutoModel": "modeling_kimi_linear.KimiLinearModel",
+        "AutoModelForCausalLM": "modeling_kimi_linear.KimiLinearForCausalLM",
+    },
+    "model_type": "kimi_linear",
+    "dtype": "bfloat16",
+    "vocab_size": 8192,
+    "bos_token_id": 1,
+    "eos_token_id": 2,
+    "pad_token_id": 0,
+    "hidden_size": 1024,
+    "num_hidden_layers": 9,
+    "num_attention_heads": 8,
+    "num_key_value_heads": 8,
+    "intermediate_size": 4096,
+    "hidden_act": "situ",
+    "activation_situ_beta": 4.0,
+    "activation_situ_linear_beta": 25.0,
+    "attn_res_block_size": 4,
+    "first_k_dense_replace": 1,
+    "moe_layer_freq": 1,
+    "num_experts": 32,
+    "num_experts_per_token": 4,
+    "num_shared_experts": 1,
+    "moe_intermediate_size": 384,
+    "routed_expert_hidden_size": 512,
+    "latent_moe_use_norm": True,
+    "moe_renormalize": True,
+    "moe_router_activation_func": "sigmoid",
+    "num_expert_group": 1,
+    "topk_group": 1,
+    "topk_method": "noaux_tc",
+    "use_grouped_topk": True,
+    "routed_scaling_factor": 1.0,
+    "q_lora_rank": 256,
+    "kv_lora_rank": 128,
+    "qk_nope_head_dim": 128,
+    "qk_rope_head_dim": 64,
+    "v_head_dim": 128,
+    "mla_use_nope": True,
+    "mla_use_output_gate": True,
+    "num_nextn_predict_layers": 0,
+    "linear_attn_config": {
+        "full_attn_layers": [4, 8, 9],
+        "kda_layers": [1, 2, 3, 5, 6, 7],
+        "head_dim": 128,
+        "num_heads": 8,
+        "short_conv_kernel_size": 4,
+        "gate_lower_bound": -5.0,
+        "use_full_rank_gate": True,
+    },
+    "max_position_embeddings": 4096,
+    "rms_norm_eps": 1e-05,
+    "tie_word_embeddings": False,
+    "use_cache": True,
+}
+
+# Mirrors the real Kimi-K3 text_config.quantization_config (ignore regexes
+# intentionally identical - only `experts.N.w{1,2,3}` are quantized; the
+# latent routed_expert_{down,up}_proj stay bf16, matching the K3 checkpoint's
+# safetensors index).
+QUANTIZATION_CONFIG = {
+    "config_groups": {
+        "group_0": {
+            "format": "mxfp4-pack-quantized",
+            "input_activations": None,
+            "output_activations": None,
+            "targets": ["Linear"],
+            "weights": {
+                "actorder": None,
+                "block_structure": None,
+                "dynamic": False,
+                "group_size": 32,
+                "num_bits": 4,
+                "observer": "minmax",
+                "observer_kwargs": {},
+                "scale_dtype": "torch.uint8",
+                "strategy": "group",
+                "symmetric": True,
+                "type": "float",
+                "zp_dtype": None,
+            },
+        }
+    },
+    "format":
+    "mxfp4-pack-quantized",
+    "global_compression_ratio":
+    None,
+    "ignore": [
+        "re:.*self_attn.*",
+        "re:.*shared_experts.*",
+        "re:.*mlp\\.(gate|up|gate_up|down)_proj.*",
+        "re:.*lm_head.*",
+        "re:.*vision_tower.*",
+        "re:.*mm_projector.*",
+    ],
+    "kv_cache_scheme":
+    None,
+    "quant_method":
+    "compressed-tensors",
+    "quantization_status":
+    "compressed",
+}
+
+
+def softplus_gate_config():
+    """K3-tiny with Kimi-Linear-48B-style KDA gate flags: no gate_lower_bound
+    (-exp(A_log)*softplus decay form) and a low-rank g_a/g_b output gate.
+    Same dims as K3-tiny otherwise; gives the softplus gate path CPU goldens
+    that the 48B real-weight testbed exercises."""
+    cfg = json.loads(json.dumps(TINY_TEXT_CONFIG))
+    del cfg["linear_attn_config"]["gate_lower_bound"]
+    cfg["linear_attn_config"]["use_full_rank_gate"] = False
+    return cfg
+
+
+E2M1_GRID = [0.0, 0.5, 1.0, 1.5, 2.0, 3.0, 4.0, 6.0]
+
+
+def store_a_log(values: torch.Tensor, cfg: dict) -> torch.Tensor:
+    """Lay out A_log the way the released checkpoint of this variant does.
+
+    `A_log` holds one log-decay scalar per KDA head (the HF reference
+    allocates it with `num_heads` entries; vLLM's KDA gate kernel indexes it
+    by head and broadcasts over the head's channels). The two released
+    checkpoints store that same vector differently, and the fixtures mirror
+    each one so the loader is covered against both:
+
+      * Kimi-K3 (`gate_lower_bound` present): a flat buffer `head_dim` wide
+        whose leading `num_heads` entries are the parameter and whose tail is
+        zero padding. Read off moonshotai/Kimi-K3's safetensors headers, every
+        one of the 69 KDA layers stores `[128]` with indices 0..95 non-zero
+        and 96..127 exactly 0.0, at num_heads=96 / head_dim=128. (`o_norm`,
+        genuinely per-head-dim and also `[128]`, is dense in the same layers.)
+      * Kimi-Linear-48B (`gate_lower_bound` absent): `[1, 1, num_heads, 1]`,
+        unpadded (moonshotai/Kimi-Linear-48B-A3B-Instruct).
+
+    Deriving the fixture layout from the released checkpoints rather than from
+    what our model builds is the point: an `A_log` written at `[num_heads]`
+    agrees with the loader by construction and cannot catch a padded
+    checkpoint.
+
+    NOTE for anyone regenerating goldens: the HF reference
+    `modeling_kimi_linear.py` allocates `A_log` with `num_heads` entries, so
+    loading the K3-form fixture (or the real Kimi-K3 checkpoint) into the
+    reference needs the padding dropped first.
+    """
+    lac = cfg["linear_attn_config"]
+    if lac.get("gate_lower_bound") is None:
+        return values.reshape(1, 1, -1, 1)
+    padded = torch.zeros(lac["head_dim"], dtype=values.dtype)
+    padded[:values.numel()] = values
+    return padded
+
+
+class _Rng:
+    """Deterministic tensor factory: draw order defines the checkpoint."""
+
+    def __init__(self, seed: int):
+        self.gen = torch.Generator(device="cpu").manual_seed(seed)
+
+    def normal(self, *shape, std=0.02):
+        return torch.randn(*shape, generator=self.gen,
+                           dtype=torch.float32) * std
+
+    def uniform(self, *shape, low=0.0, high=1.0):
+        u = torch.rand(*shape, generator=self.gen, dtype=torch.float32)
+        return low + (high - low) * u
+
+    def norm_weight(self, dim):
+        # Near-1 with jitter so a missing weight multiplication in a port
+        # cannot cancel out.
+        return 1.0 + self.normal(dim, std=0.05)
+
+    def randint(self, *shape, high):
+        return torch.randint(0,
+                             high,
+                             shape,
+                             generator=self.gen,
+                             dtype=torch.int64)
+
+
+def _make_mxfp4_expert_weight(rng: _Rng, out_dim: int, in_dim: int):
+    """Draw a weight directly on the MXFP4 grid.
+
+    Returns (bf16_weight, packed_uint8, scale_e8m0_uint8). The bf16 weight is
+    exactly `unpack(packed) * 2**(scale-127)`, i.e. what compressed-tensors
+    decompression produces.
+    """
+    assert in_dim % 32 == 0
+    num_groups = in_dim // 32
+    # E2M1 magnitude codes (0..7) and signs, uniform over the grid.
+    grid = torch.tensor(E2M1_GRID, dtype=torch.float32)
+    codes = rng.randint(out_dim, in_dim, high=8)
+    signs = torch.where(rng.randint(out_dim, in_dim, high=2) > 0, 1.0, -1.0)
+    values = grid[codes] * signs  # in [-6, 6]
+    # E8M0 group scales around 2**-8 so dequantized weights have std ~0.01,
+    # comparable to a normal(0, 0.02) init.
+    scale_exp = rng.randint(out_dim, num_groups, high=3) - 9  # {-9,-8,-7}
+    scale = (2.0**scale_exp.to(torch.float32))
+    bf16_weight = (values * scale.repeat_interleave(32, dim=1)).to(
+        torch.bfloat16)
+
+    from compressed_tensors.compressors.mx_utils import compress_mx_scale
+    from compressed_tensors.compressors.nvfp4.helpers import pack_fp4_to_uint8
+    packed = pack_fp4_to_uint8(values)
+    scale_u8 = compress_mx_scale(scale, torch.uint8)
+    return bf16_weight, packed, scale_u8
+
+
+def build_state_dicts(seed: int, cfg=None):
+    """Build (bf16_state_dict, mxfp4_state_dict) sharing all non-expert
+    tensors. Names follow moonshotai/Kimi-K3 modeling_kimi_linear.py."""
+    cfg = cfg or TINY_TEXT_CONFIG
+    rng = _Rng(seed)
+    hidden = cfg["hidden_size"]
+    lac = cfg["linear_attn_config"]
+    n_heads = lac["num_heads"]
+    head_dim = lac["head_dim"]
+    proj = n_heads * head_dim  # 1024
+    conv_k = lac["short_conv_kernel_size"]
+    q_head_dim = cfg["qk_nope_head_dim"] + cfg["qk_rope_head_dim"]  # 192
+    kda_layers_0idx = {i - 1 for i in lac["kda_layers"]}
+
+    bf16 = {}
+    mxfp4_only = {}  # replaces experts.* in the mxfp4 variant
+    mxfp4_removed = set()  # bf16 expert names not present in mxfp4 variant
+
+    def lin(name, out_d, in_d):
+        bf16[name] = rng.normal(out_d, in_d).to(torch.bfloat16)
+
+    bf16["model.embed_tokens.weight"] = rng.normal(cfg["vocab_size"],
+                                                   hidden).to(torch.bfloat16)
+
+    for i in range(cfg["num_hidden_layers"]):
+        p = f"model.layers.{i}"
+        bf16[f"{p}.input_layernorm.weight"] = rng.norm_weight(hidden).to(
+            torch.bfloat16)
+        bf16[f"{p}.post_attention_layernorm.weight"] = rng.norm_weight(
+            hidden).to(torch.bfloat16)
+        # AttnRes site parameters (per layer).
+        bf16[f"{p}.self_attention_res_norm.weight"] = rng.norm_weight(
+            hidden).to(torch.bfloat16)
+        bf16[f"{p}.mlp_res_norm.weight"] = rng.norm_weight(hidden).to(
+            torch.bfloat16)
+        lin(f"{p}.self_attention_res_proj.weight", 1, hidden)
+        lin(f"{p}.mlp_res_proj.weight", 1, hidden)
+
+        if i in kda_layers_0idx:
+            a = f"{p}.self_attn"
+            lin(f"{a}.q_proj.weight", proj, hidden)
+            lin(f"{a}.k_proj.weight", proj, hidden)
+            lin(f"{a}.v_proj.weight", proj, hidden)
+            for c in ("q_conv1d", "k_conv1d", "v_conv1d"):
+                bf16[f"{a}.{c}.weight"] = rng.normal(
+                    proj, 1, conv_k, std=0.2).to(torch.bfloat16)
+            bf16[f"{a}.A_log"] = store_a_log(
+                torch.log(rng.uniform(n_heads, low=1.0,
+                                      high=16.0)).to(torch.bfloat16), cfg)
+            bf16[f"{a}.dt_bias"] = rng.uniform(proj, low=-0.5,
+                                               high=0.5).to(torch.bfloat16)
+            lin(f"{a}.f_a_proj.weight", head_dim, hidden)
+            lin(f"{a}.f_b_proj.weight", proj, head_dim)
+            lin(f"{a}.b_proj.weight", n_heads, hidden)
+            if lac.get("use_full_rank_gate", False):
+                lin(f"{a}.g_proj.weight", proj, hidden)
+            else:
+                lin(f"{a}.g_a_proj.weight", head_dim, hidden)
+                lin(f"{a}.g_b_proj.weight", proj, head_dim)
+            bf16[f"{a}.o_norm.weight"] = rng.norm_weight(head_dim).to(
+                torch.bfloat16)
+            lin(f"{a}.o_proj.weight", hidden, proj)
+        else:
+            a = f"{p}.self_attn"
+            lin(f"{a}.q_a_proj.weight", cfg["q_lora_rank"], hidden)
+            bf16[f"{a}.q_a_layernorm.weight"] = rng.norm_weight(
+                cfg["q_lora_rank"]).to(torch.bfloat16)
+            lin(f"{a}.q_b_proj.weight", n_heads * q_head_dim,
+                cfg["q_lora_rank"])
+            lin(f"{a}.kv_a_proj_with_mqa.weight",
+                cfg["kv_lora_rank"] + cfg["qk_rope_head_dim"], hidden)
+            bf16[f"{a}.kv_a_layernorm.weight"] = rng.norm_weight(
+                cfg["kv_lora_rank"]).to(torch.bfloat16)
+            lin(f"{a}.kv_b_proj.weight",
+                n_heads * (cfg["qk_nope_head_dim"] + cfg["v_head_dim"]),
+                cfg["kv_lora_rank"])
+            lin(f"{a}.g_proj.weight", n_heads * cfg["v_head_dim"], hidden)
+            lin(f"{a}.o_proj.weight", hidden, n_heads * cfg["v_head_dim"])
+
+        if i < cfg["first_k_dense_replace"]:
+            lin(f"{p}.mlp.gate_proj.weight", cfg["intermediate_size"], hidden)
+            lin(f"{p}.mlp.up_proj.weight", cfg["intermediate_size"], hidden)
+            lin(f"{p}.mlp.down_proj.weight", hidden, cfg["intermediate_size"])
+        else:
+            m = f"{p}.block_sparse_moe"
+            lin(f"{m}.gate.weight", cfg["num_experts"], hidden)
+            bf16[f"{m}.gate.e_score_correction_bias"] = rng.normal(
+                cfg["num_experts"], std=0.1).to(torch.bfloat16)
+            latent = cfg["routed_expert_hidden_size"]
+            inter = cfg["moe_intermediate_size"]
+            for e in range(cfg["num_experts"]):
+                for w_name, (od, idim) in {
+                        "w1": (inter, latent),
+                        "w2": (latent, inter),
+                        "w3": (inter, latent),
+                }.items():
+                    base = f"{m}.experts.{e}.{w_name}"
+                    w_bf16, packed, scale = _make_mxfp4_expert_weight(
+                        rng, od, idim)
+                    bf16[f"{base}.weight"] = w_bf16
+                    mxfp4_only[f"{base}.weight_packed"] = packed
+                    mxfp4_only[f"{base}.weight_scale"] = scale
+                    mxfp4_removed.add(f"{base}.weight")
+            shared_inter = inter * cfg["num_shared_experts"]
+            lin(f"{m}.shared_experts.gate_proj.weight", shared_inter, hidden)
+            lin(f"{m}.shared_experts.up_proj.weight", shared_inter, hidden)
+            lin(f"{m}.shared_experts.down_proj.weight", hidden, shared_inter)
+            lin(f"{m}.routed_expert_down_proj.weight", latent, hidden)
+            lin(f"{m}.routed_expert_up_proj.weight", hidden, latent)
+            bf16[f"{m}.routed_expert_norm.weight"] = rng.norm_weight(
+                latent).to(torch.bfloat16)
+
+    bf16["model.norm.weight"] = rng.norm_weight(hidden).to(torch.bfloat16)
+    bf16["model.output_attn_res_norm.weight"] = rng.norm_weight(hidden).to(
+        torch.bfloat16)
+    lin("model.output_attn_res_proj.weight", 1, hidden)
+    lin("lm_head.weight", cfg["vocab_size"], hidden)
+
+    mxfp4 = {k: v for k, v in bf16.items() if k not in mxfp4_removed}
+    mxfp4.update(mxfp4_only)
+    return bf16, mxfp4
+
+
+def write_checkpoint(out_dir: str,
+                     state_dict: dict,
+                     quantized: bool,
+                     remote_code_dir: str | None,
+                     cfg=None):
+    os.makedirs(out_dir, exist_ok=True)
+    config = dict(cfg or TINY_TEXT_CONFIG)
+    if quantized:
+        config["quantization_config"] = QUANTIZATION_CONFIG
+    with open(os.path.join(out_dir, "config.json"), "w") as f:
+        json.dump(config, f, indent=2, sort_keys=True)
+    with open(os.path.join(out_dir, "generation_config.json"), "w") as f:
+        json.dump({"do_sample": False}, f)
+    save_file(state_dict, os.path.join(out_dir, "model.safetensors"))
+    if remote_code_dir:
+        for fname in ("configuration_kimi_k3.py", "modeling_kimi_linear.py"):
+            shutil.copy(os.path.join(remote_code_dir, fname),
+                        os.path.join(out_dir, fname))
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--output-root", default="/mnt/disks/persist/models")
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument(
+        "--remote-code-dir",
+        default=None,
+        help="Directory holding configuration_kimi_k3.py and "
+        "modeling_kimi_linear.py (e.g. a moonshotai/Kimi-K3 snapshot) to copy "
+        "into the checkpoints so transformers trust_remote_code loading "
+        "works. Omit to skip.")
+    args = parser.parse_args()
+
+    bf16, mxfp4 = build_state_dicts(args.seed)
+    bf16_dir = os.path.join(args.output_root, "k3-tiny")
+    mxfp4_dir = os.path.join(args.output_root, "k3-tiny-mxfp4")
+    write_checkpoint(bf16_dir, bf16, False, args.remote_code_dir)
+    write_checkpoint(mxfp4_dir, mxfp4, True, args.remote_code_dir)
+
+    sp_cfg = softplus_gate_config()
+    sp, _ = build_state_dicts(args.seed, cfg=sp_cfg)
+    sp_dir = os.path.join(args.output_root, "k3-tiny-softplus")
+    write_checkpoint(sp_dir, sp, False, args.remote_code_dir, cfg=sp_cfg)
+
+    for label, d, sd in (("bf16", bf16_dir, bf16), ("mxfp4", mxfp4_dir, mxfp4),
+                         ("softplus", sp_dir, sp)):
+        total = sum(v.numel() * v.element_size() for v in sd.values())
+        print(f"k3-tiny ({label}): {d}  "
+              f"{len(sd)} tensors, {total / 1e6:.1f} MB")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/scripts/test_slice_kimi_k3_checkpoint.py
+++ b/tests/scripts/test_slice_kimi_k3_checkpoint.py
@@ -1,0 +1,283 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The Kimi-K3 checkpoint slicer.
+
+Two properties matter and neither is visible from the slicer's output alone:
+
+  * the kept bytes are the ORIGINAL bytes, for every dtype. A slice exists to
+    reproduce load-path failures of the real checkpoint, so a repack that
+    round-tripped uint8-packed 4-bit weights or fp32 recurrent-state tensors
+    through some intermediate representation would make the rig lie.
+  * the sliced config still describes a valid layer stack. The layer lists in
+    ``linear_attn_config`` are 1-INDEXED, an off-by-one there silently turns a
+    KDA layer into a full-attention one and the checkpoint would then fail to
+    load for a reason that has nothing to do with the code under test.
+"""
+
+import importlib.util
+import json
+import struct
+import sys
+from pathlib import Path
+
+import pytest
+
+_TOOL = Path(__file__).parents[2] / "tools" / "slice_kimi_k3_checkpoint.py"
+_SPEC = importlib.util.spec_from_file_location("k3_slicer_under_test", _TOOL)
+assert _SPEC is not None and _SPEC.loader is not None
+slicer = importlib.util.module_from_spec(_SPEC)
+sys.modules["k3_slicer_under_test"] = slicer
+_SPEC.loader.exec_module(slicer)
+
+# One tensor per dtype class the real checkpoint mixes inside a single shard:
+# uint8 packed expert weights, their uint8 group scales, an fp32 KDA tensor,
+# and a bf16 projection. Values are arbitrary but distinct, and are compared
+# byte-for-byte, so nothing here depends on a tensor library.
+_TENSORS = {
+    "language_model.model.layers.0.self_attn.A_log": ("F32", [4],
+                                                      bytes(range(16))),
+    "language_model.model.layers.0.mlp.gate_proj.weight":
+    ("BF16", [2, 3], bytes(range(100, 112))),
+    "language_model.model.layers.1.block_sparse_moe.experts.0.w1.weight_packed":
+    ("U8", [3, 4], bytes(range(200, 212))),
+    "language_model.model.layers.1.block_sparse_moe.experts.0.w1.weight_scale":
+    ("U8", [3, 2], bytes(range(50, 56))),
+    "language_model.model.embed_tokens.weight": ("BF16", [2,
+                                                          2], bytes(range(8))),
+    "vision_tower.patch_embed.proj.weight": ("BF16", [2,
+                                                      2], bytes(range(20,
+                                                                      28))),
+}
+
+
+def _write_safetensors(path, tensors):
+    """Write a safetensors file from {name: (dtype, shape, raw_bytes)}."""
+    header = {}
+    cursor = 0
+    for name, (dtype, shape, raw) in tensors.items():
+        header[name] = {
+            "dtype": dtype,
+            "shape": shape,
+            "data_offsets": [cursor, cursor + len(raw)],
+        }
+        cursor += len(raw)
+    blob = json.dumps(header).encode("utf-8")
+    blob += b" " * ((-len(blob)) % 8)
+    with open(path, "wb") as fh:
+        fh.write(struct.pack("<Q", len(blob)))
+        fh.write(blob)
+        for _, _, raw in tensors.values():
+            fh.write(raw)
+
+
+def _config(num_layers=8):
+    """A config shaped like the released one: nested text_config, 1-indexed
+    layer lists, a full-attention layer every fourth position."""
+    return {
+        "architectures": ["KimiK3ForConditionalGeneration"],
+        "text_config": {
+            "num_hidden_layers": num_layers,
+            "hidden_act": "situ",
+            "linear_attn_config": {
+                "kda_layers":
+                [i for i in range(1, num_layers + 1) if i % 4 != 0],
+                "full_attn_layers":
+                [i for i in range(1, num_layers + 1) if i % 4 == 0],
+                "use_full_rank_gate":
+                True,
+            },
+        },
+    }
+
+
+def test_kept_names_are_the_leading_layers_plus_everything_outside_them():
+    weight_map = {name: "shard" for name in _TENSORS}
+    kept = slicer.kept_tensor_names(weight_map, num_layers=1, keep_vision=True)
+    assert "language_model.model.layers.0.self_attn.A_log" in kept
+    assert not any(".layers.1." in name for name in kept)
+    # Anything outside a decoder layer survives every slice depth.
+    assert "language_model.model.embed_tokens.weight" in kept
+
+
+def test_vision_tensors_are_kept_by_default_and_droppable():
+    weight_map = {name: "shard" for name in _TENSORS}
+    kept = slicer.kept_tensor_names(weight_map, 2, keep_vision=True)
+    assert "vision_tower.patch_embed.proj.weight" in kept
+    dropped = slicer.kept_tensor_names(weight_map, 2, keep_vision=False)
+    assert "vision_tower.patch_embed.proj.weight" not in dropped
+
+
+def test_slice_config_truncates_the_one_indexed_layer_lists():
+    config = _config(num_layers=12)
+    slicer.slice_config(config, 8)
+    linear = config["text_config"]["linear_attn_config"]
+    assert config["text_config"]["num_hidden_layers"] == 8
+    assert linear["full_attn_layers"] == [4, 8]
+    assert linear["kda_layers"] == [1, 2, 3, 5, 6, 7]
+    # Every kept layer is classified exactly once: the union covers 1..8 and
+    # the two lists do not overlap.
+    assert set(linear["kda_layers"]) | set(linear["full_attn_layers"]) == set(
+        range(1, 9))
+    assert not set(linear["kda_layers"]) & set(linear["full_attn_layers"])
+    # Fields that do not depend on depth are untouched.
+    assert config["text_config"]["hidden_act"] == "situ"
+    assert linear["use_full_rank_gate"] is True
+
+
+@pytest.mark.parametrize("num_layers, reason", [
+    (3, "full-attention"),
+    (16, "declares only"),
+])
+def test_slice_config_refuses_a_slice_that_would_not_load(num_layers, reason):
+    with pytest.raises(ValueError, match=reason):
+        slicer.slice_config(_config(num_layers=12), num_layers)
+
+
+def test_slice_config_refuses_a_layer_in_neither_list():
+    config = _config(num_layers=12)
+    config["text_config"]["linear_attn_config"]["kda_layers"].remove(2)
+    with pytest.raises(ValueError, match="neither"):
+        slicer.slice_config(config, 8)
+
+
+def test_tensor_nbytes_rejects_a_header_whose_range_contradicts_its_shape():
+    assert slicer.tensor_nbytes({
+        "dtype": "F32",
+        "shape": [2, 3],
+        "data_offsets": [0, 24]
+    }) == 24
+    with pytest.raises(ValueError, match="data range"):
+        slicer.tensor_nbytes({
+            "dtype": "U8",
+            "shape": [3, 4],
+            "data_offsets": [0, 11]
+        })
+
+
+def test_repack_keeps_the_original_bytes_and_dtypes(tmp_path):
+    src = tmp_path / "in.safetensors"
+    dst = tmp_path / "out.safetensors"
+    _write_safetensors(src, _TENSORS)
+    header, data_start = slicer.read_safetensors_header(str(src))
+    keep = {
+        name
+        for name in _TENSORS if ".layers.1." in name or "embed_tokens" in name
+    }
+
+    slicer.repack_shard(str(src), str(dst), header, data_start, keep)
+
+    out_header, out_start = slicer.read_safetensors_header(str(dst))
+    assert set(out_header) == keep
+    raw = dst.read_bytes()
+    for name in keep:
+        dtype, shape, original = _TENSORS[name]
+        entry = out_header[name]
+        assert entry["dtype"] == dtype
+        assert entry["shape"] == shape
+        start, end = entry["data_offsets"]
+        assert raw[out_start + start:out_start + end] == original
+    # The dropped tensors' bytes are gone, not merely unreferenced.
+    dropped_bytes = _TENSORS["language_model.model.layers.0.self_attn.A_log"][
+        2]
+    assert dropped_bytes not in raw
+
+
+def _twelve_layer_snapshot():
+    """A 12-layer checkpoint whose shards straddle the slice boundary.
+
+    Shard 1 holds only layers that survive (whole-file copy), shard 2 straddles
+    the boundary and shard 3 is mostly dropped but holds the embeddings, so one
+    run covers both the copy and the repack path.
+    """
+    tensors = {}
+    for layer in range(12):
+        prefix = f"language_model.model.layers.{layer}"
+        tensors[f"{prefix}.self_attn.A_log"] = ("F32", [
+            2
+        ], bytes([layer, 1, 2, 3, layer, 4, 5, 6]))
+        tensors[f"{prefix}.block_sparse_moe.experts.0.w1.weight_packed"] = (
+            "U8", [2, 3], bytes([layer + 60] * 6))
+    tensors["language_model.model.embed_tokens.weight"] = ("BF16", [2, 2],
+                                                           bytes(
+                                                               range(240,
+                                                                     248)))
+    tensors["vision_tower.patch_embed.proj.weight"] = ("BF16", [2, 2],
+                                                       bytes(range(230, 238)))
+    shards = {
+        "model-00001-of-00003.safetensors":
+        lambda n: any(f".layers.{i}." in n for i in range(4)),
+        "model-00002-of-00003.safetensors":
+        lambda n: any(f".layers.{i}." in n for i in range(4, 9)),
+        "model-00003-of-00003.safetensors":
+        lambda n: True,
+    }
+    placed, weight_map = {}, {}
+    for shard, belongs in shards.items():
+        placed[shard] = {
+            n: v
+            for n, v in tensors.items() if n not in weight_map and belongs(n)
+        }
+        weight_map.update({n: shard for n in placed[shard]})
+    return tensors, placed, weight_map
+
+
+def test_end_to_end_slice_of_a_local_snapshot(tmp_path):
+    src = tmp_path / "src"
+    dst = tmp_path / "dst"
+    src.mkdir()
+    tensors, placed, weight_map = _twelve_layer_snapshot()
+    for shard, contents in placed.items():
+        _write_safetensors(src / shard, contents)
+    (src / "model.safetensors.index.json").write_text(
+        json.dumps({
+            "metadata": {
+                "total_size": 0
+            },
+            "weight_map": weight_map
+        }))
+    (src / "config.json").write_text(json.dumps(_config(num_layers=12)))
+    (src / "tokenizer_config.json").write_text('{"tokenizer_class": "K3"}')
+
+    assert slicer.main(
+        ["--src", str(src), "--dst",
+         str(dst), "--num-layers", "8"]) == 0
+
+    expected = {
+        n
+        for n in tensors if not any(f".layers.{i}." in n for i in range(8, 12))
+    }
+    index = json.loads((dst / "model.safetensors.index.json").read_text())
+    config = json.loads((dst / "config.json").read_text())
+    assert config["text_config"]["num_hidden_layers"] == 8
+    assert set(index["weight_map"]) == expected
+    # total_size is recomputed over the kept tensors, not copied through.
+    assert index["metadata"]["total_size"] == sum(
+        len(tensors[n][2]) for n in expected)
+    # The config family rides along so the slice is loadable on its own.
+    assert (dst / "tokenizer_config.json").exists()
+    # Both shard paths ran: one shard was copied whole, two were repacked and
+    # so are smaller than their sources.
+    assert (dst / "model-00001-of-00003.safetensors").read_bytes() == (
+        src / "model-00001-of-00003.safetensors").read_bytes()
+    assert (dst / "model-00003-of-00003.safetensors").stat().st_size < (
+        src / "model-00003-of-00003.safetensors").stat().st_size
+    # Every tensor the index promises is really in the shard it names, with
+    # the original bytes, dtype and shape.
+    for name, shard in index["weight_map"].items():
+        header, start = slicer.read_safetensors_header(str(dst / shard))
+        dtype, shape, original = tensors[name]
+        assert header[name]["dtype"] == dtype
+        assert header[name]["shape"] == shape
+        lo, hi = header[name]["data_offsets"]
+        assert (dst / shard).read_bytes()[start + lo:start + hi] == original

--- a/tools/slice_kimi_k3_checkpoint.py
+++ b/tools/slice_kimi_k3_checkpoint.py
@@ -1,0 +1,394 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Cut a depth-sliced snapshot out of a Kimi-K3 checkpoint.
+
+The released Kimi-K3 checkpoint is 1.56 TB over 96 shards and only fits on a
+4-host TPU pod, so every bug that lives in the *load* path -- checkpoint
+layout, tensor shapes, quantization metadata -- costs a multi-host slot to
+observe. Those bugs do not depend on depth: the first few decoder layers
+already carry every tensor pattern the whole stack has. This tool keeps the
+first ``--num-layers`` decoder layers plus the embedding / head / final-norm
+block and rewrites the config and the safetensors index so the result is a
+self-consistent checkpoint that a single host can serve.
+
+The slice is deliberately NOT a distillation: the kept tensors are the
+original bytes and the kept layers are the original layers, so the model's
+output text is meaningless (a 93-layer stack truncated to 8 is not a language
+model any more) while its *load* behaviour is bit-for-bit the real thing --
+MXFP4-packed experts, fp32 KDA tensors, the multimodal ``language_model.``
+wrapper, the vision tower that has to be dropped, and the compressed-tensors
+quantization config. Serve failures reproduced on the slice are real failures
+of the real checkpoint.
+
+Layout fast path
+----------------
+When a shard's tensors are all kept, the shard is copied whole -- for a
+``gs://`` source and destination that is a server-side copy, so slicing moves
+no bytes to the caller at all. Shards that hold a mix of kept and dropped
+tensors are repacked by copying byte ranges out of the safetensors data block,
+which preserves every dtype exactly (uint8 packed weights and their uint8
+scales stay uint8, fp32 recurrent-state tensors stay fp32) without needing a
+tensor library that can represent them.
+
+Usage::
+
+    python3 tools/slice_kimi_k3_checkpoint.py \\
+        --src gs://bucket/kimi/k3 --dst gs://bucket/kimi/k3-sliced \\
+        --num-layers 8
+
+Add ``--dry-run`` to print the plan (kept shards, byte totals, config edits)
+without copying anything.
+"""
+
+import argparse
+import json
+import os
+import re
+import shutil
+import struct
+import subprocess
+import sys
+import tempfile
+
+# Tensor-name prefixes that belong to the vision stack. They are kept by
+# default: the text-only serving path has to *drop* them, and a slice that
+# omits them would not exercise that drop.
+VISION_PREFIXES = ("vision_tower.", "mm_projector.")
+
+# Matches the decoder-layer index in a tensor name, under any wrapper prefix
+# (the released checkpoint nests the text stack under `language_model.`).
+_LAYER_RE = re.compile(r"\.layers\.(\d+)\.")
+
+# safetensors dtype -> bytes per element, for recomputing the index's
+# total_size over the kept tensors only.
+_DTYPE_BYTES = {
+    "BOOL": 1,
+    "U8": 1,
+    "I8": 1,
+    "F8_E5M2": 1,
+    "F8_E4M3": 1,
+    "I16": 2,
+    "U16": 2,
+    "F16": 2,
+    "BF16": 2,
+    "I32": 4,
+    "U32": 4,
+    "F32": 4,
+    "I64": 8,
+    "U64": 8,
+    "F64": 8,
+}
+
+
+def _is_gcs(path):
+    return path.startswith("gs://")
+
+
+def _run(cmd):
+    """Run a command, raising with its stderr attached on failure."""
+    proc = subprocess.run(cmd, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    if proc.returncode != 0:
+        raise RuntimeError(f"[slice] command failed ({proc.returncode}): "
+                           f"{' '.join(cmd)}\n{proc.stderr.decode()[-2000:]}")
+    return proc.stdout
+
+
+def read_bytes(path, start=None, length=None):
+    """Read a whole object/file, or the byte range [start, start+length)."""
+    if _is_gcs(path):
+        if start is None:
+            return _run(["gsutil", "cat", path])
+        end = start + length - 1
+        return _run(["gsutil", "cat", "-r", f"{start}-{end}", path])
+    with open(path, "rb") as fh:
+        if start is None:
+            return fh.read()
+        fh.seek(start)
+        return fh.read(length)
+
+
+def read_safetensors_header(path):
+    """Return (header_dict, data_start) for a safetensors file.
+
+    Only the header is read, so this costs one small range request even when
+    the file is 17 GB in a bucket.
+    """
+    size_bytes = read_bytes(path, 0, 8)
+    (header_len, ) = struct.unpack("<Q", size_bytes)
+    header = read_bytes(path, 8, header_len)
+    return json.loads(header), 8 + header_len
+
+
+def tensor_nbytes(entry):
+    """Byte size of one safetensors header entry.
+
+    Raises when the entry's byte range disagrees with its declared dtype and
+    shape -- the checkpoint would be silently truncated for that tensor, and
+    this is the one place every kept tensor passes through.
+    """
+    start, end = entry["data_offsets"]
+    size = end - start
+    dtype = entry["dtype"]
+    if dtype not in _DTYPE_BYTES:
+        raise ValueError(f"[slice] unknown safetensors dtype {dtype!r}")
+    expected = _DTYPE_BYTES[dtype]
+    for dim in entry["shape"]:
+        expected *= dim
+    if expected != size:
+        raise ValueError(
+            f"[slice] header says dtype={dtype} shape={entry['shape']} "
+            f"({expected} bytes) but the data range is {size} bytes")
+    return size
+
+
+def kept_tensor_names(weight_map, num_layers, keep_vision):
+    """Names to keep: the first `num_layers` decoder layers plus everything
+    that is not inside a decoder layer (embeddings, final norm, head, the
+    model-level attention-residual site), minus the vision stack if dropped.
+    """
+    kept = []
+    for name in weight_map:
+        if not keep_vision and name.startswith(VISION_PREFIXES):
+            continue
+        match = _LAYER_RE.search(name)
+        if match and int(match.group(1)) >= num_layers:
+            continue
+        kept.append(name)
+    return sorted(kept)
+
+
+def slice_config(config, num_layers):
+    """Rewrite the depth-dependent fields of a Kimi-K3 config in place.
+
+    ``linear_attn_config``'s layer lists are 1-INDEXED in the released config,
+    so keeping decoder layers ``0..num_layers-1`` keeps list entries
+    ``1..num_layers`` and needs no renumbering.
+    """
+    text = config["text_config"] if "text_config" in config else config
+    old_layers = text["num_hidden_layers"]
+    if num_layers > old_layers:
+        raise ValueError(f"[slice] asked for {num_layers} layers but the "
+                         f"config declares only {old_layers}")
+    text["num_hidden_layers"] = num_layers
+    edits = {"text_config.num_hidden_layers": f"{old_layers} -> {num_layers}"}
+
+    linear = text.get("linear_attn_config")
+    if linear:
+        for key in ("kda_layers", "full_attn_layers"):
+            if key not in linear:
+                continue
+            old = linear[key]
+            new = [i for i in old if i <= num_layers]
+            linear[key] = new
+            edits[f"text_config.linear_attn_config.{key}"] = (
+                f"{len(old)} entries -> {new}")
+        covered = set(linear.get("kda_layers", [])) | set(
+            linear.get("full_attn_layers", []))
+        missing = sorted(set(range(1, num_layers + 1)) - covered)
+        if missing:
+            raise ValueError(
+                f"[slice] 1-indexed layers {missing} are in neither "
+                "kda_layers nor full_attn_layers after slicing; the layer "
+                "pattern would be ambiguous")
+        if not linear.get("full_attn_layers"):
+            raise ValueError(
+                f"[slice] no full-attention (MLA) layer survives a "
+                f"{num_layers}-layer slice; raise --num-layers so the slice "
+                "covers at least one")
+        if len(linear.get("kda_layers", [])) < 2:
+            raise ValueError(
+                f"[slice] fewer than two KDA layers survive a {num_layers}-"
+                "layer slice; raise --num-layers")
+    return edits
+
+
+def repack_shard(src_path, dst_path, header, data_start, keep_names):
+    """Write a new safetensors file holding only `keep_names`.
+
+    Byte ranges are copied straight out of the source data block, so dtypes
+    and values are preserved exactly; nothing is decoded.
+    """
+    keep = [n for n in header if n != "__metadata__" and n in keep_names]
+    keep.sort(key=lambda n: header[n]["data_offsets"][0])
+    new_header = {}
+    if "__metadata__" in header:
+        new_header["__metadata__"] = header["__metadata__"]
+    cursor = 0
+    for name in keep:
+        entry = header[name]
+        size = tensor_nbytes(entry)
+        new_header[name] = {
+            "dtype": entry["dtype"],
+            "shape": entry["shape"],
+            "data_offsets": [cursor, cursor + size],
+        }
+        cursor += size
+    blob = json.dumps(new_header, separators=(",", ":")).encode("utf-8")
+    pad = (-len(blob)) % 8
+    blob += b" " * pad
+    with open(dst_path, "wb") as out:
+        out.write(struct.pack("<Q", len(blob)))
+        out.write(blob)
+        with open(src_path, "rb") as src:
+            for name in keep:
+                start, end = header[name]["data_offsets"]
+                src.seek(data_start + start)
+                remaining = end - start
+                while remaining:
+                    chunk = src.read(min(remaining, 32 << 20))
+                    if not chunk:
+                        raise RuntimeError(
+                            f"[slice] {src_path} ended inside tensor {name}")
+                    out.write(chunk)
+                    remaining -= len(chunk)
+
+
+def copy_object(src, dst):
+    if _is_gcs(src) or _is_gcs(dst):
+        # A bucket has no directories to create, and a gs://->gs:// copy is
+        # served entirely by the storage backend: no bytes reach this host.
+        _run(["gsutil", "-q", "cp", src, dst])
+    else:
+        os.makedirs(os.path.dirname(dst) or ".", exist_ok=True)
+        shutil.copyfile(src, dst)
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--src",
+                        required=True,
+                        help="Source snapshot directory (local or gs://).")
+    parser.add_argument(
+        "--dst",
+        required=True,
+        help="Destination snapshot directory (local or gs://).")
+    parser.add_argument("--num-layers",
+                        type=int,
+                        required=True,
+                        help="Number of leading decoder layers to keep.")
+    parser.add_argument("--index-file",
+                        default=None,
+                        help="Local copy of model.safetensors.index.json. "
+                        "Read from --src when omitted (it is ~60 MB).")
+    parser.add_argument("--drop-vision",
+                        action="store_true",
+                        help="Drop vision_tower/mm_projector tensors. They "
+                        "are kept by default so the slice still exercises "
+                        "the text-only loader's vision-drop path.")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    src = args.src.rstrip("/")
+    dst = args.dst.rstrip("/")
+    keep_vision = not args.drop_vision
+
+    if args.index_file:
+        with open(args.index_file) as fh:
+            index = json.load(fh)
+    else:
+        index = json.loads(read_bytes(f"{src}/model.safetensors.index.json"))
+    weight_map = index["weight_map"]
+
+    keep = set(kept_tensor_names(weight_map, args.num_layers, keep_vision))
+    print(f"[slice] keeping {len(keep)} of {len(weight_map)} tensors "
+          f"({args.num_layers} decoder layers, "
+          f"vision={'kept' if keep_vision else 'dropped'})")
+
+    shard_of = {}
+    for name in keep:
+        shard_of.setdefault(weight_map[name], set()).add(name)
+    shards = sorted(shard_of)
+
+    # Whole-shard copies vs shards that need a repack.
+    whole, mixed, total_bytes = [], [], 0
+    new_weight_map = {}
+    for shard in shards:
+        header, data_start = read_safetensors_header(f"{src}/{shard}")
+        names = [n for n in header if n != "__metadata__"]
+        dropped = [n for n in names if n not in keep]
+        for name in shard_of[shard]:
+            entry = header[name]
+            total_bytes += tensor_nbytes(entry)
+            new_weight_map[name] = shard
+        if dropped:
+            mixed.append((shard, header, data_start, len(dropped)))
+        else:
+            whole.append(shard)
+        print(f"[slice]   {shard}: keep {len(shard_of[shard])}/{len(names)}"
+              f"{' (repack)' if dropped else ' (whole-file copy)'}")
+
+    print(f"[slice] {len(whole)} shards copied whole, {len(mixed)} repacked; "
+          f"{total_bytes} tensor bytes ({total_bytes / 2**30:.1f} GiB)")
+
+    config = json.loads(read_bytes(f"{src}/config.json"))
+    edits = slice_config(config, args.num_layers)
+    for key, value in edits.items():
+        print(f"[slice] config: {key}: {value}")
+
+    index["metadata"]["total_size"] = total_bytes
+    index["weight_map"] = dict(sorted(new_weight_map.items()))
+
+    if args.dry_run:
+        print("[slice] dry run, nothing written")
+        return 0
+
+    workdir = tempfile.mkdtemp(prefix="k3slice-")
+    try:
+        with open(os.path.join(workdir, "config.json"), "w") as fh:
+            json.dump(config, fh, indent=2, sort_keys=True)
+        with open(os.path.join(workdir, "model.safetensors.index.json"),
+                  "w") as fh:
+            json.dump(index, fh)
+        copy_object(os.path.join(workdir, "config.json"), f"{dst}/config.json")
+        copy_object(os.path.join(workdir, "model.safetensors.index.json"),
+                    f"{dst}/model.safetensors.index.json")
+
+        # Everything that is neither a shard nor the config we just rewrote:
+        # tokenizer, generation config, remote-code modules, licence.
+        if _is_gcs(src):
+            listing = _run(["gsutil", "ls", f"{src}/"]).decode().split()
+            names = [
+                os.path.basename(p) for p in listing if not p.endswith("/")
+            ]
+        else:
+            names = os.listdir(src)
+        for name in sorted(names):
+            if name.endswith(".safetensors") or name in (
+                    "config.json", "model.safetensors.index.json"):
+                continue
+            copy_object(f"{src}/{name}", f"{dst}/{name}")
+            print(f"[slice] copied {name}")
+
+        for shard in whole:
+            copy_object(f"{src}/{shard}", f"{dst}/{shard}")
+            print(f"[slice] copied whole {shard}")
+
+        for shard, header, data_start, ndropped in mixed:
+            local_src = os.path.join(workdir, f"in-{shard}")
+            local_dst = os.path.join(workdir, shard)
+            copy_object(f"{src}/{shard}", local_src)
+            repack_shard(local_src, local_dst, header, data_start, keep)
+            os.remove(local_src)
+            copy_object(local_dst, f"{dst}/{shard}")
+            os.remove(local_dst)
+            print(f"[slice] repacked {shard} (dropped {ndropped} tensors)")
+    finally:
+        shutil.rmtree(workdir, ignore_errors=True)
+
+    print(f"[slice] wrote {dst}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tpu_inference/layers/common/kda_attention.py
+++ b/tpu_inference/layers/common/kda_attention.py
@@ -39,8 +39,7 @@ from jax.sharding import PartitionSpec as P
 from tpu_inference.kernels.kda.reference.ragged_kda_chunked import (
     ragged_kda_decode_only, ragged_kda_mixed_prefill)
 from tpu_inference.layers.common.ragged_conv1d_jax import ragged_conv1d
-from tpu_inference.layers.common.sharding import (ShardingAxisName,
-                                                  rank_local_slot_indices)
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.utils import get_mesh_shape_product
 
 
@@ -182,10 +181,13 @@ def _kda_ragged_core(
 
     Returns ``(new_conv_q, new_conv_k, new_conv_v, new_recurrent,
     o [num_tokens, H, K])``.
-    """
-    # Global slot ids -> ids within this rank's shard of the state pool.
-    state_indices = rank_local_slot_indices(state_indices, conv_q.shape[0])
 
+    ``state_indices`` arrive already rank-local: the runner rebases the
+    global slot ids per DP rank (``global % local_slots``, see the
+    mamba_state_indices block in ``TPURunner._prepare_inputs``) before
+    publishing ``AttentionMetadata.mamba_state_indices``, so they index
+    this rank's shard of the state pool directly.
+    """
     q, new_conv_q = ragged_conv1d(q,
                                   conv_q,
                                   q_conv_weight,

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -81,6 +81,8 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
         Gemma4ForConditionalGeneration
     from tpu_inference.models.jax.gemma4_mtp import Gemma4MTPForCausalLM
     from tpu_inference.models.jax.gpt_oss import GptOss
+    from tpu_inference.models.jax.kimi_k3 import (
+        KimiK3ForConditionalGeneration, KimiLinearForCausalLM)
     from tpu_inference.models.jax.llama3 import LlamaForCausalLM
     from tpu_inference.models.jax.llama4 import Llama4ForCausalLM
     from tpu_inference.models.jax.llama_eagle3 import EagleLlama3ForCausalLM
@@ -105,6 +107,9 @@ def _get_model_architecture(config: PretrainedConfig) -> nnx.Module:
     _MODEL_REGISTRY["Gemma4MTPModel"] = Gemma4MTPForCausalLM
     _MODEL_REGISTRY["DFlashForCausalLM"] = DFlashForCausalLM
     _MODEL_REGISTRY["DFlashDraftModel"] = DFlashForCausalLM
+    _MODEL_REGISTRY["KimiLinearForCausalLM"] = KimiLinearForCausalLM
+    _MODEL_REGISTRY[
+        "KimiK3ForConditionalGeneration"] = KimiK3ForConditionalGeneration
 
     architectures = getattr(config, "architectures", [])
     for arch in architectures:

--- a/tpu_inference/models/jax/kimi_k3.py
+++ b/tpu_inference/models/jax/kimi_k3.py
@@ -1,0 +1,1455 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Kimi-Linear / Kimi-K3 JAX text model.
+
+One model file serves the whole family (HF ``moonshotai/Kimi-Linear-48B-A3B-
+Instruct`` and ``moonshotai/Kimi-K3``); every difference is read off the
+config rather than branched on the checkpoint name:
+
+===========================  ==================  ==========================
+config field                 Kimi-Linear-48B     Kimi-K3
+===========================  ==================  ==========================
+hidden_act                   silu                situ (+ the two betas)
+attn_res_block_size          absent              12   (attention residuals)
+routed_expert_hidden_size    absent              3584 (latent MoE)
+linear_attn_config
+  .gate_lower_bound          absent (softplus)   -5.0 (sigmoid lower bound)
+  .use_full_rank_gate        absent (g_a/g_b)    true (g_proj)
+mla_use_output_gate          absent              true
+q_lora_rank                  null                1536
+===========================  ==================  ==========================
+
+Layer stack: ``linear_attn_config.kda_layers`` (1-indexed) selects the KDA
+linear-attention layers, the rest are gated NoPE MLA. The first
+``first_k_dense_replace`` layers have a dense MLP, the rest are MoE.
+
+Reference: the HF repos' ``modeling_kimi_linear.py`` (``KimiDecoderLayer``,
+``KimiSparseMoeBlock``, ``KimiMoEGate``, ``_apply_attn_res``), the Kimi Linear
+paper (arXiv:2510.26692) for KDA, and the attention-residuals report
+(arXiv:2603.15031).
+
+Scope: text-only. Vision-tower and multimodal-projector weights are skipped by
+the loader and image requests are rejected.
+"""
+
+import functools
+import math
+from dataclasses import InitVar, dataclass
+from typing import Any, Iterable, List, Optional, Sequence, Tuple
+
+import jax
+import jax.numpy as jnp
+from flax import nnx
+from jax import lax
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+from vllm.config import VllmConfig
+
+from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.common.kda_attention import (
+    KDAParams, KDAState, kda_a_log_from_checkpoint, kda_attention)
+from tpu_inference.layers.common.moe import MoEBackend
+from tpu_inference.layers.common.sharding import \
+    ShardingAxisNameBase as ShardingAxisName
+from tpu_inference.layers.jax import JaxModule, JaxModuleList
+from tpu_inference.layers.jax.activation import SITU_BETA, SITU_LINEAR_BETA
+from tpu_inference.layers.jax.attention.mla import (
+    MLAAttention, derived_absorbed_mla_param_names)
+from tpu_inference.layers.jax.base import _init_fn as init_fn
+from tpu_inference.layers.jax.base import create_param, sharded_initializer
+from tpu_inference.layers.jax.embed import JaxEmbed
+from tpu_inference.layers.jax.linear import JaxEinsum, JaxLmHead
+from tpu_inference.layers.jax.mlp import GatedMLP
+from tpu_inference.layers.jax.moe.moe import JaxMoE
+from tpu_inference.layers.jax.moe.utils import get_expert_parallelism
+from tpu_inference.layers.jax.norm import JaxRmsNorm
+from tpu_inference.layers.jax.quantization.configs import QuantizationConfig
+from tpu_inference.logger import init_logger
+from tpu_inference.models.common.linear_attention import (
+    compute_linear_attention_layers, linear_attn_config)
+from tpu_inference.models.jax.deepseek_v3 import DeepSeekV3Router
+from tpu_inference.models.jax.utils.weight_utils import (
+    JaxAutoWeightsLoader, LoadableWithIterator,
+    load_nnx_param_from_reshaped_torch)
+from tpu_inference.utils import get_mesh_shape_product
+
+logger = init_logger(__name__)
+
+# Checkpoint prefixes the text-only path does not implement. Kept as an
+# explicit skip list (rather than ignoring unknown weights wholesale) so a
+# genuinely unexpected tensor still fails loudly.
+VISION_SKIP_PREFIXES = (
+    "vision_tower",
+    "model.vision_tower",
+    "multi_modal_projector",
+    "model.multi_modal_projector",
+    "mm_projector",
+    "model.mm_projector",
+)
+
+# The released Kimi-K3 checkpoint is the multimodal wrapper: every text tensor
+# is stored under ``language_model.`` (``language_model.model.*`` and
+# ``language_model.lm_head.weight``) alongside the vision tensors above, and
+# `architectures` is ``KimiK3ForConditionalGeneration``. Kimi-Linear-48B stores
+# the same text stack unprefixed, so strip the prefix when it is present rather
+# than requiring one layout -- the same way :class:`KimiConfig` accepts the
+# text config either nested in ``text_config`` or at the top level, and the
+# same convention the other conditional-generation models here follow.
+WRAPPER_TEXT_PREFIX = "language_model."
+
+# Routed-expert weight names in the Kimi checkpoints vs the canonical names
+# `JaxMoE._load_weights` expects.
+_EXPERT_PARAM_MAP = {"w1": "gate_proj", "w2": "down_proj", "w3": "up_proj"}
+
+
+def routed_expert_shardings() -> Tuple[P, P]:
+    """``(edf, efd)`` specs for the routed-expert kernels.
+
+    The routed experts are almost the whole model -- ~94 GiB of
+    Kimi-Linear-48B, ~1.4 TB of Kimi-K3 -- so they are split along two axes at
+    once:
+
+      * the expert axis ``E`` over :data:`ShardingAxisName.ATTN_DATA_EXPERT`,
+        which is what lets the MEGABLX_GMM backend dispatch each token to the
+        experts resident on this shard; and
+      * the intermediate axis ``F`` over the tensor axis
+        :data:`ShardingAxisName.MODEL`, the axis attention and the dense
+        weights are already sharded on.
+
+    Sharding only ``E`` -- the earlier layout -- forces a choice no single
+    mesh can satisfy. Kimi-K3's non-expert stack is ~113 GB and needs
+    ``model`` > 1 to fit, but on a fixed device budget every device given to
+    ``model`` is one taken from the expert axis, so the experts end up
+    replicated instead. Composing the two removes the conflict: at 32 devices,
+    ``E`` over 4 and ``F`` over 8 splits the expert bytes 32 ways while
+    ``model=8`` still shards attention.
+
+    The collectives follow from where each contraction lands, and are already
+    implemented -- this introduces no new communication:
+
+      * ``gate``/``up`` contract ``D``, replicated in ``edf``, so each shard's
+        product is already complete and nothing is reduced;
+      * ``down`` contracts ``F``, which is sharded, so every shard holds a
+        partial sum over its slice and they must be added.
+        ``sparse_moe_distributed_fwd`` reduces over ``<spec>[1]`` of each
+        kernel spec -- exactly ``F`` for ``efd`` and ``None`` for ``edf`` --
+        and ``dense_moe_func`` runs under automatic sharding, where XLA
+        inserts the same reduction.
+
+    ``ATTN_DATA_EXPERT`` and ``MODEL`` are disjoint mesh axes, so the two
+    splits multiply rather than collide. ``MODEL`` is used for ``F`` rather
+    than a compound axis containing ``attn_dp``: under attention data
+    parallelism distinct ``attn_dp`` ranks hold *different tokens*, so
+    reducing a partial sum across that axis would mix them.
+    """
+    return (P(ShardingAxisName.ATTN_DATA_EXPERT, None, ShardingAxisName.MODEL),
+            P(ShardingAxisName.ATTN_DATA_EXPERT, ShardingAxisName.MODEL, None))
+
+
+def experts_are_block_quantized(quant_config) -> bool:
+    """Whether the routed-expert weights arrive with per-block scales.
+
+    Not ``quant_config is not None``: the unquantized path supplies an
+    ``UnquantizedConfig`` rather than ``None``, and its weights carry no block
+    scales, so the tiling constraint that goes with them does not apply.
+    """
+    if quant_config is None:
+        return False
+    from tpu_inference.layers.jax.quantization.unquantized import \
+        UnquantizedConfig
+    return not isinstance(quant_config, UnquantizedConfig)
+
+
+def kda_head_ways(mesh: Optional[Mesh]) -> int:
+    """How many ways the KDA head axis is split on this mesh."""
+    if mesh is None:
+        return 1
+    return get_mesh_shape_product(mesh, list(ShardingAxisName.ATTN_HEAD))
+
+
+def validate_kda_head_sharding(num_heads: int,
+                               mesh: Optional[Mesh],
+                               prefix: str = "self_attn") -> int:
+    """Refuse a mesh that would split a KDA head across devices.
+
+    Most per-head tensors store the head axis flattened into
+    ``num_heads * head_dim``, and that product can divide when the head count
+    does not: Kimi-K3's 12288 divides by 64 while ``num_heads=96`` does not,
+    and a 64-way split of the flattened axis would hand each device 1.5
+    heads' worth of channels, which every KDA op would then misread.
+
+    ``A_log`` is shaped ``[num_heads]`` and carries the same split, so
+    ``shard_map`` would eventually reject such a mesh on that argument. This
+    check exists to reject it at model construction with the head count
+    named, rather than at the first forward pass inside a divisibility error
+    listing several unrelated arguments.
+    """
+    ways = kda_head_ways(mesh)
+    if num_heads % ways:
+        mesh_desc = ", ".join(f"{n}={s}" for n, s in mesh.shape.items())
+        raise ValueError(
+            f"[kda] '{prefix}': {num_heads} KDA heads do not divide by the "
+            f"{ways} ways the head axis {ShardingAxisName.ATTN_HEAD} is "
+            f"split, so a head would be torn across devices. The flattened "
+            f"num_heads*head_dim axis may still divide, which is why this is "
+            f"checked here rather than left to the sharding machinery "
+            f"(mesh: {mesh_desc}).")
+    return ways
+
+
+def routed_expert_sharding_ways(mesh: Mesh) -> Tuple[int, int]:
+    """``(expert_ways, tensor_ways)`` the routed-expert kernels are split."""
+    return (get_mesh_shape_product(mesh,
+                                   list(ShardingAxisName.ATTN_DATA_EXPERT)),
+            get_mesh_shape_product(mesh, ShardingAxisName.MODEL))
+
+
+def validate_routed_expert_sharding(config: "KimiConfig", mesh: Mesh, *,
+                                    block_quantized: bool) -> Tuple[int, int]:
+    """Check the routed experts really are split, and that the dims divide.
+
+    Raises rather than letting the load proceed: both failure modes surface
+    far from their cause. A mesh that replicates the experts dies as an
+    out-of-memory part-way through loading the layers, and a dimension that
+    does not divide dies inside the sharding machinery without naming the mesh
+    that produced it.
+    """
+    expert_ways, tensor_ways = routed_expert_sharding_ways(mesh)
+    mesh_desc = ", ".join(f"{n}={s}" for n, s in mesh.shape.items())
+
+    if config.num_experts % expert_ways:
+        raise ValueError(
+            f"[kimi] num_experts={config.num_experts} is not divisible by the "
+            f"{expert_ways} ways the expert axis "
+            f"{ShardingAxisName.ATTN_DATA_EXPERT} is split (mesh: "
+            f"{mesh_desc}).")
+    if config.moe_intermediate_size % tensor_ways:
+        raise ValueError(
+            f"[kimi] moe_intermediate_size={config.moe_intermediate_size} is "
+            f"not divisible by the {tensor_ways} ways the tensor axis "
+            f"'{ShardingAxisName.MODEL}' is split (mesh: {mesh_desc}).")
+    if block_quantized and tensor_ways > 1:
+        # Measured on a 2x4 mesh with the tiny fixtures: a per-shard F that is
+        # not a multiple of 128 makes the grouped matmul emit a handful of
+        # NaNs (9 of 8192 output entries) while every other entry stays
+        # correct to ~1e-8, so it corrupts silently rather than failing. The
+        # grouped matmul tiles the intermediate dimension at a multiple of
+        # 128; sharding F is what can leave a remainder there, and only the
+        # block-quantized path is affected (the bf16 twin is clean at the same
+        # per-shard width). Kimi-K3's F=3072 over 8 gives 384, which is fine.
+        # A multiple of 128 is also a multiple of `MXFP4_BLOCK_SIZE`, so this
+        # subsumes "the per-shard block-scale count must divide".
+        f_local = config.moe_intermediate_size // tensor_ways
+        if f_local % 128:
+            raise ValueError(
+                f"[kimi] splitting moe_intermediate_size="
+                f"{config.moe_intermediate_size} {tensor_ways} ways over "
+                f"'{ShardingAxisName.MODEL}' leaves {f_local} per shard, "
+                f"which is not a multiple of 128. The block-quantized grouped "
+                f"matmul returns NaNs for a few entries at that width instead "
+                f"of failing. Choose a tensor-parallel width that divides "
+                f"{config.moe_intermediate_size} into multiples of 128 "
+                f"(mesh: {mesh_desc}).")
+
+    num_devices = math.prod(mesh.axis_sizes)
+    if num_devices > 1 and expert_ways * tensor_ways == 1:
+        raise ValueError(
+            f"[kimi] the routed experts would be replicated on all "
+            f"{num_devices} devices: the expert axis "
+            f"{ShardingAxisName.ATTN_DATA_EXPERT} and the tensor axis "
+            f"'{ShardingAxisName.MODEL}' are both 1 in this mesh "
+            f"({mesh_desc}). They are the bulk of the model, so this runs out "
+            f"of memory part-way through loading. Give the mesh expert "
+            f"parallelism, tensor parallelism, or both.")
+
+    params = (config.num_experts * 3 * config.moe_hidden_size *
+              config.moe_intermediate_size)
+    logger.info(
+        "[kimi] routed experts split %d ways: E over %s (%d) x F over '%s' "
+        "(%d); %.3fG of %.3fG expert parameters per device (mesh: %s)",
+        expert_ways * tensor_ways, ShardingAxisName.ATTN_DATA_EXPERT,
+        expert_ways, ShardingAxisName.MODEL, tensor_ways,
+        params / expert_ways / tensor_ways / 1e9, params / 1e9, mesh_desc)
+    return expert_ways, tensor_ways
+
+
+# Params whose checkpoint layout is NOT "2-D [out, in], transpose it", as
+# (name suffix, reshape_dims, permute_dims).
+_LOADER_LAYOUT_OVERRIDES = (
+    # The HF embedding is [vocab, hidden] and so is ours.
+    ("embed_tokens.weight", None, (0, 1)),
+    # Depthwise conv weight is [channels, 1, kernel_size] on both sides.
+    ("conv1d.weight", None, (0, 1, 2)),
+)
+
+
+def load_kda_a_log(jax_param,
+                   torch_weight,
+                   _shard_id: int = -1,
+                   *,
+                   param_name: str = "self_attn.A_log") -> None:
+    """Load the KDA log-decay parameter.
+
+    The parameter is one scalar per head, but the released checkpoints store
+    that vector in two different layouts; which layouts are accepted, and the
+    evidence that the parameter is per head rather than per channel, are in
+    :func:`~tpu_inference.layers.common.kda_attention.kda_a_log_from_checkpoint`.
+    """
+    flat = kda_a_log_from_checkpoint(torch_weight,
+                                     jax_param.get_value().shape[0],
+                                     param_name)
+    load_nnx_param_from_reshaped_torch(jax_param,
+                                       flat,
+                                       _shard_id,
+                                       reshape_dims=None,
+                                       permute_dims=None,
+                                       param_name=param_name)
+
+
+# Params needing a dedicated loader rather than a reshape/permute of the
+# generic rule, as (name suffix, loader).
+_LOADER_FN_OVERRIDES = (("self_attn.A_log", load_kda_a_log), )
+
+
+def summarize_kda_decay_layout(
+        weights: Iterable[Tuple[str, Any]]) -> Iterable[Tuple[str, Any]]:
+    """Log, once per load, how this checkpoint stores the KDA decay.
+
+    ``A_log`` means the same thing in every Kimi checkpoint -- one log-decay
+    scalar per head -- but the released ones store that vector in two
+    different layouts and nothing in the config says which
+    (see :func:`load_kda_a_log`); only the tensor's shape does. Recording it on
+    the first KDA layer rather than after the load keeps the line in the log
+    even when a later tensor is what fails.
+    """
+    logged = False
+    for name, weight in weights:
+        if not logged and name.endswith("self_attn.A_log"):
+            logged = True
+            logger.info(
+                "[kimi] KDA decay: checkpoint stores A_log as %s; reading it "
+                "as one log-decay scalar per head (any trailing entries must "
+                "be zero padding).", list(getattr(weight, "shape", ())))
+        yield name, weight
+
+
+def _weight_init(random_init: bool):
+    return sharded_initializer if random_init else nnx.initializers.uniform()
+
+
+def attach_default_weight_loaders(model: JaxModule) -> None:
+    """Give every parameter an explicit checkpoint loader.
+
+    ``JaxAutoWeightsLoader`` otherwise infers a reshape/permute from the
+    parameter name, and its rules are written for MHA models: a name ending in
+    ``q_proj.weight`` / ``o_proj.weight`` is assumed to be a 3-D
+    ``[heads, head_dim, hidden]`` parameter and unpacking its shape raises on
+    anything else. Every Kimi projection is a plain 2-D matrix, so state the
+    layout instead of letting it be inferred.
+    """
+    for name, param in model.named_parameters():
+        if hasattr(param, "weight_loader"):
+            # Set by a quant method, which owns the layout for that param.
+            continue
+        loader = None
+        for suffix, loader_fn in _LOADER_FN_OVERRIDES:
+            if name.endswith(suffix):
+                loader = functools.partial(loader_fn, param_name=name)
+                break
+        if loader is None:
+            reshape_dims = permute_dims = None
+            for suffix, reshape, permute in _LOADER_LAYOUT_OVERRIDES:
+                if name.endswith(suffix):
+                    reshape_dims, permute_dims = reshape, permute
+                    break
+            loader = functools.partial(load_nnx_param_from_reshaped_torch,
+                                       reshape_dims=reshape_dims,
+                                       permute_dims=permute_dims,
+                                       param_name=name)
+        param.set_metadata("weight_loader", loader)
+
+
+def adapt_wrapper_checkpoint(
+        weights: Iterable[Tuple[str, Any]]) -> Iterable[Tuple[str, Any]]:
+    """Present a multimodal-wrapper checkpoint as the text stack.
+
+    Strips :data:`WRAPPER_TEXT_PREFIX` from the text tensors and drops the
+    vision ones, which this build does not implement. A checkpoint that is
+    already text-only passes through unchanged.
+
+    The drop is counted and reported once rather than per tensor: the released
+    Kimi-K3 checkpoint carries 168 vision tensors, and a line each would bury
+    the rest of the load log. Only the listed prefixes are dropped, so a
+    genuinely unexpected tensor still reaches the loader and fails loudly.
+    """
+    skipped: list[str] = []
+    for name, weight in weights:
+        if any(name.startswith(p + ".") for p in VISION_SKIP_PREFIXES):
+            skipped.append(name)
+            continue
+        if name.startswith(WRAPPER_TEXT_PREFIX):
+            name = name[len(WRAPPER_TEXT_PREFIX):]
+        yield name, weight
+    if skipped:
+        logger.info(
+            "[kimi] skipped %d vision/projector checkpoint tensors (e.g. %s); "
+            "this build serves the text stack only.", len(skipped),
+            ", ".join(sorted(skipped)[:3]))
+
+
+class KimiConfig:
+    """Flattened view of a Kimi text config, with the family defaults applied.
+
+    Reading the config through one object keeps the "Kimi-Linear-48B leaves
+    this out" knowledge in a single place instead of scattering
+    ``getattr(cfg, ..., default)`` calls through the modules.
+    """
+
+    def __init__(self, hf_config: Any):
+        # KimiK3ForConditionalGeneration nests the text stack.
+        self.hf_config = getattr(hf_config, "text_config", hf_config)
+        c = self.hf_config
+
+        self.hidden_size: int = c.hidden_size
+        self.intermediate_size: int = c.intermediate_size
+        self.num_hidden_layers: int = c.num_hidden_layers
+        self.vocab_size: int = c.vocab_size
+        self.rms_norm_eps: float = c.rms_norm_eps
+        self.hidden_act: str = c.hidden_act
+        self.situ_beta: float = getattr(c, "activation_situ_beta", SITU_BETA)
+        self.situ_linear_beta: float = getattr(c,
+                                               "activation_situ_linear_beta",
+                                               SITU_LINEAR_BETA)
+
+        # --- MLA ---
+        self.num_attention_heads: int = c.num_attention_heads
+        self.num_key_value_heads: int = c.num_key_value_heads
+        self.q_lora_rank: Optional[int] = getattr(c, "q_lora_rank", None)
+        self.kv_lora_rank: int = c.kv_lora_rank
+        self.qk_nope_head_dim: int = c.qk_nope_head_dim
+        self.qk_rope_head_dim: int = c.qk_rope_head_dim
+        self.v_head_dim: int = c.v_head_dim
+        self.mla_use_nope: bool = getattr(c, "mla_use_nope", False)
+        self.mla_use_output_gate: bool = getattr(c, "mla_use_output_gate",
+                                                 False)
+
+        # --- KDA ---
+        # Parsed through the shared helper so that the KV-cache manager (which
+        # must know which layers are recurrent before any module exists) and
+        # the model agree on the layer list by construction.
+        linear_cfg = linear_attn_config(c)
+        self.kda_layers: set = set(compute_linear_attention_layers(c))
+        self.kda_num_heads: int = linear_cfg.get("num_heads",
+                                                 self.num_attention_heads)
+        self.kda_head_dim: int = linear_cfg.get("head_dim", self.v_head_dim)
+        self.kda_conv_kernel_size: int = linear_cfg.get(
+            "short_conv_kernel_size", 4)
+        # Absent => the -exp(A_log)*softplus decay form (Kimi-Linear-48B).
+        self.kda_gate_lower_bound: Optional[float] = linear_cfg.get(
+            "gate_lower_bound", None)
+        self.kda_use_full_rank_gate: bool = linear_cfg.get(
+            "use_full_rank_gate", False)
+
+        # --- MoE ---
+        self.num_experts: int = getattr(c, "num_experts", 0)
+        self.num_experts_per_token: int = getattr(c, "num_experts_per_token",
+                                                  1)
+        self.moe_intermediate_size: int = getattr(c, "moe_intermediate_size",
+                                                  0)
+        self.num_shared_experts: Optional[int] = getattr(
+            c, "num_shared_experts", None)
+        self.first_k_dense_replace: int = getattr(c, "first_k_dense_replace",
+                                                  0)
+        self.moe_layer_freq: int = getattr(c, "moe_layer_freq", 1)
+        self.moe_renormalize: bool = getattr(c, "moe_renormalize", True)
+        self.moe_router_activation_func: str = getattr(
+            c, "moe_router_activation_func", "sigmoid")
+        self.num_expert_group: int = getattr(c, "num_expert_group", 1)
+        self.topk_group: int = getattr(c, "topk_group", 1)
+        self.routed_scaling_factor: float = getattr(c, "routed_scaling_factor",
+                                                    1.0)
+        # Absent => routed experts run at full hidden width (Kimi-Linear-48B).
+        self.routed_expert_hidden_size: Optional[int] = getattr(
+            c, "routed_expert_hidden_size", None)
+        self.latent_moe_use_norm: bool = getattr(c, "latent_moe_use_norm",
+                                                 False)
+
+        # --- Attention residuals ---
+        # Absent => the plain residual stream (Kimi-Linear-48B).
+        self.attn_res_block_size: Optional[int] = getattr(
+            c, "attn_res_block_size", None)
+
+    @property
+    def use_attn_residuals(self) -> bool:
+        return self.attn_res_block_size is not None
+
+    @property
+    def moe_hidden_size(self) -> int:
+        """Width the routed experts operate at (the latent dim for Kimi-K3)."""
+        return self.routed_expert_hidden_size or self.hidden_size
+
+    def is_kda_layer(self, layer_idx: int) -> bool:
+        return layer_idx in self.kda_layers
+
+    def is_moe_layer(self, layer_idx: int) -> bool:
+        if self.num_experts == 0 or layer_idx < self.first_k_dense_replace:
+            return False
+        return (layer_idx + 1) % self.moe_layer_freq == 0
+
+    def is_attn_res_checkpoint(self, layer_idx: int) -> bool:
+        return (self.use_attn_residuals
+                and layer_idx % self.attn_res_block_size == 0)
+
+
+def apply_attn_res(prefix_sum_TD: jax.Array,
+                   block_residual: Sequence[jax.Array],
+                   proj_weight_D1: jax.Array, norm_weight_D: jax.Array,
+                   eps: float) -> jax.Array:
+    """Mix the depth checkpoints with the running prefix sum.
+
+    A 1-dimensional learned pseudo-query attends over the candidate vectors
+    ``{block_residual..., prefix_sum}``: each candidate is RMS-normalized
+    (the norm's scale is *not* applied inside the norm), scored against
+    ``norm.weight * proj.weight``, and the softmax over those scores mixes the
+    un-normalized candidates. Computed in fp32, matching the reference
+    (``modeling_kimi_linear.py::_apply_attn_res``).
+    """
+    v_TBD = jnp.stack(tuple(block_residual) + (prefix_sum_TD, ), axis=1)
+    v_f32 = v_TBD.astype(jnp.float32)
+    variance = jnp.mean(v_f32 * v_f32, axis=-1, keepdims=True)
+    k_TBD = v_f32 * lax.rsqrt(variance + eps)
+    score_weight_D = (norm_weight_D.astype(jnp.float32) *
+                      proj_weight_D1.reshape(-1).astype(jnp.float32))
+    scores_TB = jnp.sum(k_TBD * score_weight_D, axis=-1)
+    probs_TB = jax.nn.softmax(scores_TB, axis=-1)
+    # The mix replaces the residual stream, so it is computed at full fp32
+    # precision rather than the TPU default (which costs ~4 digits of
+    # agreement per layer here); the contraction is over <=8 depth
+    # checkpoints, so this is free.
+    out_TD = jnp.einsum('TB,TBD->TD',
+                        probs_TB,
+                        v_f32,
+                        precision=lax.Precision.HIGHEST)
+    return out_TD.astype(prefix_sum_TD.dtype)
+
+
+def build_attn_res_site(*, hidden_size: int, dtype: jnp.dtype,
+                        rms_norm_eps: float, rngs: nnx.Rngs, random_init: bool,
+                        prefix: str) -> Tuple[JaxEinsum, JaxRmsNorm]:
+    """Build one attention-residual mix site: its ``(proj, norm)`` pair.
+
+    The two tensors are returned rather than wrapped in a module because the
+    checkpoint names them as siblings (``<site>_res_proj.weight`` /
+    ``<site>_res_norm.weight``), and the recursive weight loader resolves
+    names by attribute path.
+    """
+    proj = JaxEinsum(
+        einsum_str="TD,DO->TO",
+        kernel_shape=(hidden_size, 1),
+        rngs=rngs,
+        quant_config=None,
+        param_dtype=dtype,
+        kernel_init=nnx.with_partitioning(_weight_init(random_init), P()),
+        prefix=prefix + "_proj",
+    )
+    norm = JaxRmsNorm(hidden_size,
+                      epsilon=rms_norm_eps,
+                      scale_init=nnx.with_partitioning(init_fn, (None, )),
+                      param_dtype=dtype,
+                      dtype=dtype,
+                      quant_config=None,
+                      prefix=prefix + "_norm",
+                      rngs=rngs)
+    return proj, norm
+
+
+class _RawWeight(JaxModule):
+    """A module owning a single ``weight`` parameter.
+
+    Used for checkpoint entries like ``self_attn.q_conv1d.weight`` that are
+    plain tensors rather than a linear layer.
+    """
+
+    def __init__(self, shape: Tuple[int, ...], dtype: jnp.dtype,
+                 rngs: nnx.Rngs, sharding: P, random_init: bool):
+        self.weight = create_param(rngs,
+                                   shape=shape,
+                                   dtype=dtype,
+                                   sharding=sharding,
+                                   random_init=random_init)
+
+
+@dataclass(kw_only=True)
+class KimiDeltaAttention(JaxModule):
+    """KDA (Kimi Delta Attention) linear-attention layer.
+
+    Owns the checkpoint parameters and delegates the math to
+    ``layers/common/kda_attention.py``. Its state (three conv windows plus the
+    recurrent state) is threaded through the ``kv_cache`` slot exactly like an
+    attention layer's KV cache, so the decoder loop stays uniform.
+
+    NOTE(sharding): the per-head parameters are split over ``ATTN_HEAD`` and
+    the state-carrying math runs under a ``shard_map`` over ``ATTN_DATA``.
+    The two are orthogonal -- ``ATTN_DATA`` splits tokens and state slots,
+    ``ATTN_HEAD`` splits the head axis of the same arrays -- and the core is
+    head-parallel, so no head-axis collective is needed inside the map. The
+    ``shard_map`` is a correctness requirement, not an optimization, because
+    the ragged metadata is laid out per DP rank; the head split is a memory
+    one. Only ``o_proj`` contracts the head axis, and it does so outside the
+    map where XLA inserts the all-reduce.
+    """
+    hidden_size: int
+    num_heads: int
+    head_dim: int
+    conv_kernel_size: int
+    rms_norm_eps: float
+    dtype: jnp.dtype
+    use_full_rank_gate: bool
+    mesh: Mesh
+    gate_lower_bound: Optional[float] = None
+    random_init: bool = False
+    quant_config: Optional[QuantizationConfig] = None
+    prefix: str = ""
+
+    rngs: InitVar[nnx.Rngs]
+
+    def __post_init__(self, rngs: nnx.Rngs):
+        D = self.hidden_size
+        HP = self.num_heads * self.head_dim
+        K = self.head_dim
+        weight_init = _weight_init(self.random_init)
+
+        # The linear-attention math is head-parallel: every op in the
+        # state-carrying core -- the depthwise convs, the per-(head, channel)
+        # gate, the recurrent scan, the headwise RMSNorm -- works on one head
+        # at a time and never contracts or reduces across heads. So the head
+        # axis is split over `ATTN_HEAD`, the axis MLA and the dense MLP
+        # already use. Everything indexed by head takes it; the low-rank
+        # bottlenecks (`f_a_proj` / `g_a_proj`, whose output is `head_dim`
+        # wide and shared by all heads) and `o_norm` (per channel *within* a
+        # head) are not per-head and stay replicated.
+        #
+        # `num_heads * head_dim` is laid out head-major, so splitting the
+        # flattened axis N ways equals splitting the head axis -- but only
+        # when N divides the head count. `validate_kda_head_sharding` refuses
+        # the rest: `num_heads * head_dim` can divide when `num_heads` does
+        # not, and the result is a silently torn head.
+        head = ShardingAxisName.ATTN_HEAD
+        validate_kda_head_sharding(self.num_heads, self.mesh, self.prefix)
+
+        def _einsum(name: str, shape: Tuple[int, int],
+                    sharding: P = P()) -> JaxEinsum:
+            return JaxEinsum(
+                einsum_str="TD,DP->TP",
+                kernel_shape=shape,
+                rngs=rngs,
+                quant_config=self.quant_config,
+                param_dtype=self.dtype,
+                kernel_init=nnx.with_partitioning(weight_init, sharding),
+                prefix=f"{self.prefix}.{name}",
+            )
+
+        def _conv() -> _RawWeight:
+            # fp32, not the model dtype: Kimi-K3 checkpoints the short-conv
+            # weights in fp32 (Kimi-Linear-48B checkpoints them in bf16), and
+            # a bf16 parameter would round them away at load. vLLM's KDA layer
+            # holds them in fp32 for the same reason
+            # (`params_dtype=torch.float32` on its conv1d). See `_params` for
+            # where the compute dtype is applied.
+            return _RawWeight(shape=(HP, 1, self.conv_kernel_size),
+                              dtype=jnp.float32,
+                              rngs=rngs,
+                              sharding=P(head, None, None),
+                              random_init=self.random_init)
+
+        self.q_proj = _einsum("q_proj", (D, HP), P(None, head))
+        self.k_proj = _einsum("k_proj", (D, HP), P(None, head))
+        self.v_proj = _einsum("v_proj", (D, HP), P(None, head))
+        self.q_conv1d = _conv()
+        self.k_conv1d = _conv()
+        self.v_conv1d = _conv()
+        self.f_a_proj = _einsum("f_a_proj", (D, K))
+        self.f_b_proj = _einsum("f_b_proj", (K, HP), P(None, head))
+        self.b_proj = _einsum("b_proj", (D, self.num_heads), P(None, head))
+        if self.use_full_rank_gate:
+            self.g_proj = _einsum("g_proj", (D, HP), P(None, head))
+        else:
+            self.g_a_proj = _einsum("g_a_proj", (D, K))
+            self.g_b_proj = _einsum("g_b_proj", (K, HP), P(None, head))
+        # Row-parallel: contracts the split head axis, so its output is a
+        # partial sum that XLA all-reduces (the standard TP output pattern,
+        # and what MLA's o_proj already does).
+        self.o_proj = _einsum("o_proj", (HP, D), P(head, None))
+        self.A_log = create_param(rngs,
+                                  shape=(self.num_heads, ),
+                                  dtype=jnp.float32,
+                                  sharding=P(head),
+                                  random_init=self.random_init)
+        self.dt_bias = create_param(rngs,
+                                    shape=(HP, ),
+                                    dtype=jnp.float32,
+                                    sharding=P(head),
+                                    random_init=self.random_init)
+        # fp32 for the same reason as the conv weights: Kimi-K3 checkpoints
+        # `o_norm.weight` in fp32, and the gated RMSNorm that consumes it runs
+        # in fp32 anyway, so a bf16 parameter would round the checkpoint value
+        # away for nothing. (Kimi-Linear-48B checkpoints it in bf16; widening
+        # that is exact.) Only the weight is used -- the norm math itself
+        # lives in `kda_attention._gated_rmsnorm`.
+        self.o_norm = JaxRmsNorm(K,
+                                 epsilon=self.rms_norm_eps,
+                                 scale_init=nnx.with_partitioning(
+                                     init_fn, (None, )),
+                                 param_dtype=jnp.float32,
+                                 dtype=jnp.float32,
+                                 quant_config=None,
+                                 prefix=self.prefix + ".o_norm",
+                                 rngs=rngs)
+
+    def _params(self) -> KDAParams:
+        """Assemble the functional parameter bundle.
+
+        ``kda_attention`` takes torch-style ``[out, in]`` matrices (it computes
+        ``x @ w.T``) while these params are stored transposed, hence ``.T``.
+        """
+
+        def _t(layer: JaxEinsum) -> jax.Array:
+            # Weights keep their checkpoint dtype; the layer decides the
+            # compute dtype (they differ when a bf16 checkpoint is run in fp32
+            # for parity checks).
+            return layer.weight.value.astype(self.dtype).T
+
+        gate_kwargs = {}
+        if self.use_full_rank_gate:
+            gate_kwargs["g_proj"] = _t(self.g_proj)
+        else:
+            gate_kwargs["g_a_proj"] = _t(self.g_a_proj)
+            gate_kwargs["g_b_proj"] = _t(self.g_b_proj)
+        return KDAParams(
+            q_proj=_t(self.q_proj),
+            k_proj=_t(self.k_proj),
+            v_proj=_t(self.v_proj),
+            # The conv weights are held in fp32 (see `_conv`) but the ragged
+            # conv's prefill branch is a `lax.conv_general_dilated`, which
+            # rejects mixed dtypes, so the weight meets the activations at the
+            # model dtype. This is the one place the checkpoint's extra conv
+            # precision is dropped; the other two branches (the decode einsum
+            # and the accumulate-in-fp32 loop) would take fp32 directly, so
+            # running the whole conv in fp32 is a compute-dtype decision for
+            # `ragged_conv1d`, not a loading one.
+            q_conv_weight=self.q_conv1d.weight.value.astype(self.dtype),
+            k_conv_weight=self.k_conv1d.weight.value.astype(self.dtype),
+            v_conv_weight=self.v_conv1d.weight.value.astype(self.dtype),
+            # The decay is computed in fp32 in the reference regardless of the
+            # checkpoint dtype.
+            A_log=self.A_log.value.astype(jnp.float32),
+            dt_bias=self.dt_bias.value.astype(jnp.float32),
+            f_a_proj=_t(self.f_a_proj),
+            f_b_proj=_t(self.f_b_proj),
+            b_proj=_t(self.b_proj),
+            # Not cast: the gated RMSNorm runs in fp32 and the parameter is
+            # already fp32, so the checkpoint value reaches the math intact.
+            o_norm_weight=self.o_norm.weight.value,
+            o_proj=_t(self.o_proj),
+            **gate_kwargs)
+
+    def __call__(
+            self, x_TD: jax.Array, state: Sequence[jax.Array],
+            md: AttentionMetadata) -> Tuple[Tuple[jax.Array, ...], jax.Array]:
+        """Runs the sublayer over one `kv_cache` slot.
+
+        The slot arrives as a plain tuple of the four state arrays -- that is
+        how the KV-cache manager allocates a `MambaSpec` layer, and how the
+        decoder loop threads it. Naming them via `KDAState` here (and handing
+        a plain tuple back) keeps the jitted model's input and output pytrees
+        the same shape, so `self.kv_caches = model_fn(...)` round-trips
+        without a retrace.
+        """
+        if md.has_initial_state is None:
+            raise ValueError(
+                "[kda] AttentionMetadata.has_initial_state is None, so this "
+                "layer cannot tell which slots must resume recurrent/conv "
+                "state. The runner publishes the field for models that "
+                "register mamba kv-cache layers; a None here means this "
+                "model's KDA layers were not registered as such. Not "
+                "re-deriving it from query_start_loc on purpose -- that "
+                "derivation is wrong under attention DP (see the field docs "
+                "in layers/common/attention_metadata.py).")
+        has_initial_state = md.has_initial_state.astype(jnp.bool_)
+        new_state, out = kda_attention(x_TD,
+                                       self._params(),
+                                       KDAState(*state),
+                                       md.mamba_state_indices,
+                                       md.query_start_loc,
+                                       md.request_distribution,
+                                       has_initial_state,
+                                       num_heads=self.num_heads,
+                                       head_dim=self.head_dim,
+                                       kernel_size=self.conv_kernel_size,
+                                       gate_lower_bound=self.gate_lower_bound,
+                                       rms_norm_eps=self.rms_norm_eps,
+                                       mesh=self.mesh)
+        return tuple(new_state), out
+
+
+class KimiRoutedExperts(JaxMoE):
+    """Routed experts, with the Kimi checkpoint's ``w1``/``w2``/``w3`` naming.
+
+    NOTE(backend): Kimi-K3 runs this on an unfused MoE backend. The fused GMM
+    kernels take the raw router logits and select experts internally, which
+    drops the ``e_score_correction_bias`` that this model's noaux_tc routing
+    depends on, and they have no ``situ`` activation branch. When the perf
+    phase moves K3 onto GMM, the bias must be passed explicitly through
+    ``extra_backend_kwargs["e_score_correction_bias"]``.
+    """
+
+    def _load_weights(self, weights: Iterable, **kwargs):
+
+        def adapted():
+            for name, weight in weights:
+                parts = name.split(".")
+                if len(parts) >= 2 and parts[-2] in _EXPERT_PARAM_MAP:
+                    parts[-2] = _EXPERT_PARAM_MAP[parts[-2]]
+                    name = ".".join(parts)
+                # `JaxMoE._load_weights` only prepends the expert axis, it does
+                # not transpose, while the expert kernels are declared
+                # `(E, in, out)` and the checkpoint stores `[out, in]`.
+                if weight.ndim == 2:
+                    weight = weight.transpose(0, 1)
+                yield name, weight
+
+        return super()._load_weights(adapted(), **kwargs)
+
+
+class KimiSparseMoeBlock(JaxModule):
+    """Kimi MoE block: routed experts (optionally latent) + shared experts.
+
+    For Kimi-K3 the routed path is a *latent* MoE -- the token is projected
+    7168 -> 3584 once, every expert runs at that width, the weighted expert
+    sum is RMS-normalized and projected back up. The shared experts always run
+    at full hidden width on the original input, so they cannot be folded into
+    the routed path the way DeepSeek-V3's ``SharedFusedMoe`` does.
+    """
+
+    def __init__(self,
+                 *,
+                 config: "KimiConfig",
+                 mesh: Mesh,
+                 dtype: jnp.dtype,
+                 quant_config: Optional[QuantizationConfig],
+                 rngs: nnx.Rngs,
+                 moe_backend: MoEBackend,
+                 num_expert_parallelism: int = 1,
+                 random_init: bool = False,
+                 prefix: str = ""):
+        self.config = config
+        self.use_latent_moe = config.routed_expert_hidden_size is not None
+        moe_hidden = config.moe_hidden_size
+        weight_init = _weight_init(random_init)
+        edf_sharding, efd_sharding = routed_expert_shardings()
+
+        self.gate = DeepSeekV3Router(
+            hidden_size=config.hidden_size,
+            num_experts=config.num_experts,
+            num_experts_per_tok=config.num_experts_per_token,
+            n_groups=config.num_expert_group,
+            topk_groups=config.topk_group,
+            norm_topk_prob=config.moe_renormalize,
+            rngs=rngs,
+            routed_scaling_factor=config.routed_scaling_factor,
+            dtype=dtype,
+            moe_backend=moe_backend,
+            activation_ffw_td=P(ShardingAxisName.MLP_DATA, None),
+            ed_sharding=P(None, None),
+            e_sharding=P(None, ),
+            scoring_func=config.moe_router_activation_func,
+            random_init=random_init,
+            quant_config=None)
+
+        if self.use_latent_moe:
+            self.routed_expert_down_proj = JaxEinsum(
+                einsum_str="TD,DL->TL",
+                kernel_shape=(config.hidden_size, moe_hidden),
+                rngs=rngs,
+                quant_config=None,
+                param_dtype=dtype,
+                kernel_init=nnx.with_partitioning(weight_init, P(None, None)),
+                prefix=f"{prefix}.routed_expert_down_proj")
+            self.routed_expert_up_proj = JaxEinsum(
+                einsum_str="TL,LD->TD",
+                kernel_shape=(moe_hidden, config.hidden_size),
+                rngs=rngs,
+                quant_config=None,
+                param_dtype=dtype,
+                kernel_init=nnx.with_partitioning(weight_init, P(None, None)),
+                prefix=f"{prefix}.routed_expert_up_proj")
+            if config.latent_moe_use_norm:
+                self.routed_expert_norm = JaxRmsNorm(
+                    moe_hidden,
+                    epsilon=config.rms_norm_eps,
+                    scale_init=nnx.with_partitioning(init_fn, (None, )),
+                    param_dtype=dtype,
+                    dtype=dtype,
+                    quant_config=None,
+                    prefix=f"{prefix}.routed_expert_norm",
+                    rngs=rngs)
+
+        self.experts = KimiRoutedExperts(
+            dtype=dtype,
+            num_local_experts=config.num_experts,
+            apply_expert_weight_before_computation=False,
+            expert_axis_name=ShardingAxisName.ATTN_DATA_EXPERT,
+            num_expert_parallelism=num_expert_parallelism,
+            hidden_size=moe_hidden,
+            intermediate_size_moe=config.moe_intermediate_size,
+            num_experts_per_tok=config.num_experts_per_token,
+            mesh=mesh,
+            hidden_act=config.hidden_act,
+            rngs=rngs,
+            random_init=random_init,
+            quant_config=quant_config,
+            activation_ffw_td=P(ShardingAxisName.MLP_DATA, None),
+            activation_ffw_ted=P(ShardingAxisName.MLP_DATA, None, None),
+            # The routed experts are the bulk of the weights, and they are
+            # split over the expert axis *and* the tensor axis at once --
+            # see `routed_expert_shardings` for why one axis is not enough
+            # and where the down-projection's reduction comes from.
+            edf_sharding=edf_sharding,
+            efd_sharding=efd_sharding,
+            moe_backend=moe_backend,
+            qwix_quantized_weight_dtype=None,
+            prefix=f"{prefix}.experts",
+            router=self.gate,
+            scoring_func=config.moe_router_activation_func,
+            renormalize=config.moe_renormalize)
+        # Read back by `situ_params` inside the MoE backends: SiTU transforms
+        # the up branch too, so the betas cannot ride on the activation name.
+        self.experts.situ_beta = config.situ_beta
+        self.experts.situ_linear_beta = config.situ_linear_beta
+
+        if config.num_shared_experts:
+            self.shared_experts = GatedMLP(
+                dtype=dtype,
+                hidden_act=config.hidden_act,
+                hidden_size=config.hidden_size,
+                intermediate_size=(config.moe_intermediate_size *
+                                   config.num_shared_experts),
+                situ_beta=config.situ_beta,
+                situ_linear_beta=config.situ_linear_beta,
+                rngs=rngs,
+                random_init=random_init,
+                activation_ffw_td=P(ShardingAxisName.MLP_DATA, None),
+                df_sharding=P(None, ShardingAxisName.ATTN_HEAD),
+                fd_sharding=P(ShardingAxisName.ATTN_HEAD, None),
+                quant_config=None,
+                prefix=f"{prefix}.shared_experts")
+
+    def named_parameters(self, *args, **kwargs):
+        for name, param in super().named_parameters(*args, **kwargs):
+            # `self.gate` is also reachable as `experts.router`; yield it once,
+            # under its checkpoint name.
+            if ".router." in name or name.startswith("router."):
+                continue
+            yield name, param
+
+    def __call__(self, x_TD: jax.Array) -> jax.Array:
+        identity_TD = x_TD
+        routed_in = x_TD
+        if self.use_latent_moe:
+            routed_in = self.routed_expert_down_proj(x_TD)
+
+        # The router scores the FULL-width hidden state, not the latent one.
+        routing = self.gate(x_TD)
+        if self.config.routed_scaling_factor != 1.0:
+            # The reference applies the scale to the top-k weights inside the
+            # gate. With a latent MoE that is NOT the same as scaling the
+            # block output: the latent RMSNorm sits in between and is
+            # scale-invariant. (Kimi-K3 uses 1.0; Kimi-Linear-48B uses 2.446.)
+            assert isinstance(routing, tuple), (
+                "[kimi-k3] routed_scaling_factor needs an unfused MoE backend "
+                "whose router returns (weights, indices); fused backends "
+                "select experts internally from raw logits")
+            weights_TX, indices_TX = routing
+            routing = (weights_TX * self.config.routed_scaling_factor,
+                       indices_TX)
+        y, _ = self.experts(routed_in, router_logits=routing)
+
+        if self.use_latent_moe:
+            if self.config.latent_moe_use_norm:
+                y = self.routed_expert_norm(y)
+            y = self.routed_expert_up_proj(y)
+
+        if hasattr(self, "shared_experts"):
+            y = y + self.shared_experts(identity_TD)
+        return y
+
+
+class KimiDecoderLayer(JaxModule):
+    """One decoder layer, with or without attention residuals.
+
+    With attention residuals the plain residual stream is replaced by a
+    ``prefix_sum`` (running sum of the attention and MLP outputs) plus a list
+    of depth checkpoints (``block_residual``); each of the two sites mixes
+    them with a learned 1-dim pseudo-query. See :func:`apply_attn_res`.
+    """
+
+    def __init__(self, *, config: "KimiConfig", layer_idx: int,
+                 input_layernorm: JaxRmsNorm,
+                 post_attention_layernorm: JaxRmsNorm, self_attn: JaxModule,
+                 mlp: JaxModule, rngs: nnx.Rngs, dtype: jnp.dtype,
+                 random_init: bool, prefix: str):
+        self.config = config
+        self.layer_idx = layer_idx
+        self.input_layernorm = input_layernorm
+        self.post_attention_layernorm = post_attention_layernorm
+        self.self_attn = self_attn
+        # The checkpoint names the feed-forward `block_sparse_moe` on MoE
+        # layers and `mlp` on dense ones; the weight loader resolves by
+        # attribute path, so register it under the matching name.
+        self.mlp_attr = ("block_sparse_moe" if isinstance(
+            mlp, KimiSparseMoeBlock) else "mlp")
+        setattr(self, self.mlp_attr, mlp)
+        if config.use_attn_residuals:
+            site_kwargs = dict(hidden_size=config.hidden_size,
+                               dtype=dtype,
+                               rms_norm_eps=config.rms_norm_eps,
+                               rngs=rngs,
+                               random_init=random_init)
+            (self.self_attention_res_proj,
+             self.self_attention_res_norm) = build_attn_res_site(
+                 prefix=f"{prefix}.self_attention_res", **site_kwargs)
+            self.mlp_res_proj, self.mlp_res_norm = build_attn_res_site(
+                prefix=f"{prefix}.mlp_res", **site_kwargs)
+
+    def _mlp(self) -> JaxModule:
+        return getattr(self, self.mlp_attr)
+
+    def _mix(self, proj: JaxEinsum, norm: JaxRmsNorm, prefix_sum_TD,
+             block_residual):
+        return apply_attn_res(prefix_sum_TD, block_residual, proj.weight.value,
+                              norm.weight.value, self.config.rms_norm_eps)
+
+    def __call__(
+        self,
+        x_TD: jax.Array,
+        *,
+        kv_cache,
+        attention_metadata: AttentionMetadata,
+        block_residual: Optional[List[jax.Array]] = None,
+    ):
+        if not self.config.use_attn_residuals:
+            residual = x_TD
+            hidden = self.input_layernorm(x_TD)
+            new_cache, attn_out = self.self_attn(hidden, kv_cache,
+                                                 attention_metadata)
+            hidden = residual + attn_out
+            residual = hidden
+            hidden = self.post_attention_layernorm(hidden)
+            return (new_cache, residual + self._mlp()(hidden), block_residual)
+
+        prefix_sum = x_TD
+        hidden = x_TD
+        if block_residual:
+            hidden = self._mix(self.self_attention_res_proj,
+                               self.self_attention_res_norm, prefix_sum,
+                               block_residual)
+
+        if self.config.is_attn_res_checkpoint(self.layer_idx):
+            # Start a new depth block: this layer's input becomes a checkpoint
+            # and the prefix sum restarts from the attention output.
+            block_residual = list(block_residual) + [prefix_sum]
+            prefix_sum = None
+
+        hidden = self.input_layernorm(hidden)
+        new_cache, attn_out = self.self_attn(hidden, kv_cache,
+                                             attention_metadata)
+        prefix_sum = attn_out if prefix_sum is None else prefix_sum + attn_out
+
+        hidden = self._mix(self.mlp_res_proj, self.mlp_res_norm, prefix_sum,
+                           block_residual)
+        hidden = self.post_attention_layernorm(hidden)
+        prefix_sum = prefix_sum + self._mlp()(hidden)
+
+        return new_cache, prefix_sum, block_residual
+
+
+class KimiLinearModel(JaxModule):
+    """The Kimi text stack: embeddings, decoder layers, final norm."""
+
+    def __init__(self,
+                 *,
+                 config: "KimiConfig",
+                 rngs: nnx.Rngs,
+                 mesh: Mesh,
+                 dtype: jnp.dtype,
+                 kv_cache_dtype: str = "auto",
+                 quant_config: Optional[QuantizationConfig] = None,
+                 moe_backend: MoEBackend = MoEBackend.DENSE_MAT,
+                 num_expert_parallelism: int = 1,
+                 random_init: bool = False,
+                 prefix: str = "model"):
+        self.config = config
+        self.mesh = mesh
+        self.dtype = dtype
+        self.moe_backend = moe_backend
+        self.num_expert_parallelism = num_expert_parallelism
+
+        self.embed_tokens = JaxEmbed(
+            num_embeddings=config.vocab_size,
+            features=config.hidden_size,
+            param_dtype=dtype,
+            dtype=dtype,
+            embedding_init=nnx.with_partitioning(
+                init_fn, (ShardingAxisName.MLP_TENSOR, )),
+            rngs=rngs,
+            quant_config=quant_config,
+            prefix=prefix + ".embed_tokens",
+        )
+
+        self.layers = JaxModuleList([
+            self._build_layer(i,
+                              rngs=rngs,
+                              dtype=dtype,
+                              quant_config=quant_config,
+                              kv_cache_dtype=kv_cache_dtype,
+                              random_init=random_init,
+                              prefix=f"{prefix}.layers.{i}")
+            for i in range(config.num_hidden_layers)
+        ])
+
+        if config.use_attn_residuals:
+            (self.output_attn_res_proj,
+             self.output_attn_res_norm) = build_attn_res_site(
+                 hidden_size=config.hidden_size,
+                 dtype=dtype,
+                 rms_norm_eps=config.rms_norm_eps,
+                 rngs=rngs,
+                 random_init=random_init,
+                 prefix=prefix + ".output_attn_res")
+
+        self.norm = JaxRmsNorm(config.hidden_size,
+                               epsilon=config.rms_norm_eps,
+                               scale_init=nnx.with_partitioning(
+                                   init_fn, (None, )),
+                               param_dtype=dtype,
+                               dtype=dtype,
+                               quant_config=quant_config,
+                               prefix=prefix + ".norm",
+                               rngs=rngs)
+
+    def _build_layer(self, layer_idx: int, *, rngs, dtype, quant_config,
+                     kv_cache_dtype, random_init, prefix) -> KimiDecoderLayer:
+        config = self.config
+
+        def _norm(name):
+            return JaxRmsNorm(config.hidden_size,
+                              epsilon=config.rms_norm_eps,
+                              scale_init=nnx.with_partitioning(
+                                  init_fn, (None, )),
+                              param_dtype=dtype,
+                              dtype=dtype,
+                              quant_config=quant_config,
+                              prefix=f"{prefix}.{name}",
+                              rngs=rngs)
+
+        input_layernorm = _norm("input_layernorm")
+        post_attention_layernorm = _norm("post_attention_layernorm")
+
+        if config.is_kda_layer(layer_idx):
+            self_attn = KimiDeltaAttention(
+                hidden_size=config.hidden_size,
+                num_heads=config.kda_num_heads,
+                head_dim=config.kda_head_dim,
+                conv_kernel_size=config.kda_conv_kernel_size,
+                rms_norm_eps=config.rms_norm_eps,
+                dtype=dtype,
+                use_full_rank_gate=config.kda_use_full_rank_gate,
+                gate_lower_bound=config.kda_gate_lower_bound,
+                random_init=random_init,
+                quant_config=None,
+                rngs=rngs,
+                mesh=self.mesh,
+                prefix=f"{prefix}.self_attn")
+        else:
+            self_attn = MLAAttention(
+                hidden_size=config.hidden_size,
+                num_attention_heads=config.num_attention_heads,
+                num_key_value_heads=1,
+                head_dim=config.v_head_dim,
+                dtype=dtype,
+                kv_cache_dtype=kv_cache_dtype,
+                mesh=self.mesh,
+                q_lora_rank=config.q_lora_rank,
+                kv_lora_rank=config.kv_lora_rank,
+                qk_nope_head_dim=config.qk_nope_head_dim,
+                qk_rope_head_dim=config.qk_rope_head_dim,
+                v_head_dim=config.v_head_dim,
+                rms_norm_eps=config.rms_norm_eps,
+                rope=None,
+                use_nope=config.mla_use_nope,
+                use_output_gate=config.mla_use_output_gate,
+                random_init=random_init,
+                rngs=rngs,
+                quant_config=quant_config,
+                activation_attention_td=P(ShardingAxisName.ATTN_DATA, None),
+                activation_q_td=P(ShardingAxisName.ATTN_DATA, None),
+                query_nth=P(None, ShardingAxisName.ATTN_DATA, None),
+                query_tnh=P(ShardingAxisName.ATTN_DATA, None, None),
+                keyvalue_skh=P(ShardingAxisName.ATTN_DATA, None),
+                activation_attention_out_td=P(ShardingAxisName.ATTN_DATA,
+                                              None),
+                attn_o_nth=P(None, ShardingAxisName.ATTN_DATA, None),
+                anh_sharding=(None, ShardingAxisName.ATTN_HEAD, None),
+                q_da_sharding=P(None, ShardingAxisName.ATTN_HEAD),
+                ap_sharding=P(None, ShardingAxisName.ATTN_HEAD),
+                kv_da_sharding=P(None, ShardingAxisName.ATTN_HEAD),
+                rd_sharding=P(ShardingAxisName.ATTN_HEAD, None),
+                prefix=f"{prefix}.self_attn")
+
+        if config.is_moe_layer(layer_idx):
+            mlp = KimiSparseMoeBlock(
+                config=config,
+                mesh=self.mesh,
+                dtype=dtype,
+                quant_config=quant_config,
+                rngs=rngs,
+                moe_backend=self.moe_backend,
+                num_expert_parallelism=self.num_expert_parallelism,
+                random_init=random_init,
+                prefix=f"{prefix}.block_sparse_moe")
+        else:
+            mlp = GatedMLP(dtype=dtype,
+                           hidden_act=config.hidden_act,
+                           hidden_size=config.hidden_size,
+                           intermediate_size=config.intermediate_size,
+                           situ_beta=config.situ_beta,
+                           situ_linear_beta=config.situ_linear_beta,
+                           rngs=rngs,
+                           random_init=random_init,
+                           activation_ffw_td=P(ShardingAxisName.MLP_DATA,
+                                               None),
+                           df_sharding=P(None, ShardingAxisName.ATTN_HEAD),
+                           fd_sharding=P(ShardingAxisName.ATTN_HEAD, None),
+                           quant_config=quant_config,
+                           prefix=f"{prefix}.mlp")
+
+        return KimiDecoderLayer(
+            config=config,
+            layer_idx=layer_idx,
+            input_layernorm=input_layernorm,
+            post_attention_layernorm=post_attention_layernorm,
+            self_attn=self_attn,
+            mlp=mlp,
+            rngs=rngs,
+            dtype=dtype,
+            random_init=random_init,
+            prefix=prefix)
+
+    def __call__(
+        self,
+        kv_caches: List[Any],
+        input_ids: Optional[jax.Array],
+        attention_metadata: Any,
+        inputs_embeds: Optional[jax.Array] = None,
+        layer_name_to_kv_cache: Optional[dict] = None,
+    ) -> Tuple[List[Any], jax.Array]:
+        """Runs the stack.
+
+        Two things are per-layer rather than global on a hybrid model:
+
+        * ``attention_metadata`` is a ``{layer_name: metadata}`` dict whenever
+          the model spans more than one kv-cache group (the KDA layers and the
+          MLA layers land in different groups, each with its own block table).
+        * ``kv_caches`` is ordered by kv-cache tensor, not by layer, so the
+          slot for layer ``i`` has to be looked up rather than indexed.
+        """
+        x = (inputs_embeds
+             if inputs_embeds is not None else self.embed_tokens(input_ids))
+
+        block_residual: List[jax.Array] = []
+        for i, layer in enumerate(self.layers):
+            layer_name = f"layer.{i}"
+            layer_md = (attention_metadata[layer_name] if isinstance(
+                attention_metadata, dict) else attention_metadata)
+            cache_idx = (layer_name_to_kv_cache[layer_name]
+                         if layer_name_to_kv_cache
+                         and layer_name in layer_name_to_kv_cache else i)
+            kv_caches[cache_idx], x, block_residual = layer(
+                x,
+                kv_cache=kv_caches[cache_idx],
+                attention_metadata=layer_md,
+                block_residual=block_residual)
+
+        if self.config.use_attn_residuals:
+            x = apply_attn_res(x, block_residual,
+                               self.output_attn_res_proj.weight.value,
+                               self.output_attn_res_norm.weight.value,
+                               self.config.rms_norm_eps)
+        return kv_caches, self.norm(x)
+
+
+class KimiLinearForCausalLM(JaxModule, LoadableWithIterator):
+    """Kimi-Linear-48B / Kimi-K3 text stack (KDA + gated NoPE MLA hybrid)."""
+
+    def __init__(self,
+                 vllm_config: VllmConfig,
+                 rng_key: jax.Array,
+                 mesh: Mesh,
+                 *,
+                 moe_backend: MoEBackend | None = None,
+                 random_init: bool = False) -> None:
+        self.vllm_config = vllm_config
+        self.mesh = mesh
+        rngs = nnx.Rngs(rng_key)
+
+        model_config = vllm_config.model_config
+        config = KimiConfig(model_config.hf_config)
+        self.config = config
+        dtype = model_config.dtype
+
+        # How the routed-expert bytes are split, checked and reported before
+        # anything is allocated: a mesh that replicates them only shows up as
+        # an out-of-memory some layers into the load.
+        self.num_expert_parallelism, self.num_expert_tensor_parallelism = (
+            validate_routed_expert_sharding(
+                config,
+                mesh,
+                block_quantized=experts_are_block_quantized(
+                    vllm_config.quant_config)))
+        # `num_expert_parallelism` stays the *expert*-axis count on purpose:
+        # it is what the GMM backend uses to decide whether tokens have to be
+        # dispatched to another shard, which sharding F does not change.
+        assert self.num_expert_parallelism == get_expert_parallelism(
+            ShardingAxisName.ATTN_DATA_EXPERT, mesh)
+        if moe_backend is None:
+            moe_backend = self._select_moe_backend()
+        logger.info(
+            "[kimi] MoE backend=%s, expert_parallelism=%d, "
+            "expert_tensor_parallelism=%d (experts sharded on %s x '%s')",
+            moe_backend.value, self.num_expert_parallelism,
+            self.num_expert_tensor_parallelism,
+            ShardingAxisName.ATTN_DATA_EXPERT, ShardingAxisName.MODEL)
+
+        self.model = KimiLinearModel(
+            config=config,
+            rngs=rngs,
+            mesh=mesh,
+            dtype=dtype,
+            kv_cache_dtype=vllm_config.cache_config.cache_dtype,
+            quant_config=vllm_config.quant_config,
+            moe_backend=moe_backend,
+            num_expert_parallelism=self.num_expert_parallelism,
+            random_init=random_init,
+            prefix="model")
+        self.lm_head = JaxLmHead(
+            hidden_size=config.hidden_size,
+            vocab_size=model_config.get_vocab_size(),
+            param_dtype=dtype,
+            dtype=dtype,
+            rngs=rngs,
+            kernel_init=nnx.with_partitioning(
+                init_fn, (None, ShardingAxisName.MLP_TENSOR)),
+            prefix="lm_head",
+        )
+        attach_default_weight_loaders(self)
+
+    def _select_moe_backend(self) -> MoEBackend:
+        """Pick a backend that can see the router's expert selection.
+
+        Kimi routes with noaux_tc: the router adds ``e_score_correction_bias``
+        to the scores it ranks by but not to the weights it returns, and K3
+        additionally uses the SiTU activation. The fused backends take raw
+        router logits and select experts themselves, so they would silently
+        drop the bias (changing which experts run) and have no SiTU branch —
+        hence one of the two unfused backends, which consume the
+        ``(weights, indices)`` the router already produced.
+
+        Between those two: MEGABLX_GMM dispatches each token to the experts
+        resident on this shard, which is what makes a split expert axis work
+        at all, so it is the choice whenever the expert axis is split.
+        DENSE_MAT evaluates every expert for every token and therefore needs
+        every expert's weights locally.
+
+        Note this keys on the *expert* axis only. Sharding ``F`` over the
+        tensor axis (see :func:`routed_expert_shardings`) divides the bytes
+        each device holds but not which experts it holds, so it does not make
+        DENSE_MAT viable for a large expert count -- with the expert axis at 1
+        every device still owns a slice of all 896 K3 experts.
+        """
+        if self.num_expert_parallelism > 1:
+            return MoEBackend.MEGABLX_GMM
+        if self.num_expert_tensor_parallelism > 1:
+            # Not fatal -- a small MoE is fine like this -- but it is how a
+            # mesh silently ends up evaluating every expert on every device,
+            # so say so with the numbers rather than let it show up as an OOM.
+            logger.warning(
+                "[kimi] the expert axis %s is 1, so every device holds a "
+                "slice of all %d experts and DENSE_MAT evaluates all of them "
+                "per token; only the tensor axis '%s' (%d) is dividing the "
+                "expert bytes. Give the mesh expert parallelism to use "
+                "MEGABLX_GMM instead.", ShardingAxisName.ATTN_DATA_EXPERT,
+                self.config.num_experts, ShardingAxisName.MODEL,
+                self.num_expert_tensor_parallelism)
+        return MoEBackend.DENSE_MAT
+
+    def __call__(
+        self,
+        kv_caches: List[Any],
+        input_ids: jax.Array,
+        attention_metadata: Any,
+        inputs_embeds: Optional[jax.Array] = None,
+        _input_positions=None,
+        layer_name_to_kv_cache: Optional[Sequence[Tuple[str, int]]] = None,
+        *args,
+        **kwargs,
+    ) -> Tuple[List[Any], jax.Array, List[jax.Array], Optional[jax.Array]]:
+        kv_caches, x = self.model(
+            kv_caches,
+            input_ids,
+            attention_metadata,
+            inputs_embeds,
+            layer_name_to_kv_cache=dict(layer_name_to_kv_cache)
+            if layer_name_to_kv_cache else None)
+        return kv_caches, x, [], None
+
+    def compute_logits(self, hidden_states: jax.Array) -> jax.Array:
+        return self.lm_head(hidden_states)
+
+    def load_weights(self, weights: Iterable) -> set:
+        if not isinstance(weights, Iterable):
+            return super().load_weights(weights)
+        loader = JaxAutoWeightsLoader(self)
+        loaded = loader.load_weights(
+            summarize_kda_decay_layout(adapt_wrapper_checkpoint(weights)))
+        # The absorbed-MLA up-projections are split out of `kv_b_proj` during
+        # that call rather than read from the checkpoint, so they carry no
+        # checkpoint name of their own.
+        return loaded | derived_absorbed_mla_param_names(self)
+
+
+class KimiK3ForConditionalGeneration(KimiLinearForCausalLM):
+    """Kimi-K3 (text-only serving; vision-tower weights are skipped).
+
+    The multimodal checkpoint wraps the same text stack twice over: in a
+    ``text_config``, which :class:`KimiConfig` unwraps, and under a
+    ``language_model.`` weight prefix, which
+    :func:`adapt_wrapper_checkpoint` strips. Image inputs are rejected -- MoonViT-V2
+    is a later phase.
+    """
+
+    def get_multimodal_embeddings(self, **kwargs):
+        raise NotImplementedError(
+            "[kimi-k3] vision inputs are not supported: this build serves the "
+            "text stack only (MoonViT-V2 is not implemented). Send text-only "
+            "requests.")

--- a/tpu_inference/models/jax/kimi_k3.py
+++ b/tpu_inference/models/jax/kimi_k3.py
@@ -505,7 +505,12 @@ class KimiConfig:
     def is_moe_layer(self, layer_idx: int) -> bool:
         if self.num_experts == 0 or layer_idx < self.first_k_dense_replace:
             return False
-        return (layer_idx + 1) % self.moe_layer_freq == 0
+        # Matches the reference (modeling_kimi_linear.py::KimiDecoderLayer):
+        # `layer_idx % moe_layer_freq == 0`. Both released configs set
+        # moe_layer_freq=1, where every phase is equivalent, but at freq>1
+        # this differs from the `(layer_idx + 1) % freq` form some other
+        # models in this repo use.
+        return layer_idx % self.moe_layer_freq == 0
 
     def is_attn_res_checkpoint(self, layer_idx: int) -> bool:
         return (self.use_attn_residuals
@@ -825,8 +830,12 @@ class KimiRoutedExperts(JaxMoE):
                 # `JaxMoE._load_weights` only prepends the expert axis, it does
                 # not transpose, while the expert kernels are declared
                 # `(E, in, out)` and the checkpoint stores `[out, in]`.
+                # `transpose(1, 0)` is the axis swap under both conventions:
+                # torch swaps dims 1 and 0, numpy permutes axes to (1, 0).
+                # (The torch-idiomatic `transpose(0, 1)` would be an identity
+                # permutation on a numpy array.)
                 if weight.ndim == 2:
-                    weight = weight.transpose(0, 1)
+                    weight = weight.transpose(1, 0)
                 yield name, weight
 
         return super()._load_weights(adapted(), **kwargs)
@@ -859,6 +868,9 @@ class KimiSparseMoeBlock(JaxModule):
         weight_init = _weight_init(random_init)
         edf_sharding, efd_sharding = routed_expert_shardings()
 
+        # The router is deliberately replicated (P(None) shardings below):
+        # its [hidden, num_experts] table is negligible next to the experts,
+        # and every device needs the full per-token scores to route.
         self.gate = DeepSeekV3Router(
             hidden_size=config.hidden_size,
             num_experts=config.num_experts,
@@ -878,6 +890,11 @@ class KimiSparseMoeBlock(JaxModule):
             quant_config=None)
 
         if self.use_latent_moe:
+            # The latent down/up projections are deliberately replicated
+            # (P(None, None)): they sit on the data-parallel activation path
+            # outside the expert-sharded region, so splitting these two small
+            # dense weights would buy little memory at the cost of a
+            # collective on every MoE block.
             self.routed_expert_down_proj = JaxEinsum(
                 einsum_str="TD,DL->TL",
                 kernel_shape=(config.hidden_size, moe_hidden),
@@ -1182,6 +1199,14 @@ class KimiLinearModel(JaxModule):
                 mesh=self.mesh,
                 prefix=f"{prefix}.self_attn")
         else:
+            if not config.mla_use_nope:
+                raise NotImplementedError(
+                    f"[kimi] layer {layer_idx}: MLA with rotary embeddings "
+                    f"(mla_use_nope=False) is not wired up in this port -- "
+                    f"no rope module is constructed here (`rope=None` below). "
+                    f"Every released Kimi-Linear/Kimi-K3 config sets "
+                    f"mla_use_nope=true; wire a DeepseekScalingRotaryEmbedding "
+                    f"through this call before loading such a config.")
             self_attn = MLAAttention(
                 hidden_size=config.hidden_size,
                 num_attention_heads=config.num_attention_heads,

--- a/tpu_inference/models/vllm/experimental/__init__.py
+++ b/tpu_inference/models/vllm/experimental/__init__.py
@@ -19,6 +19,14 @@
 _TPU_VLLM_MODELS = {
     "DeepseekV4ForCausalLM":
     "tpu_inference.models.vllm.experimental.deepseek_v4:DeepseekV4ForCausalLM",
+    # Kimi-K3 (HF moonshotai/Kimi-K3) is unknown to the pinned vLLM. Register
+    # the architecture so vLLM's config/registry resolution succeeds; on TPU
+    # the model is served by the JAX implementation
+    # (tpu_inference.models.jax.kimi_k3), never by this torch class. vLLM's
+    # KimiLinearForCausalLM (the K3 text-stack family) provides the correct
+    # static model-interface traits for registry inspection.
+    "KimiK3ForConditionalGeneration":
+    "vllm.model_executor.models.kimi_linear:KimiLinearForCausalLM",
 }
 
 


### PR DESCRIPTION
Piece 5 of 6 of the Kimi-K3 enablement stack. Adds the Kimi-K3 JAX model itself (models/jax/kimi_k3.py: hybrid KDA+MLA stack, MoE with SiTU experts, router, weight loaders), the registry entries in model_loader.py and models/vllm/experimental, the checkpoint slicing tool (tools/slice_kimi_k3_checkpoint.py), the tiny-fixture generator and fetch script, and the remaining K3 test suites (test_kimi_k3*, MLA-extraction test, hybrid e2e). Depends on split 4/6 (its base branch). The full stack was validated end-to-end in #3292: CI green, gsm8k 0.976.

**CI coverage sequencing:** the fixture-gated behavioral suites in this PR (golden parity, MXFP4 fidelity, hybrid e2e) skip in this PR's own CI until the pipeline wiring in split 6/6 (#3328) lands — that split sources `fetch_k3_tiny_fixtures.sh` (shipped here) under a file-existence guard. The suites do run today on the integration branch (#3292's CI).
