### PR TITLE
[DO NOT REVIEW] K3 split 6/6: multi-host infra

### DIFF
--- a/.buildkite/models/moonshotai_Kimi-Linear-48B-A3B-Instruct.yml
+++ b/.buildkite/models/moonshotai_Kimi-Linear-48B-A3B-Instruct.yml
@@ -39,7 +39,9 @@ steps:
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_UnitTest" "unverified"
         else
           # Exports K3_TINY_*; without it every suite below skips.
-          source .buildkite/scripts/fetch_k3_tiny_fixtures.sh
+          # The script lands with the Kimi test-fixtures piece; guard so this
+          # step is safe to merge in any order relative to it.
+          [ -f .buildkite/scripts/fetch_k3_tiny_fixtures.sh ] && source .buildkite/scripts/fetch_k3_tiny_fixtures.sh || true
           .buildkite/scripts/run_in_docker.sh \
             python3 -m pytest -s -v -x \
             /workspace/tpu_inference/tests/models/jax/test_kimi_k3.py \

--- a/.buildkite/models/moonshotai_Kimi-Linear-48B-A3B-Instruct.yml
+++ b/.buildkite/models/moonshotai_Kimi-Linear-48B-A3B-Instruct.yml
@@ -1,0 +1,145 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Kimi-Linear-48B-A3B-Instruct: the KDA + gated-MLA hybrid served by the
+# JAX-native KimiLinearForCausalLM. Every stage is tpu7x-only -- the model
+# needs the MLA and KDA kernels -- and reports "unverified" elsewhere.
+#
+# The sharding is the reason these steps look unlike the other model files.
+# The experts do not fit replicated, so they are split 8 ways, and expert
+# parallelism forces attention data parallelism with it: tensor_parallelism 1,
+# expert_parallelism 8, enable_dp_attention. `--tensor-parallel-size 8` still
+# names the device count; the strategy decides what those devices hold.
+# gpu_memory_utilization stays at 0.60 because warmup at the largest token
+# shape needs temporaries on the order of the KV pool itself, and 0.95 dies
+# compiling that shape rather than at run time.
+
+steps:
+  - label: "${TPU_VERSION:-tpu6e} Unit tests for moonshotai/Kimi-Linear-48B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_UnitTest"
+    soft_fail: true
+    agents:
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+    commands:
+      - |
+        if [ "${TPU_VERSION:-tpu6e}" != "tpu7x" ]; then
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_UnitTest" "unverified"
+        else
+          # Exports K3_TINY_*; without it every suite below skips.
+          source .buildkite/scripts/fetch_k3_tiny_fixtures.sh
+          .buildkite/scripts/run_in_docker.sh \
+            python3 -m pytest -s -v -x \
+            /workspace/tpu_inference/tests/models/jax/test_kimi_k3.py \
+            /workspace/tpu_inference/tests/models/jax/test_kimi_k3_router.py \
+            /workspace/tpu_inference/tests/models/jax/test_kimi_k3_mxfp4.py
+        fi
+  - label: "${TPU_VERSION:-tpu6e} Record unit test result for moonshotai/Kimi-Linear-48B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-Linear-48B_UnitTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_UnitTest"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "moonshotai/Kimi-Linear-48B-A3B-Instruct"
+      CI_STAGE: "UnitTest"
+      CI_CATEGORY: "text-only"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_UnitTest
+
+  - label: "${TPU_VERSION:-tpu6e} Accuracy for moonshotai/Kimi-Linear-48B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-Linear-48B_UnitTest"
+    soft_fail: true
+    agents:
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      TEST_MODEL: moonshotai/Kimi-Linear-48B-A3B-Instruct
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
+      # gsm8k measured 0.8749 strict-match on this config; 0.85 leaves room
+      # for run-to-run variation without accepting a broken decode path.
+      MINIMUM_ACCURACY_THRESHOLD: "0.85"
+      MODEL_IMPL_TYPE: flax_nnx
+      NEW_MODEL_DESIGN: "1"
+      # The sharding strategy is nested, which the key=value form of
+      # lm_eval's model_args cannot express.
+      ACCURACY_MODEL_ARGS_JSON: '{"pretrained":"moonshotai/Kimi-Linear-48B-A3B-Instruct","tensor_parallel_size":8,"max_model_len":2048,"max_num_seqs":64,"gpu_memory_utilization":0.6,"trust_remote_code":true,"additional_config":{"sharding":{"sharding_strategy":{"tensor_parallelism":1,"expert_parallelism":8,"enable_dp_attention":true}}}}'
+    commands:
+      - |
+        if [ "${TPU_VERSION:-tpu6e}" != "tpu7x" ]; then
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_Accuracy" "unverified"
+        else
+          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
+        fi
+  - label: "${TPU_VERSION:-tpu6e} Record accuracy result for moonshotai/Kimi-Linear-48B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-Linear-48B_Accuracy"
+    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_Accuracy"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "moonshotai/Kimi-Linear-48B-A3B-Instruct"
+      CI_STAGE: "Accuracy/Correctness"
+      CI_CATEGORY: "text-only"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_Accuracy
+
+  - label: "${TPU_VERSION:-tpu6e} Performance benchmarks for moonshotai/Kimi-Linear-48B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-Linear-48B_Accuracy"
+    soft_fail: true
+    agents:
+      queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
+    env:
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      TEST_MODEL: moonshotai/Kimi-Linear-48B-A3B-Instruct
+      TENSOR_PARALLEL_SIZE: "${TENSOR_PARALLEL_SIZE_MULTI:-8}"
+      # 4.88 req/s measured on this config; guard at ~88% of it.
+      MINIMUM_THROUGHPUT_THRESHOLD: "4.3"
+      INPUT_LEN: "1800"
+      OUTPUT_LEN: "128"
+      PREFIX_LEN: "0"
+      MAX_MODEL_LEN: "2048"
+      MAX_NUM_SEQS: "64"
+      MAX_NUM_BATCHED_TOKENS: "1024"
+      MODEL_IMPL_TYPE: flax_nnx
+      NEW_MODEL_DESIGN: "1"
+      # Compact JSON: EXTRA_SERVE_FLAGS is split on whitespace.
+      EXTRA_SERVE_FLAGS: '--trust-remote-code --gpu-memory-utilization 0.60 --additional-config {"sharding":{"sharding_strategy":{"tensor_parallelism":1,"expert_parallelism":8,"enable_dp_attention":true}}}'
+      # The tokenizer ships as repo code, so the client needs the opt-in too.
+      CLIENT_TRUST_REMOTE_CODE: "1"
+    commands:
+      - |
+        if [ "${TPU_VERSION:-tpu6e}" != "tpu7x" ]; then
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_Benchmark" "unverified"
+        else
+          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/benchmark.sh
+        fi
+  - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for moonshotai/Kimi-Linear-48B-A3B-Instruct"
+    key: "${TPU_VERSION:-tpu6e}_record_moonshotai_Kimi-Linear-48B_Benchmark"
+    depends_on: "${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_Benchmark"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "moonshotai/Kimi-Linear-48B-A3B-Instruct"
+      CI_STAGE: "Benchmark"
+      CI_CATEGORY: "text-only"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_moonshotai_Kimi-Linear-48B_Benchmark

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -175,7 +175,9 @@ steps:
         commands:
           - |
             # Exports K3_TINY_* for the Kimi suites; without it they skip.
-            source .buildkite/scripts/fetch_k3_tiny_fixtures.sh
+            # The script lands with the Kimi test-fixtures piece; guard so
+            # this step is safe to merge in any order relative to it.
+            [ -f .buildkite/scripts/fetch_k3_tiny_fixtures.sh ] && source .buildkite/scripts/fetch_k3_tiny_fixtures.sh || true
             .buildkite/scripts/run_in_docker.sh \
               python3 -m pytest -s -v -x \
               /workspace/tpu_inference/tests/models/jax/test_kimi_k3.py \
@@ -200,7 +202,9 @@ steps:
         commands:
           - |
             # Exports K3_KDA_GOLDENS for the KDA reference test; no-op off tpu7x.
-            source .buildkite/scripts/fetch_k3_tiny_fixtures.sh
+            # The script lands with the Kimi test-fixtures piece; guard so this
+            # pre-existing kernels step keeps passing if this piece merges first.
+            [ -f .buildkite/scripts/fetch_k3_tiny_fixtures.sh ] && source .buildkite/scripts/fetch_k3_tiny_fixtures.sh || true
             .buildkite/scripts/run_in_docker.sh \
               python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels \
               --ignore=/workspace/tpu_inference/tests/kernels/ragged_paged_attention_kernel_v2_test.py \

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -156,6 +156,36 @@ steps:
             rm -f .coverage.part* .coveragerc pex coverage.pex .coverage
             exit $EXIT_CODE
 
