### PR TITLE
[DSv4] Add 3 rope related kernels: qnorm_rope(), rope(), rope_quant() deepseek v4

### DIFF
--- a/tests/kernels/deepseek_v4/rope_test.py
+++ b/tests/kernels/deepseek_v4/rope_test.py
@@ -1,0 +1,238 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
+
+from tpu_inference.kernels.experimental.deepseek_v4.rope import (qnorm_rope,
+                                                                 rope,
+                                                                 rope_quant)
+
+# DeepSeek-V4-Flash: head_dim 512, qk_rope_head_dim 64, 64 attention heads.
+HEAD_DIM = 512
+ROTARY_DIM = 64
+NUM_HEADS = 64
+
+
+def rope_ref_impl(x, positions, cos_sin_cache, inverse=False):
+    """Reference implementation of ``DeepseekV4ScalingRotaryEmbedding.forward_native``.
+
+  GPT-J interleaved rotation over the *trailing* ``rotary_dim`` channels.
+  """
+    rotary_dim = cos_sin_cache.shape[1]
+    orig_dtype = x.dtype
+    xf = jnp.asarray(x).astype(jnp.float32)
+
+    cos, sin = jnp.split(jnp.asarray(cos_sin_cache)[positions].astype(
+        jnp.float32),
+                         2,
+                         axis=-1)
+    cos = jnp.repeat(cos, 2, axis=-1)  # repeat_interleave
+    sin = jnp.repeat(sin, 2, axis=-1)
+    if inverse:
+        sin = -sin
+    if xf.ndim == 3:  # [num_tokens, num_heads, head_dim]: broadcast over heads
+        cos = cos[:, None, :]
+        sin = sin[:, None, :]
+
+    x_pass, x_rot = xf[..., :-rotary_dim], xf[..., -rotary_dim:]
+    # rotate_gptj: [-x1, x0, -x3, x2, ...]
+    rotated = jnp.stack([-x_rot[..., 1::2], x_rot[..., 0::2]],
+                        axis=-1).reshape(x_rot.shape)
+    out_rot = x_rot * cos + rotated * sin
+    return jnp.concatenate([x_pass, out_rot], axis=-1).astype(orig_dtype)
+
+
+def quant_ref_impl(y, quant_dtype):
+    """Reference implementation of ``quantization.quantize_tensor(..., axis=-1)``."""
+    dtype_max = float(jnp.finfo(quant_dtype).max)
+    yf = jnp.asarray(y).astype(jnp.float32)
+    abs_max = jnp.max(jnp.abs(yf), axis=-1, keepdims=True)
+    scale = abs_max / dtype_max
+    # quantize_tensor leaves an all-zero row at NaN; the kernel returns zeros.
+    scale_inv = jnp.where(abs_max == 0.0, 0.0, 1.0 / scale)
+    return (yf * scale_inv).astype(quant_dtype), jnp.squeeze(scale, -1)
+
+
+def qnorm_rope_ref_impl(x, positions, cos_sin_cache, eps, inverse=False):
+    """Reference implementation of ``DeepseekV4Attention.qnorm_rope``.
+
+  Per-head RMSNorm (no weight) over the whole ``head_dim``, in float32, then
+  the same RoPE ``rope_ref_impl`` applies.
+  """
+    xf = jnp.asarray(x).astype(jnp.float32)
+    rms = jax.lax.rsqrt(jnp.mean(xf * xf, axis=-1, keepdims=True) + eps)
+    return rope_ref_impl(xf * rms, positions, cos_sin_cache,
+                         inverse=inverse).astype(x.dtype)
+
+
+def assert_bits_equal(actual, expected):
+    """Byte-for-byte equality, for dtypes NumPy will not compare directly."""
+    np.testing.assert_array_equal(
+        np.asarray(actual).view(np.uint8),
+        np.asarray(expected).view(np.uint8))
+
+
+def make_cos_sin_cache(max_position, rotary_dim, seed=0):
+    """A cos/sin cache with the layout DeepSeek-V4 builds: ``[cos | sin]``."""
+    rng = np.random.default_rng(seed)
+    freqs = rng.uniform(0.0, 2.0 * np.pi,
+                        (max_position, rotary_dim // 2)).astype(np.float32)
+    return np.concatenate([np.cos(freqs), np.sin(freqs)],
+                          axis=-1).astype(np.float32)
+
+
+class RopeTest(parameterized.TestCase):
+
+    def _run(
+        self,
+        shape,
+        num_positions,
+        inverse,
+        dtype,
+        seed=0,
+        max_position=4096,
+    ):
+        rng = np.random.default_rng(seed)
+        x = rng.normal(size=shape).astype(dtype)
+        positions = rng.integers(0, max_position,
+                                 size=(num_positions, )).astype(np.int32)
+        cos_sin_cache = make_cos_sin_cache(max_position, ROTARY_DIM, seed)
+
+        expected = rope_ref_impl(x, positions, cos_sin_cache, inverse=inverse)
+        actual = rope(
+            jnp.asarray(x),
+            jnp.asarray(positions),
+            jnp.asarray(cos_sin_cache),
+            inverse=inverse,
+        )
+        return np.asarray(actual), expected
+
+    @parameterized.product(
+        num_tokens=(8, 64, 256),
+        inverse=(False, True),
+    )
+    def test_matches_reference_multi_head(self, num_tokens, inverse):
+        """``qnorm_rope`` / ``_o_proj`` shape: [tokens, heads, head_dim]."""
+        actual, expected = self._run((num_tokens, NUM_HEADS, HEAD_DIM),
+                                     num_tokens, inverse, np.float32)
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+
+    @parameterized.product(
+        num_tokens=(8, 128),
+        inverse=(False, True),
+    )
+    def test_matches_reference_single_head(self, num_tokens, inverse):
+        """``kv_rope`` shape: [tokens, head_dim]."""
+        actual, expected = self._run((num_tokens, HEAD_DIM), num_tokens,
+                                     inverse, np.float32)
+        np.testing.assert_allclose(actual, expected, rtol=1e-6, atol=1e-6)
+
+    def test_nope_channels_untouched(self):
+        """Everything before the trailing ``rotary_dim`` must pass through."""
+        rng = np.random.default_rng(7)
+        x = rng.normal(size=(64, 8, HEAD_DIM)).astype(np.float32)
+        positions = rng.integers(0, 4096, size=(64, )).astype(np.int32)
+        cos_sin_cache = make_cos_sin_cache(4096, ROTARY_DIM)
+
+        actual = np.asarray(
+            rope(jnp.asarray(x), jnp.asarray(positions),
+                 jnp.asarray(cos_sin_cache)))
+        np.testing.assert_array_equal(actual[..., :-ROTARY_DIM],
+                                      x[..., :-ROTARY_DIM])
+
+
+class RopeQuantTest(parameterized.TestCase):
+    """RoPE fused with the indexer's per-row fp8 quantization."""
+
+    @parameterized.product(
+        num_tokens=(8, 64, 256),
+        inverse=(False, True),
+    )
+    def test_matches_reference(self, num_tokens, inverse):
+        """Indexer query shape: [tokens, index_n_heads, index_head_dim]."""
+        indexer_head_dim = 128
+        indexer_num_heads = 64
+        shape = (num_tokens, indexer_num_heads, indexer_head_dim)
+        seed = 0
+        rng = np.random.default_rng(seed)
+        x = rng.normal(size=shape).astype(jnp.bfloat16)
+        positions = rng.integers(0, 4096, size=(shape[0], )).astype(np.int32)
+        cos_sin_cache = make_cos_sin_cache(4096, ROTARY_DIM, seed)
+
+        # The kernel quantizes the float32 rotation directly -- it never rounds to
+        # ``x.dtype`` in between -- so neither does the reference.
+        q_expected, scales_expected = quant_ref_impl(
+            rope_ref_impl(x.astype(np.float32),
+                          positions,
+                          cos_sin_cache,
+                          inverse=inverse),
+            jnp.float8_e4m3fn,
+        )
+        q, scales = rope_quant(
+            jnp.asarray(x),
+            jnp.asarray(positions),
+            jnp.asarray(cos_sin_cache),
+            inverse=inverse,
+            quant_dtype=jnp.float8_e4m3fn,
+        )
+        np.testing.assert_allclose(np.asarray(scales),
+                                   np.asarray(scales_expected),
+                                   rtol=1e-6,
+                                   atol=1e-6)
+        assert_bits_equal(q, q_expected)
+
+
+class QNormRopeTest(parameterized.TestCase):
+    """RoPE fused with the per-head RMSNorm that precedes it on ``q``."""
+
+    @parameterized.product(num_tokens=(8, 64, 256), )
+    def test_matches_reference_multi_head(self, num_tokens):
+        """``qnorm_rope`` shape: [tokens, heads, head_dim]."""
+        num_heads = 128
+        head_dim = 512
+        seed = 0
+        shape = (num_tokens, num_heads, head_dim)
+        max_position = 4096
+        dtype = jnp.bfloat16
+        rng = np.random.default_rng(seed)
+        x = rng.normal(size=shape).astype(np.float32)
+        positions = rng.integers(0, max_position,
+                                 size=(shape[0], )).astype(np.int32)
+        cos_sin_cache = make_cos_sin_cache(max_position, ROTARY_DIM, seed)
+        eps = 1e-6
+        x = jnp.asarray(x, dtype=dtype)
+        positions = jnp.asarray(positions)
+        cos_sin_cache = jnp.asarray(cos_sin_cache)
+
+        expected = qnorm_rope_ref_impl(x,
+                                       positions,
+                                       cos_sin_cache,
+                                       eps,
+                                       inverse=False)
+        actual = qnorm_rope(
+            jnp.asarray(x),
+            jnp.asarray(positions),
+            jnp.asarray(cos_sin_cache),
+            eps=eps,
+            inverse=False,
+        )
+        np.testing.assert_allclose(actual, expected, rtol=1e-2, atol=1e-2)
+
+
+if __name__ == "__main__":
+    jax.config.update("jax_default_matmul_precision", "highest")
+    absltest.main()

--- a/tpu_inference/kernels/experimental/deepseek_v4/rope.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/rope.py
@@ -1,0 +1,614 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import dataclasses
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+# Native lane count; the roped channels are the tail of the last lane block.
+LANE = 128
+
+DEFAULT_VMEM_LIMIT_BYTES = 100 * 1024 * 1024
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True, kw_only=True)
+class CosSinRef(pltpu.BufferedRef):
+    """Per-token gather of ``cos_sin_cache`` rows into a ``(tile_n, rotary_dim)``"""
+
+    tile_n: int = dataclasses.field(metadata=dict(static=True))
+
+    @classmethod
+    def create(cls, *, spec, dtype, buffer_count, tile_n):
+        standard_ref = pltpu.BufferedRef.create(
+            spec=spec,
+            dtype_or_type=dtype,
+            buffer_type=pltpu.BufferType.INPUT,
+            buffer_count=buffer_count,
+            grid_rank=1,
+            use_lookahead=False,
+        )
+        return cls(
+            tile_n=tile_n,
+            **{
+                f.name: getattr(standard_ref, f.name)
+                for f in dataclasses.fields(pltpu.BufferedRef)
+            },
+        )
+
+    def copy_in(self, src_ref, grid_indices):
+        cos_sin_cache_ref, positions_ref = src_ref
+        slot = self.current_copy_in_slot
+        sem = self.sem_recvs.at[slot]
+        pid = grid_indices[0]
+
+        dest_ref = self.window_ref.at[slot]  # (tile_n, rotary_dim)
+        width = self.window_ref.shape[-1]
+
+        @pl.loop(0, self.tile_n, unroll=True)
+        def _(i):
+            position = positions_ref[pid * self.tile_n + i]
+            src = cos_sin_cache_ref.at[position, pl.ds(0, width)]
+            pltpu.make_async_copy(src, dest_ref.at[i, :], sem).start()
+
+    def wait_in(self, src_ref, grid_indices):
+        del src_ref, grid_indices
+        slot = self.current_wait_in_slot
+        vmem_ref = self.window_ref.at[slot]
+        pltpu.make_async_copy(vmem_ref, vmem_ref,
+                              self.sem_recvs.at[slot]).wait()
+
+
+def _lane_gather(operand, indices):
+    """``out[b..., i] = operand[b..., indices[i]]`` over the last axis.
+
+  The leading axes come along as batch dimensions. ``indices`` is a constant
+  1-D array, so this lowers to a lane shuffle rather than a real dynamic
+  gather.
+  """
+    rank = operand.ndim
+    lanes = indices.shape[0]
+    coords = jnp.broadcast_to(indices, (*operand.shape[:-1], lanes))[..., None]
+    batching = tuple(range(rank - 1))
+    dimension_numbers = jax.lax.GatherDimensionNumbers(
+        offset_dims=(),
+        collapsed_slice_dims=(rank - 1, ),
+        start_index_map=(rank - 1, ),
+        operand_batching_dims=batching,
+        start_indices_batching_dims=batching,
+    )
+    return jax.lax.gather(
+        operand,
+        coords,
+        dimension_numbers=dimension_numbers,
+        slice_sizes=(1, ) * rank,
+        unique_indices=False,
+        mode=jax.lax.GatherScatterMode.PROMISE_IN_BOUNDS,
+    )
+
+
+def _cos_sin_lanes(cos_sin, *, rotary_dim, inverse):
+    """The reference's ``np.split`` + ``np.repeat(..., 2)``, over a whole block.
+
+  ``cos_sin`` is one packed ``[cos | sin]`` row per token. The reference splits
+  it in half, repeats each half so both channels of a pair share a frequency,
+  rotates ``x[..., -rotary_dim:]`` and concatenates the NoPE part back on.
+
+  A kernel block is ``LANE`` lanes wide and the roped channels are its tail, so
+  rather than slicing them out we widen cos/sin to the full block and hand the
+  NoPE lanes the identity rotation -- multiplying by ``cos = 1``, ``sin = 0``
+  is exactly the reference's pass-through concatenation::
+
+      lane      0 ... 63 | 64  65  66  67 ...   (LANE 128, rotary_dim 64)
+      channel   -- NoPE -|  0   1   2   3
+      cos       1 ...  1 | c0  c0  c1  c1       <- np.repeat(cos, 2)
+      sin       0 ...  0 | s0  s0  s1  s1
+  """
+    half = rotary_dim // 2
+    channel = jnp.arange(LANE) - (LANE - rotary_dim)  # < 0 on the NoPE lanes
+    is_rot = channel >= 0
+    # ``np.repeat(..., 2)``: channels 2k and 2k+1 both read frequency k. Clamped
+    # to keep the gather in bounds on the NoPE lanes, replaced just below.
+    freq = jnp.maximum(channel, 0) // 2
+
+    cos_sin = cos_sin.astype(jnp.float32)
+    cos = _lane_gather(cos_sin, freq)  # np.split(...)[0], repeated
+    sin = _lane_gather(cos_sin, half + freq)  # np.split(...)[1], repeated
+    if inverse:
+        sin = -sin
+    return jnp.where(is_rot, cos, 1.0), jnp.where(is_rot, sin, 0.0)
+
+
+def _rotate_gptj(x):
+    """The reference's ``rotated``: ``[-x1, x0, -x3, x2, ...]`` along the lanes.
+
+  ``np.stack([-x[..., 1::2], x[..., 0::2]], -1).reshape(...)`` says, lane by
+  lane, "take the partner lane ``i ^ 1``, negated on the even ones" -- a
+  constant-index lane shuffle and a sign, no reshape. Lane parity may be read
+  for channel parity because ``LANE - rotary_dim`` is even.
+  """
+    lane = jnp.arange(LANE)
+    sign = jnp.where(lane % 2 == 0, -1.0, 1.0).astype(jnp.float32)
+    return _lane_gather(x, lane ^ 1) * sign
+
+
+def _dtype_max(dtype):
+    info = (jnp.iinfo(dtype)
+            if jnp.issubdtype(dtype, jnp.integer) else jnp.finfo(dtype))
+    return float(info.max)
+
+
+def _rope_body(
+    x_ref,
+    cos_sin_ref,
+    *out_refs,
+    rotary_dim,
+    inverse,
+    out_dtype,
+    quant_dtype,
+):
+    """Process one ``(tile_n, [num_heads,] LANE)`` chunk.
+
+  Without ``quant_dtype`` the rotation is written back into ``x_ref`` in place.
+  With it, the rotated chunk is quantized along the lanes and written to the
+  ``(q_ref, scale_ref)`` outputs instead.
+  """
+    x = x_ref[...].astype(jnp.float32)
+    cos, sin = _cos_sin_lanes(cos_sin_ref[...],
+                              rotary_dim=rotary_dim,
+                              inverse=inverse)
+    if x.ndim == 3:  # [tokens, heads, lanes]: cos/sin are per token
+        cos = cos[:, None, :]
+        sin = sin[:, None, :]
+
+    rotated = _rotate_gptj(x)
+    y = x * cos + rotated * sin
+
+    if quant_dtype is None:
+        x_ref[...] = y.astype(out_dtype)
+        return
+
+    q_ref, scale_ref = out_refs
+    dtype_max = _dtype_max(quant_dtype)
+    # One scale per row, i.e. over the whole ``LANE``-wide channel axis.
+    abs_max = jnp.max(jnp.abs(y), axis=-1, keepdims=True)
+    scale = abs_max / dtype_max
+    scale_inv = jnp.where(abs_max == 0.0, 0.0, 1.0 / scale)
+    q_ref[...] = (y * scale_inv).astype(quant_dtype)
+    scale_ref[...] = scale.reshape(scale_ref.shape)
+
+
+def _kernel(
+    # scalar prefetch
+    positions_ref,
+    # HBM inputs
+    x_hbm_ref,
+    cos_sin_cache_hbm_ref,
+    # HBM outputs: (out,) aliased onto x_hbm_ref, or (q, scales) when quantizing
+    *out_hbm_refs,
+    num_tiles: int,
+    tile_n: int,
+    x_block_shape: tuple[int, ...],
+    scale_block_shape: tuple[int, ...],
+    lane_block: int,
+    rotary_dim: int,
+    inverse: bool,
+    in_dtype: jnp.dtype,
+    out_dtype: jnp.dtype,
+    cos_sin_dtype: jnp.dtype,
+    quant_dtype: jnp.dtype | None,
+):
+
+    def x_index_map(i):
+        if len(x_block_shape) == 3:
+            return (i, 0, lane_block)
+        return (i, lane_block)
+
+    x_spec = pl.BlockSpec(block_shape=x_block_shape,
+                          memory_space=pltpu.VMEM,
+                          index_map=x_index_map)
+
+    cos_sin_spec = pl.BlockSpec(
+        block_shape=(tile_n, rotary_dim),
+        memory_space=pltpu.VMEM,
+        index_map=lambda i: (i, 0),
+    )
+    cos_sin_alloc = CosSinRef.create(spec=cos_sin_spec,
+                                     dtype=cos_sin_dtype,
+                                     buffer_count=2,
+                                     tile_n=tile_n)
+
+    if quant_dtype is None:
+        del x_hbm_ref  # aliased to the output; read/written through the latter.
+        (out_hbm_ref, ) = out_hbm_refs
+        x_ref_args = (out_hbm_ref, )
+        out_ref_args = ()
+        out_specs = []
+        # input_output since we only update the last rope_dim channels in place.
+        x_alloc = pltpu.BufferedRef.input_output(x_spec,
+                                                 out_dtype,
+                                                 buffer_count=2)
+        out_allocs = ()
+    else:
+        q_hbm_ref, scale_hbm_ref = out_hbm_refs
+        x_ref_args = (x_hbm_ref, )
+        out_ref_args = (q_hbm_ref, scale_hbm_ref)
+        q_spec = pl.BlockSpec(
+            block_shape=x_block_shape,
+            memory_space=pltpu.VMEM,
+            index_map=x_index_map,
+        )
+        scale_spec = pl.BlockSpec(
+            block_shape=scale_block_shape,
+            memory_space=pltpu.VMEM,
+            # Same block as ``q``, minus the channel axis it reduces away.
+            index_map=lambda i: x_index_map(i)[:-1],
+        )
+        out_specs = [q_spec, scale_spec]
+        x_alloc = pltpu.BufferedRef.input(x_spec, in_dtype, buffer_count=2)
+        out_allocs = (
+            pltpu.BufferedRef.output(q_spec, quant_dtype, buffer_count=2),
+            pltpu.BufferedRef.output(scale_spec, jnp.float32, buffer_count=2),
+        )
+
+    pipeline = pltpu.emit_pipeline(
+        functools.partial(
+            _rope_body,
+            rotary_dim=rotary_dim,
+            inverse=inverse,
+            out_dtype=out_dtype,
+            quant_dtype=quant_dtype,
+        ),
+        grid=(num_tiles, ),
+        in_specs=[x_spec, cos_sin_spec],
+        out_specs=out_specs,
+    )
+
+    @pl.with_scoped(allocations=(x_alloc, cos_sin_alloc, *out_allocs))
+    def _run(allocations):
+        pipeline(
+            *x_ref_args,
+            (cos_sin_cache_hbm_ref, positions_ref),
+            *out_ref_args,
+            allocations=allocations,
+        )
+
+    _run()
+
+
+def _qnorm_rope_body(
+    x_ref,
+    cos_sin_ref,
+    out_ref,
+    *,
+    rotary_dim,
+    eps,
+    inverse,
+    out_dtype,
+):
+    """Process one ``(tile_n, num_heads, head_dim)`` chunk.
+
+  Per-head RMSNorm (no weight) over the whole ``head_dim``, then the same
+  rotation ``_rope_body`` applies.
+  """
+    x = x_ref[...].astype(jnp.float32)
+    # ``torch.rsqrt(qf.pow(2).mean(-1, keepdim=True) + eps)``.
+    rms = jax.lax.rsqrt(jnp.mean(x * x, axis=-1, keepdims=True) + eps)
+    y = x * rms
+
+    # Only the last lane block holds roped channels; the rest of the row passes
+    # through with nothing but the norm applied.
+    tail = y[..., -LANE:]
+    cos, sin = _cos_sin_lanes(cos_sin_ref[...],
+                              rotary_dim=rotary_dim,
+                              inverse=inverse)
+    assert tail.ndim == 3
+    cos = cos[:, None, :]
+    sin = sin[:, None, :]
+    roped = tail * cos + _rotate_gptj(tail) * sin
+
+    out_ref[...] = jnp.concatenate([y[..., :-LANE], roped],
+                                   axis=-1).astype(out_dtype)
+
+
+def _qnorm_rope_kernel(
+    # scalar prefetch
+    positions_ref,
+    # HBM inputs
+    x_hbm_ref,
+    cos_sin_cache_hbm_ref,
+    # HBM output, aliased onto x_hbm_ref
+    out_hbm_ref,
+    *,
+    num_tiles: int,
+    tile_n: int,
+    x_block_shape: tuple[int, ...],
+    rotary_dim: int,
+    eps: float,
+    inverse: bool,
+    in_dtype: jnp.dtype,
+    cos_sin_dtype: jnp.dtype,
+):
+    x_spec = pl.BlockSpec(
+        block_shape=x_block_shape,
+        memory_space=pltpu.VMEM,
+        index_map=lambda i: (i, 0, 0),
+    )
+    cos_sin_spec = pl.BlockSpec(
+        block_shape=(tile_n, rotary_dim),
+        memory_space=pltpu.VMEM,
+        index_map=lambda i: (i, 0),
+    )
+    cos_sin_alloc = CosSinRef.create(spec=cos_sin_spec,
+                                     dtype=cos_sin_dtype,
+                                     buffer_count=2,
+                                     tile_n=tile_n)
+
+    pipeline = pltpu.emit_pipeline(
+        functools.partial(
+            _qnorm_rope_body,
+            rotary_dim=rotary_dim,
+            eps=eps,
+            inverse=inverse,
+            out_dtype=in_dtype,
+        ),
+        grid=(num_tiles, ),
+        in_specs=[x_spec, cos_sin_spec],
+        out_specs=[x_spec],
+    )
+    allocations = (
+        pltpu.BufferedRef.input(x_spec, in_dtype, buffer_count=2),
+        cos_sin_alloc,
+        pltpu.BufferedRef.output(x_spec, in_dtype, buffer_count=2),
+    )
+
+    @pl.with_scoped(allocations=allocations)
+    def _run(allocations):
+        pipeline(
+            x_hbm_ref,
+            (cos_sin_cache_hbm_ref, positions_ref),
+            out_hbm_ref,
+            allocations=allocations,
+        )
+
+    _run()
+
+
+def _largest_divisor(x: int, cap: int) -> int:
+    """Largest divisor of ``x`` that is <= ``cap``."""
+    for candidate in range(min(x, cap), 0, -1):
+        if x % candidate == 0:
+            return candidate
+    return 1
+
+
+def _rope_call(
+    x: jax.Array,
+    positions: jax.Array,
+    cos_sin_cache: jax.Array,
+    *,
+    inverse: bool,
+    quant_dtype: jnp.dtype | None,
+    name: str,
+):
+    """Builds the ``pallas_call``; see the public wrappers for the contract."""
+    if x.ndim not in (2, 3):
+        raise ValueError(f"x must be rank 2 or 3, got {x.shape}")
+    assert positions.ndim == 1 and positions.shape[0] == x.shape[0]
+    assert cos_sin_cache.ndim == 2
+
+    num_tokens = x.shape[0]
+    head_dim = x.shape[-1]
+    rows_per_token = x.shape[1] if x.ndim == 3 else 1
+    rotary_dim = cos_sin_cache.shape[1]
+
+    assert head_dim % LANE == 0
+    assert rotary_dim % 2 == 0 and rotary_dim <= LANE
+    if quant_dtype is not None and head_dim != LANE:
+        # Only the last lane block is pipelined in, but the scale is a reduction
+        # over the whole row, so the two have to coincide (the indexer's head_dim
+        # is exactly LANE).
+        raise ValueError(
+            f"quantization requires head_dim == {LANE}, got {head_dim}")
+
+    tile_n = _largest_divisor(num_tokens, cap=128)
+    assert num_tokens % tile_n == 0
+
+    x_block_shape = ((tile_n, rows_per_token, LANE) if x.ndim == 3 else
+                     (tile_n, LANE))
+    # One scale per row: x.shape minus the channel axis.
+    scale_block_shape = x_block_shape[:-1]
+    kernel = functools.partial(
+        _kernel,
+        num_tiles=num_tokens // tile_n,
+        tile_n=tile_n,
+        x_block_shape=x_block_shape,
+        scale_block_shape=scale_block_shape,
+        lane_block=head_dim // LANE -
+        1,  # last lane block has the roped channels
+        rotary_dim=rotary_dim,
+        inverse=inverse,
+        in_dtype=x.dtype,
+        out_dtype=x.dtype,
+        cos_sin_dtype=cos_sin_cache.dtype,
+        quant_dtype=quant_dtype,
+    )
+
+    if quant_dtype is None:
+        out_shape = jax.ShapeDtypeStruct(x.shape, x.dtype)
+        out_specs = pl.BlockSpec(memory_space=pltpu.HBM)
+        input_output_aliases = {1: 0}  # x (after the scalar prefetch) -> out
+    else:
+        out_shape = (
+            jax.ShapeDtypeStruct(x.shape, quant_dtype),
+            jax.ShapeDtypeStruct(x.shape[:-1], jnp.float32),
+        )
+        out_specs = (
+            pl.BlockSpec(memory_space=pltpu.HBM),
+            pl.BlockSpec(memory_space=pltpu.HBM),
+        )
+        input_output_aliases = {}
+
+    grid_spec = pltpu.PrefetchScalarGridSpec(
+        num_scalar_prefetch=1,
+        in_specs=(
+            pl.BlockSpec(memory_space=pltpu.HBM),  # x
+            pl.BlockSpec(memory_space=pltpu.HBM),  # cos_sin_cache
+        ),
+        out_specs=out_specs,
+    )
+
+    return pl.pallas_call(
+        kernel,
+        out_shape=out_shape,
+        grid_spec=grid_spec,
+        input_output_aliases=input_output_aliases,
+        compiler_params=pltpu.CompilerParams(
+            vmem_limit_bytes=DEFAULT_VMEM_LIMIT_BYTES,
+            disable_bounds_checks=True,
+        ),
+        name=name,
+    )(positions, x, cos_sin_cache)
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=("inverse", "name"),
+    donate_argnames=("x", ),
+)
+def rope(
+    x: jax.
+    Array,  # [num_tokens, head_dim] or [num_tokens, num_heads, head_dim]
+    positions: jax.Array,  # [num_tokens] int
+    cos_sin_cache: jax.Array,  # [max_position, rotary_dim] float32
+    *,
+    inverse: bool = False,
+    name: str = "rope",
+) -> jax.Array:
+    """Applies DeepSeek-V4 RoPE to the trailing ``rotary_dim`` channels of ``x``.
+
+  Args:
+    x: ``[num_tokens, head_dim]`` or ``[num_tokens, num_heads, head_dim]``.
+    positions: ``[num_tokens]``, the RoPE position of each token.
+    cos_sin_cache: ``[max_position, rotary_dim]``, ``[cos | sin]`` packed side
+      by side (``rotary_dim // 2`` columns each), as built by
+      ``DeepseekV4ScalingRotaryEmbedding``.
+    inverse: negate ``sin``, i.e. apply the transposed rotation.
+    name: kernel name.
+
+  Returns:
+    ``x`` with the trailing ``rotary_dim`` channels rotated, same shape and
+    dtype. ``x`` is donated -- the kernel updates the buffer in place.
+  """
+    return _rope_call(
+        x,
+        positions,
+        cos_sin_cache,
+        inverse=inverse,
+        quant_dtype=None,
+        name=name,
+    )
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=("eps", "inverse", "name"),
+    donate_argnames=("x", ),
+)
+def qnorm_rope(
+    x: jax.
+    Array,  # [num_tokens, num_heads, head_dim] or [num_tokens, head_dim]
+    positions: jax.Array,  # [num_tokens] int
+    cos_sin_cache: jax.Array,  # [max_position, rotary_dim] float32
+    *,
+    eps: float = 1e-6,
+    inverse: bool = False,
+    name: str = "qnorm_rope",
+) -> jax.Array:
+    """Per-head RMSNorm (no weight) fused with DeepSeek-V4 RoPE."""
+    assert x.ndim == 3
+    assert positions.ndim == 1 and positions.shape[0] == x.shape[0]
+    assert cos_sin_cache.ndim == 2
+
+    num_tokens = x.shape[0]
+    head_dim = x.shape[-1]
+    rows_per_token = x.shape[1]
+    rotary_dim = cos_sin_cache.shape[1]
+    assert head_dim % LANE == 0
+    assert rotary_dim % 2 == 0 and rotary_dim <= LANE
+    tile_n = _largest_divisor(num_tokens, cap=64)
+
+    x_block_shape = (tile_n, rows_per_token, head_dim)
+    kernel = functools.partial(
+        _qnorm_rope_kernel,
+        num_tiles=num_tokens // tile_n,
+        tile_n=tile_n,
+        x_block_shape=x_block_shape,
+        rotary_dim=rotary_dim,
+        eps=eps,
+        inverse=inverse,
+        in_dtype=x.dtype,
+        cos_sin_dtype=cos_sin_cache.dtype,
+    )
+
+    grid_spec = pltpu.PrefetchScalarGridSpec(
+        num_scalar_prefetch=1,
+        in_specs=(
+            pl.BlockSpec(memory_space=pltpu.HBM),  # x
+            pl.BlockSpec(memory_space=pltpu.HBM),  # cos_sin_cache
+        ),
+        out_specs=pl.BlockSpec(memory_space=pltpu.HBM),
+    )
+
+    return pl.pallas_call(
+        kernel,
+        out_shape=jax.ShapeDtypeStruct(x.shape, x.dtype),
+        grid_spec=grid_spec,
+        input_output_aliases={1: 0},  # x (after the scalar prefetch) -> out
+        compiler_params=pltpu.CompilerParams(
+            vmem_limit_bytes=DEFAULT_VMEM_LIMIT_BYTES,
+            disable_bounds_checks=True,
+        ),
+        name=name,
+    )(positions, x, cos_sin_cache)
+
+
+@functools.partial(jax.jit, static_argnames=("inverse", "quant_dtype", "name"))
+def rope_quant(
+    x: jax.
+    Array,  # [num_tokens, head_dim] or [num_tokens, num_heads, head_dim]
+    positions: jax.Array,  # [num_tokens] int
+    cos_sin_cache: jax.Array,  # [max_position, rotary_dim] float32
+    *,
+    inverse: bool = False,
+    quant_dtype: jnp.dtype = jnp.float8_e4m3fn,
+    name: str = "rope_quant",
+) -> tuple[jax.Array, jax.Array]:
+    """RoPE fused with per-row dynamic quantization of the rotated values.
+
+  Same rotation as ``rope``, but the result is quantized to ``quant_dtype``
+  inside the kernel.
+  """
+    return _rope_call(
+        x,
+        positions,
+        cos_sin_cache,
+        inverse=inverse,
+        quant_dtype=quant_dtype,
+        name=name,
+    )

