### PR TITLE
test: Unit tests for orchestrator logic and JAX profile options

### DIFF
--- a/experiments/tests/test_jax_options.py
+++ b/experiments/tests/test_jax_options.py
@@ -1,0 +1,49 @@
+import yaml
+import json
+import unittest
+
+class TestJaxOptionsParsing(unittest.TestCase):
+    def test_yaml_to_python_dictionary_fidelity(self):
+        # We simulate the exact YAML block we will introduce to the configs
+        yaml_content = """
+        trace_configs:
+          - batch_size: 256
+            input_len: 1024
+            output_len: 64
+            jax_advanced_configuration:
+              tpu_enable_periodic_counter_sampling: true
+              tpu_tc_perf_counter_sampling_options: 'interval_us:10 scaling:0 counter_size_bits:1 indices:56 indices:57 indices:58 indices:38 indices:105'
+              tpu_cmn_perf_counter_sampling_options: 'interval_us:32 scaling:0 counter_size_bits:2 indices:1 indices:2 indices:58'
+              num_tensor_cores_to_trace_per_device: 1
+        """
+        
+        # 1. Orchestrator Loads YAML
+        parsed_yaml = yaml.safe_load(yaml_content)
+        trace_config = parsed_yaml["trace_configs"][0]
+        
+        # 2. Orchestrator extracts payload and json.dumps it into CLI args
+        advanced_config = trace_config.get("jax_advanced_configuration")
+        cli_argument_string = json.dumps(advanced_config)
+        
+        # 3. vLLM Subprocess json.loads it from CLI args
+        restored_python_dict = json.loads(cli_argument_string)
+        
+        # 4. Compare it against the EXACT Hardcoded python representation requested by the user
+        exact_python_representation = {
+            "tpu_enable_periodic_counter_sampling" : True,
+            "tpu_tc_perf_counter_sampling_options" : (
+                'interval_us:10 scaling:0 counter_size_bits:1 indices:56 indices:57 indices:58 indices:38 indices:105'
+            ),
+            "tpu_cmn_perf_counter_sampling_options" : (
+                'interval_us:32 scaling:0 counter_size_bits:2 indices:1 indices:2 indices:58'
+            ),
+            "num_tensor_cores_to_trace_per_device": 1,
+        }
+        
+        self.assertEqual(restored_python_dict, exact_python_representation)
+        self.assertEqual(type(restored_python_dict['tpu_enable_periodic_counter_sampling']), bool)
+        self.assertEqual(type(restored_python_dict['num_tensor_cores_to_trace_per_device']), int)
+        self.assertEqual(type(restored_python_dict['tpu_tc_perf_counter_sampling_options']), str)
+
+if __name__ == '__main__':
+    unittest.main(verbosity=2)

