### PR TITLE
[Multimodal] Update tuned block sizes for flash attention kernel

### DIFF
--- a/tools/kernel/tuner/v1/flash_attention_kernel_tuner.py
+++ b/tools/kernel/tuner/v1/flash_attention_kernel_tuner.py
@@ -45,7 +45,7 @@ class FlashAttentionKernelTuner(KernelTunerBase):
                          run_config=self.run_config)
 
     def generate_cases(self) -> list[TuningCase]:
-        tuning_key = TuningKey(batch_size=16,
+        tuning_key = TuningKey(batch_size=8,
                                num_heads=16,
                                q_seq_len=2560,
                                kv_seq_len=2560,
@@ -53,7 +53,7 @@ class FlashAttentionKernelTuner(KernelTunerBase):
 
         block_q_values = [32, 64, 128, 256, 512, 640]
         block_k_values = [128, 256, 512, 640, 1280, 2560]
-        block_b_values = [1, 2, 4, 8, 16]
+        block_b_values = [1, 2, 4, 8]
 
         cases = []
         for bq, bk, bb in itertools.product(block_q_values, block_k_values,

--- a/tools/kernel/tuner/v1/flash_attention_kernel_tuner.py
+++ b/tools/kernel/tuner/v1/flash_attention_kernel_tuner.py
@@ -45,7 +45,7 @@ class FlashAttentionKernelTuner(KernelTunerBase):
                          run_config=self.run_config)
 
     def generate_cases(self) -> list[TuningCase]:
-        tuning_key = TuningKey(batch_size=8,
+        tuning_key = TuningKey(batch_size=16,
                                num_heads=16,
                                q_seq_len=2560,
                                kv_seq_len=2560,
@@ -53,7 +53,7 @@ class FlashAttentionKernelTuner(KernelTunerBase):
 
         block_q_values = [32, 64, 128, 256, 512, 640]
         block_k_values = [128, 256, 512, 640, 1280, 2560]
-        block_b_values = [1, 2, 4, 8]
+        block_b_values = [1, 2, 4, 8, 16]
 
         cases = []
         for bq, bk, bb in itertools.product(block_q_values, block_k_values,

--- a/tpu_inference/kernels/flash_attention/tuned_params.py
+++ b/tpu_inference/kernels/flash_attention/tuned_params.py
@@ -58,6 +58,19 @@ tuned_params_mapping: dict[TuningKey, TunableParams] = {
         block_k=512,
         block_b=1,
     ),
+    TuningKey(
+        batch_size=16,
+        num_heads=16,
+        q_seq_len=2560,
+        kv_seq_len=2560,
+        head_dim=72,
+    ):
+    TunableParams(
+        block_q=640,
+        block_k_major=2560,
+        block_k=512,
+        block_b=1,
+    ),
 }
 
 


### PR DESCRIPTION
# Description

Add tuned block sizes for flash attention kernel Gemma4 workloads. 
Ran on kernel tuning buildkite with env var:
```
KERNEL_TUNING_KERNEL_TUNER_NAME=flash_attention_kernel_tuner
KERNEL_TUNING_CASE_SET_ID=fa_buildkite_002
KERNEL_TUNING_RUN_ID=001
KERNEL_TUNING_CASE_SET_DESC=Flash attention 16x16x2560x72 sweep
KERNEL_TUNING_TPU_VERSION=tpu7x
KERNEL_TUNING_TPU_CORES=2
```
Detailed instructions are here: https://github.com/vllm-project/tpu-inference/blob/804b52e5f18973b94723445f3998b81f1b0e39eb/tools/kernel/tuner/v1/README.md#3-running-on-tpu-vms-via-buildkite

# Tests

Tuned with flash attention auto tuner.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