--- a/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_attention.py
+++ b/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_attention.py
@@ -45,6 +45,7 @@ from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache
 from vllm.v1.kv_cache_interface import (KVCacheSpec, MLAAttentionSpec,
                                         SlidingWindowMLASpec)
 
+from tpu_inference.kernels.experimental.deepseek_v4 import rope as rope_kernel
 from tpu_inference.kernels.experimental.deepseek_v4.core_attention.mla import \
     mla_ragged_paged_attention
 from tpu_inference.kernels.experimental.deepseek_v4.core_attention.mla_swa import \
@@ -79,6 +80,21 @@ def _largest_divisor(x: int, cap: int) -> int:
         if x % candidate == 0:
             return candidate
     return 1
+
+
+def sharded_rope(rope_fn, mesh, x, positions, cos_sin_cache, **kwargs):
+    data_spec = P(ShardingAxisName.ATTN_DATA)
+
+    def _rope(x, positions, cos_sin_cache):
+        return rope_fn(x, positions, cos_sin_cache, **kwargs)
+
+    return jax.shard_map(
+        _rope,
+        mesh=mesh,
+        in_specs=(data_spec, data_spec, P()),
+        out_specs=data_spec,
+        check_vma=False,
+    )(x, positions, cos_sin_cache)
 
 
 class VllmDeepseekV4SWACache(DeepseekV4SWACache):
