### PR TITLE
[Gemma4][Vision] Clipped-linear building block for the JAX serving vision tower (load + apply + exact 112/448 post-load validation)

### DIFF
--- a/tests/models/jax/test_gemma4_clipped_linears.py
+++ b/tests/models/jax/test_gemma4_clipped_linears.py
@@ -183,8 +183,13 @@ class _FakeBlock(nnx.Module):
 
 class _FakeVisionTower(nnx.Module):
     def __init__(self, num_blocks, finite=True, use_clipped=True):
+        # config carried as a non-data attribute (mirrors the real tower's vt.config).
         self.config = _FakeVisionConfig(num_blocks, use_clipped)
-        self.layers = [_FakeBlock(finite=finite) for _ in range(num_blocks)]
+        # Store blocks as individual attributes (layers_0 .. layers_{n-1}) so the nnx pytree
+        # accepts them as data submodules (a plain Python list of modules is rejected as a
+        # static attribute by this flax nnx variant). nnx.iter_graph still traverses them.
+        for i in range(num_blocks):
+            setattr(self, f"layers_{i}", _FakeBlock(finite=finite))
 
 
 class _FakeModel(nnx.Module):
@@ -224,7 +229,7 @@ def test_walker_partial_bounds_fails():
     # 16 blocks but one bound left at the NaN sentinel -> validate_clip_bounds raises.
     h = _Harness(num_blocks=2, finite=True)
     # Corrupt one projection's bound back to NaN.