--- a/experiments/tests/test_orchestrator.py
+++ b/experiments/tests/test_orchestrator.py
@@ -1,0 +1,142 @@
+import unittest
+import os
+import tempfile
+import sys
+import yaml
+from unittest.mock import patch, MagicMock
+
+sys.path.append(os.path.dirname(os.path.abspath(__file__)))
+run_sweep = __import__('run_sweep_orchestrator')
+
+class TestOrchestratorExp(unittest.TestCase):
+    def setUp(self):
+        self.test_dir = tempfile.TemporaryDirectory()
+        self.config_path = os.path.join(self.test_dir.name, "test_exp_config.yaml")
+
+    def tearDown(self):
+        self.test_dir.cleanup()
+
+    def create_mock_config(self, content):
+        with open(self.config_path, "w") as f:
+            yaml.dump(content, f)
+            
+    def write_raw_yaml_string(self, content):
+        with open(self.config_path, "w") as f:
+            f.write(content)
+
+    @patch("run_sweep_orchestrator.subprocess.run")
+    @patch("run_sweep_orchestrator.datetime")
+    def test_chronological_id_generation(self, mock_datetime, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        mock_now = MagicMock()
+        mock_now.strftime.return_value = "20261111_000000"
+        mock_datetime.now.return_value = mock_now
+
+        self.create_mock_config({
+             "sweep_matrix": {
+                 "model": ["test/model"],
+                 "batch_size": [1],
+                 "input_len": [128],
+                 "output_len": [64]
+             }
+         })
+
+        test_args = ["--config", self.config_path, "--result-dir", self.test_dir.name]
+        with patch("sys.argv", ["run_sweep_orchestrator.py"] + test_args):
+            run_sweep.main()
+
+        expected_dir = os.path.join(self.test_dir.name, "20261111_000000")
+        self.assertTrue(os.path.exists(expected_dir))
+
+    @patch("run_sweep_orchestrator.subprocess.run")
+    def test_custom_experiment_id_and_resumption(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        self.create_mock_config({
+            "sweep_matrix": {
+                 "model": ["meta-llama/test", "google/test2"],
+                 "batch_size": [1, 2],
+                 "input_len": [128],
+                 "output_len": [16]
+            }
+        })
+
+        test_args = ["--config", self.config_path, "--result-dir", self.test_dir.name, "--experiment-id", "RESUME_ID_X"]
+
+        with patch("sys.argv", ["run_sweep_orchestrator.py"] + test_args):
+            run_sweep.main()
+
+        self.assertEqual(mock_run.call_count, 4)
+
+        expected_dir = os.path.join(self.test_dir.name, "RESUME_ID_X")
+        csv_file = os.path.join(expected_dir, "results.csv")
+        
+        import csv
+        with open(csv_file, 'w', newline='') as f:
+            writer = csv.DictWriter(f, fieldnames=["model", "batch_size", "input_len", "output_len"])
+            writer.writeheader()
+            writer.writerow({"model": "meta-llama/test", "batch_size": "1", "input_len": "128", "output_len": "16"})
+            writer.writerow({"model": "meta-llama/test", "batch_size": "2", "input_len": "128", "output_len": "16"})
+
+        mock_run.reset_mock()
+        
+        with patch("sys.argv", ["run_sweep_orchestrator.py"] + test_args):
+            run_sweep.main()
+
+        self.assertEqual(mock_run.call_count, 2)
+        
+    @patch("run_sweep_orchestrator.subprocess.run")
+    def test_backward_compatibility_migration(self, mock_run):
+        mock_run.return_value = MagicMock(returncode=0)
+        self.create_mock_config({
+             "model": "google/model-old",
+             "sweep_matrix": {
+                 "batches": [4],
+                 "inputs": [32],
+                 "output_lens": [32]
+             }
+         })
+
+        test_args = ["--config", self.config_path, "--result-dir", self.test_dir.name, "--experiment-id", "EXP_COMPAT"]
+        with patch("sys.argv", ["run_sweep_orchestrator.py"] + test_args):
+            run_sweep.main()
+
+        cmd = mock_run.call_args[0][0]
+        self.assertIn("--model", cmd)
+        self.assertIn("google/model-old", cmd)
+        self.assertIn("--batch-size", cmd)
+
+    @patch("run_sweep_orchestrator.subprocess.run")
+    def test_multiple_models_via_yaml_string(self, mock_run):
+        # Validate exact inline string injection parsing flow lists uniformly simulating exact PyYAML behavior mapping over explicit multi-model boundaries
+        mock_run.return_value = MagicMock(returncode=0)
+        yaml_content = """
+sweep_matrix:
+  model: [meta-llama/test-1, google/test-2]
+  batch_size: [1, 2]
+  input_len: [128]
+  output_len: [32]
+"""
+        self.write_raw_yaml_string(yaml_content)
+
+        test_args = ["--config", self.config_path, "--result-dir", self.test_dir.name, "--experiment-id", "MULTI_MODEL_STR"]
+        with patch("sys.argv", ["run_sweep_orchestrator.py"] + test_args):
+            run_sweep.main()
+
+        # 2 models * 2 batch_sizes * 1 * 1 = 4 total iterations
+        self.assertEqual(mock_run.call_count, 4)
+        
+        # Capture the iterations
+        models_called = []
+        for call_arg in mock_run.call_args_list:
+            cmd = call_arg[0][0] # The command list
+            # The model is the index after "--model"
+            if "--model" in cmd:
+                model_name = cmd[cmd.index("--model") + 1]
+                models_called.append(model_name)
+                
+        self.assertEqual(models_called.count("meta-llama/test-1"), 2)
+        self.assertEqual(models_called.count("google/test-2"), 2)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Overview
This PR adds internal unit tests to verify coordinate combinations are skipping safely and ensure nested JAX profiler parameters parse correctly from YAML lists without crashing.

## Changes
- Add `test_orchestrator.py` to evaluate that our N-dimensional parameter math expands properly and accurately evaluates CSV outputs to skip finished experiment runs. 
- Add `test_jax_options.py` to verify that dictionary strings passed to `--jax-advanced-configuration` parse safely.