@@ -212,9 +228,17 @@ class VllmDeepseekV4MLAAttention(DeepseekV4Attention):
         """Inverse-RoPE + wo_a (per-group bmm) + wo_b output projection.
         """
         t = o.shape[0]
-        o_f = o.to(torch.float32).view(t, self.n_local_heads, self.head_dim)
-        o_ref, _ = self.rotary_emb(positions, o_f, inverse=True)
-        o_ref = o_ref.to(torch.bfloat16)
+        o_f = o.view(t, self.n_local_heads, self.head_dim)
+        mesh = get_vllm_model_wrapper_context().mesh
+        o_ref = torch_view(
+            sharded_rope(
+                rope_kernel.rope,
+                mesh,
+                jax_view(o_f),
+                jax_view(positions),
+                jax_view(self.rotary_emb.cos_sin_cache),
+                inverse=True,
+            ))
 
         # --- wo_a: per-group batched matmul [t, g, d] x [d, g, r] -> [t, g, r].
         o_ref = o_ref.view(t, self.n_local_groups, -1)  # [t, g, d]
@@ -259,24 +283,31 @@ class VllmDeepseekV4MLAAttention(DeepseekV4Attention):
     ) -> torch.Tensor:
         """Per-head RMSNorm (no weight) + GPT-J interleaved RoPE on q.
         """