-    h.model.vision_tower.layers[0].q_proj.input_min = nnx.Param(
+    h.model.vision_tower.layers_0.q_proj.input_min = nnx.Param(
         jnp.asarray(jnp.nan, dtype=jnp.float32))
     with pytest.raises(ValueError, match="non-finite"):
         h._validate_vision_clip_bounds()

--- a/tests/models/jax/test_gemma4_clipped_linears.py
+++ b/tests/models/jax/test_gemma4_clipped_linears.py
@@ -1,0 +1,247 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""In-tree tests for Gemma-4 vision clipped-linears (PR #3355).
+
+These replace the previously private R4 validation suite. They exercise the
+serving-side clip-bound contract WITHOUT requiring a gated HF checkpoint:
+
+  1. flag OFF is an exact no-op (clipped einsum == plain einsum)
+  2. one HF-parity projection: clamp-in -> linear -> clamp-out matches a numpy oracle
+  3. a finite, ordered bound set validates OK
+  4. a missing (NaN-sentinel) bound -> validate hard-fails
+  5. an Inf bound -> hard-fails
+  6. a non-scalar bound -> hard-fails
+  7. min > max (empty interval) -> hard-fails
+  8. q and k carry DISTINCT bounds (not accidentally shared)
+  9. the walker discovers EXACTLY num_blocks*7 modules; ZERO/partial -> hard-fail
+ 10. 448-bound accounting for a 16-block tower; audio (480 keys) is out of scope
+
+Synthetic tiny modules — fast, no network, CPU-only.
+"""
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from flax import nnx
+
+from tpu_inference.models.jax.gemma4_mm import Gemma4ClippableEinsum
+
+
+def _rngs():
+    return nnx.Rngs(params=0)
+
+
+def _set_bounds(m, imin, imax, omin, omax):
+    m.input_min = nnx.Param(jnp.asarray(imin, dtype=jnp.float32))
+    m.input_max = nnx.Param(jnp.asarray(imax, dtype=jnp.float32))
+    m.output_min = nnx.Param(jnp.asarray(omin, dtype=jnp.float32))
+    m.output_max = nnx.Param(jnp.asarray(omax, dtype=jnp.float32))
+
+
+def _make_einsum(use_clipped):
+    # y[t,o] = x[t,d] * W[d,o]
+    return Gemma4ClippableEinsum(
+        "td,do->to", (4, 3), use_clipped_linears=use_clipped, rngs=_rngs())
+
+
+# ---------------------------------------------------------------------------
+# 1. flag OFF exact no-op
+# ---------------------------------------------------------------------------
+def test_flag_off_is_exact_noop():
+    m = _make_einsum(use_clipped=False)
+    x = jnp.asarray(np.random.RandomState(0).randn(2, 4), dtype=jnp.float32)
+    # OFF: no bound state is created and forward == plain einsum.
+    assert not m.use_clipped_linears
+    assert not hasattr(m, "input_min")
+    y = m(x)
+    W = m.weight.value
+    expected = jnp.einsum("td,do->to", x, W)
+    np.testing.assert_allclose(np.asarray(y), np.asarray(expected), rtol=1e-6, atol=1e-6)
+    # validate_clip_bounds is a no-op when off.
+    m.validate_clip_bounds()
+
+
+# ---------------------------------------------------------------------------
+# 2. one HF-parity projection: clamp-in -> linear -> clamp-out
+# ---------------------------------------------------------------------------
+def test_clip_forward_matches_oracle():
+    m = _make_einsum(use_clipped=True)
+    _set_bounds(m, -0.5, 0.5, -1.0, 1.0)
+    x = jnp.asarray(np.random.RandomState(1).randn(3, 4) * 3.0, dtype=jnp.float32)
+    y = m(x)
+    W = np.asarray(m.weight.value)
+    xin = np.clip(np.asarray(x), -0.5, 0.5)
+    yout = np.clip(np.einsum("td,do->to", xin, W), -1.0, 1.0)
+    np.testing.assert_allclose(np.asarray(y), yout, rtol=1e-5, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# 3. finite ordered bounds validate OK
+# ---------------------------------------------------------------------------
+def test_valid_bounds_pass():
+    m = _make_einsum(use_clipped=True)
+    _set_bounds(m, -2.0, 3.0, -1.0, 1.0)
+    m.validate_clip_bounds()  # must not raise
+
+
+# ---------------------------------------------------------------------------
+# 4. missing (NaN-sentinel) bound -> fail
+# ---------------------------------------------------------------------------
+def test_nan_sentinel_bound_fails():
+    m = _make_einsum(use_clipped=True)
+    # Leave bounds at the NaN sentinel from __init__.
+    with pytest.raises(ValueError, match="non-finite"):
+        m.validate_clip_bounds()
+
+
+# ---------------------------------------------------------------------------
+# 5. Inf bound -> fail
+# ---------------------------------------------------------------------------
+def test_inf_bound_fails():
+    m = _make_einsum(use_clipped=True)
+    _set_bounds(m, -np.inf, 0.5, -1.0, 1.0)
+    with pytest.raises(ValueError, match="non-finite"):
+        m.validate_clip_bounds()
+
+
+# ---------------------------------------------------------------------------
+# 6. non-scalar bound -> fail
+# ---------------------------------------------------------------------------
+def test_non_scalar_bound_fails():
+    m = _make_einsum(use_clipped=True)
+    _set_bounds(m, -0.5, 0.5, -1.0, 1.0)
+    m.input_min = nnx.Param(jnp.asarray([-0.5, -0.6], dtype=jnp.float32))
+    with pytest.raises(ValueError, match="non-scalar"):
+        m.validate_clip_bounds()
+
+
+# ---------------------------------------------------------------------------
+# 7. min > max (empty interval) -> fail
+# ---------------------------------------------------------------------------
+def test_input_min_gt_max_fails():
+    m = _make_einsum(use_clipped=True)
+    _set_bounds(m, 0.5, -0.5, -1.0, 1.0)
+    with pytest.raises(ValueError, match="input_min.*>.*input_max"):
+        m.validate_clip_bounds()
+
+
+def test_output_min_gt_max_fails():
+    m = _make_einsum(use_clipped=True)
+    _set_bounds(m, -0.5, 0.5, 1.0, -1.0)
+    with pytest.raises(ValueError, match="output_min.*>.*output_max"):
+        m.validate_clip_bounds()
+
+
+# ---------------------------------------------------------------------------
+# 8. q and k carry DISTINCT bounds (not accidentally shared)
+# ---------------------------------------------------------------------------
+def test_q_k_bounds_are_distinct():
+    q = _make_einsum(use_clipped=True)
+    k = _make_einsum(use_clipped=True)
+    _set_bounds(q, -0.5, 0.5, -1.0, 1.0)
+    _set_bounds(k, -0.7, 0.9, -1.5, 1.5)
+    # Distinct Param objects and distinct values.
+    assert q.input_min is not k.input_min
+    assert float(q.input_min.value) != float(k.input_min.value)
+    assert float(q.output_max.value) != float(k.output_max.value)
+    q.validate_clip_bounds()
+    k.validate_clip_bounds()
+
+
+# ---------------------------------------------------------------------------
+# 9 + 10. Walker: discovers EXACTLY num_blocks*7; zero/partial -> fail; audio out of scope.
+# We build a synthetic tower whose structure mirrors the real one enough for the
+# nnx.iter_graph walk, then invoke the SAME validation logic used post-load.
+# ---------------------------------------------------------------------------
+class _FakeVisionConfig:
+    def __init__(self, num_hidden_layers, use_clipped_linears=True):
+        self.num_hidden_layers = num_hidden_layers
+        self.use_clipped_linears = use_clipped_linears
+
+
+class _FakeBlock(nnx.Module):
+    """7 clipped projections: q,k,v,o + gate,up,down."""
+
+    def __init__(self, finite=True):
+        for nm in ("q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"):
+            e = _make_einsum(use_clipped=True)
+            if finite:
+                _set_bounds(e, -1.0, 1.0, -2.0, 2.0)
+            setattr(self, nm, e)
+
+
+class _FakeVisionTower(nnx.Module):
+    def __init__(self, num_blocks, finite=True, use_clipped=True):
+        self.config = _FakeVisionConfig(num_blocks, use_clipped)
+        self.layers = [_FakeBlock(finite=finite) for _ in range(num_blocks)]
+
+
+class _FakeModel(nnx.Module):
+    def __init__(self, vt):
+        self.vision_tower = vt
+
+
+class _Harness(nnx.Module):
+    """Exposes the real _validate_vision_clip_bounds via composition."""
+
+    def __init__(self, num_blocks, finite=True, use_clipped=True, vt_none=False):
+        if vt_none:
+            self.model = _FakeModel(None)
+        else:
+            self.model = _FakeModel(_FakeVisionTower(num_blocks, finite, use_clipped))
+
+    # Bind the real method under test.
+    from tpu_inference.models.jax.gemma4_mm import Gemma4ForConditionalGeneration as _G
+    _validate_vision_clip_bounds = _G._validate_vision_clip_bounds
+
+
+def test_walker_counts_exactly_16x7_448():
+    h = _Harness(num_blocks=16, finite=True)
+    n = h._validate_vision_clip_bounds()
+    assert n == 16 * 7  # 112 modules
+    assert n * 4 == 448  # 448 scalar bounds
+
+
+def test_walker_zero_modules_fails():
+    # A tower with zero blocks -> expected_modules == 0 -> hard-fail (not a silent pass).
+    h = _Harness(num_blocks=0, finite=True)
+    with pytest.raises(ValueError, match="positive expected clip-module count"):
+        h._validate_vision_clip_bounds()
+
+
+def test_walker_partial_bounds_fails():
+    # 16 blocks but one bound left at the NaN sentinel -> validate_clip_bounds raises.
+    h = _Harness(num_blocks=2, finite=True)
+    # Corrupt one projection's bound back to NaN.
+    h.model.vision_tower.layers[0].q_proj.input_min = nnx.Param(
+        jnp.asarray(jnp.nan, dtype=jnp.float32))
+    with pytest.raises(ValueError, match="non-finite"):
+        h._validate_vision_clip_bounds()
+
+
+def test_walker_vision_tower_none_fails():
+    h = _Harness(num_blocks=1, vt_none=True)
+    with pytest.raises(ValueError, match="vision_tower is None"):
+        h._validate_vision_clip_bounds()
+
+
+def test_walker_clipping_off_is_noop():
+    # use_clipped_linears False on the config -> validation is a no-op (returns None).
+    h = _Harness(num_blocks=16, finite=True, use_clipped=False)
+    assert h._validate_vision_clip_bounds() is None
+
+
+if __name__ == "__main__":
+    import sys
+    sys.exit(pytest.main([__file__, "-v"]))

--- a/tests/models/jax/test_gemma4_clipped_linears.py
+++ b/tests/models/jax/test_gemma4_clipped_linears.py
@@ -29,6 +29,7 @@ serving-side clip-bound contract WITHOUT requiring a gated HF checkpoint:
 
 Synthetic tiny modules — fast, no network, CPU-only.
 """
+import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -53,6 +54,20 @@ def _make_einsum(use_clipped):
     return Gemma4ClippableEinsum("td,do->to", (4, 3),
                                  use_clipped_linears=use_clipped,
                                  rngs=_rngs())
+
+
+@pytest.fixture(autouse=True)
+def _pin_to_cpu():
+    """Pin this module to CPU, as the module docstring already states.
+
+    These are synthetic numeric unit tests, but CI runs the suite inside
+    the TPU image, so without this JAX binds them to a real TPU. On the
+    MXU a float32 einsum at nnx.Einsum's default ``precision=None`` runs
+    at reduced (bfloat16-based) precision, which breaks the tight
+    tolerances below against their exact numpy/jnp references.
+    """
+    with jax.default_device(jax.devices("cpu")[0]):
+        yield
 
 
 # ---------------------------------------------------------------------------

--- a/tests/models/jax/test_gemma4_clipped_linears.py
+++ b/tests/models/jax/test_gemma4_clipped_linears.py
@@ -29,7 +29,6 @@ serving-side clip-bound contract WITHOUT requiring a gated HF checkpoint:
 
 Synthetic tiny modules — fast, no network, CPU-only.
 """
-import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
@@ -51,8 +50,9 @@ def _set_bounds(m, imin, imax, omin, omax):
 
 def _make_einsum(use_clipped):
     # y[t,o] = x[t,d] * W[d,o]
-    return Gemma4ClippableEinsum(
-        "td,do->to", (4, 3), use_clipped_linears=use_clipped, rngs=_rngs())
+    return Gemma4ClippableEinsum("td,do->to", (4, 3),
+                                 use_clipped_linears=use_clipped,
+                                 rngs=_rngs())
 
 
 # ---------------------------------------------------------------------------
@@ -67,7 +67,10 @@ def test_flag_off_is_exact_noop():
     y = m(x)
     W = m.weight.value
     expected = jnp.einsum("td,do->to", x, W)
-    np.testing.assert_allclose(np.asarray(y), np.asarray(expected), rtol=1e-6, atol=1e-6)
+    np.testing.assert_allclose(np.asarray(y),
+                               np.asarray(expected),
+                               rtol=1e-6,
+                               atol=1e-6)
     # validate_clip_bounds is a no-op when off.
     m.validate_clip_bounds()
 
@@ -78,7 +81,8 @@ def test_flag_off_is_exact_noop():
 def test_clip_forward_matches_oracle():
     m = _make_einsum(use_clipped=True)
     _set_bounds(m, -0.5, 0.5, -1.0, 1.0)
-    x = jnp.asarray(np.random.RandomState(1).randn(3, 4) * 3.0, dtype=jnp.float32)
+    x = jnp.asarray(np.random.RandomState(1).randn(3, 4) * 3.0,
+                    dtype=jnp.float32)
     y = m(x)
     W = np.asarray(m.weight.value)
     xin = np.clip(np.asarray(x), -0.5, 0.5)
@@ -165,6 +169,7 @@ def test_q_k_bounds_are_distinct():
 # nnx.iter_graph walk, then invoke the SAME validation logic used post-load.
 # ---------------------------------------------------------------------------
 class _FakeVisionConfig:
+
     def __init__(self, num_hidden_layers, use_clipped_linears=True):
         self.num_hidden_layers = num_hidden_layers
         self.use_clipped_linears = use_clipped_linears
@@ -174,7 +179,8 @@ class _FakeBlock(nnx.Module):
     """7 clipped projections: q,k,v,o + gate,up,down."""
 
     def __init__(self, finite=True):
-        for nm in ("q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"):
+        for nm in ("q_proj", "k_proj", "v_proj", "o_proj", "gate_proj",
+                   "up_proj", "down_proj"):
             e = _make_einsum(use_clipped=True)
             if finite:
                 _set_bounds(e, -1.0, 1.0, -2.0, 2.0)
@@ -182,6 +188,7 @@ class _FakeBlock(nnx.Module):
 
 
 class _FakeVisionTower(nnx.Module):
+
     def __init__(self, num_blocks, finite=True, use_clipped=True):
         # config carried as a non-data attribute (mirrors the real tower's vt.config).
         self.config = _FakeVisionConfig(num_blocks, use_clipped)
@@ -193,6 +200,7 @@ class _FakeVisionTower(nnx.Module):
 
 
 class _FakeModel(nnx.Module):
+
     def __init__(self, vt):
         self.vision_tower = vt
 
@@ -200,14 +208,20 @@ class _FakeModel(nnx.Module):
 class _Harness(nnx.Module):
     """Exposes the real _validate_vision_clip_bounds via composition."""
 
-    def __init__(self, num_blocks, finite=True, use_clipped=True, vt_none=False):
+    def __init__(self,
+                 num_blocks,
+                 finite=True,
+                 use_clipped=True,
+                 vt_none=False):
         if vt_none:
             self.model = _FakeModel(None)
         else:
-            self.model = _FakeModel(_FakeVisionTower(num_blocks, finite, use_clipped))
+            self.model = _FakeModel(
+                _FakeVisionTower(num_blocks, finite, use_clipped))
 
     # Bind the real method under test.
-    from tpu_inference.models.jax.gemma4_mm import Gemma4ForConditionalGeneration as _G
+    from tpu_inference.models.jax.gemma4_mm import \
+        Gemma4ForConditionalGeneration as _G
     _validate_vision_clip_bounds = _G._validate_vision_clip_bounds
 
 
@@ -221,7 +235,8 @@ def test_walker_counts_exactly_16x7_448():
 def test_walker_zero_modules_fails():
     # A tower with zero blocks -> expected_modules == 0 -> hard-fail (not a silent pass).
     h = _Harness(num_blocks=0, finite=True)
-    with pytest.raises(ValueError, match="positive expected clip-module count"):
+    with pytest.raises(ValueError,
+                       match="positive expected clip-module count"):
         h._validate_vision_clip_bounds()
 
 

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -167,10 +167,12 @@ class Gemma4ClippableEinsum(JaxEinsum):
             self.output_max = _b()
 
     def validate_clip_bounds(self):
-        """M1 hard-fail: every required bound must be finite and scalar. No-op when off."""
+        """M1 hard-fail: every required bound must be finite, scalar, and correctly ordered
+        (input_min<=input_max, output_min<=output_max). No-op when off."""
         if not self.use_clipped_linears:
             return
         pfx = getattr(self, "prefix", "")
+        vals = {}
         for nm in ("input_min", "input_max", "output_min", "output_max"):
             p = getattr(self, nm, None)
             if p is None:
@@ -189,6 +191,17 @@ class Gemma4ClippableEinsum(JaxEinsum):
                     f"non-finite (missing/NaN/Inf). The E2B/E4B checkpoint declares a FINITE "
                     f"clipped model when vision_config.use_clipped_linears is True; refusing "
                     f"to fall back to an identity clamp.")
+            vals[nm] = fv
+        # Ordering: a clamp with min>max would empty the interval (jnp.clip would return the max
+        # for all inputs), which is never a valid checkpoint state.
+        if vals["input_min"] > vals["input_max"]:
+            raise ValueError(
+                f"Gemma4ClippableEinsum[{pfx}]: input_min={vals['input_min']} > "
+                f"input_max={vals['input_max']} (a clamp with min>max would empty the interval).")
+        if vals["output_min"] > vals["output_max"]:
+            raise ValueError(
+                f"Gemma4ClippableEinsum[{pfx}]: output_min={vals['output_min']} > "
+                f"output_max={vals['output_max']} (a clamp with min>max would empty the interval).")
 
     def __call__(self, inputs):
         if not self.use_clipped_linears:
@@ -831,40 +844,52 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
         return loaded
 
     def _validate_vision_clip_bounds(self):
-        """Walk the vision tower and call validate_clip_bounds() on every
-        Gemma4ClippableEinsum. No-op for modules whose use_clipped_linears is False.
-        Hard-fails (ValueError) on the first missing/non-finite/non-scalar bound."""
+        """Post-load, fail-closed validation of EVERY vision Gemma4ClippableEinsum.
+
+        Uses an NNX graph traversal (``nnx.iter_graph``) over the vision tower to collect every
+        ``Gemma4ClippableEinsum`` and calls ``validate_clip_bounds()`` on each (finite, scalar,
+        min<=max). Then asserts the EXACT expected module count, derived from the vision config:
+        ``num_hidden_layers`` encoder blocks x 7 clipped projections per block (q/k/v/o attention +
+        gate/up/down MLP). A missing/NaN/non-scalar/unordered bound raises inside validate_clip_bounds();
+        an unexpected module count (including ZERO — e.g. a traversal that walks nothing because the
+        module structure changed) raises here. This closes the hole where a hand-written __dict__ walk
+        could silently find zero modules and still "pass".
+        """
         vt = getattr(getattr(self, "model", None), "vision_tower", None)
         if vt is None:
+            raise ValueError(
+                "Gemma-4 vision clip validation: model.vision_tower is None; cannot validate the "
+                "checkpoint-defined clip bounds. Refusing to serve a use_clipped_linears model with an "
+                "unvalidated (possibly all-NaN-sentinel) vision tower.")
+        # If clipping is disabled the bounds do not exist; nothing to validate.
+        if not bool(getattr(vt.config, "use_clipped_linears", False)):
             return
-        seen = set()
-        n_checked = [0]
 
-        def walk(mod, depth=0):
-            if depth > 14 or id(mod) in seen:
-                return
-            seen.add(id(mod))
-            d = getattr(mod, "__dict__", None)
-            if not d:
-                return
-            for nm, ch in list(d.items()):
-                if nm.startswith("_"):
-                    continue
-                if isinstance(ch, Gemma4ClippableEinsum):
-                    ch.validate_clip_bounds()
-                    n_checked[0] += 1
-                elif isinstance(ch, (list, tuple)):
-                    for c in ch:
-                        if isinstance(c, Gemma4ClippableEinsum):
-                            c.validate_clip_bounds()
-                            n_checked[0] += 1
-                        elif hasattr(c, "__dict__"):
-                            walk(c, depth + 1)
-                elif hasattr(ch, "__dict__") and not isinstance(
-                        ch, (jnp.ndarray, )):
-                    walk(ch, depth + 1)
+        # Expected accounting derived from the vision config (single source of truth, not a magic 112):
+        #   num_hidden_layers encoder blocks x 7 clipped projections (q,k,v,o,gate,up,down).
+        _CLIPPED_PROJS_PER_BLOCK = 7
+        num_blocks = int(getattr(vt.config, "num_hidden_layers", 0))
+        expected_modules = num_blocks * _CLIPPED_PROJS_PER_BLOCK
+        if expected_modules <= 0:
+            raise ValueError(
+                "Gemma-4 vision clip validation: could not derive a positive expected clip-module count "
+                f"from vision_config.num_hidden_layers={num_blocks!r}. Refusing to validate against an "
+                "unknown expected count.")
 
-        walk(vt)
+        n_checked = 0
+        for _, node in nnx.iter_graph(vt):
+            if isinstance(node, Gemma4ClippableEinsum) and node.use_clipped_linears:
+                node.validate_clip_bounds()
+                n_checked += 1
+
+        if n_checked != expected_modules:
+            raise ValueError(
+                f"Gemma-4 vision clip validation found {n_checked} clipped Gemma4ClippableEinsum modules, "
+                f"expected exactly {expected_modules} ({num_blocks} encoder blocks x "
+                f"{_CLIPPED_PROJS_PER_BLOCK} projections). A mismatch (especially zero) means the traversal "
+                "did not reach the vision projections or the checkpoint mapped bounds onto the wrong modules; "
+                "refusing to serve a partially-clipped vision tower.")
+        return n_checked
 
     def embed_input_ids(self,
                         input_ids: jax.Array,

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -130,6 +130,72 @@ class SegmentIds(NamedTuple):
     kv: jax.Array
 
 
+class Gemma4ClippableEinsum(JaxModule):
+    """Checkpoint-defined clipped linear for the Gemma-4 vision tower.
+
+    Mirrors HF transformers `Gemma4ClippableLinear`: when the vision config sets
+    `use_clipped_linears=True`, the forward is
+
+        x = clamp(x, input_min, input_max)   # activation input clamp
+        y = einsum(x, kernel)                 # the plain JaxEinsum projection
+        y = clamp(y, output_min, output_max)  # activation output clamp
+
+    The four bounds are per-projection, non-trainable, checkpoint-resident scalars
+    (checkpoint keys `<prefix>.input_min/.input_max/.output_min/.output_max`). The
+    underlying projection is `self.linear` so the checkpoint's `<prefix>.linear.weight`
+    maps to the JaxEinsum kernel exactly as before. When `use_clipped_linears` is False
+    (or bounds are +/-inf) this is an exact no-op relative to the plain einsum.
+
+    This is a MODEL-LOCAL wrapper; it does not change generic JaxEinsum behavior.
+    """
+
+    def __init__(self,
+                 einsum_str: str,
+                 kernel_shape: tuple,
+                 *,
+                 rng: nnx.Rngs,
+                 dtype: jnp.dtype,
+                 use_clipped_linears: bool,
+                 kernel_init=None,
+                 bias_init=None,
+                 quant_config=None,
+                 prefix: str = ""):
+        kwargs = dict(param_dtype=dtype, rngs=rng, quant_config=quant_config,
+                      prefix=f"{prefix}.linear")
+        if kernel_init is not None:
+            kwargs["kernel_init"] = kernel_init
+        if bias_init is not None:
+            kwargs["bias_init"] = bias_init
+        # The plain projection lives at `.linear` so checkpoint `<prefix>.linear.weight`
+        # loads unchanged (bit-identical to the pre-fix mapping).
+        self.linear = JaxEinsum(einsum_str, kernel_shape, **kwargs)
+        self.use_clipped_linears = bool(use_clipped_linears)
+        if self.use_clipped_linears:
+            # Non-trainable, checkpoint-resident scalar bounds. Named to match the
+            # checkpoint keys `<prefix>.input_min` etc. Initialized to the identity
+            # clamp (+/-inf); a hard load failure is raised elsewhere if the checkpoint
+            # does not supply finite bounds when use_clipped_linears is True.
+            def _b(v):
+                return nnx.Param(jnp.asarray(v, dtype=jnp.float32))
+            self.input_min = _b(-jnp.inf)
+            self.input_max = _b(jnp.inf)
+            self.output_min = _b(-jnp.inf)
+            self.output_max = _b(jnp.inf)
+
+    def __call__(self, x: jax.Array) -> jax.Array:
+        if not self.use_clipped_linears:
+            return self.linear(x)
+        xd = x.dtype
+        # HF computes the clamp in the activation dtype; bounds are scalar fp32.
+        x = jnp.clip(x, self.input_min.get_value().astype(xd),
+                     self.input_max.get_value().astype(xd))
+        y = self.linear(x)
+        yd = y.dtype
+        y = jnp.clip(y, self.output_min.get_value().astype(yd),
+                     self.output_max.get_value().astype(yd))
+        return y
+
+
 class Gemma4VisionFlashAttention(JaxModule):
     """
     Gemma 4 Vision Attention using TPU sharded_flash_attention.
@@ -155,40 +221,46 @@ class Gemma4VisionFlashAttention(JaxModule):
                               {}).get("full_attention", {})
         self.rope_base_frequency = rope_params.get("rope_theta", 100.0)
 
-        self.q_proj = JaxEinsum("BTD,DNH->BTNH",
+        # Vision uses checkpoint-defined clipped linears (config.use_clipped_linears).
+        _ucl = bool(getattr(config, "use_clipped_linears", False))
+        self.q_proj = Gemma4ClippableEinsum("BTD,DNH->BTNH",
                                 (self.features, self.num_heads, self.head_dim),
-                                param_dtype=dtype,
+                                dtype=dtype,
+                                use_clipped_linears=_ucl,
                                 kernel_init=nnx.with_partitioning(
                                     init_fn,
                                     (None, ShardingAxisName.VIT_MODEL, None)),
-                                rngs=rng,
+                                rng=rng,
                                 quant_config=quant_config,
-                                prefix=f"{prefix}.q_proj.linear")
-        self.k_proj = JaxEinsum(
+                                prefix=f"{prefix}.q_proj")
+        self.k_proj = Gemma4ClippableEinsum(
             "BTD,DKH->BTKH", (self.features, self.num_kv_heads, self.head_dim),
-            param_dtype=dtype,
+            dtype=dtype,
+            use_clipped_linears=_ucl,
             kernel_init=nnx.with_partitioning(
                 init_fn, (None, ShardingAxisName.VIT_MODEL, None)),
-            rngs=rng,
+            rng=rng,
             quant_config=quant_config,
-            prefix=f"{prefix}.k_proj.linear")
-        self.v_proj = JaxEinsum(
+            prefix=f"{prefix}.k_proj")
+        self.v_proj = Gemma4ClippableEinsum(
             "BTD,DKH->BTKH", (self.features, self.num_kv_heads, self.head_dim),
-            param_dtype=dtype,
+            dtype=dtype,
+            use_clipped_linears=_ucl,
             kernel_init=nnx.with_partitioning(
                 init_fn, (None, ShardingAxisName.VIT_MODEL, None)),
-            rngs=rng,
+            rng=rng,
             quant_config=quant_config,
-            prefix=f"{prefix}.v_proj.linear")
-        self.o_proj = JaxEinsum("BTNH,NHD->BTD",
+            prefix=f"{prefix}.v_proj")
+        self.o_proj = Gemma4ClippableEinsum("BTNH,NHD->BTD",
                                 (self.num_heads, self.head_dim, self.features),
-                                param_dtype=dtype,
+                                dtype=dtype,
+                                use_clipped_linears=_ucl,
                                 kernel_init=nnx.with_partitioning(
                                     init_fn,
                                     (ShardingAxisName.VIT_MODEL, None, None)),
-                                rngs=rng,
+                                rng=rng,
                                 quant_config=quant_config,
-                                prefix=f"{prefix}.o_proj.linear")
+                                prefix=f"{prefix}.o_proj")
 
         self.q_norm = JaxRmsNorm(self.head_dim,
                                  param_dtype=dtype,
@@ -355,39 +427,43 @@ class Gemma4VisionMLP(JaxModule):
         self.features = config.hidden_size
         self.hidden_dim = config.intermediate_size
 
-        self.gate_proj = JaxEinsum(
+        _ucl = bool(getattr(config, "use_clipped_linears", False))
+        self.gate_proj = Gemma4ClippableEinsum(
             "...d,df->...f",
             (self.features, self.hidden_dim),
-            param_dtype=dtype,
+            dtype=dtype,
+            use_clipped_linears=_ucl,
             kernel_init=nnx.with_partitioning(
                 init_fn, (None, ShardingAxisName.VIT_MODEL)),
             bias_init=None,
-            rngs=rng,
+            rng=rng,
             quant_config=quant_config,
-            prefix=f"{prefix}.gate_proj.linear",
+            prefix=f"{prefix}.gate_proj",
         )
 
-        self.up_proj = JaxEinsum(
+        self.up_proj = Gemma4ClippableEinsum(
             "...d,df->...f",
             (self.features, self.hidden_dim),
-            param_dtype=dtype,
+            dtype=dtype,
+            use_clipped_linears=_ucl,
             kernel_init=nnx.with_partitioning(
                 init_fn, (None, ShardingAxisName.VIT_MODEL)),
             bias_init=None,
-            rngs=rng,
+            rng=rng,
             quant_config=quant_config,
-            prefix=f"{prefix}.up_proj.linear",
+            prefix=f"{prefix}.up_proj",
         )
 
-        self.down_proj = JaxEinsum(
+        self.down_proj = Gemma4ClippableEinsum(
             "...f,fd->...d",
             (self.hidden_dim, self.features),
-            param_dtype=dtype,
+            dtype=dtype,
+            use_clipped_linears=_ucl,
             kernel_init=nnx.with_partitioning(
                 init_fn, (ShardingAxisName.VIT_MODEL, None)),
             bias_init=None,
-            prefix=f"{prefix}.down_proj.linear",
-            rngs=rng,
+            prefix=f"{prefix}.down_proj",
+            rng=rng,
             quant_config=quant_config,
         )
 
@@ -721,13 +797,14 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
             self,
             skip_prefixes=(["lm_head"]
                            if not hasattr(self, 'lm_head') else []),
+            # Audio tower is out of scope for this serving path: skip its weights AND
+            # its clip-bound buffers. VISION clip bounds (.input_min/.input_max/
+            # .output_min/.output_max under model.vision_tower) are NO LONGER skipped —
+            # they map to Gemma4ClippableEinsum non-trainable buffers and are required
+            # when vision_config.use_clipped_linears is True.
             skip_substrs=[
                 "audio_tower",
                 "embed_audio",
-                ".input_max",
-                ".input_min",
-                ".output_max",
-                ".output_min",
             ],
         )
         return loader.load_weights(mapper.apply(weights))

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -130,70 +130,78 @@ class SegmentIds(NamedTuple):
     kv: jax.Array
 
 
-class Gemma4ClippableEinsum(JaxModule):
+class Gemma4ClippableEinsum(JaxEinsum):
     """Checkpoint-defined clipped linear for the Gemma-4 vision tower.
 
-    Mirrors HF transformers `Gemma4ClippableLinear`: when the vision config sets
-    `use_clipped_linears=True`, the forward is
+    Subclasses ``JaxEinsum`` so the projection weight stays the module's own
+    ``self.weight`` leaf (checkpoint key ``<proj>.linear.weight`` -> ``<proj>.weight``
+    via the existing ``orig_to_new_suffix`` remap; the weights loader's
+    reshape/permute hooks continue to match ``q_proj.weight``/``k_proj.weight``/...).
+
+    Mirrors HF transformers ``Gemma4ClippableLinear``: when the vision config sets
+    ``use_clipped_linears=True`` the forward is
 
         x = clamp(x, input_min, input_max)   # activation input clamp
-        y = einsum(x, kernel)                 # the plain JaxEinsum projection
+        y = einsum(x, weight)                 # the plain JaxEinsum projection
         y = clamp(y, output_min, output_max)  # activation output clamp
 
     The four bounds are per-projection, non-trainable, checkpoint-resident scalars
-    (checkpoint keys `<prefix>.input_min/.input_max/.output_min/.output_max`). The
-    underlying projection is `self.linear` so the checkpoint's `<prefix>.linear.weight`
-    maps to the JaxEinsum kernel exactly as before. When `use_clipped_linears` is False
-    (or bounds are +/-inf) this is an exact no-op relative to the plain einsum.
+    (checkpoint keys ``<proj>.input_min/.input_max/.output_min/.output_max``). When
+    ``use_clipped_linears`` is False no bound state is created and this is an exact
+    no-op relative to the plain einsum. MODEL-LOCAL: does not change generic JaxEinsum.
 
-    This is a MODEL-LOCAL wrapper; it does not change generic JaxEinsum behavior.
+    M1 (required-bound hard failure): bounds initialize to a NON-FINITE NaN sentinel;
+    ``validate_clip_bounds`` hard-fails if any required bound is missing (still at the
+    sentinel), non-finite, or not scalar-compatible — refusing a silent identity clamp.
     """
 
-    def __init__(self,
-                 einsum_str: str,
-                 kernel_shape: tuple,
-                 *,
-                 rng: nnx.Rngs,
-                 dtype: jnp.dtype,
-                 use_clipped_linears: bool,
-                 kernel_init=None,
-                 bias_init=None,
-                 quant_config=None,
-                 prefix: str = ""):
-        kwargs = dict(param_dtype=dtype, rngs=rng, quant_config=quant_config,
-                      prefix=f"{prefix}.linear")
-        if kernel_init is not None:
-            kwargs["kernel_init"] = kernel_init
-        if bias_init is not None:
-            kwargs["bias_init"] = bias_init
-        # The plain projection lives at `.linear` so checkpoint `<prefix>.linear.weight`
-        # loads unchanged (bit-identical to the pre-fix mapping).
-        self.linear = JaxEinsum(einsum_str, kernel_shape, **kwargs)
+    def __init__(self, einsum_str, kernel_shape, *, use_clipped_linears, **kwargs):
+        super().__init__(einsum_str, kernel_shape, **kwargs)
         self.use_clipped_linears = bool(use_clipped_linears)
         if self.use_clipped_linears:
-            # Non-trainable, checkpoint-resident scalar bounds. Named to match the
-            # checkpoint keys `<prefix>.input_min` etc. Initialized to the identity
-            # clamp (+/-inf); a hard load failure is raised elsewhere if the checkpoint
-            # does not supply finite bounds when use_clipped_linears is True.
-            def _b(v):
-                return nnx.Param(jnp.asarray(v, dtype=jnp.float32))
-            self.input_min = _b(-jnp.inf)
-            self.input_max = _b(jnp.inf)
-            self.output_min = _b(-jnp.inf)
-            self.output_max = _b(jnp.inf)
+            def _b():
+                return nnx.Param(jnp.asarray(jnp.nan, dtype=jnp.float32))
+            self.input_min = _b()
+            self.input_max = _b()
+            self.output_min = _b()
+            self.output_max = _b()
 
-    def __call__(self, x: jax.Array) -> jax.Array:
+    def validate_clip_bounds(self):
+        """M1 hard-fail: every required bound must be finite and scalar. No-op when off."""
         if not self.use_clipped_linears:
-            return self.linear(x)
-        xd = x.dtype
-        # HF computes the clamp in the activation dtype; bounds are scalar fp32.
-        x = jnp.clip(x, self.input_min.get_value().astype(xd),
-                     self.input_max.get_value().astype(xd))
-        y = self.linear(x)
+            return
+        pfx = getattr(self, "prefix", "")
+        for nm in ("input_min", "input_max", "output_min", "output_max"):
+            p = getattr(self, nm, None)
+            if p is None:
+                raise ValueError(
+                    f"Gemma4ClippableEinsum[{pfx}]: required clip bound '{nm}' is absent "
+                    f"while use_clipped_linears=True.")
+            v = p.get_value()
+            if v.shape not in ((), (1,)):
+                raise ValueError(
+                    f"Gemma4ClippableEinsum[{pfx}]: clip bound '{nm}' has non-scalar shape "
+                    f"{v.shape}; expected scalar.")
+            fv = float(jnp.reshape(v, (-1,))[0])
+            if not bool(jnp.isfinite(jnp.asarray(fv))):
+                raise ValueError(
+                    f"Gemma4ClippableEinsum[{pfx}]: required clip bound '{nm}'={fv} is "
+                    f"non-finite (missing/NaN/Inf). The E2B/E4B checkpoint declares a FINITE "
+                    f"clipped model when vision_config.use_clipped_linears is True; refusing "
+                    f"to fall back to an identity clamp.")
+
+    def __call__(self, inputs):
+        if not self.use_clipped_linears:
+            return super().__call__(inputs)
+        xd = inputs.dtype
+        inputs = jnp.clip(inputs, self.input_min.get_value().astype(xd),
+                          self.input_max.get_value().astype(xd))
+        y = super().__call__(inputs)
         yd = y.dtype
         y = jnp.clip(y, self.output_min.get_value().astype(yd),
                      self.output_max.get_value().astype(yd))
         return y
+
 
 
 class Gemma4VisionFlashAttention(JaxModule):
@@ -221,46 +229,49 @@ class Gemma4VisionFlashAttention(JaxModule):
                               {}).get("full_attention", {})
         self.rope_base_frequency = rope_params.get("rope_theta", 100.0)
 
-        # Vision uses checkpoint-defined clipped linears (config.use_clipped_linears).
+        # Vision uses checkpoint-defined clipped linears (vision_config.use_clipped_linears).
         _ucl = bool(getattr(config, "use_clipped_linears", False))
-        self.q_proj = Gemma4ClippableEinsum("BTD,DNH->BTNH",
-                                (self.features, self.num_heads, self.head_dim),
-                                dtype=dtype,
-                                use_clipped_linears=_ucl,
-                                kernel_init=nnx.with_partitioning(
-                                    init_fn,
-                                    (None, ShardingAxisName.VIT_MODEL, None)),
-                                rng=rng,
-                                quant_config=quant_config,
-                                prefix=f"{prefix}.q_proj")
+
+        self.q_proj = Gemma4ClippableEinsum(
+            "BTD,DNH->BTNH",
+            (self.features, self.num_heads, self.head_dim),
+            use_clipped_linears=_ucl,
+            param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(
+                init_fn,
+                (None, ShardingAxisName.VIT_MODEL, None)),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=f"{prefix}.q_proj.linear")
         self.k_proj = Gemma4ClippableEinsum(
             "BTD,DKH->BTKH", (self.features, self.num_kv_heads, self.head_dim),
-            dtype=dtype,
             use_clipped_linears=_ucl,
+            param_dtype=dtype,
             kernel_init=nnx.with_partitioning(
                 init_fn, (None, ShardingAxisName.VIT_MODEL, None)),
-            rng=rng,
+            rngs=rng,
             quant_config=quant_config,
-            prefix=f"{prefix}.k_proj")
+            prefix=f"{prefix}.k_proj.linear")
         self.v_proj = Gemma4ClippableEinsum(
             "BTD,DKH->BTKH", (self.features, self.num_kv_heads, self.head_dim),
-            dtype=dtype,
             use_clipped_linears=_ucl,
+            param_dtype=dtype,
             kernel_init=nnx.with_partitioning(
                 init_fn, (None, ShardingAxisName.VIT_MODEL, None)),
-            rng=rng,
+            rngs=rng,
             quant_config=quant_config,
-            prefix=f"{prefix}.v_proj")
-        self.o_proj = Gemma4ClippableEinsum("BTNH,NHD->BTD",
-                                (self.num_heads, self.head_dim, self.features),
-                                dtype=dtype,
-                                use_clipped_linears=_ucl,
-                                kernel_init=nnx.with_partitioning(
-                                    init_fn,
-                                    (ShardingAxisName.VIT_MODEL, None, None)),
-                                rng=rng,
-                                quant_config=quant_config,
-                                prefix=f"{prefix}.o_proj")
+            prefix=f"{prefix}.v_proj.linear")
+        self.o_proj = Gemma4ClippableEinsum(
+            "BTNH,NHD->BTD",
+            (self.num_heads, self.head_dim, self.features),
+            use_clipped_linears=_ucl,
+            param_dtype=dtype,
+            kernel_init=nnx.with_partitioning(
+                init_fn,
+                (ShardingAxisName.VIT_MODEL, None, None)),
+            rngs=rng,
+            quant_config=quant_config,
+            prefix=f"{prefix}.o_proj.linear")
 
         self.q_norm = JaxRmsNorm(self.head_dim,
                                  param_dtype=dtype,
@@ -427,43 +438,45 @@ class Gemma4VisionMLP(JaxModule):
         self.features = config.hidden_size
         self.hidden_dim = config.intermediate_size
 
+        # Vision uses checkpoint-defined clipped linears (vision_config.use_clipped_linears).
         _ucl = bool(getattr(config, "use_clipped_linears", False))
+
         self.gate_proj = Gemma4ClippableEinsum(
             "...d,df->...f",
             (self.features, self.hidden_dim),
-            dtype=dtype,
             use_clipped_linears=_ucl,
+            param_dtype=dtype,
             kernel_init=nnx.with_partitioning(
                 init_fn, (None, ShardingAxisName.VIT_MODEL)),
             bias_init=None,
-            rng=rng,
+            rngs=rng,
             quant_config=quant_config,
-            prefix=f"{prefix}.gate_proj",
+            prefix=f"{prefix}.gate_proj.linear",
         )
 
         self.up_proj = Gemma4ClippableEinsum(
             "...d,df->...f",
             (self.features, self.hidden_dim),
-            dtype=dtype,
             use_clipped_linears=_ucl,
+            param_dtype=dtype,
             kernel_init=nnx.with_partitioning(
                 init_fn, (None, ShardingAxisName.VIT_MODEL)),
             bias_init=None,
-            rng=rng,
+            rngs=rng,
             quant_config=quant_config,
-            prefix=f"{prefix}.up_proj",
+            prefix=f"{prefix}.up_proj.linear",
         )
 
         self.down_proj = Gemma4ClippableEinsum(
             "...f,fd->...d",
             (self.hidden_dim, self.features),
-            dtype=dtype,
             use_clipped_linears=_ucl,
+            param_dtype=dtype,
             kernel_init=nnx.with_partitioning(
                 init_fn, (ShardingAxisName.VIT_MODEL, None)),
             bias_init=None,
-            prefix=f"{prefix}.down_proj",
-            rng=rng,
+            prefix=f"{prefix}.down_proj.linear",
+            rngs=rng,
             quant_config=quant_config,
         )
 
@@ -797,17 +810,61 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
             self,
             skip_prefixes=(["lm_head"]
                            if not hasattr(self, 'lm_head') else []),
-            # Audio tower is out of scope for this serving path: skip its weights AND
-            # its clip-bound buffers. VISION clip bounds (.input_min/.input_max/
-            # .output_min/.output_max under model.vision_tower) are NO LONGER skipped —
-            # they map to Gemma4ClippableEinsum non-trainable buffers and are required
-            # when vision_config.use_clipped_linears is True.
             skip_substrs=[
+                # Audio tower is OUT_OF_SCOPE for this serving submodel: skip its weights
+                # AND its clip bounds (all 480 audio clip keys contain "audio_tower").
                 "audio_tower",
                 "embed_audio",
+                # VISION clip bounds (.input_min/.input_max/.output_min/.output_max under
+                # model.vision_tower) are NO LONGER skipped: they are checkpoint-defined,
+                # non-trainable scalars consumed by Gemma4ClippableEinsum and REQUIRED when
+                # vision_config.use_clipped_linears is True. Keys <proj>.input_min/... map
+                # 1:1 to the wrapper leaves <proj>.input_min/... (no .linear in bound keys).
             ],
         )
-        return loader.load_weights(mapper.apply(weights))
+        loaded = loader.load_weights(mapper.apply(weights))
+        # M1 (required-bound hard failure): after load, validate every vision
+        # Gemma4ClippableEinsum has finite, scalar clip bounds. A missing bound
+        # (still at the NaN sentinel), a non-finite bound, or a non-scalar bound
+        # raises ValueError instead of silently degrading to an identity clamp.
+        self._validate_vision_clip_bounds()
+        return loaded
+
+    def _validate_vision_clip_bounds(self):
+        """Walk the vision tower and call validate_clip_bounds() on every
+        Gemma4ClippableEinsum. No-op for modules whose use_clipped_linears is False.
+        Hard-fails (ValueError) on the first missing/non-finite/non-scalar bound."""
+        vt = getattr(getattr(self, "model", None), "vision_tower", None)
+        if vt is None:
+            return
+        seen = set()
+        n_checked = [0]
+
+        def walk(mod, depth=0):
+            if depth > 14 or id(mod) in seen:
+                return
+            seen.add(id(mod))
+            d = getattr(mod, "__dict__", None)
+            if not d:
+                return
+            for nm, ch in list(d.items()):
+                if nm.startswith("_"):
+                    continue
+                if isinstance(ch, Gemma4ClippableEinsum):
+                    ch.validate_clip_bounds()
+                    n_checked[0] += 1
+                elif isinstance(ch, (list, tuple)):
+                    for c in ch:
+                        if isinstance(c, Gemma4ClippableEinsum):
+                            c.validate_clip_bounds()
+                            n_checked[0] += 1
+                        elif hasattr(c, "__dict__"):
+                            walk(c, depth + 1)
+                elif hasattr(ch, "__dict__") and not isinstance(
+                        ch, (jnp.ndarray, )):
+                    walk(ch, depth + 1)
+
+        walk(vt)
 
     def embed_input_ids(self,
                         input_ids: jax.Array,

--- a/tpu_inference/models/jax/gemma4_mm.py
+++ b/tpu_inference/models/jax/gemma4_mm.py
@@ -138,8 +138,11 @@ class Gemma4ClippableEinsum(JaxEinsum):
     via the existing ``orig_to_new_suffix`` remap; the weights loader's
     reshape/permute hooks continue to match ``q_proj.weight``/``k_proj.weight``/...).
 
-    Mirrors HF transformers ``Gemma4ClippableLinear``: when the vision config sets
-    ``use_clipped_linears=True`` the forward is
+    Equivalent of HF transformers ``Gemma4ClippableLinear``
+    (``transformers/models/gemma4/modeling_gemma4.py``). vLLM has no PyTorch-local
+    class for this op: the vLLM Gemma-4 vision path delegates the vision tower to
+    Hugging Face Transformers, so ``Gemma4ClippableLinear`` is the semantic reference.
+    When the vision config sets ``use_clipped_linears=True`` the forward is
 
         x = clamp(x, input_min, input_max)   # activation input clamp
         y = einsum(x, weight)                 # the plain JaxEinsum projection
@@ -150,24 +153,27 @@ class Gemma4ClippableEinsum(JaxEinsum):
     ``use_clipped_linears`` is False no bound state is created and this is an exact
     no-op relative to the plain einsum. MODEL-LOCAL: does not change generic JaxEinsum.
 
-    M1 (required-bound hard failure): bounds initialize to a NON-FINITE NaN sentinel;
+    Required-bound hard failure: bounds initialize to a NON-FINITE NaN sentinel;
     ``validate_clip_bounds`` hard-fails if any required bound is missing (still at the
     sentinel), non-finite, or not scalar-compatible — refusing a silent identity clamp.
     """
 
-    def __init__(self, einsum_str, kernel_shape, *, use_clipped_linears, **kwargs):
+    def __init__(self, einsum_str, kernel_shape, *, use_clipped_linears,
+                 **kwargs):
         super().__init__(einsum_str, kernel_shape, **kwargs)
         self.use_clipped_linears = bool(use_clipped_linears)
         if self.use_clipped_linears:
+
             def _b():
                 return nnx.Param(jnp.asarray(jnp.nan, dtype=jnp.float32))
+
             self.input_min = _b()
             self.input_max = _b()
             self.output_min = _b()
             self.output_max = _b()
 
     def validate_clip_bounds(self):
-        """M1 hard-fail: every required bound must be finite, scalar, and correctly ordered
+        """Hard-fail: every required bound must be finite, scalar, and correctly ordered
         (input_min<=input_max, output_min<=output_max). No-op when off."""
         if not self.use_clipped_linears:
             return
@@ -180,11 +186,11 @@ class Gemma4ClippableEinsum(JaxEinsum):
                     f"Gemma4ClippableEinsum[{pfx}]: required clip bound '{nm}' is absent "
                     f"while use_clipped_linears=True.")
             v = p.get_value()