+      # Kimi-K3 runs in its own step rather than in part2. Its suites each
+      # build a model, so they add ~15 minutes that the JAX compilation cache
+      # does not pay back on a second run, and part2 is already the longest
+      # step in this pipeline. They stay collected-and-skipped in part2 --
+      # nothing there exports K3_TINY_* -- so they run exactly once.
+      - label: "${TPU_VERSION:-tpu6e} JAX unit tests - Kimi-K3"
+        key: ${TPU_VERSION:-tpu6e}_test_7_4
+        soft_fail: true
+        env:
+          USE_PREBUILT_IMAGE: "1"
+          TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+        agents:
+          queue: ${TPU_QUEUE_SINGLE:-tpu_v6e_queue}
+        # Kimi-K3 needs the MLA and KDA kernels, so every suite below skips
+        # off tpu7x and the step would provision a TPU to report skips.
+        if: '"${TPU_VERSION:-tpu6e}" == "tpu7x"'
+        commands:
+          - |
+            # Exports K3_TINY_* for the Kimi suites; without it they skip.
+            source .buildkite/scripts/fetch_k3_tiny_fixtures.sh
+            .buildkite/scripts/run_in_docker.sh \
+              python3 -m pytest -s -v -x \
+              /workspace/tpu_inference/tests/models/jax/test_kimi_k3.py \
+              /workspace/tpu_inference/tests/models/jax/test_kimi_k3_router.py \
+              /workspace/tpu_inference/tests/models/jax/test_kimi_k3_mxfp4.py \
+              /workspace/tpu_inference/tests/models/jax/test_kimi_k3_mxfp4_real_layer.py \
+              /workspace/tpu_inference/tests/models/jax/test_kimi_k3_mxfp4_shard_decode.py \
+              /workspace/tpu_inference/tests/layers/common/test_kda_attention.py \
+              /workspace/tpu_inference/tests/layers/common/test_kda_attention_dp.py
+
       - label: "${TPU_VERSION:-tpu6e} JAX unit tests - kernels"
         key: ${TPU_VERSION:-tpu6e}_test_8
         soft_fail: true
@@ -169,6 +199,8 @@ steps:
         if: build.env("NIGHTLY") == "1" || "${RUN_KERNEL_TESTS:-0}" == "1"
         commands:
           - |
+            # Exports K3_KDA_GOLDENS for the KDA reference test; no-op off tpu7x.
+            source .buildkite/scripts/fetch_k3_tiny_fixtures.sh
             .buildkite/scripts/run_in_docker.sh \
               python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels \
               --ignore=/workspace/tpu_inference/tests/kernels/ragged_paged_attention_kernel_v2_test.py \