-        orig_dtype = q.dtype
-        qf = q.to(torch.float32)
-
-        # Per-head RMSNorm (no weight) over the full head_dim.
-        rms = torch.rsqrt(qf.pow(2).mean(dim=-1, keepdim=True) + self.eps)
-        qf = qf * rms
-
-        # GPT-J interleaved RoPE on the trailing rope slice (NoPE passed through).
-        q_out, _ = self.rotary_emb(positions, qf)
-        return q_out.to(orig_dtype)
+        mesh = get_vllm_model_wrapper_context().mesh
+        return torch_view(
+            sharded_rope(
+                rope_kernel.qnorm_rope,
+                mesh,
+                jax_view(q),
+                jax_view(positions),
+                jax_view(self.rotary_emb.cos_sin_cache),
+                eps=self.eps,
+            ))
 
     def kv_rope(
             self,
             kv: torch.Tensor,  # [num_tokens, head_dim]
             positions: torch.Tensor,  # [num_tokens], int64
     ) -> torch.Tensor:
-        kv, _ = self.rotary_emb(positions, kv.unsqueeze(1))
-        return kv.squeeze(1)
+        mesh = get_vllm_model_wrapper_context().mesh
+        return torch_view(
+            sharded_rope(
+                rope_kernel.rope,
+                mesh,
+                jax_view(kv),
+                jax_view(positions),
+                jax_view(self.rotary_emb.cos_sin_cache),
+            ))
 
     def attention_impl(
             self,

--- a/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_indexer.py
+++ b/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_indexer.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """TPU-compatible DeepSeek-V4 Lightning Indexer."""
 
+import functools
 from typing import Optional, Tuple
 
 import jax
@@ -33,7 +34,7 @@ from vllm.v1.kv_cache_interface import MLAAttentionSpec
 # =====================================================================
 from tpu_inference.kernels.experimental.deepseek_v4.indexer.streamindex_topk import \
     streamindex_topk
-from tpu_inference.layers.common import quantization
+from tpu_inference.kernels.experimental.deepseek_v4.rope import rope_quant
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.vllm.custom_ops.experimental.deepseek_v4.deepseek_v4_compressor import \
     VllmDeepseekCompressor
@@ -57,33 +58,24 @@ def fused_indexer_q_rope_quant(
     q: torch.Tensor,
     positions: torch.Tensor,
     rotary_emb: torch.nn.Module,
+    mesh,
 ) -> Tuple[torch.Tensor, torch.Tensor]:
     """Applies RoPE and dynamically quantizes the queries
-
-  Args:
-      q: Un-rotated query tensor of shape [num_tokens, num_heads, head_dim]
-      positions: Token positions of shape [num_tokens]
-      rotary_emb: The vLLM RoPE CustomOp module (Intercepted by TPU rope.py)
-
-  Returns:
-      q_quant: Int8 quantized, RoPE-applied queries
-      q_scales: Quantization scales
   """
+    data_spec = P(ShardingAxisName.ATTN_DATA)
 
-    # Apply the custom rotary embedding op directly in-place on the query tensor.
-    q, _ = rotary_emb(positions, q)
-
-    q = jax_view(q)
-    q_quant_jax, q_scales_jax = quantization.quantize_tensor(jnp.float8_e4m3fn,
-                                                             q,
-                                                             axis=-1)
-    q_quant = torch_view(q_quant_jax)
-    q_scales = torch_view(q_scales_jax)
+    q_quant_jax, q_scales_jax = jax.shard_map(
+        functools.partial(rope_quant, quant_dtype=jnp.float8_e4m3fn),
+        mesh=mesh,
+        in_specs=(data_spec, data_spec, P()),
+        out_specs=(data_spec, data_spec),
+        check_vma=False,
+    )(jax_view(q), jax_view(positions), jax_view(rotary_emb.cos_sin_cache))
 
     # Note: vLLM's implementation rounds the scale factors up to the
-    # next power of 2, but the standard division scale returned by quantize_tensor
-    # is sufficient here.
-    return q_quant, q_scales.squeeze(-1)
+    # next power of 2, but the standard division scale returned by the kernel
+    # (abs_max / dtype_max, one per row) is sufficient here.
+    return torch_view(q_quant_jax), torch_view(q_scales_jax)
 
 
 class VllmDeepseekV4IndexerCache(DeepseekV4IndexerCache):
@@ -140,11 +132,14 @@ class VllmDeepseekV4Indexer(DeepseekV4Indexer):
         slot_mapping: Optional[torch.Tensor] = None,
     ):
 