-            if v.shape not in ((), (1,)):
+            if v.shape not in ((), (1, )):
                 raise ValueError(
                     f"Gemma4ClippableEinsum[{pfx}]: clip bound '{nm}' has non-scalar shape "
                     f"{v.shape}; expected scalar.")
-            fv = float(jnp.reshape(v, (-1,))[0])
+            fv = float(jnp.reshape(v, (-1, ))[0])
             if not bool(jnp.isfinite(jnp.asarray(fv))):
                 raise ValueError(
                     f"Gemma4ClippableEinsum[{pfx}]: required clip bound '{nm}'={fv} is "
@@ -197,24 +203,27 @@ class Gemma4ClippableEinsum(JaxEinsum):
         if vals["input_min"] > vals["input_max"]:
             raise ValueError(
                 f"Gemma4ClippableEinsum[{pfx}]: input_min={vals['input_min']} > "
-                f"input_max={vals['input_max']} (a clamp with min>max would empty the interval).")
+                f"input_max={vals['input_max']} (a clamp with min>max would empty the interval)."
+            )
         if vals["output_min"] > vals["output_max"]:
             raise ValueError(
                 f"Gemma4ClippableEinsum[{pfx}]: output_min={vals['output_min']} > "
-                f"output_max={vals['output_max']} (a clamp with min>max would empty the interval).")
+                f"output_max={vals['output_max']} (a clamp with min>max would empty the interval)."
+            )
 
     def __call__(self, inputs):
         if not self.use_clipped_linears:
             return super().__call__(inputs)
         xd = inputs.dtype