--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -56,6 +56,25 @@ ENV_VARS=(
   -e MAX_NUM_SEQS="${MAX_NUM_SEQS:-}"
   -e MAX_NUM_BATCHED_TOKENS="${MAX_NUM_BATCHED_TOKENS:-}"
   -e USE_CHAT_TEMPLATE="${USE_CHAT_TEMPLATE:-}"
+  # Escape hatches for engine configuration a step cannot express through the
+  # named variables above; see the scripts that read them.
+  -e ACCURACY_MODEL_ARGS_JSON="${ACCURACY_MODEL_ARGS_JSON:-}"
+  -e EXTRA_SERVE_FLAGS="${EXTRA_SERVE_FLAGS:-}"
+  -e CLIENT_TRUST_REMOTE_CODE="${CLIENT_TRUST_REMOTE_CODE:-}"
+  # Read by run_serving_probe.sh: what to serve, how long to allow for weight
+  # loading, and what to pass through to the serving probe.
+  -e MODEL="${MODEL:-}"
+  -e STARTUP_TIMEOUT_SECONDS="${STARTUP_TIMEOUT_SECONDS:-}"
+  -e PROBE_EXTRA_FLAGS="${PROBE_EXTRA_FLAGS:-}"
+  # Selects the MXFP4 expert decode path; empty means the default (decode each
+  # shard on the device that keeps it), 0 forces the whole-layer host decode.
+  -e MXFP4_SHARD_THEN_DECODE="${MXFP4_SHARD_THEN_DECODE:-}"
+  # Kimi-K3 test checkpoints, set by fetch_k3_tiny_fixtures.sh and empty
+  # everywhere else; the suites that read them skip when they are empty.
+  -e K3_TINY_CKPT="${K3_TINY_CKPT:-}"
+  -e K3_TINY_MXFP4_CKPT="${K3_TINY_MXFP4_CKPT:-}"
+  -e K3_TINY_SOFTPLUS_CKPT="${K3_TINY_SOFTPLUS_CKPT:-}"
+  -e K3_KDA_GOLDENS="${K3_KDA_GOLDENS:-}"
   -e BENCH_DATASET="${BENCH_DATASET:-}"
   -e USE_BATCHED_RPA_KERNEL="${USE_BATCHED_RPA_KERNEL:-}"
   -e GPU_MEMORY_UTILIZATION="${GPU_MEMORY_UTILIZATION:-}"

--- a/.buildkite/scripts/run_multihost.sh
+++ b/.buildkite/scripts/run_multihost.sh
@@ -398,7 +398,9 @@ docker exec \
 mh_timing serve_launched
 
 # 4. Wait for the server to be healthy
-wait_for_server "$VLLM_PORT" "node" "vllm serve" "/root/vllm_serve.log" "${SERVE_STARTUP_TIMEOUT_SECONDS:-7200}"
+# STARTUP_TIMEOUT_SECONDS is the run_serving_probe.sh name for the same knob;
+# honor either so one env block works on both rigs.
+wait_for_server "$VLLM_PORT" "node" "vllm serve" "/root/vllm_serve.log" "${SERVE_STARTUP_TIMEOUT_SECONDS:-${STARTUP_TIMEOUT_SECONDS:-7200}}"
 mh_timing serve_healthy
 
 # 5. Run Benchmarks / Validation

--- a/.buildkite/scripts/run_multihost.sh
+++ b/.buildkite/scripts/run_multihost.sh
@@ -100,11 +100,42 @@ fi
 
 SSH_OPTS=(-o StrictHostKeyChecking=no -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o IPQoS=none -i ~/.ssh/id_rsa)
 
+# A multi-host slot is expensive and scarce, so one run has to yield every piece
+# of evidence a diagnosis could need. These two helpers exist for that: greppable
+# phase timings, and worker-side logs on the way out (see cleanup below).
+MH_PHASE_MARK=$SECONDS
+mh_timing() {
+  local phase="$1"
+  local now=$SECONDS
+  # One line per phase, fixed prefix, so `grep '\[mh-timing\]'` on any build's
+  # log gives the whole startup profile and two builds can be diffed directly.
+  echo "[mh-timing] ${phase}=$((now - MH_PHASE_MARK)) (elapsed=${now})"
+  MH_PHASE_MARK=$now
+}
+
+# Only dump worker containers once they have actually been asked to start;
+# cleanup() also runs before the cluster is up, to clear leftovers.
+MH_CLUSTER_STARTED=0
+
 # Cleanup function that runs on exit to tear down the Ray cluster
 cleanup() {
   echo "🧹 Cleaning up containers on head and workers..."
   IFS=',' read -r -a WORKER_IPS_ARRAY <<< "${WORKER_IPS:-}"
-  
+
+  # Worker-side evidence, on success as well as failure. Only the head's serve
+  # log used to be printed, so a crash confined to a worker (an OOM on one host,
+  # a failed image pull, a Ray registration error) left no trace in the job log
+  # at all and the run had to be repeated to see it.
+  if [[ ${MH_CLUSTER_STARTED} -eq 1 && ${#WORKER_IPS_ARRAY[@]} -gt 0 && -n "${WORKER_IPS_ARRAY[0]}" ]]; then
+    for worker_ip in "${WORKER_IPS_ARRAY[@]}"; do
+      echo "==== WORKER ${worker_ip} docker logs ===="
+      ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" \
+        "docker logs --tail 200 node 2>&1 || echo '(no container named node on this worker)'" \
+        || echo "(unreachable over ssh: ${worker_ip})"
+      echo "==== END WORKER ${worker_ip} docker logs ===="
+    done
+  fi
+
   echo "   -> Cleaning workers..."
   if [[ ${#WORKER_IPS_ARRAY[@]} -gt 0 && -n "${WORKER_IPS_ARRAY[0]}" ]]; then
     for worker_ip in "${WORKER_IPS_ARRAY[@]}"; do
@@ -113,11 +144,17 @@ cleanup() {
   fi
 
   echo "   -> Cleaning Head Node..."
+  # /tmp survives between builds on a persistent agent, so delete the copy
+  # after printing it: otherwise `docker cp` failing (no container, serve never
+  # started) leaves the PREVIOUS build's serve log in place and this prints it
+  # as if it belonged to this build.
+  rm -f /tmp/vllm_serve.log || true
   docker cp node:/root/vllm_serve.log /tmp/vllm_serve.log >/dev/null 2>&1 || true
   if [[ -f /tmp/vllm_serve.log ]]; then
     echo "==================== START OF VLLM SERVE LOG ===================="
     cat /tmp/vllm_serve.log || true
     echo "==================== END OF VLLM SERVE LOG ===================="
+    rm -f /tmp/vllm_serve.log || true
   fi
   docker stop node >/dev/null 2>&1 || true
   docker rm -f node >/dev/null 2>&1 || true
@@ -156,6 +193,7 @@ wait_for_server() {
   echo "   -> Found PID: $pid"
 
   local end_time=$((SECONDS + timeout))
+  local polls=0
   while [[ $SECONDS -lt $end_time ]]; do
     # 2. Check health
     if curl -fs "localhost:${port}/health" > /dev/null; then
@@ -169,6 +207,15 @@ wait_for_server() {
       echo "Displaying logs from $container_name:$log_path"
       docker exec "$container_name" cat "$log_path" || true
       return 1
+    fi
+
+    # 4. Show where startup has got to. Without this the log only appears
+    # after the server is up or has died, so a large model's weight load and
+    # warmup -- tens of minutes -- look identical to a hang.
+    polls=$((polls + 1))
+    if ((polls % 12 == 0)); then
+      echo "--- $service_name still starting (${SECONDS}s of ${timeout}s); last lines of $log_path:"
+      docker exec "$container_name" tail -n 3 "$log_path" || true
     fi
 
     sleep 5
@@ -194,85 +241,44 @@ docker system prune -a --volumes -f || true
 # Source the environment setup script
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/setup_docker_env.sh"
+
 # setup_environment traces a long tail of docker tag/build/push plumbing and
 # one line per variable it sources from /etc/environment. It echoes its own
 # progress, so the trace adds nothing; xtrace is on for this whole script, so
 # turn it off across the call and back on after.
 { set +x; } 2>/dev/null
-# Pass "true" to enable pushing to GCR
-setup_environment "${IMAGE_NAME}" "true"
-set -x
+if [[ "${USE_PREBUILT_IMAGE:-0}" == "1" ]]; then
+  # An upstream cpu-builder step already built this commit's image and pushed it
+  # to the CI cache, so pull it instead of spending ~10+ minutes rebuilding it on
+  # the head node of a scarce multi-host slice. Nothing is built and nothing is
+  # pushed here: every node -- head and workers alike -- pulls the CI cache ref
+  # directly, which they can do because the whole slice shares one service
+  # account and run_cluster.sh already authenticates to that registry host.
+  setup_environment "${IMAGE_NAME}" "false"
+  if [[ -z "${PREBUILT_IMAGE_REF:-}" ]]; then
+    echo "[FATAL][run_multihost] USE_PREBUILT_IMAGE=1 but setup_environment did not" >&2
+    echo "[FATAL][run_multihost] publish PREBUILT_IMAGE_REF; refusing to guess the" >&2
+    echo "[FATAL][run_multihost] image the workers should pull." >&2
+    exit 1
+  fi
+  DOCKER_IMAGE="${PREBUILT_IMAGE_REF}"
+else
+  # Pass "true" to enable pushing to GCR
+  setup_environment "${IMAGE_NAME}" "true"
 
-DOCKER_IMAGE="${IMAGE_NAME}:${BUILDKITE_COMMIT:-latest}"
+  DOCKER_IMAGE="${IMAGE_NAME}:${BUILDKITE_COMMIT:-latest}"
+fi
+set -x
+mh_timing image_ready
 
 # Clean up potential leftovers from previous runs
 echo "--- Cleaning up previous cluster state..."
 cleanup
 
-# 1. Start Ray Head Node locally
-echo "--- Starting Ray Head Node Locally"
-# This call carries ~a dozen -e flags; its xtrace line is long and adds
-# nothing over the "Starting Ray Head Node Locally" banner above. The worker
-# start below is already quiet, since xtrace does not echo ssh heredoc bodies.
-{ set +x; } 2>/dev/null
-bash "${TOP_DIR}/scripts/multihost/run_cluster.sh" \
-  "${DOCKER_IMAGE}" \
-  "${HEAD_INTERNAL_IP}" \
-  --head \
-  "${HOST_HF_HOME}" \
-  -e HF_TOKEN="${HF_TOKEN:-}" \
-  -e TPU_MULTIHOST_BACKEND=ray \
-  -e JAX_PLATFORMS='' \
-  -e TPU_BACKEND_TYPE=jax \
-  -e MODEL_IMPL_TYPE=vllm \
-  -e VLLM_DISABLE_SHARED_EXPERTS_STREAM="${VLLM_DISABLE_SHARED_EXPERTS_STREAM:-1}" \
-  -e NEW_MODEL_DESIGN="${NEW_MODEL_DESIGN:-0}" \
-  -e MOE_REQUANTIZE_BLOCK_SIZE="${MOE_REQUANTIZE_BLOCK_SIZE:-}" \
-  -e MOE_REQUANTIZE_WEIGHT_DTYPE="${MOE_REQUANTIZE_WEIGHT_DTYPE:-}" \
-  -e MOE_ALL_GATHER_ACTIVATION_DTYPE="${MOE_ALL_GATHER_ACTIVATION_DTYPE:-}" \
-  -e FORCE_MOE_RANDOM_ROUTING="${FORCE_MOE_RANDOM_ROUTING:-}" &
-set -x
-
-sleep 60
-
-# 2. Distribute run_cluster.sh to workers and start them
-IFS=',' read -r -a WORKER_IPS_ARRAY <<< "${WORKER_IPS}"
-for worker_ip in "${WORKER_IPS_ARRAY[@]}"; do
-    echo "--- Distributing and starting Ray Worker on ${worker_ip}"
-
-    # Prune Worker Node BEFORE it tries to pull the new giant image
-    echo "   -> Pruning Docker on worker to free disk space..."
-    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "docker system prune -a --volumes -f" || true
-    
-    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "mkdir -p ~/tpu-inference/scripts/multihost" || true
-    # shellcheck disable=SC2002
-    cat "${TOP_DIR}/scripts/multihost/run_cluster.sh" | base64 | ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "base64 -d > ~/tpu-inference/scripts/multihost/run_cluster.sh"
-    
-    # shellcheck disable=SC2087
-    # shellcheck disable=SC2029
-    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" << EOF &
-bash ~/tpu-inference/scripts/multihost/run_cluster.sh '${DOCKER_IMAGE}' '${HEAD_INTERNAL_IP}' --worker '${HOST_HF_HOME}' \
-  -e HF_TOKEN='${HF_TOKEN:-}' \
-  -e TPU_MULTIHOST_BACKEND=ray \
-  -e JAX_PLATFORMS='' \
-  -e TPU_BACKEND_TYPE=jax \
-  -e MODEL_IMPL_TYPE=vllm \
-  -e VLLM_DISABLE_SHARED_EXPERTS_STREAM='${VLLM_DISABLE_SHARED_EXPERTS_STREAM:-1}' \
-  -e NEW_MODEL_DESIGN='${NEW_MODEL_DESIGN:-0}' \
-  -e MOE_REQUANTIZE_BLOCK_SIZE='${MOE_REQUANTIZE_BLOCK_SIZE:-}' \
-  -e MOE_REQUANTIZE_WEIGHT_DTYPE='${MOE_REQUANTIZE_WEIGHT_DTYPE:-}' \
-  -e MOE_ALL_GATHER_ACTIVATION_DTYPE='${MOE_ALL_GATHER_ACTIVATION_DTYPE:-}' \
-  -e FORCE_MOE_RANDOM_ROUTING='${FORCE_MOE_RANDOM_ROUTING:-}'
-EOF
-done
-
-
-echo "--- Waiting for all worker nodes to connect"
-# Wait a few seconds for all worker nodes to connect
-sleep 120
-
-# 3. Start vLLM server on the head node
-echo "--- Starting vLLM server on head node"
+# Resolve the serve command here, before anything starts, so the config block
+# below can print it. Consuming "$1" at this point is equivalent to consuming it
+# later: nothing in between reads the positional parameters, and the remaining
+# arguments are still the benchmark command.
 MODEL="${TEST_MODEL:-gs://tpu-commons-ci/qwen/models--Qwen--Qwen3-30B-A3B/snapshots/ad44e777bcd18fa416d9da3bd8f70d33ebb85d39}"
 VLLM_PORT="8000"
 
@@ -294,14 +300,106 @@ if [ "$#" -ge 1 ]; then
     shift
 fi
 
+# Everything a later reader needs to know what this run actually was, in one
+# block, before any of it can scroll past a failure. Without it a red build has
+# to be re-derived from the pipeline yml, which is a different file at a
+# different commit than the one that ran.
+echo "==== MULTIHOST CONFIG ===="
+echo "DOCKER_IMAGE          = ${DOCKER_IMAGE}"
+echo "USE_PREBUILT_IMAGE    = ${USE_PREBUILT_IMAGE:-0}"
+echo "HEAD_INTERNAL_IP      = ${HEAD_INTERNAL_IP}"
+echo "WORKER_IPS            = ${WORKER_IPS}"
+echo "TPU_VERSION           = ${TPU_VERSION:-}"
+echo "MODEL_IMPL_TYPE       = ${MODEL_IMPL_TYPE:-vllm}"
+echo "NEW_MODEL_DESIGN      = ${NEW_MODEL_DESIGN:-0}"
+echo "HOST_HF_HOME          = ${HOST_HF_HOME}"
+echo "SERVE_CMD             = ${VLLM_SERVE_CMD}"
+echo "BENCHMARK_CMD         = ${*:-<default curl test>}"
+echo "==== END MULTIHOST CONFIG ===="
+
+# 1. Start Ray Head Node locally
+echo "--- Starting Ray Head Node Locally"
+# xtrace off for this invocation: its argv carries HF_TOKEN, and `set -x`
+# would print the secret into the build log. (The worker start below goes
+# through an ssh heredoc, whose body xtrace does not echo.)
+{ set +x; } 2>/dev/null
+bash "${TOP_DIR}/scripts/multihost/run_cluster.sh" \
+  "${DOCKER_IMAGE}" \
+  "${HEAD_INTERNAL_IP}" \
+  --head \
+  "${HOST_HF_HOME}" \
+  -e HF_TOKEN="${HF_TOKEN:-}" \
+  -e TPU_MULTIHOST_BACKEND=ray \
+  -e JAX_PLATFORMS='' \
+  -e TPU_BACKEND_TYPE=jax \
+  -e MODEL_IMPL_TYPE="${MODEL_IMPL_TYPE:-vllm}" \
+  -e VLLM_XLA_CHECK_RECOMPILATION="${VLLM_XLA_CHECK_RECOMPILATION:-1}" \
+  -e MXFP4_SHARD_THEN_DECODE="${MXFP4_SHARD_THEN_DECODE:-}" \
+  -e VLLM_DISABLE_SHARED_EXPERTS_STREAM="${VLLM_DISABLE_SHARED_EXPERTS_STREAM:-1}" \
+  -e NEW_MODEL_DESIGN="${NEW_MODEL_DESIGN:-0}" \
+  -e MOE_REQUANTIZE_BLOCK_SIZE="${MOE_REQUANTIZE_BLOCK_SIZE:-}" \
+  -e MOE_REQUANTIZE_WEIGHT_DTYPE="${MOE_REQUANTIZE_WEIGHT_DTYPE:-}" \
+  -e MOE_ALL_GATHER_ACTIVATION_DTYPE="${MOE_ALL_GATHER_ACTIVATION_DTYPE:-}" \
+  -e FORCE_MOE_RANDOM_ROUTING="${FORCE_MOE_RANDOM_ROUTING:-}" &
+set -x
+
+sleep 60
+mh_timing head_container_up
+
+# 2. Distribute run_cluster.sh to workers and start them
+IFS=',' read -r -a WORKER_IPS_ARRAY <<< "${WORKER_IPS}"
+# From here on a worker may hold state worth reading on the way out.
+MH_CLUSTER_STARTED=1
+for worker_ip in "${WORKER_IPS_ARRAY[@]}"; do
+    echo "--- Distributing and starting Ray Worker on ${worker_ip}"
+
+    # Prune Worker Node BEFORE it tries to pull the new giant image
+    echo "   -> Pruning Docker on worker to free disk space..."
+    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "docker system prune -a --volumes -f" || true
+    
+    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "mkdir -p ~/tpu-inference/scripts/multihost" || true
+    # shellcheck disable=SC2002
+    cat "${TOP_DIR}/scripts/multihost/run_cluster.sh" | base64 | ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "base64 -d > ~/tpu-inference/scripts/multihost/run_cluster.sh"
+    
+    # shellcheck disable=SC2087
+    # shellcheck disable=SC2029
+    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" << EOF &
+bash ~/tpu-inference/scripts/multihost/run_cluster.sh '${DOCKER_IMAGE}' '${HEAD_INTERNAL_IP}' --worker '${HOST_HF_HOME}' \
+  -e HF_TOKEN='${HF_TOKEN:-}' \
+  -e TPU_MULTIHOST_BACKEND=ray \
+  -e JAX_PLATFORMS='' \
+  -e TPU_BACKEND_TYPE=jax \
+  -e MODEL_IMPL_TYPE='${MODEL_IMPL_TYPE:-vllm}' \
+  -e VLLM_XLA_CHECK_RECOMPILATION='${VLLM_XLA_CHECK_RECOMPILATION:-1}' \
+  -e MXFP4_SHARD_THEN_DECODE='${MXFP4_SHARD_THEN_DECODE:-}' \
+  -e VLLM_DISABLE_SHARED_EXPERTS_STREAM='${VLLM_DISABLE_SHARED_EXPERTS_STREAM:-1}' \
+  -e NEW_MODEL_DESIGN='${NEW_MODEL_DESIGN:-0}' \
+  -e MOE_REQUANTIZE_BLOCK_SIZE='${MOE_REQUANTIZE_BLOCK_SIZE:-}' \
+  -e MOE_REQUANTIZE_WEIGHT_DTYPE='${MOE_REQUANTIZE_WEIGHT_DTYPE:-}' \
+  -e MOE_ALL_GATHER_ACTIVATION_DTYPE='${MOE_ALL_GATHER_ACTIVATION_DTYPE:-}' \
+  -e FORCE_MOE_RANDOM_ROUTING='${FORCE_MOE_RANDOM_ROUTING:-}'
+EOF
+done
+
+
+echo "--- Waiting for all worker nodes to connect"
+# Wait a few seconds for all worker nodes to connect
+sleep 120
+mh_timing workers_started
+
+# 3. Start vLLM server on the head node (command resolved above, with the config)
+echo "--- Starting vLLM server on head node"
+
 # Launch vllm serve in the background inside the local 'node' container
 docker exec \
   -d \
   -e HF_HOME=/root/.cache/huggingface \
   node bash -c "${VLLM_SERVE_CMD} > /root/vllm_serve.log 2>&1"
+mh_timing serve_launched
 
 # 4. Wait for the server to be healthy
-wait_for_server "$VLLM_PORT" "node" "vllm serve" "/root/vllm_serve.log"
+wait_for_server "$VLLM_PORT" "node" "vllm serve" "/root/vllm_serve.log" "${SERVE_STARTUP_TIMEOUT_SECONDS:-7200}"
+mh_timing serve_healthy
 
 # 5. Run Benchmarks / Validation
 if [ "$#" -gt 0 ]; then

--- a/.buildkite/scripts/run_serving_probe.sh
+++ b/.buildkite/scripts/run_serving_probe.sh
@@ -1,0 +1,132 @@
+#!/bin/bash
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Serve one model on a single host and run tests/e2e/multihost/serving_probe.py
+# against it. The multi-host rig (run_multihost.sh) already pairs a serve
+# command with a client command; this is the same pairing for the jobs that fit
+# on one host, so a single-host and a multi-host run are checked by identical
+# invariants.
+#
+# RUN THIS INSIDE THE CONTAINER, e.g.
+#   .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/.buildkite/scripts/run_serving_probe.sh
+#
+# Configuration is by environment variable:
+#   MODEL                 model id or gs:// snapshot to serve (required)
+#   EXTRA_SERVE_FLAGS     extra flags appended to `vllm serve` verbatim
+#   PROBE_EXTRA_FLAGS     extra flags appended to the probe verbatim
+#   PORT                  default 8000
+#   TENSOR_PARALLEL_SIZE  default 8
+#   MAX_MODEL_LEN         default 2048
+#   MAX_NUM_SEQS          default 16
+#   GPU_MEMORY_UTILIZATION default 0.8
+#   STARTUP_TIMEOUT_SECONDS how long to wait for /health, default 3600. Weight
+#                         streaming from GCS dominates it, so scale it with the
+#                         checkpoint size, not with the model's compute.
+#   PROBE_CONCURRENCY     default 8
+#   PROBE_LONG_TOKENS     default 512
+#
+# The serve log is echoed on every exit path, including success, because the
+# load-path detail this script exists to expose (which tensor failed, which
+# shard was being read) is only in that log.
+
+set -uo pipefail
+
+MODEL=${MODEL:?MODEL must be set to the model id or gs:// path to serve}
+PORT=${PORT:-8000}
+TENSOR_PARALLEL_SIZE=${TENSOR_PARALLEL_SIZE:-8}
+MAX_MODEL_LEN=${MAX_MODEL_LEN:-2048}
+MAX_NUM_SEQS=${MAX_NUM_SEQS:-16}
+GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION:-0.8}
+STARTUP_TIMEOUT_SECONDS=${STARTUP_TIMEOUT_SECONDS:-3600}
+PROBE_CONCURRENCY=${PROBE_CONCURRENCY:-8}
+PROBE_LONG_TOKENS=${PROBE_LONG_TOKENS:-512}
+SERVE_LOG=${SERVE_LOG:-/tmp/vllm_serve.log}
+PROBE=${PROBE:-/workspace/tpu_inference/tests/e2e/multihost/serving_probe.py}
+
+echo "[serve-probe] model=${MODEL}"
+echo "[serve-probe] tp=${TENSOR_PARALLEL_SIZE} max_model_len=${MAX_MODEL_LEN}" \
+     "max_num_seqs=${MAX_NUM_SEQS} util=${GPU_MEMORY_UTILIZATION}"
+echo "[serve-probe] serve extra flags: ${EXTRA_SERVE_FLAGS:-<none>}"
+echo "[serve-probe] probe extra flags: ${PROBE_EXTRA_FLAGS:-<none>}"
+echo "[serve-probe] MODEL_IMPL_TYPE=${MODEL_IMPL_TYPE:-<unset>}" \
+     "NEW_MODEL_DESIGN=${NEW_MODEL_DESIGN:-<unset>}"
+
+SERVER_PID=""
+# Reached only through the EXIT trap installed below.
+# shellcheck disable=SC2317
+dump_serve_log() {
+  echo "--- [serve-probe] vllm serve log (${SERVE_LOG}) ---"
+  cat "${SERVE_LOG}" 2>/dev/null || echo "[serve-probe] no serve log written"
+  echo "--- [serve-probe] end of serve log ---"
+  if [ -n "${SERVER_PID}" ]; then
+    kill "${SERVER_PID}" 2>/dev/null || true
+  fi
+}
+trap dump_serve_log EXIT
+
+echo "--- [serve-probe] starting vllm serve ---"
+# shellcheck disable=SC2086
+vllm serve "${MODEL}" \
+  --port "${PORT}" \
+  --tensor-parallel-size "${TENSOR_PARALLEL_SIZE}" \
+  --max-model-len "${MAX_MODEL_LEN}" \
+  --max-num-seqs "${MAX_NUM_SEQS}" \
+  --gpu-memory-utilization "${GPU_MEMORY_UTILIZATION}" \
+  ${EXTRA_SERVE_FLAGS:-} \
+  > "${SERVE_LOG}" 2>&1 &
+SERVER_PID=$!
+
+echo "--- [serve-probe] waiting up to ${STARTUP_TIMEOUT_SECONDS}s for /health ---"
+START=$(date +%s)
+READY=0
+while true; do
+  if curl -sf "http://localhost:${PORT}/health" > /dev/null 2>&1; then
+    READY=1
+    break
+  fi
+  if ! kill -0 "${SERVER_PID}" 2>/dev/null; then
+    wait "${SERVER_PID}"
+    SERVE_RC=$?
+    echo "[serve-probe] FAILED: vllm serve exited with ${SERVE_RC} after" \
+         "$(( $(date +%s) - START ))s without becoming healthy"
+    exit 1
+  fi
+  ELAPSED=$(( $(date +%s) - START ))
+  if [ "${ELAPSED}" -ge "${STARTUP_TIMEOUT_SECONDS}" ]; then
+    echo "[serve-probe] FAILED: /health never came up within" \
+         "${STARTUP_TIMEOUT_SECONDS}s (server still running)"
+    exit 1
+  fi
+  if [ $(( ELAPSED % 60 )) -lt 10 ]; then
+    # Echo where the server has got to. Streaming a large checkpoint takes
+    # tens of minutes, and without this the job looks identical to a hang
+    # until the serve log is dumped at exit.
+    echo "[serve-probe] still loading, ${ELAPSED}s elapsed; last serve line:" \
+         "$(tail -n 1 "${SERVE_LOG}" 2>/dev/null | tr -d '\r' | tail -c 300)"
+  fi
+  sleep 10
+done
+echo "[serve-probe] healthy after $(( $(date +%s) - START ))s"
+
+echo "--- [serve-probe] running serving probes ---"
+# shellcheck disable=SC2086
+python3 "${PROBE}" \
+  --base-url "http://localhost:${PORT}" \
+  --concurrency "${PROBE_CONCURRENCY}" \
+  --long-tokens "${PROBE_LONG_TOKENS}" \
+  ${PROBE_EXTRA_FLAGS:-}
+PROBE_RC=$?
+echo "[serve-probe] probes exited ${PROBE_RC} (ready=${READY})"
+exit "${PROBE_RC}"

--- a/.buildkite/scripts/run_serving_probe.sh
+++ b/.buildkite/scripts/run_serving_probe.sh
@@ -23,7 +23,8 @@
 #   .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/.buildkite/scripts/run_serving_probe.sh
 #
 # Configuration is by environment variable:
-#   MODEL                 model id or gs:// snapshot to serve (required)
+#   MODEL                 model id or gs:// snapshot to serve (required;
+#                         TEST_MODEL is accepted as a fallback name)
 #   EXTRA_SERVE_FLAGS     extra flags appended to `vllm serve` verbatim
 #   PROBE_EXTRA_FLAGS     extra flags appended to the probe verbatim
 #   PORT                  default 8000
@@ -31,7 +32,9 @@
 #   MAX_MODEL_LEN         default 2048
 #   MAX_NUM_SEQS          default 16
 #   GPU_MEMORY_UTILIZATION default 0.8
-#   STARTUP_TIMEOUT_SECONDS how long to wait for /health, default 3600. Weight
+#   STARTUP_TIMEOUT_SECONDS how long to wait for /health, default 3600
+#                         (SERVE_STARTUP_TIMEOUT_SECONDS, the run_multihost.sh
+#                         name, is honored as a fallback). Weight
 #                         streaming from GCS dominates it, so scale it with the
 #                         checkpoint size, not with the model's compute.
 #   PROBE_CONCURRENCY     default 8
@@ -43,13 +46,18 @@
 
 set -uo pipefail
 
+# TEST_MODEL is the name the nightly model steps already export; accept it so
+# the same step env drives either harness.
+MODEL="${MODEL:-${TEST_MODEL:-}}"
 MODEL=${MODEL:?MODEL must be set to the model id or gs:// path to serve}
 PORT=${PORT:-8000}
 TENSOR_PARALLEL_SIZE=${TENSOR_PARALLEL_SIZE:-8}
 MAX_MODEL_LEN=${MAX_MODEL_LEN:-2048}
 MAX_NUM_SEQS=${MAX_NUM_SEQS:-16}
 GPU_MEMORY_UTILIZATION=${GPU_MEMORY_UTILIZATION:-0.8}
-STARTUP_TIMEOUT_SECONDS=${STARTUP_TIMEOUT_SECONDS:-3600}
+# SERVE_STARTUP_TIMEOUT_SECONDS is the run_multihost.sh name for the same
+# knob; honor either so one env block works on both rigs.
+STARTUP_TIMEOUT_SECONDS="${STARTUP_TIMEOUT_SECONDS:-${SERVE_STARTUP_TIMEOUT_SECONDS:-3600}}"
 PROBE_CONCURRENCY=${PROBE_CONCURRENCY:-8}
 PROBE_LONG_TOKENS=${PROBE_LONG_TOKENS:-512}
 SERVE_LOG=${SERVE_LOG:-/tmp/vllm_serve.log}

--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -135,8 +135,15 @@ setup_environment() {
     fi
   fi
 
-  local CI_IMAGE_REPO="us-central1-docker.pkg.dev/cloud-ullm-inference-ci-cd/tpu-inference-ci/${IMAGE_NAME}"
-  local LOCAL_TPU_VERSION="${TPU_VERSION:-tpu6e}" 
+  # Callers pass either a bare image name ("vllm-tpu") or a fully-qualified
+  # registry path ("us-central1-docker.pkg.dev/<project>/tpu-inference/vllm-tpu")
+  # when they also need to push that image somewhere else. The CI cache repo is
+  # addressed by the bare name only, so interpolating a full path here produced a
+  # doubled registry path -- ".../tpu-inference-ci/us-central1-docker.pkg.dev/..."
+  # -- which no pull or push can resolve. Strip any registry/repo prefix; this is
+  # a no-op for the bare-name callers.
+  local CI_IMAGE_REPO="us-central1-docker.pkg.dev/cloud-ullm-inference-ci-cd/tpu-inference-ci/${IMAGE_NAME##*/}"
+  local LOCAL_TPU_VERSION="${TPU_VERSION:-tpu6e}"
 
   local DOCKERFILE_NAME="Dockerfile"
 
@@ -156,8 +163,14 @@ setup_environment() {
     echo "HF_TOKEN already exists in /etc/environment."
   fi
 
+  # Suppress xtrace while sourcing: /etc/environment carries HF_TOKEN, and
+  # under `set -x` the assignment -- secret included -- lands in the build
+  # log. Restore xtrace only if the caller had it on.
+  case "$-" in *x*) _had_xtrace=1 ;; *) _had_xtrace=0 ;; esac
+  { set +x; } 2>/dev/null
   # shellcheck disable=1091
   source /etc/environment
+  [ "${_had_xtrace}" = "1" ] && set -x
   cleanup_docker_resource "${IMAGE_NAME}"
 
   if [ -z "${BUILDKITE:-}" ]; then
@@ -200,6 +213,11 @@ setup_environment() {
   # Pull-Only Mode for TPU execution nodes
   # ==========================================
   if [[ "${USE_PREBUILT_IMAGE:-0}" == "1" ]]; then
+    # Publish the registry ref that was pulled. Callers that have to hand the
+    # image to *another* machine (multi-host: the Ray workers pull it themselves)
+    # need the remote ref, not the node-local tags applied below.
+    PREBUILT_IMAGE_REF="${CI_IMAGE_REPO}:${CACHE_TAG}"
+    export PREBUILT_IMAGE_REF
     echo "Pulling pre-built Docker image: ${CI_IMAGE_REPO}:${CACHE_TAG} ..."
     docker pull "${CI_IMAGE_REPO}:${CACHE_TAG}"
     verify_image_vllm "${CI_IMAGE_REPO}:${CACHE_TAG}" "${VLLM_COMMIT_HASH}"

--- a/scripts/vllm/integration/lm_eval_accuracy.py
+++ b/scripts/vllm/integration/lm_eval_accuracy.py
@@ -61,12 +61,20 @@ def evaluate_with_vllm(
         model.model.llm_engine.engine_core.shutdown()
 
 
-def _parse_model_args(value: str) -> str | dict[str, Any]:
+def parse_model_args(value: str) -> str | dict[str, Any]:
+    """lm_eval model_args in either accepted form.
+
+    A JSON object goes to `create_from_arg_obj` and can carry nested values;
+    anything else is passed through as the comma-separated `key=value` string
+    `create_from_arg_string` expects.
+    """
     if not value.lstrip().startswith("{"):
         return value
     parsed = json.loads(value)
     if not isinstance(parsed, dict):
-        raise ValueError("--model_args JSON must be an object")
+        raise ValueError(
+            f"model_args JSON must be an object, got {type(parsed).__name__}: "
+            f"{value[:200]}")
     return parsed
 
 
@@ -103,7 +111,7 @@ def main() -> None:
         )
 
     results = evaluate_with_vllm(
-        model_args=_parse_model_args(args.model_args),
+        model_args=parse_model_args(args.model_args),
         tasks=args.tasks,
         batch_size=args.batch_size,
         max_batch_size=args.max_batch_size,

--- a/scripts/vllm/integration/test_accuracy.py
+++ b/scripts/vllm/integration/test_accuracy.py
@@ -15,7 +15,7 @@ import os
 import threading
 
 import pytest
-from lm_eval_accuracy import evaluate_with_vllm
+from lm_eval_accuracy import evaluate_with_vllm, parse_model_args
 from vllm.platforms import current_platform
 
 MODEL_NAMES = []
@@ -27,9 +27,26 @@ RTOL = 0.03
 _JSON_WRITE_LOCK = threading.Lock()
 
 
-def run_test(model_name, expected_value, more_args=None):
-    """Run the end to end accuracy test."""
-    print(f"Running test for model: {model_name}")
+def build_model_args(model_name, more_args=None):
+    """The lm_eval `model_args` for this model.
+
+    Normally a `key=value` string built from the model name. A model whose
+    engine configuration cannot be written that way -- anything needing a
+    nested value, such as a sharding strategy under `additional_config` --
+    supplies the whole thing as a JSON object in ACCURACY_MODEL_ARGS_JSON
+    instead, and lm_eval takes it through `create_from_arg_obj`.
+
+    `more_args` is comma-separated string syntax, so it applies only to the
+    string form; appending it to a JSON override would produce neither valid
+    JSON nor a valid arg string. A caller that sets the override owns the
+    whole configuration, `more_args` included.
+    """
+    override = os.environ.get("ACCURACY_MODEL_ARGS_JSON")
+    if override:
+        model_args = parse_model_args(override)
+        print(f"[accuracy] model_args from ACCURACY_MODEL_ARGS_JSON: "
+              f"{model_args}")
+        return model_args
 
     if model_name in ["Qwen/Qwen3-30B-A3B", "Qwen/Qwen2.5-VL-7B-Instruct"]:
         model_args = f"pretrained={model_name},max_model_len=4096,max_num_batched_tokens=16384"
@@ -43,6 +60,14 @@ def run_test(model_name, expected_value, more_args=None):
 
     if more_args is not None:
         model_args = "{},{}".format(model_args, more_args)
+    return model_args
+
+
+def run_test(model_name, expected_value, more_args=None):
+    """Run the end to end accuracy test."""
+    print(f"Running test for model: {model_name}")
+
+    model_args = build_model_args(model_name, more_args)
 
     apply_chat_template = os.environ.get("USE_CHAT_TEMPLATE", "0") == "1"
     if apply_chat_template:

--- a/tests/e2e/benchmarking/benchmark.sh
+++ b/tests/e2e/benchmarking/benchmark.sh
@@ -225,6 +225,14 @@ else
     exit 1
 fi
 
+if [ -n "${EXTRA_SERVE_FLAGS:-}" ]; then
+    echo "Appending EXTRA_SERVE_FLAGS: $EXTRA_SERVE_FLAGS"
+    # Whatever `vllm serve` accepts and has no variable of its own above.
+    # Split on whitespace, so no single flag or value may contain a space --
+    # pass --additional-config as compact JSON, not pretty-printed.
+    read -r -a _extra_flags <<< "$EXTRA_SERVE_FLAGS"
+    extra_serve_args+=("${_extra_flags[@]}")
+fi
 
 # Spin up the vLLM server
 echo "Spinning up the vLLM server..."
@@ -257,9 +265,17 @@ fi
 
 echo "Starting the benchmark for $test_model..."
 echo "Current working directory: $(pwd)"
+
+# The client builds a tokenizer of its own, so a model whose tokenizer ships
+# as repo code needs the same opt-in the server got.
+client_extra_args=()
+if [ -n "${CLIENT_TRUST_REMOTE_CODE:-}" ]; then
+    client_extra_args+=(--trust-remote-code)
+fi
 python benchmarks/benchmark_serving.py \
 --backend vllm \
 --model "$test_model" \
+"${client_extra_args[@]}" \
 --dataset-name "$dataset_name" \
 --dataset-path "$dataset_path" \
 "${dataset_args[@]}" 2>&1 | tee -a "$BENCHMARK_LOG_FILE"

--- a/tests/e2e/multihost/serving_probe.py
+++ b/tests/e2e/multihost/serving_probe.py
@@ -1,0 +1,333 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Correctness probes for a model served across several hosts.
+
+Runs against an already-serving OpenAI-compatible endpoint (the completions
+API only) and checks invariants that hold regardless of the host count, so a
+multi-host serve can be compared against a single-host one:
+
+  health        the endpoint reports ready and names exactly one model
+  determinism   the same greedy request twice returns the same text
+  isolation     N concurrent requests each answer their OWN prompt; no
+                response may contain another request's unique marker,
+                run twice: equal-length prompts, then a wide spread of
+                prompt lengths in one batch
+  long          a long greedy generation terminates and does not collapse
+                into a single repeated token
+  needle        a fact planted at several depths of a long prompt is
+                retrieved verbatim (skipped unless --needle-tokens is given)
+
+Greedy decoding makes every check above exact, EXCEPT that token-level
+equality across *different batch shapes* is not asserted anywhere: padding
+buckets change XLA reduction order, so argmax can flip on near-ties. That is
+a property of batched serving, not of the model, so the isolation probe keys
+on unique markers rather than on token equality.
+
+``--allow-incoherent`` drops only the checks that need the served model to be
+a working language model (repeating its own marker, producing long
+non-degenerate text, retrieving the needle) and keeps every structural one, so
+a checkpoint that is deliberately not a language model -- a depth-sliced
+snapshot cut down to fit one host -- can still be probed for state leaks
+across concurrent requests.
+
+Exits non-zero on the first failed probe, and prints every observed value it
+checked so a failure can be diagnosed from the log alone.
+"""
+
+import argparse
+import json
+import random
+import string
+import sys
+from concurrent.futures import ThreadPoolExecutor
+
+import requests
+
+# Prompts that a coherent instruct model continues recognizably. They are only
+# used for the determinism probe, which compares the server against itself.
+_PROMPTS = [
+    "Question: What is 17 multiplied by 24?\nAnswer:",
+    "The capital city of Japan is",
+    "In Python, the shortest way to reverse a string s is",
+]
+
+
+class ProbeFailure(AssertionError):
+    """A probe's invariant did not hold. The message names the invariant."""
+
+
+def _complete(base_url: str,
+              model: str,
+              prompt: str,
+              max_tokens: int,
+              timeout: float = 1800.0) -> dict:
+    """One greedy completion. Returns the first choice."""
+    resp = requests.post(
+        f"{base_url}/v1/completions",
+        headers={"Content-Type": "application/json"},
+        data=json.dumps({
+            "model": model,
+            "prompt": prompt,
+            "max_tokens": max_tokens,
+            "temperature": 0.0,
+            "seed": 0,
+        }),
+        timeout=timeout,
+    )
+    if resp.status_code != 200:
+        raise ProbeFailure(
+            f"[probe] completions returned HTTP {resp.status_code} for a "
+            f"{len(prompt)}-char prompt: {resp.text[:500]}")
+    return resp.json()["choices"][0]
+
+
+def probe_health(base_url: str) -> str:
+    """Endpoint is ready and serves exactly one model. Returns its id."""
+    resp = requests.get(f"{base_url}/health", timeout=60)
+    if resp.status_code != 200:
+        raise ProbeFailure(
+            f"[probe:health] /health returned HTTP {resp.status_code}")
+    models = requests.get(f"{base_url}/v1/models", timeout=60).json()["data"]
+    ids = [m["id"] for m in models]
+    if len(ids) != 1:
+        raise ProbeFailure(
+            f"[probe:health] expected exactly one served model, got {ids}")
+    print(f"[probe:health] OK, serving {ids[0]!r}")
+    return ids[0]
+
+
+def probe_determinism(base_url: str, model: str, max_tokens: int) -> None:
+    """Greedy decoding is reproducible when the request is repeated."""
+    for prompt in _PROMPTS:
+        first = _complete(base_url, model, prompt, max_tokens)
+        second = _complete(base_url, model, prompt, max_tokens)
+        print(f"[probe:determinism] prompt={prompt!r}\n"
+              f"  run1 ({first['finish_reason']}): {first['text']!r}\n"
+              f"  run2 ({second['finish_reason']}): {second['text']!r}")
+        if not first["text"].strip():
+            raise ProbeFailure(
+                f"[probe:determinism] empty completion for {prompt!r} "
+                f"(finish_reason={first['finish_reason']})")
+        if first["text"] != second["text"]:
+            raise ProbeFailure(
+                "[probe:determinism] the same greedy request returned two "
+                f"different completions for {prompt!r}:\n"
+                f"  {first['text']!r}\n  {second['text']!r}")
+    print(f"[probe:determinism] OK, {len(_PROMPTS)} prompts reproducible")
+
+
+def _markers(count: int, seed: int = 0) -> list:
+    """`count` distinct pronounceable markers, e.g. 'zubmiq'."""
+    rng = random.Random(seed)
+    out = []
+    while len(out) < count:
+        marker = "".join(rng.choice(string.ascii_lowercase) for _ in range(6))
+        if marker not in out:
+            out.append(marker)
+    return out
+
+
+def probe_isolation(base_url: str,
+                    model: str,
+                    concurrency: int,
+                    ragged: bool = False,
+                    require_coherence: bool = True) -> None:
+    """Concurrent requests do not leak each other's state.
+
+    Each request carries a unique marker and is asked to repeat it. A response
+    that contains another request's marker means state crossed request slots —
+    the failure mode that a sharded state pool, or slot indices that are
+    global where they should be rank-local, would produce.
+
+    With `ragged`, the requests are padded to widely different prompt lengths.
+    Equal-length prompts exercise none of the ragged bookkeeping: it is unequal
+    sequence lengths in one batch that make per-request offsets and per-rank
+    packing disagree, so this variant is where a wrong slice shows up.
+
+    `require_coherence=False` keeps the leak check — the invariant this probe
+    exists for — but drops the "the response repeats its own marker" check,
+    which needs a model that follows the instruction. Depth-sliced or otherwise
+    truncated checkpoints emit meaningless text by construction, and for those
+    the leak check is still meaningful while the echo check is not.
+    """
+    tag = "ragged" if ragged else "isolation"
+    markers = _markers(concurrency, seed=1 if ragged else 0)
+    filler = "The shelves hold old paper records nobody has opened in years. "
+    prompts = []
+    for i, m in enumerate(markers):
+        # 0, 10, 20, ... filler sentences (~13 tokens each), so the longest
+        # request in the batch is ~1000 tokens and fits a 2048 context.
+        pad = filler * (i * 10)
+        prompts.append(
+            f"{pad}Repeat the word {m} five times, separated by spaces.\n{m}"
+            if ragged else
+            f"Repeat the word {m} five times, separated by spaces.\n{m}")
+
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        choices = list(
+            pool.map(lambda p: _complete(base_url, model, p, 32), prompts))
+
+    for i, (marker, choice) in enumerate(zip(markers, choices)):
+        text = choice["text"]
+        print(f"[probe:{tag}] req {i} marker={marker} "
+              f"prompt_chars={len(prompts[i])} -> {text!r}")
+        foreign = [m for m in markers if m != marker and m in text]
+        if foreign:
+            raise ProbeFailure(
+                f"[probe:{tag}] request {i} (marker {marker}) emitted "
+                f"another request's marker(s) {foreign} — state crossed "
+                f"request slots. Text: {text!r}")
+        if marker not in text:
+            if require_coherence:
+                raise ProbeFailure(
+                    f"[probe:{tag}] request {i} never repeated its own "
+                    f"marker {marker}; got {text!r}")
+            print(f"[probe:{tag}] req {i} did not repeat its own marker "
+                  "(not asserted: --allow-incoherent)")
+    print(f"[probe:{tag}] OK, {concurrency} concurrent requests, "
+          "no marker crossed requests")
+
+
+def probe_long_generation(base_url: str,
+                          model: str,
+                          max_tokens: int,
+                          require_coherence: bool = True) -> None:
+    """A long generation terminates and stays non-degenerate.
+
+    `require_coherence=False` keeps the request-completes check and still
+    prints every observed value, but does not assert the output is long or
+    non-degenerate: a truncated model legitimately produces degenerate text.
+    """
+    prompt = ("Write a detailed explanation of how a hash table works, "
+              "including collision handling.\n")
+    choice = _complete(base_url, model, prompt, max_tokens)
+    text = choice["text"]
+    words = text.split()
+    print(f"[probe:long] finish_reason={choice['finish_reason']} "
+          f"chars={len(text)} words={len(words)}")
+    print(f"[probe:long] text: {text!r}")
+    if not words:
+        raise ProbeFailure(f"[probe:long] empty completion "
+                           f"(finish_reason={choice['finish_reason']})")
+    top_share = max(words.count(w) for w in set(words)) / len(words)
+    if not require_coherence:
+        print(f"[probe:long] OK (coherence not asserted: --allow-incoherent), "
+              f"{len(words)} words, most frequent is {top_share:.0%}")
+        return
+    if len(words) < max_tokens // 8:
+        raise ProbeFailure(
+            f"[probe:long] asked for {max_tokens} tokens but got only "
+            f"{len(words)} words (finish_reason={choice['finish_reason']})")
+    if top_share > 0.5:
+        raise ProbeFailure(
+            f"[probe:long] degenerate output: one word is {top_share:.0%} of "
+            f"the {len(words)} generated words")
+    print(f"[probe:long] OK, most frequent word is {top_share:.0%} of output")
+
+
+def probe_needle(base_url: str, model: str, needle_tokens: int) -> None:
+    """A fact planted mid-context is retrieved after a long prefill.
+
+    Approximates token count with a filler sentence of known length; the exact
+    prompt length is printed so the log records what was actually run.
+    """
+    filler = ("The archive room is quiet and the shelves are full of old "
+              "paper records that nobody has opened in years. ")
+    # ~24 tokens per filler sentence; deliberately conservative so the prompt
+    # lands under, not over, the requested budget.
+    repeats = max(1, needle_tokens // 24)
+    secret = "84713"
+    for depth_pct in (10, 50, 90):
+        cut = repeats * depth_pct // 100
+        haystack = (filler * cut + f"The vault access code is {secret}. " +
+                    filler * (repeats - cut))
+        prompt = (f"{haystack}\n"
+                  "Question: What is the vault access code? "
+                  "Answer with the number only.\nAnswer:")
+        choice = _complete(base_url, model, prompt, 16)
+        text = choice["text"]
+        print(f"[probe:needle] depth={depth_pct}% prompt_chars={len(prompt)} "
+              f"-> {text!r}")
+        if secret not in text:
+            raise ProbeFailure(
+                f"[probe:needle] code {secret} planted at {depth_pct}% depth "
+                f"was not retrieved; got {text!r}")
+    print("[probe:needle] OK, retrieved at 10%/50%/90% depth")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--base-url", default="http://localhost:8000")
+    parser.add_argument("--model",
+                        default=None,
+                        help="Served model id; discovered from /v1/models "
+                        "when omitted.")
+    parser.add_argument("--concurrency", type=int, default=8)
+    parser.add_argument("--long-tokens", type=int, default=512)
+    parser.add_argument("--needle-tokens",
+                        type=int,
+                        default=0,
+                        help="Prompt budget for the needle probe. 0 skips it.")
+    parser.add_argument(
+        "--allow-incoherent",
+        action="store_true",
+        help="Do not assert that the served model produces meaningful text. "
+        "Every structural invariant still runs and still fails the probe: "
+        "the endpoint answers, greedy decoding is reproducible, concurrent "
+        "requests do not leak each other's markers, a long request comes "
+        "back non-empty. Use it for a checkpoint that is known not to be a "
+        "working language model -- a depth-sliced snapshot cut down so a "
+        "single host can serve it -- where the load and serve paths are "
+        "under test and the text is expected to be meaningless.")
+    args = parser.parse_args()
+
+    served = probe_health(args.base_url)
+    model = args.model or served
+    coherent = not args.allow_incoherent
+    if not coherent:
+        print("[probe] --allow-incoherent: text-quality assertions are off; "
+              "structural invariants still enforced")
+
+    try:
+        probe_determinism(args.base_url, model, max_tokens=32)
+        probe_isolation(args.base_url,
+                        model,
+                        args.concurrency,
+                        require_coherence=coherent)
+        probe_isolation(args.base_url,
+                        model,
+                        args.concurrency,
+                        ragged=True,
+                        require_coherence=coherent)
+        probe_long_generation(args.base_url,
+                              model,
+                              args.long_tokens,
+                              require_coherence=coherent)
+        if args.needle_tokens and coherent:
+            probe_needle(args.base_url, model, args.needle_tokens)
+        elif args.needle_tokens:
+            print("[probe:needle] SKIPPED (--allow-incoherent: retrieval is "
+                  "not defined for a model that is not a language model)")
+        else:
+            print("[probe:needle] SKIPPED (--needle-tokens not set)")
+    except ProbeFailure as e:
+        print(f"FAILED: {e}", file=sys.stderr)
+        return 1
+
+    print("All probes passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/layers/jax/test_misc.py
+++ b/tests/layers/jax/test_misc.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""`layers/jax/misc.shard_put` -- the Llama-4 weight placement helper.
+
+It is a second copy of the placement logic in
+`models/jax/utils/weight_utils.shard_put`, and it has to make the same
+multi-host choice: under the Ray backend a process addresses only its own
+devices, so `jax.device_put(x, NamedSharding(full_mesh, ...))` is rejected and
+the array has to be assembled from process-local shards instead.
+"""
+
+from unittest import mock
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+
+from tpu_inference import envs
+from tpu_inference.layers.jax.misc import shard_put
+
+
+def _mesh(num_devices):
+    devices = jax.devices()[:num_devices]
+    if len(devices) < num_devices:
+        pytest.skip(f"needs {num_devices} devices, have {len(devices)}")
+    return Mesh(np.array(devices).reshape(1, num_devices), ("data", "model"))
+
+
+def test_multihost_placement_uses_the_process_local_api():
+    """Without this, a multi-host Llama-4 load dies the same way the MXFP4
+    expert placement did: device_put over a mesh whose devices this process
+    does not all address."""
+    mesh = _mesh(2)
+    x = jnp.arange(16, dtype=jnp.float32).reshape(2, 8)
+    with mock.patch.object(envs, "TPU_MULTIHOST_BACKEND", "ray"):
+        with mock.patch("jax.make_array_from_callback",
+                        side_effect=jax.make_array_from_callback) as spy:
+            out = shard_put(x, (None, "model"), mesh)
+    spy.assert_called_once()
+    assert spy.call_args[0][1].mesh is mesh
+    np.testing.assert_array_equal(np.asarray(out), np.asarray(x))
+
+
+def test_single_host_placement_is_unchanged():
+    """Anti-vacuity for the above, and the compatibility claim: with the
+    backend unset the process-local path is not taken at all."""
+    mesh = _mesh(2)
+    x = jnp.arange(16, dtype=jnp.float32).reshape(2, 8)
+    with mock.patch.object(envs, "TPU_MULTIHOST_BACKEND", ""):
+        with mock.patch("jax.make_array_from_callback",
+                        side_effect=jax.make_array_from_callback) as spy:
+            out = shard_put(x, (None, "model"), mesh)
+    spy.assert_not_called()
+    assert out.sharding.spec == P(None, "model")
+    np.testing.assert_array_equal(np.asarray(out), np.asarray(x))
+
+
+def test_both_paths_agree_on_values_and_sharding():
+    mesh = _mesh(2)
+    x = jnp.arange(32, dtype=jnp.float32).reshape(4, 8)
+    with mock.patch.object(envs, "TPU_MULTIHOST_BACKEND", ""):
+        single = shard_put(x, (None, "model"), mesh)
+    with mock.patch.object(envs, "TPU_MULTIHOST_BACKEND", "ray"):
+        multi = shard_put(x, (None, "model"), mesh)
+    assert single.sharding == multi.sharding
+    np.testing.assert_array_equal(np.asarray(single), np.asarray(multi))
+
+
+def test_single_device_mesh_keeps_its_shortcut():
+    """A 1-device mesh still bypasses sharding entirely (the comment in the
+    helper: naming a sharding there triggers a recursive-jit error)."""
+    mesh = _mesh(1)
+    x = jnp.arange(8, dtype=jnp.float32)
+    with mock.patch.object(envs, "TPU_MULTIHOST_BACKEND", "ray"):
+        with mock.patch("jax.make_array_from_callback") as spy:
+            out = shard_put(x, ("model", ), mesh)
+    spy.assert_not_called()
+    np.testing.assert_array_equal(np.asarray(out), np.asarray(x))

--- a/tests/scripts/test_accuracy_model_args.py
+++ b/tests/scripts/test_accuracy_model_args.py
@@ -1,0 +1,108 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""`build_model_args` in the accuracy harness.
+
+A model whose engine configuration does not fit `key=value` -- anything with
+a nested value, such as a sharding strategy -- has to reach lm_eval as a JSON
+object instead, and the two forms are not interchangeable downstream: one
+goes to `create_from_arg_string`, the other to `create_from_arg_obj`.
+"""
+
+import importlib.util
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT_DIR = Path(__file__).parents[2] / "scripts" / "vllm" / "integration"
+# test_accuracy.py imports its sibling by bare name.
+sys.path.insert(0, str(_SCRIPT_DIR))
+_SPEC = importlib.util.spec_from_file_location(
+    "accuracy_harness_under_test", _SCRIPT_DIR / "test_accuracy.py")
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+_SHARDED = {
+    "pretrained": "some-org/Some-Model",
+    "tensor_parallel_size": 8,
+    "trust_remote_code": True,
+    "additional_config": {
+        "sharding": {
+            "sharding_strategy": {
+                "tensor_parallelism": 1,
+                "expert_parallelism": 8,
+                "enable_dp_attention": True,
+            }
+        }
+    },
+}
+
+
+@pytest.fixture(autouse=True)
+def no_override(monkeypatch):
+    """Every test states its own override, or the absence of one."""
+    monkeypatch.delenv("ACCURACY_MODEL_ARGS_JSON", raising=False)
+
+
+def test_default_is_the_key_value_string():
+    assert _MODULE.build_model_args("some-org/Some-Model") == (
+        "pretrained=some-org/Some-Model,max_model_len=4096")
+
+
+def test_more_args_is_appended_to_the_string_form():
+    assert _MODULE.build_model_args(
+        "some-org/Some-Model",
+        "kv_cache_dtype=fp8") == ("pretrained=some-org/Some-Model,"
+                                  "max_model_len=4096,"
+                                  "kv_cache_dtype=fp8")
+
+
+def test_override_returns_the_parsed_object(monkeypatch):
+    """The nested value survives, which is the whole point of the hook."""
+    monkeypatch.setenv("ACCURACY_MODEL_ARGS_JSON", json.dumps(_SHARDED))
+
+    model_args = _MODULE.build_model_args("some-org/Some-Model")
+
+    assert model_args == _SHARDED
+    assert model_args["additional_config"]["sharding"]["sharding_strategy"][
+        "expert_parallelism"] == 8
+
+
+def test_override_ignores_the_per_model_defaults(monkeypatch):
+    """A model with a defaults entry does not get it merged in underneath."""
+    monkeypatch.setenv("ACCURACY_MODEL_ARGS_JSON",
+                       '{"pretrained":"Qwen/Qwen3-30B-A3B"}')
+
+    assert _MODULE.build_model_args("Qwen/Qwen3-30B-A3B") == {
+        "pretrained": "Qwen/Qwen3-30B-A3B"
+    }
+
+
+def test_override_does_not_get_more_args_concatenated(monkeypatch):
+    """Appending comma syntax to a dict would corrupt both forms."""
+    monkeypatch.setenv("ACCURACY_MODEL_ARGS_JSON", json.dumps(_SHARDED))
+
+    assert _MODULE.build_model_args("some-org/Some-Model",
+                                    "kv_cache_dtype=fp8") == _SHARDED
+
+
+def test_malformed_json_fails_rather_than_falling_back(monkeypatch):
+    """Quietly serving the defaults instead would look like a passing run."""
+    monkeypatch.setenv("ACCURACY_MODEL_ARGS_JSON",
+                       '{"pretrained": "some-org/Some-Model"')
+
+    with pytest.raises(json.JSONDecodeError):
+        _MODULE.build_model_args("some-org/Some-Model")

--- a/tpu_inference/layers/jax/misc.py
+++ b/tpu_inference/layers/jax/misc.py
@@ -34,8 +34,9 @@ def shard_put(x: jax.Array, sharding_names: Tuple[str, ...] | P,
     # sharding over the whole mesh is rejected ("must be a Device or a
     # Sharding which represents addressable devices"). `general_device_put`
     # assembles the global array from each process's addressable shards, and
-    # falls through to a plain `device_put` when there is a single process --
-    # so single-host behaviour is unchanged.
+    # falls through to a plain `device_put` when TPU_MULTIHOST_BACKEND is not
+    # "ray" (or the input is not fully addressable) -- so behaviour outside
+    # the Ray multi-host backend is unchanged.
     source_mesh = (x.sharding.mesh if isinstance(getattr(x, "sharding", None),
                                                  NamedSharding) else None)
     return general_device_put(x,

--- a/tpu_inference/layers/jax/misc.py
+++ b/tpu_inference/layers/jax/misc.py
@@ -19,6 +19,8 @@ import jax
 from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 
+from tpu_inference.layers.common.utils import general_device_put
+
 
 # TODO(xiang): move this to weight_utils.py
 def shard_put(x: jax.Array, sharding_names: Tuple[str, ...] | P,
@@ -27,4 +29,15 @@ def shard_put(x: jax.Array, sharding_names: Tuple[str, ...] | P,
     # to avoid the recursive jit error.
     if math.prod(mesh.axis_sizes) == 1:
         return jax.device_put(x, mesh.devices.flatten()[0])
-    return jax.device_put(x, NamedSharding(mesh, P(*sharding_names)))
+    # Not `jax.device_put(x, NamedSharding(mesh, ...))`: under the Ray
+    # multi-host backend a process addresses only its own devices, so naming a
+    # sharding over the whole mesh is rejected ("must be a Device or a
+    # Sharding which represents addressable devices"). `general_device_put`
+    # assembles the global array from each process's addressable shards, and
+    # falls through to a plain `device_put` when there is a single process --
+    # so single-host behaviour is unchanged.
+    source_mesh = (x.sharding.mesh if isinstance(getattr(x, "sharding", None),
+                                                 NamedSharding) else None)
+    return general_device_put(x,
+                              NamedSharding(mesh, P(*sharding_names)),
+                              source_mesh=source_mesh)


### PR DESCRIPTION
Piece 6 of 6 of the Kimi-K3 enablement stack, independent of splits 1-5 (based on main). CI and multi-host serving infrastructure: run_multihost.sh Ray-cluster fixes, the serving probe (tests/e2e/multihost/serving_probe.py + run_serving_probe.sh), prebuilt-image ref passthrough and secret-safe sourcing in setup_docker_env.sh, env passthrough additions in run_in_docker.sh, the Kimi step in pipeline_jax.yml and the Kimi-Linear nightly model config, the ACCURACY_MODEL_ARGS_JSON override in the accuracy harness, EXTRA_SERVE_FLAGS/CLIENT_TRUST_REMOTE_CODE in benchmark.sh, and multi-host-safe shard_put in layers/jax/misc.py — plus tests for the harness and misc changes. The full stack was validated end-to-end in #3292: CI green, gsm8k 0.976.

**Recommended merge order:** after K3 split 5/6 (#3327), which carries the Kimi unit-test files and `.buildkite/scripts/fetch_k3_tiny_fixtures.sh` that the new CI steps here consume. Merging this piece first is still non-destructive: every `source` of the fixtures script is guarded by a file-existence check, so the pre-existing nightly kernels step keeps passing regardless of order; until #3327 lands, only the new Kimi-specific test steps would fail (on the missing test files).

**Probe harness wiring:** the multi-host serving-probe harness (`run_serving_probe.sh` + `tests/e2e/multihost/serving_probe.py`) is exercised by dev-pipeline runs today; it is consumed by the K3 pod dev steps and by the future multi-host CI step — no per-commit CI step in this PR invokes it yet.