+        wrapper_ctx = get_vllm_model_wrapper_context()
+        mesh = wrapper_ctx.mesh
+
         q, _ = self.wq_b(query)
         q = q.view(-1, self.n_head, self.head_dim)
 
         q_quant, q_scales = fused_indexer_q_rope_quant(q, positions,
-                                                       rotary_emb)
+                                                       rotary_emb, mesh)
 
         # Fold the query quantization scales into the weights.
         weights = (indexer_weights.to(q.dtype) * self.softmax_scale *
@@ -152,11 +147,9 @@ class VllmDeepseekV4Indexer(DeepseekV4Indexer):
 
         self.compressor(hidden_states, positions, rotary_emb)
 
-        wrapper_ctx = get_vllm_model_wrapper_context()
         kv_cache_index = wrapper_ctx.layer_name_to_kvcache_index[
             self.k_cache.prefix]
         kv_cache = wrapper_ctx.kv_caches[kv_cache_index]
-        mesh = wrapper_ctx.mesh
         attn_metadata_dict = get_forward_context().attn_metadata
         attn_metadata = attn_metadata_dict[self.k_cache.prefix]
 


### PR DESCRIPTION
[DSv4] Add 3 rope related kernels: qnorm_rope(), rope(), rope_quant() deepseek v4.

Integrated E2E
Quality validated:
MMLU pro: https://paste.googleplex.com/5012199352434688
MMLU: https://paste.googleplex.com/4786340578328576 

Rope-relate ops' performance improves by a lot.

xprof after:
https://screenshot-v2.corp.google.com/0cc8uqcoienog
xprof before:
https://screenshot-v2.corp.google.com/65s8obesse97g