-        inputs = jnp.clip(inputs, self.input_min.get_value().astype(xd),
+        inputs = jnp.clip(inputs,
+                          self.input_min.get_value().astype(xd),
                           self.input_max.get_value().astype(xd))
         y = super().__call__(inputs)
         yd = y.dtype
-        y = jnp.clip(y, self.output_min.get_value().astype(yd),
+        y = jnp.clip(y,
+                     self.output_min.get_value().astype(yd),
                      self.output_max.get_value().astype(yd))
         return y
-
 
 
 class Gemma4VisionFlashAttention(JaxModule):
@@ -246,13 +255,11 @@ class Gemma4VisionFlashAttention(JaxModule):
         _ucl = bool(getattr(config, "use_clipped_linears", False))
 
         self.q_proj = Gemma4ClippableEinsum(
-            "BTD,DNH->BTNH",
-            (self.features, self.num_heads, self.head_dim),
+            "BTD,DNH->BTNH", (self.features, self.num_heads, self.head_dim),
             use_clipped_linears=_ucl,
             param_dtype=dtype,
             kernel_init=nnx.with_partitioning(
-                init_fn,
-                (None, ShardingAxisName.VIT_MODEL, None)),
+                init_fn, (None, ShardingAxisName.VIT_MODEL, None)),
             rngs=rng,
             quant_config=quant_config,
             prefix=f"{prefix}.q_proj.linear")
@@ -275,13 +282,11 @@ class Gemma4VisionFlashAttention(JaxModule):
             quant_config=quant_config,
             prefix=f"{prefix}.v_proj.linear")
         self.o_proj = Gemma4ClippableEinsum(
-            "BTNH,NHD->BTD",
-            (self.num_heads, self.head_dim, self.features),
+            "BTNH,NHD->BTD", (self.num_heads, self.head_dim, self.features),
             use_clipped_linears=_ucl,
             param_dtype=dtype,
             kernel_init=nnx.with_partitioning(
-                init_fn,
-                (ShardingAxisName.VIT_MODEL, None, None)),
+                init_fn, (ShardingAxisName.VIT_MODEL, None, None)),
             rngs=rng,
             quant_config=quant_config,
             prefix=f"{prefix}.o_proj.linear")
