### PR TITLE
Fix vLLM upstream compatibility breaks 

### DIFF
--- a/tests/layers/vllm/test_awq.py
+++ b/tests/layers/vllm/test_awq.py
@@ -28,7 +28,6 @@ from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
                                              init_distributed_environment)
 from vllm.engine.arg_utils import EngineArgs
 from vllm.forward_context import set_forward_context
-from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                LinearBase,
                                                MergedColumnParallelLinear,
@@ -41,6 +40,7 @@ from vllm.scalar_type import scalar_types
 
 from tests.layers.common import utils as test_utils
 from tpu_inference.layers.common.moe import MoEBackend
+from tpu_inference.layers.vllm.interface.moe import FusedMoEFactory
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.awq import (VllmAWQConfig,
                                                         VllmAWQLinearMethod,
@@ -492,7 +492,7 @@ def test_fused_moe(num_devices, num_tokens, intermediate_size, hidden_size,
 
     quant_config = get_tpu_quantization_config(vllm_config, mesh)
     with set_current_vllm_config(vllm_config):
-        vllm_fused_moe = FusedMoE(
+        vllm_fused_moe = FusedMoEFactory(
             num_experts=num_experts,
             top_k=topk,
             hidden_size=hidden_size,

--- a/tests/layers/vllm/test_compressed_tensors_moe.py
+++ b/tests/layers/vllm/test_compressed_tensors_moe.py
@@ -24,10 +24,11 @@ from vllm.config import set_current_vllm_config
 from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
                                              init_distributed_environment)
 from vllm.engine.arg_utils import EngineArgs
-from vllm.model_executor.layers.fused_moe import FusedMoE, RoutedExperts
+from vllm.model_executor.layers.fused_moe import RoutedExperts
 
 # yapf: disable
 from tests.layers.common import utils as test_utils
+from tpu_inference.layers.vllm.interface.moe import FusedMoEFactory
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.compressed_tensors.compressed_tensors_moe import \
     VllmCompressedTensorsW8A8Fp8MoEMethod
@@ -137,10 +138,10 @@ def test_fused_moe_method(mesh, num_tokens, intermediate_size, hidden_size,
     quant_config = get_tpu_quantization_config(vllm_config, mesh)
 
     with set_current_vllm_config(vllm_config):
-        layer = FusedMoE(num_experts=num_experts,
-                         top_k=topk,
-                         hidden_size=hidden_size,
-                         intermediate_size=intermediate_size)
+        layer = FusedMoEFactory(num_experts=num_experts,
+                                top_k=topk,
+                                hidden_size=hidden_size,
+                                intermediate_size=intermediate_size)
         layer.moe_config.moe_parallel_config.use_ep = use_ep
     weight_quant = quant_config.target_scheme_map['Linear']['weights']
     input_quant = quant_config.target_scheme_map['Linear']['input_activations']

--- a/tests/layers/vllm/test_compressed_tensors_moe_w4a8.py
+++ b/tests/layers/vllm/test_compressed_tensors_moe_w4a8.py
@@ -25,13 +25,14 @@ from vllm.config import set_current_vllm_config
 from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
                                              init_distributed_environment)
 from vllm.engine.arg_utils import EngineArgs
-from vllm.model_executor.layers.fused_moe import FusedMoE, RoutedExperts
+from vllm.model_executor.layers.fused_moe import RoutedExperts
 from vllm.model_executor.layers.quantization.utils.quant_utils import (
     pack_quantized_values_into_int32, quantize_weights)
 from vllm.scalar_type import scalar_types
 
 # yapf: disable
 from tests.layers.common import utils as test_utils
+from tpu_inference.layers.vllm.interface.moe import FusedMoEFactory
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.compressed_tensors.compressed_tensors_moe.compressed_tensors_moe_w4a8 import \
     VllmCompressedTensorsW4A8MoEMethod
@@ -171,10 +172,10 @@ def test_fused_moe_method_w4(mesh, num_tokens, intermediate_size, hidden_size,
     input_quant = quant_config.target_scheme_map['Linear']['input_activations']
 
     with set_current_vllm_config(vllm_config):
-        layer = FusedMoE(num_experts=num_experts,
-                         top_k=topk,
-                         hidden_size=hidden_size,
-                         intermediate_size=intermediate_size)
+        layer = FusedMoEFactory(num_experts=num_experts,
+                                top_k=topk,
+                                hidden_size=hidden_size,
+                                intermediate_size=intermediate_size)
         layer.moe_config.moe_parallel_config.use_ep = use_ep
         moe = quant_config.get_moe_config(layer.routed_experts)
         method = VllmCompressedTensorsW4A8MoEMethod(weight_quant, input_quant,

--- a/tests/layers/vllm/test_fp8.py
+++ b/tests/layers/vllm/test_fp8.py
@@ -31,7 +31,6 @@ from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
 from vllm.engine.arg_utils import EngineArgs
 from vllm.forward_context import set_forward_context
 from vllm.model_executor.layers import linear as vllm_linear
-from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                LinearBase,
                                                MergedColumnParallelLinear,
@@ -42,6 +41,7 @@ from tests.layers.common import utils as test_utils
 from tpu_inference import envs
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
+from tpu_inference.layers.vllm.interface.moe import FusedMoEFactory
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.fp8 import (VllmFp8Config,
                                                         VllmFp8LinearMethod,
@@ -451,7 +451,7 @@ def test_fused_moe(use_ep, num_devices, num_tokens, intermediate_size,
 
     quant_config = get_tpu_quantization_config(vllm_config, mesh)
     with set_current_vllm_config(vllm_config):
-        vllm_fused_moe = FusedMoE(
+        vllm_fused_moe = FusedMoEFactory(
             num_experts=num_experts,
             top_k=topk,
             hidden_size=hidden_size,

--- a/tests/layers/vllm/test_mla_attention.py
+++ b/tests/layers/vllm/test_mla_attention.py
@@ -272,6 +272,7 @@ class TestVllmTPUMultiHeadLatentAttentionWrapper:
         mla_modules.indexer = None
         mla_modules.indexer_rotary_emb = "indexer_rotary_emb"
         mla_modules.is_sparse = False
+        mla_modules.g_proj = "g_proj"
 
         wrapper = VllmMultiHeadLatentAttentionWrapper(
             hidden_size=128,
@@ -286,6 +287,7 @@ class TestVllmTPUMultiHeadLatentAttentionWrapper:
             cache_config=None,
             quant_config=None,
             prefix="test_wrapper",
+            non_causal_multi_token_decode=True,
         )
 
         assert wrapper.hidden_size == 128
@@ -301,6 +303,7 @@ class TestVllmTPUMultiHeadLatentAttentionWrapper:
         assert wrapper.o_proj == "o_proj"
         assert wrapper.indexer is None
         assert wrapper.is_sparse is False
+        assert wrapper.g_proj == "g_proj"
 
         mock_tpu_mla_attn.assert_called_once_with(
             num_heads=8,
@@ -316,5 +319,38 @@ class TestVllmTPUMultiHeadLatentAttentionWrapper:
             kv_b_proj=mla_modules.kv_b_proj,
             use_sparse=False,
             indexer=None,
+            non_causal_multi_token_decode=True,
         )
         assert wrapper.mla_attn == mock_tpu_mla_attn.return_value
+
+    def test_forward_applies_gate_and_skips_indexer(self):
+        wrapper = VllmMultiHeadLatentAttentionWrapper.__new__(
+            VllmMultiHeadLatentAttentionWrapper)
+        torch.nn.Module.__init__(wrapper)
+
+        wrapper.q_lora_rank = None
+        wrapper.kv_lora_rank = 2
+        wrapper.qk_nope_head_dim = 2
+        wrapper.qk_rope_head_dim = 1
+        wrapper.qk_head_dim = 3
+        wrapper.v_head_dim = 2
+        wrapper.num_heads = 1
+        wrapper.kv_a_proj_with_mqa = MagicMock(
+            return_value=(torch.zeros(2, 3), ))
+        wrapper.q_proj = MagicMock(return_value=(torch.zeros(2, 3), ))
+        wrapper.kv_a_layernorm = MagicMock(side_effect=lambda value: value)
+        wrapper.rotary_emb = None
+        wrapper.indexer = MagicMock()
+        wrapper.indexer_rope_emb = None
+        wrapper.is_sparse = True
+        wrapper.skip_topk = True
+        wrapper.mla_attn = MagicMock(return_value=torch.full((2, 2), 4.0))
+        wrapper.g_proj = MagicMock(return_value=(torch.zeros(2, 2), ))
+        wrapper.o_proj = MagicMock(side_effect=lambda value: (value, ))
+
+        hidden_states = torch.ones(2, 3)
+        output = wrapper.forward(torch.arange(2), hidden_states)
+
+        wrapper.indexer.assert_not_called()
+        wrapper.g_proj.assert_called_once_with(hidden_states)
+        torch.testing.assert_close(output, torch.full((2, 2), 2.0))

--- a/tests/layers/vllm/test_mxfp4.py
+++ b/tests/layers/vllm/test_mxfp4.py
@@ -29,10 +29,10 @@ from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
                                              init_distributed_environment)
 from vllm.engine.arg_utils import EngineArgs
 from vllm.forward_context import set_forward_context
-from vllm.model_executor.layers.fused_moe import FusedMoE
 
 from tests.layers.common import utils as test_utils
 from tpu_inference.layers.common.moe import MoEBackend
+from tpu_inference.layers.vllm.interface.moe import FusedMoEFactory
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.mxfp4 import (VllmMxfp4Config,
                                                           VllmMxfp4MoEMethod)
@@ -177,7 +177,7 @@ def test_mxfp4_fused_moe(num_devices, num_tokens, intermediate_size,
 
     quant_config = get_tpu_quantization_config(vllm_config, mesh)
     with set_current_vllm_config(vllm_config):
-        vllm_fused_moe = FusedMoE(
+        vllm_fused_moe = FusedMoEFactory(
             num_experts=num_experts,
             top_k=topk,
             hidden_size=hidden_size,
@@ -275,7 +275,7 @@ def test_mxfp4_fused_moe_use_kernel(num_devices, num_tokens, intermediate_size,
 
     quant_config = get_tpu_quantization_config(vllm_config, mesh)
     with set_current_vllm_config(vllm_config):
-        vllm_fused_moe = FusedMoE(
+        vllm_fused_moe = FusedMoEFactory(
             num_experts=num_experts,
             top_k=topk,
             hidden_size=hidden_size,

--- a/tests/layers/vllm/test_nvfp4.py
+++ b/tests/layers/vllm/test_nvfp4.py
@@ -28,7 +28,6 @@ from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
                                              init_distributed_environment)
 from vllm.engine.arg_utils import EngineArgs
 from vllm.forward_context import set_forward_context
-from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.fused_moe.activation import MoEActivation
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                RowParallelLinear)
@@ -37,6 +36,7 @@ from tests.layers.common import utils as test_utils
 from tests.layers.vllm.nvfp4_utils import (NVFP4_GROUP_SIZE, quantize_to_nvfp4,
                                            ref_dequant_nvfp4)
 from tpu_inference.layers.common.quant_methods import NVFP4
+from tpu_inference.layers.vllm.interface.moe import FusedMoEFactory
 from tpu_inference.layers.vllm.quantization.nvfp4 import (VllmNvfp4Config,
                                                           VllmNvfp4MoEMethod)
 
@@ -285,7 +285,7 @@ def test_fused_moe(num_devices, num_tokens, intermediate_size, hidden_size,
     config.vllm_config = vllm_config
 
     with set_current_vllm_config(vllm_config):
-        moe_layer = FusedMoE(
+        moe_layer = FusedMoEFactory(
             num_experts=num_experts,
             top_k=topk,
             hidden_size=hidden_size,

--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -29,7 +29,6 @@ from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
                                              init_distributed_environment)
 from vllm.engine.arg_utils import EngineArgs
 from vllm.forward_context import set_forward_context
-from vllm.model_executor.layers.fused_moe import FusedMoE
 from vllm.model_executor.layers.linear import (ColumnParallelLinear,
                                                LinearBase,
                                                MergedColumnParallelLinear,
@@ -41,6 +40,7 @@ from tests.layers.common import utils as test_utils
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
 from tpu_inference.layers.vllm.custom_ops.fused_moe import _all_reduce_over_tp
+from tpu_inference.layers.vllm.interface.moe import FusedMoEFactory
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.unquantized import (
     VllmUnquantizedConfig, VllmUnquantizedFusedMoEMethod,
@@ -578,7 +578,7 @@ def test_fused_moe(use_ep, num_devices, num_tokens, intermediate_size,
 
     quant_config = get_tpu_quantization_config(vllm_config, mesh)
     with set_current_vllm_config(vllm_config):
-        vllm_fused_moe = FusedMoE(
+        vllm_fused_moe = FusedMoEFactory(
             num_experts=num_experts,
             top_k=topk,
             hidden_size=hidden_size,
@@ -701,7 +701,7 @@ def test_fused_moe_use_kernel(num_devices, num_tokens, intermediate_size,
 
     quant_config = get_tpu_quantization_config(vllm_config, mesh)
     with set_current_vllm_config(vllm_config):
-        vllm_fused_moe = FusedMoE(
+        vllm_fused_moe = FusedMoEFactory(
             num_experts=num_experts,
             top_k=topk,
             hidden_size=hidden_size,

--- a/tpu_inference/layers/vllm/custom_ops/mla_attention.py
+++ b/tpu_inference/layers/vllm/custom_ops/mla_attention.py
@@ -222,6 +222,7 @@ class VllmMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
         quant_config: QuantizationConfig | None = None,
         prefix: str = "",
         skip_topk: bool = False,
+        non_causal_multi_token_decode: bool = False,
         allow_short_prefill_indexer_scoring_skip: bool = False,
     ) -> None:
         torch.nn.Module.__init__(self)
@@ -246,6 +247,7 @@ class VllmMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
         self.indexer = mla_modules.indexer
         self.indexer_rope_emb = mla_modules.indexer_rotary_emb
         self.is_sparse = mla_modules.is_sparse
+        self.g_proj = getattr(mla_modules, "g_proj", None)
         self.skip_topk = skip_topk
 
         if self.indexer is not None and not self.skip_topk:
@@ -267,6 +269,7 @@ class VllmMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
             kv_b_proj=self.kv_b_proj,
             use_sparse=self.is_sparse,
             indexer=self.indexer,
+            non_causal_multi_token_decode=non_causal_multi_token_decode,
         )
 
         self.prefix = prefix
@@ -317,9 +320,8 @@ class VllmMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
         if self.rotary_emb is not None:
             q_pe, k_pe = self.rotary_emb(positions, q_pe, k_pe)
 
-        if self.indexer and self.is_sparse:
-            _topk_indices = self.indexer(hidden_states, q_c, positions,
-                                         self.indexer_rope_emb)
+        if self.indexer and self.is_sparse and not self.skip_topk:
+            self.indexer(hidden_states, q_c, positions, self.indexer_rope_emb)
 
         if llama_4_scaling is not None:
             q_nope *= llama_4_scaling
@@ -332,5 +334,8 @@ class VllmMultiHeadLatentAttentionWrapper(MultiHeadLatentAttentionWrapper):
             output_shape=(hidden_states.shape[0],
                           self.num_heads * self.v_head_dim),
         )
+
+        if self.g_proj is not None:
+            attn_out = attn_out * self.g_proj(hidden_states)[0].sigmoid()
 
         return self.o_proj(attn_out)[0]

--- a/tpu_inference/layers/vllm/interface/moe.py
+++ b/tpu_inference/layers/vllm/interface/moe.py
@@ -14,11 +14,18 @@
 import torch
 from torchax.interop import jax_view, torch_view
 from vllm.forward_context import is_forward_context_available
+from vllm.model_executor.layers import fused_moe as vllm_fused_moe
 from vllm.model_executor.layers.fused_moe import (FusedMoEMethodBase,
                                                   RoutedExperts)
 from vllm.model_executor.layers.fused_moe.config import FusedMoEConfig
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import \
     get_layer_from_name
+
+# TODO: Remove this fallback after the vLLM LKG exports FusedMoEFactory.
+if hasattr(vllm_fused_moe, "FusedMoEFactory"):
+    FusedMoEFactory = vllm_fused_moe.FusedMoEFactory
+else:
+    FusedMoEFactory = vllm_fused_moe.FusedMoE
 
 from tpu_inference import envs
 from tpu_inference.layers.common.moe import MoEBackend, moe_apply

--- a/tpu_inference/models/vllm/experimental/deepseek_v4.py
+++ b/tpu_inference/models/vllm/experimental/deepseek_v4.py
@@ -13,7 +13,7 @@ from vllm.distributed import (get_pp_group, get_tensor_model_parallel_rank,
 from vllm.model_executor.layers.activation import (SiluAndMul,
                                                    SiluAndMulWithClamp)
 from vllm.model_executor.layers.fused_moe import (
-    FusedMoE, GateLinear, fused_moe_make_expert_params_mapping)
+    GateLinear, fused_moe_make_expert_params_mapping)
 from vllm.model_executor.layers.layernorm import RMSNorm
 from vllm.model_executor.layers.linear import (MergedColumnParallelLinear,
                                                RowParallelLinear)
@@ -35,6 +35,7 @@ from vllm.sequence import IntermediateTensors
 
 from tpu_inference.layers.vllm.custom_ops.experimental.deepseek_v4.deepseek_v4_attention import \
     VllmDeepseekV4MLAAttention
+from tpu_inference.layers.vllm.interface.moe import FusedMoEFactory
 
 
 class DeepseekV4MLP(nn.Module):
@@ -167,7 +168,7 @@ class DeepseekV4MoE(nn.Module):
         self.experts_start_idx = self.tp_rank * self.n_local_experts
         self.experts_end_idx = self.experts_start_idx + self.n_local_experts
 
-        self.experts = FusedMoE(
+        self.experts = FusedMoEFactory(
             shared_experts=self.shared_experts,
             gate=self.gate,
             num_experts=config.n_routed_experts,
@@ -201,7 +202,7 @@ class DeepseekV4MoE(nn.Module):
 
         org_shape = hidden_states.shape
         if self.experts.is_internal_router:
-            # In this case, the gate/router runs inside the FusedMoE class
+            # In this case, the gate/router runs inside the MoE runner.
             final_hidden_states = self.experts(
                 hidden_states=hidden_states,
                 router_logits=hidden_states,


### PR DESCRIPTION
# Description
Fix vLLM upstream compatibility breaks blocking nightly LKG promotion:
  - Support the new MLA decode argument, gating projection, and skip_topk behavior.
  - Add compatibility for the FusedMoE → FusedMoEFactory rename.
  - Add regression coverage for the MLA changes

# Tests

 - MLA unit tests: 7 passed on all revisions.
 - Compressed-tensors MoE tests: 8 passed on all revisions.
 - Collection of seven affected MoE test modules: 510 tests collected successfully.
 - MXFP4 tests on the failing revision: 10 passed, 4 skipped.
 - DeepSeek-V4 runtime import check.
 - Full pre-commit hooks, syntax compilation, and diff checks.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
