### PR TITLE
Cache Mamba state allocators during KV cache reinit

### DIFF
--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -35,7 +35,8 @@ from vllm.v1.request import Request
 
 from tpu_inference import utils as common_utils
 from tpu_inference.runner.input_batch import CachedRequestState
-from tpu_inference.runner.kv_cache import get_attention_page_size_bytes
+from tpu_inference.runner.kv_cache import (_get_mamba_cache_allocator,
+                                           get_attention_page_size_bytes)
 from tpu_inference.runner.tpu_runner import TPUModelRunner
 
 
@@ -930,6 +931,35 @@ class TestKVCacheManager:
             assert mamba_states[1].shape == (expected_num_blocks, 8, 64, 32)
 
             assert self.runner.layer_name_to_kvcache_index[f'layer.{i}'] == i
+
+    def test_reinitialize_kv_cache_reuses_mamba_allocators(self):
+        num_blocks = 100
+        page_size_bytes = 16 * 1024
+        layer_names = ['layer.0', 'layer.1']
+        kv_cache_config = self._create_mamba_kv_cache_config(
+            num_blocks, page_size_bytes, layer_names)
+
+        if not hasattr(self.runner.vllm_config, 'sharding_config'
+                       ) or self.runner.vllm_config.sharding_config is None:
+            self.runner.vllm_config.sharding_config = MagicMock()
+            self.runner.vllm_config.sharding_config.total_dp_size = 1
+
+        _get_mamba_cache_allocator.cache_clear()
+        try:
+            with patch('dataclasses.replace') as mock_replace:
+                mock_replaced_spec = MagicMock()
+                mock_replaced_spec.page_size_bytes = page_size_bytes
+                mock_replace.return_value = mock_replaced_spec
+
+                self.runner.initialize_kv_cache(kv_cache_config)
+                self.runner.delete_kv_cache()
+                self.runner.reinitialize_kv_cache()
+
+            cache_info = _get_mamba_cache_allocator.cache_info()
+            assert cache_info.misses == 2
+            assert cache_info.hits == 6
+        finally:
+            _get_mamba_cache_allocator.cache_clear()
 
     def test_initialize_kv_cache_no_duplicate_shared_layers(self):
         block_size = self.runner.vllm_config.cache_config.block_size

--- a/tpu_inference/runner/kv_cache.py
+++ b/tpu_inference/runner/kv_cache.py
@@ -116,6 +116,27 @@ def _get_kv_cache_allocator(
     return _allocate
 
 
+@cache
+def _get_mamba_cache_allocator(
+        cache_shape: tuple, cache_dtype: jnp.dtype,
+        sharding: NamedSharding) -> Callable[[], jax.Array]:
+
+    @partial(jax.jit, out_shardings=sharding)
+    def _allocate() -> jax.Array:
+        return jnp.empty(
+            shape=cache_shape,
+            dtype=cache_dtype,
+        )
+
+    return _allocate
+
+
+def create_mamba_cache(cache_shape: tuple, cache_dtype: jnp.dtype,
+                       sharding: NamedSharding) -> jax.Array:
+    """Creates a fresh Mamba state array with a cached allocator."""
+    return _get_mamba_cache_allocator(cache_shape, cache_dtype, sharding)()
+
+
 def create_kv_caches(
     num_blocks: int,
     block_size: int,

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -48,6 +48,7 @@ from tpu_inference.runner.input_batch import CachedRequestState, InputBatch
 from tpu_inference.runner.kv_cache import (KVCacheMetadata,
                                            create_kv_cache_of_shape,
                                            create_kv_caches,
+                                           create_mamba_cache,
                                            get_attention_page_size_bytes)
 
 if TYPE_CHECKING:
@@ -893,13 +894,9 @@ class KVCacheManager:
 
                         # NOTE: conv state will always be BF16 and SSM state will always be FP32
                         # regardless of the `kv-cache-dtype` (as is in upstream vLLM)
-                        def _allocate_mamba(c_shape=cache_shape,
-                                            c_dtype=jax_dtype):
-                            return jnp.empty(shape=c_shape, dtype=c_dtype)
-
-                        mamba_allocate = jax.jit(_allocate_mamba,
-                                                 out_shardings=sharding)
-                        mamba_states.append(mamba_allocate())
+                        mamba_states.append(
+                            create_mamba_cache(cache_shape, jax_dtype,
+                                               sharding))
 
                     metadata["mamba"].count += 1
                     if metadata["mamba"].shape is None:


### PR DESCRIPTION
# Description

Jax is re-jitting the mamba state allocation function every time, leading to slow weigh transfer in RL post-training in MaxText / Tunix. Similar to [PR 3180] (https://github.com/vllm-project/tpu-inference/pull/3180), we apply the same fix to mamba state allocation function.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