@@ -836,7 +841,7 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
             ],
         )
         loaded = loader.load_weights(mapper.apply(weights))
-        # M1 (required-bound hard failure): after load, validate every vision
+        # Required-bound hard failure: after load, validate every vision
         # Gemma4ClippableEinsum has finite, scalar clip bounds. A missing bound
         # (still at the NaN sentinel), a non-finite bound, or a non-scalar bound
         # raises ValueError instead of silently degrading to an identity clamp.
@@ -878,7 +883,8 @@ class Gemma4ForConditionalGeneration(JaxModule, LoadableWithIterator):
 
         n_checked = 0
         for _, node in nnx.iter_graph(vt):
-            if isinstance(node, Gemma4ClippableEinsum) and node.use_clipped_linears:
+            if isinstance(node,
+                          Gemma4ClippableEinsum) and node.use_clipped_linears:
                 node.validate_clip_bounds()
                 n_checked += 1
 


### PR DESCRIPTION
## What

Adds `Gemma4ClippableEinsum` — the vLLM-JAX serving building block for Gemma-4's clipped-linear
vision projections — plus its checkpoint load + fail-closed post-load validation.

This PR owns the **component**: clamp-in -> einsum -> clamp-out, the four per-projection activation
clip bounds (`input_min/input_max/output_min/output_max`), and exact post-load accounting of
**112 modules / 448 scalar bounds**.

