### PR TITLE
[Fix] Restrict generation-config downloads for bm-infra

### DIFF
--- a/.buildkite/benchmark/scripts/parser_case.py
+++ b/.buildkite/benchmark/scripts/parser_case.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # yapf: disable
 import json
+import os
 import shlex
 import sys
 
@@ -243,6 +244,12 @@ def main():
         srv_cmd_type = srv_opts.get("command_type", "")
         srv_resolved_args = resolve_device_args(srv_opts.get("args", {}), current_machine)
         cli_resolved_args = resolve_device_args(cli_opts.get("args", {}), current_machine)
+
+        gcs_gen_config = srv_resolved_args.get("generation-config")
+        if gcs_gen_config and isinstance(gcs_gen_config, str) and gcs_gen_config.startswith("gs://"):
+            print(f"export GCS_GEN_CONFIG={shlex.quote(gcs_gen_config)}")
+            artifact_folder = os.environ.get("ARTIFACT_FOLDER", "/workspace/tpu_inference/artifacts")
+            srv_resolved_args["generation-config"] = f"{artifact_folder}/generation_configs"
 
         srv_cmd = build_command(srv_cmd_type, srv_resolved_args)
         cli_cmd = build_command(cli_cmd_type, cli_resolved_args)

--- a/.buildkite/benchmark/scripts/parser_case.py
+++ b/.buildkite/benchmark/scripts/parser_case.py
@@ -245,11 +245,13 @@ def main():
         srv_resolved_args = resolve_device_args(srv_opts.get("args", {}), current_machine)
         cli_resolved_args = resolve_device_args(cli_opts.get("args", {}), current_machine)
 
+        is_multihost = str(merged_env.get("IS_MULTI_HOST_BENCH", "false")).lower() == "true"
         gcs_gen_config = srv_resolved_args.get("generation-config")
         if gcs_gen_config and isinstance(gcs_gen_config, str) and gcs_gen_config.startswith("gs://"):
-            print(f"export GCS_GEN_CONFIG={shlex.quote(gcs_gen_config)}")
-            artifact_folder = os.environ.get("ARTIFACT_FOLDER", "/workspace/tpu_inference/artifacts")
-            srv_resolved_args["generation-config"] = f"{artifact_folder}/generation_configs"
+            if not is_multihost:
+                print(f"export GCS_GEN_CONFIG={shlex.quote(gcs_gen_config)}")
+                artifact_folder = os.environ.get("ARTIFACT_FOLDER", "/workspace/tpu_inference/artifacts")
+                srv_resolved_args["generation-config"] = f"{artifact_folder}/generation_configs"
 
         srv_cmd = build_command(srv_cmd_type, srv_resolved_args)
         cli_cmd = build_command(cli_cmd_type, cli_resolved_args)

--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -412,7 +412,7 @@ fi
 
 # Prep specialized configurations (DeepSeek)
 if [[ "$MODEL" == "deepseek-ai/DeepSeek-R1" && "${IS_MULTI_HOST_BENCH:-false}" == "false" ]]; then
-  if [[ -n "$GCS_GEN_CONFIG" ]]; then
+  if [[ -n "${GCS_GEN_CONFIG:-}" ]]; then
     if command -v gsutil &> /dev/null; then
       echo "Syncing generation configs for DeepSeek-R1 from GCS: $GCS_GEN_CONFIG"
       GENERATION_CONFIG_FOLDER="$ARTIFACT_FOLDER/generation_configs"

--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -412,13 +412,17 @@ fi
 
 # Prep specialized configurations (DeepSeek)
 if [[ "$MODEL" == "deepseek-ai/DeepSeek-R1" && "${IS_MULTI_HOST_BENCH:-false}" == "false" ]]; then
-  if command -v gsutil &> /dev/null; then
-    echo "Syncing generation configs for DeepSeek-R1"
-    GENERATION_CONFIG_FOLDER="$ARTIFACT_FOLDER/generation_configs"
-    mkdir -p "$GENERATION_CONFIG_FOLDER"
-    gsutil -m cp -r gs://tpu-commons-ci/deepseek/* "$GENERATION_CONFIG_FOLDER" || echo "Warning: failed to sync generation configs ${DATASET}"
+  if [[ -n "$GCS_GEN_CONFIG" ]]; then
+    if command -v gsutil &> /dev/null; then
+      echo "Syncing generation configs for DeepSeek-R1 from GCS: $GCS_GEN_CONFIG"
+      GENERATION_CONFIG_FOLDER="$ARTIFACT_FOLDER/generation_configs"
+      mkdir -p "$GENERATION_CONFIG_FOLDER"
+      gsutil -m cp "${GCS_GEN_CONFIG}/config.json" "${GCS_GEN_CONFIG}/generation_config.json" "$GENERATION_CONFIG_FOLDER" || echo "Warning: failed to sync generation configs ${DATASET}"
+    else
+      echo "Warning: gsutil not found. Skipping DeepSeek-R1 generation configs download from GCS."
+    fi
   else
-    echo "Warning: gsutil not found. Skipping DeepSeek-R1 generation configs download from GCS."
+    echo "gcs gen config path not found, skipping download the generation configs"
   fi
 fi
 

--- a/.buildkite/scripts/run_multihost.sh
+++ b/.buildkite/scripts/run_multihost.sh
@@ -436,7 +436,7 @@ if [[ "${VLLM_SERVE_CMD}" =~ --generation-config[=\ ]+gs://([^ ]+) ]]; then
     echo "--- Detected GCS generation-config: $gcs_path"
     echo "--- Pre-downloading config to workspace inside container..."
 
-    download_cmd="mkdir -p /workspace && gsutil -m cp -r ${config_url} /workspace/ && "
+    download_cmd="mkdir -p /workspace/${config_dir_name}/${config_file_name} && gsutil -m cp ${gcs_path}/config.json ${gcs_path}/generation_config.json /workspace/${config_dir_name}/${config_file_name}/ && "
     
     VLLM_SERVE_CMD=$(echo "${VLLM_SERVE_CMD}" | sed -E "s|--generation-config[=\ ]+gs://[^ ]+|--generation-config /workspace/${config_dir_name}/${config_file_name}|g")
     VLLM_SERVE_CMD="${download_cmd}${VLLM_SERVE_CMD}"


### PR DESCRIPTION
# PR Description

### Summary
Fixes `[Errno 28] No space left on device` by restricting `generation-config` downloads to configuration files (`config.json`, `generation_config.json`), preventing massive model weights (641 GiB) from being downloaded.

### Key Changes
- **`parser_case.py`**: Dynamically parse GCS `generation-config` paths and rewrite them to local container paths using `$ARTIFACT_FOLDER`.
- **`run_bm.sh`**: Restrict single-host downloader to only download the 2 configuration files when `generation-config` is specified in JSON.
- **`run_multihost.sh`**: Restrict multi-host downloader to only pull the 2 configuration files instead of recursive directory copying.

### Affected Cases
This change stabilizes and affects the following benchmark runs:
- **Single-Host (Daily)**: 
  - `.buildkite/benchmark/cases/daily/deepseek_dp_attention.json`
  - `.buildkite/benchmark/cases/daily/deepseek.json`
  - `.buildkite/benchmark/cases/daily/deepseek_profile.json`
- **Multi-Host (Daily)**: 
  - `run_jax_deepseek_v3_1k_8k.json`
  - and another procedure which call `.buildkite/scripts/run_multihost.sh` and there is `--generation-config` in VLLM_SERVE_CMD.

# Tests

[buildkite](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/1857)

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