## Semantic reference

Equivalent of HF transformers `Gemma4ClippableLinear`
(`transformers/models/gemma4/modeling_gemma4.py`). vLLM has no PyTorch-local class for this op; the
vLLM Gemma-4 vision path delegates the vision tower to HF Transformers, so `Gemma4ClippableLinear`
is the semantic reference.

## What this PR owns (and validates)

- `Gemma4ClippableEinsum` forward: `clamp(x, input_min, input_max)` -> einsum -> `clamp(y, output_min, output_max)`.
- Checkpoint load of the four bounds per clipped projection.
- **Fail-closed** post-load validation over the vision tower (runs after Orbax restore, before first JIT):
  every required bound must be present, finite, scalar, and correctly ordered (`min <= max`). Missing /
  NaN / Inf / non-scalar / `min > max` -> `ValueError` (no silent identity clamp).
- Exact accounting: 16 vision blocks x 7 clipped projections = 112 modules / 448 bounds.

## What this PR does NOT own (explicit scope boundary)

- **Whole-serving semantic parity** for a full Gemma-4 multimodal forward. That depends on the exported
  weights being complete + correct, the decoder/runtime semantics, and checkpoint-completeness — none of
  which live in this component.
- **Checkpoint export completeness** (e.g. shared-KV-layer K/V + k_norm ownership). That is a separate
  export/serving invariant, tracked elsewhere.
- Decoder / RoPE / positions / PLE runtime semantics.

## Correction to earlier claims in this PR's history

An earlier revision of this description attributed a whole-serving numerical residual to a
"BF16 + flash-attention near-tie floor" and described the serving vision tower as becoming
"numerically faithful" / "exact in FP32". **That attribution was later falsified** by true-FP32 analysis:

- The clipped-linear component math is exact (unit-verified here: 448/448 bounds, clamp math bit-exact).
- A separate whole-serving RED observed on a current head was root-caused to **incomplete exported weights**
  (shared-layer K/V + k_norm stripped from the served checkpoint leaving fused-qkv columns at random init),
  **not** to this clipped-linear code and **not** to a BF16/flash near-tie floor.
- A distinct, historical shipping-image **RoPE config bug** was separately root-caused; the current head is
  RoPE-safe. That RoPE issue is unrelated to this component.

This PR is therefore scoped and validated at the **component level**; whole-stack parity is established
(and gated) elsewhere in the program, against complete exported weights.

## Tests

`tests/models/jax/test_gemma4_clipped_linears.py` (component-level; CPU; synthetic tiny modules, no gated
checkpoint): flag-off exact no-op, HF-parity clamp oracle, finite/ordered-bounds OK, NaN-sentinel / Inf /
non-scalar / min>max fail-closed, q!=k distinct bounds, walker discovers exactly `num_blocks*7` modules,
zero-modules / partial-bounds / vision_tower-None fail-closed.

## CI note

`pre-commit` and `DCO` are green on the current head. The `buildkite/tpu-inference-ci` `pipeline-upload`
step fails ~11s on this fork PR; it fails identically on every commit of this branch (including before any
code change here) while internal (non-fork) PRs pass it — i.e. it is a fork-build pipeline-upload
permission limitation, not a branch-owned failure. Running CI from the org side clears it.

---
_Revised with [Navi](https://navibot.dev?utm_source=github&utm_medium=pr_description&utm_campaign=PR3355&ref=dengcchi) on behalf of Loki Chen (@lokic233)._
