### PR TITLE
[DSv4] Add a fused reverse-rope-quant-wo-a kernel

### DIFF
--- a/tests/kernels/deepseek_v4/o_projection_test.py
+++ b/tests/kernels/deepseek_v4/o_projection_test.py
@@ -1,0 +1,142 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
+
+from tests.kernels.deepseek_v4.rope_test import (make_cos_sin_cache,
+                                                 rope_ref_impl)
+from tpu_inference.kernels.experimental.deepseek_v4.o_projection import (
+    LANE, gather_cos_sin, wo_a_projection)
+
+# DeepSeek-V4: head_dim 512, qk_rope_head_dim 64, 8 heads per group.
+HEAD_DIM = 512
+ROTARY_DIM = 64
+MAX_POSITION = 4096
+HEADS_PER_GROUP = 8
+
+
+def o_projection_ref_impl(activations, wo_a, wo_a_scale, *, num_groups):
+    """``DeepseekV4Attention._o_proj``'s wo_a einsum, up to (not incl.) ``wo_b``."""
+    num_tokens = activations.shape[0]
+    o_f = activations.reshape(num_tokens, num_groups, -1)  # [t, g, d]
+    reduction = o_f.shape[-1]
+    w = wo_a.reshape(reduction, num_groups, -1)
+    s = wo_a_scale.reshape(num_groups, -1)
+    z = (jnp.einsum(
+        "tgd,dgr->tgr",
+        o_f,
+        w.astype(jnp.bfloat16),
+        preferred_element_type=jnp.float32,
+    ) * s.astype(jnp.bfloat16)[None, ...])
+    return z.astype(jnp.bfloat16).reshape(num_tokens, -1)
+
+
+def make_inputs(rng,
+                *,
+                num_tokens,
+                num_groups,
+                lora_rank,
+                heads_per_group=HEADS_PER_GROUP):
+    """Activations in the ``[T, G * H, head_dim]`` view the kernel takes."""
+    reduction = heads_per_group * HEAD_DIM
+    num_heads = num_groups * heads_per_group
+    activations = jnp.asarray(
+        rng.standard_normal((num_tokens, num_heads, HEAD_DIM)),
+        dtype=jnp.bfloat16,
+    )
+    wo_a = jnp.asarray(
+        rng.standard_normal((reduction, num_groups * lora_rank)),
+        dtype=jnp.float8_e4m3fn,
+    )
+    wo_a_scale = jnp.asarray(rng.uniform(0.5, 1.5,
+                                         size=num_groups * lora_rank),
+                             dtype=jnp.float32)
+    return activations, wo_a, wo_a_scale
+
+
+class OProjectionTest(parameterized.TestCase):
+
+    @parameterized.named_parameters(
+        dict(  # DeepSeek-V4-Flash, unsharded.
+            testcase_name="dsv4_flash",
+            num_tokens=256,
+            num_groups=8,
+            lora_rank=1024,
+        ),
+        dict(  # The benchmarked shape: activations [1024, 128, 512].
+            testcase_name="dsv4_pro",
+            num_tokens=1024,
+            num_groups=16,
+            lora_rank=1024,
+        ),
+    )
+    def test_matches_reference(
+        self,
+        *,
+        num_tokens,
+        num_groups,
+        lora_rank,
+        tile_t=None,
+        tile_r=None,
+        sub_t=None,
+    ):
+        """The fused inverse-RoPE path against ``rope`` + the wo_a einsum."""
+        rng = np.random.default_rng(0)
+        activations, wo_a, wo_a_scale = make_inputs(
+            rng,
+            num_tokens=num_tokens,
+            num_groups=num_groups,
+            lora_rank=lora_rank,
+        )
+        positions = jnp.asarray(rng.integers(0,
+                                             MAX_POSITION,
+                                             size=(num_tokens, )),
+                                dtype=jnp.int32)
+        cos_sin_cache = jnp.asarray(make_cos_sin_cache(MAX_POSITION,
+                                                       ROTARY_DIM),
+                                    dtype=jnp.float32)
+        cos_sin = gather_cos_sin(positions, cos_sin_cache, inverse=True)
+        self.assertEqual(cos_sin.shape, (num_tokens, 2 * LANE))
+        out = wo_a_projection(
+            activations,
+            wo_a,
+            wo_a_scale,
+            cos_sin,
+            tile_t=tile_t,
+            tile_r=tile_r,
+            sub_t=sub_t,
+            quantize_activations=False,
+        )
+
+        roped = rope_ref_impl(activations,
+                              positions,
+                              cos_sin_cache,
+                              inverse=True)
+        expected = o_projection_ref_impl(roped,
+                                         wo_a,
+                                         wo_a_scale,
+                                         num_groups=num_groups)
+
+        np.testing.assert_allclose(
+            np.asarray(out, dtype=np.float32),
+            np.asarray(expected, dtype=np.float32),
+            rtol=1e-2,
+            atol=1e-2,
+        )
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tpu_inference/kernels/experimental/deepseek_v4/o_projection.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/o_projection.py
@@ -1,0 +1,366 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+from tpu_inference.kernels.experimental.deepseek_v4.rope import (
+    LANE, CosSinRef, _cos_sin_lanes, _rotate_gptj)
+
+DEFAULT_VMEM_LIMIT_BYTES = 100 * 1024 * 1024
+
+SUBLANE = 8
+
+FP8_E4M3_MAX = float(jnp.finfo(jnp.float8_e4m3fn).max)
+
+
+def _largest_divisor(x: int, cap: int) -> int:
+    """Largest divisor of ``x`` that is <= ``cap``."""
+    for candidate in range(min(x, cap), 0, -1):
+        if x % candidate == 0:
+            return candidate
+    return 1
+
+
+def _cos_sin_body(cos_sin_ref, out_ref, *, rotary_dim, inverse, out_dtype):
+    """Expand a ``(tile_n, rotary_dim)`` block to ``(tile_n, 2 * LANE)``."""
+    cos, sin = _cos_sin_lanes(cos_sin_ref[...],
+                              rotary_dim=rotary_dim,
+                              inverse=inverse)
+    out_ref[...] = jnp.concatenate([cos, sin], axis=-1).astype(out_dtype)
+
+
+def _cos_sin_kernel(
+    # scalar prefetch
+    positions_ref,
+    # HBM input
+    cos_sin_cache_hbm_ref,
+    # HBM output
+    out_hbm_ref,
+    *,
+    num_tiles: int,
+    tile_n: int,
+    rotary_dim: int,
+    inverse: bool,
+    cos_sin_dtype: jnp.dtype,
+    out_dtype: jnp.dtype,
+):
+    cos_sin_spec = pl.BlockSpec(
+        block_shape=(tile_n, rotary_dim),
+        memory_space=pltpu.VMEM,
+        index_map=lambda i: (i, 0),
+    )
+    out_spec = pl.BlockSpec(
+        block_shape=(tile_n, 2 * LANE),
+        memory_space=pltpu.VMEM,
+        index_map=lambda i: (i, 0),
+    )
+    # The per-token row gather; one buffer of lookahead hides its DMAs.
+    cos_sin_alloc = CosSinRef.create(spec=cos_sin_spec,
+                                     dtype=cos_sin_dtype,
+                                     buffer_count=2,
+                                     tile_n=tile_n)
+
+    pipeline = pltpu.emit_pipeline(
+        functools.partial(
+            _cos_sin_body,
+            rotary_dim=rotary_dim,
+            inverse=inverse,
+            out_dtype=out_dtype,
+        ),
+        grid=(num_tiles, ),
+        in_specs=[cos_sin_spec],
+        out_specs=[out_spec],
+    )
+    allocations = (
+        cos_sin_alloc,
+        pltpu.BufferedRef.output(out_spec, out_dtype, buffer_count=2),
+    )
+
+    @pl.with_scoped(allocations=allocations)
+    def _run(allocations):
+        pipeline(
+            (cos_sin_cache_hbm_ref, positions_ref),
+            out_hbm_ref,
+            allocations=allocations,
+        )
+
+    _run()
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=("inverse", "out_dtype", "name"),
+)
+def gather_cos_sin(
+    positions: jax.Array,  # [T] int
+    cos_sin_cache: jax.Array,  # [max_position, rotary_dim] float32
+    *,
+    inverse: bool = False,
+    out_dtype: jnp.dtype = jnp.float32,
+    name: str = "gather_cos_sin",
+) -> jax.Array:
+    """Builds ``wo_a_projection``'s ``[T, 2 * LANE]`` cos/sin table.
+
+  Gathers ``cos_sin_cache[positions]`` based on the token positions, expands
+  each row to ``[2 * LANE]``
+  """
+    assert positions.ndim == 1
+    assert cos_sin_cache.ndim == 2
+
+    num_tokens = positions.shape[0]
+    rotary_dim = cos_sin_cache.shape[1]
+    assert rotary_dim % 2 == 0 and rotary_dim <= LANE
+
+    tile_n = _largest_divisor(num_tokens, cap=128)
+
+    return pl.pallas_call(
+        functools.partial(
+            _cos_sin_kernel,
+            num_tiles=num_tokens // tile_n,
+            tile_n=tile_n,
+            rotary_dim=rotary_dim,
+            inverse=inverse,
+            cos_sin_dtype=cos_sin_cache.dtype,
+            out_dtype=out_dtype,
+        ),
+        out_shape=jax.ShapeDtypeStruct((num_tokens, 2 * LANE), out_dtype),
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=1,
+            in_specs=(pl.BlockSpec(memory_space=pltpu.HBM), ),
+            out_specs=pl.BlockSpec(memory_space=pltpu.HBM),
+        ),
+        compiler_params=pltpu.CompilerParams(
+            vmem_limit_bytes=DEFAULT_VMEM_LIMIT_BYTES,
+            disable_bounds_checks=True,
+        ),
+        name=name,
+    )(positions, cos_sin_cache)
+
+
+def _rope_heads(x, cos_sin, *, head_dim):
+    """apply RoPE to the last rope dim of head dim of ``x``."""
+    cos = cos_sin[:, :LANE]
+    sin = cos_sin[:, LANE:]
+    lo = head_dim - LANE
+    tail = x[:, :, lo:].astype(jnp.float32)
+    roped = tail * cos[:, None, :] + _rotate_gptj(tail) * sin[:, None, :]
+    return jnp.concatenate([x[:, :, :lo], roped.astype(x.dtype)], axis=-1)
+
+
+def _kernel(
+    # inputs
+    x_ref,  # VMEM (tile_t, H, head_dim) bf16
+    w_ref,  # VMEM (D, tile_r) fp8
+    scale_ref,  # VMEM (1, tile_r) f32
+    cos_sin_ref,  # VMEM (tile_t, 2 * LANE) f32
+    # output
+    out_ref,  # VMEM (tile_t, tile_r) out_dtype
+    *,
+    tile_t: int,
+    num_sub_t: int,
+    quantize_activations: bool,
+    head_dim: int,
+):
+    rhs = w_ref[...]
+    scale = scale_ref[...]
+    cos_sin = cos_sin_ref[...]
+    sub_t = tile_t // num_sub_t
+    out_dtype = x_ref.dtype
+    for s in range(num_sub_t):
+        # Subchunk the tile to allow more Instruction level parallelism
+        # opportunities to be exploited by the LLO compiler.
+        rows = slice(s * sub_t, (s + 1) * sub_t)
+        x = _rope_heads(x_ref[rows], cos_sin[rows], head_dim=head_dim)
+        x = x.reshape(sub_t, -1)
+        inv = None
+        if quantize_activations:
+            amax = jnp.max(jnp.abs(x), axis=1, keepdims=True)
+            inv = (FP8_E4M3_MAX /
+                   jnp.maximum(amax, jnp.bfloat16(1e-30))).astype(jnp.bfloat16)
+            lhs = (x * inv).astype(jnp.float8_e4m3fn)
+        else:
+            lhs = x
+
+        partial = jax.lax.dot_general(
+            lhs,
+            rhs,
+            (((1, ), (0, )), ((), ())),
+            preferred_element_type=jnp.float32,
+        )
+        if quantize_activations:
+            assert inv is not None
+            partial = partial * (1.0 / inv.astype(jnp.float32))
+        out_ref[rows] = (partial * scale).astype(out_dtype)
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=(
+        "tile_t",
+        "tile_r",
+        "sub_t",
+        "quantize_activations",
+        "name",
+    ),
+)
+def wo_a_projection(
+    x: jax.Array,  # [T, G * H, head_dim] bf16
+    wo_a: jax.Array,  # [D, G * R] fp8
+    wo_a_scale: jax.Array,  # [G * R] float32
+    cos_sin: jax.Array,  # [T, 2 * LANE] float32
+    *,
+    tile_t: int | None = None,
+    tile_r: int | None = None,
+    sub_t: int | None = None,
+    quantize_activations: bool = True,
+    name: str = "wo_a_projection",
+) -> jax.Array:
+    """Do DSv4 wo_a projection.
+
+  T: num_tokens
+  G: num_groups
+  H: num_heads_per_group
+  D: H * head_dim
+  R: o_lora_dim
+
+  Equivalent to
+  x = rope(x)
+  return ``einsum("tgd,dgr->tgr", x.view(t, g, d), wo_a.view(d, g, r),
+  preferred_element_type=f32) * wo_a_scale.view(g, r).to(bf16)``
+
+  ``quantize_activations`` quantizes each activation block's rows to fp8 in
+  the kernel so both MXU operands are fp8.
+  """
+    assert x.ndim == 3
+    assert x.dtype == jnp.bfloat16
+    assert wo_a.ndim == 2 and wo_a_scale.ndim == 1
+
+    num_tokens, num_heads, head_dim = x.shape
+    reduction, out_features = wo_a.shape
+    assert out_features == wo_a_scale.shape[0]
+
+    assert reduction % head_dim == 0
+    heads_per_group = reduction // head_dim
+
+    # DSv4's heads_per_group is 8, exactly equal to SUBLANE
+    # The kernel is based on this assumption, which makes it
+    # simpler.
+    assert heads_per_group == SUBLANE
+    assert num_heads % heads_per_group == 0
+    num_groups = num_heads // heads_per_group
+    assert out_features % num_groups == 0
+    lora_rank = out_features // num_groups
+
+    assert cos_sin.ndim == 2 and cos_sin.shape == (num_tokens, 2 * LANE)
+    assert head_dim % LANE == 0
+
+    if tile_r is None:
+        tile_r = lora_rank
+    if tile_t is None:
+        tile_t = _largest_divisor(num_tokens, cap=1024)
+    if sub_t is None:
+        # 128 is chosen based on large batch size (t) microbenchmarks
+        sub_t = _largest_divisor(tile_t, cap=128)
+    assert lora_rank % tile_r == 0
+    assert num_tokens % tile_t == 0
+    assert tile_t % sub_t == 0
+    num_t_tiles = num_tokens // tile_t
+    num_r_tiles = lora_rank // tile_r
+
+    return pl.pallas_call(
+        functools.partial(
+            _kernel,
+            tile_t=tile_t,
+            num_sub_t=tile_t // sub_t,
+            quantize_activations=quantize_activations,
+            head_dim=head_dim,
+        ),
+        out_shape=jax.ShapeDtypeStruct((num_tokens, out_features), x.dtype),
+        grid=(num_groups, num_t_tiles, num_r_tiles),
+        in_specs=[
+            # x: one group's heads, [t, g, 0] over [T, G * H, head_dim].
+            pl.BlockSpec((tile_t, heads_per_group, head_dim), lambda g, t, r:
+                         (t, g, 0)),
+            # wo_a: the whole reduction, column block g * R + r * tile_r.
+            pl.BlockSpec((reduction, tile_r), lambda g, t, r:
+                         (0, g * num_r_tiles + r)),
+            # wo_a_scale
+            pl.BlockSpec((1, tile_r), lambda g, t, r:
+                         (0, g * num_r_tiles + r)),
+            # cos_sin: one token block
+            pl.BlockSpec((tile_t, 2 * LANE), lambda g, t, r: (t, 0)),
+        ],
+        out_specs=pl.BlockSpec((tile_t, tile_r), lambda g, t, r:
+                               (t, g * num_r_tiles + r)),
+        compiler_params=pltpu.CompilerParams(
+            vmem_limit_bytes=DEFAULT_VMEM_LIMIT_BYTES,
+            disable_bounds_checks=True,
+        ),
+        name=name,
+    )(x, wo_a, wo_a_scale.reshape(1, out_features), cos_sin)
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=(
+        "head_dim",
+        "inverse",
+        "tile_t",
+        "tile_r",
+        "sub_t",
+        "quantize_activations",
+        "name",
+    ),
+)
+def fused_reverse_rope_wo_a_projection(
+    x: jax.Array,  # [T, G * H, head_dim] bf16
+    positions: jax.Array,  # [T] int
+    cos_sin_cache: jax.Array,  # [max_position, rotary_dim] float32
+    wo_a: jax.Array,  # [D, G * R] fp8
+    wo_a_scale: jax.Array,  # [G * R] float32
+    *,
+    head_dim: int,
+    inverse: bool = True,
+    tile_t: int | None = None,
+    tile_r: int | None = None,
+    sub_t: int | None = None,
+    quantize_activations: bool = True,
+    name: str = "wo_a_projection",
+) -> jax.Array:
+    """``The RoPE-fused ``wo_a_projection``."""
+    assert x.ndim == 3
+    assert x.shape[2] == head_dim
+
+    cos_sin = gather_cos_sin(
+        positions,
+        cos_sin_cache,
+        inverse=inverse,
+        name=f"{name}_gather_cos_sin",
+    )
+    return wo_a_projection(
+        x,
+        wo_a,
+        wo_a_scale,
+        cos_sin,
+        tile_t=tile_t,
+        tile_r=tile_r,
+        sub_t=sub_t,
+        quantize_activations=quantize_activations,
+        name=name,
+    )

--- a/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_attention.py
+++ b/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_attention.py
@@ -29,6 +29,7 @@ rebinds it on ``amd.model`` directly. It is invoked from
 ``_maybe_patch_for_deepseek_v4`` in ``vllm_model_wrapper`` while ``is_rocm`` is
 forced True and the package has been reloaded onto the AMD implementation.
 """
+import functools
 from unittest.mock import patch
 
 import jax
@@ -52,6 +53,8 @@ from tpu_inference.kernels.experimental.deepseek_v4.core_attention.mla_swa impor
     mla_sliding_window_ragged_paged_attention
 from tpu_inference.kernels.experimental.deepseek_v4.core_attention.sparse_mla import \
     sparse_ragged_paged_attention
+from tpu_inference.kernels.experimental.deepseek_v4.o_projection import \
+    fused_reverse_rope_wo_a_projection
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.vllm.custom_ops.experimental.deepseek_v4.deepseek_v4_compressor import \
     VllmDeepseekCompressor
@@ -227,35 +230,36 @@ class VllmDeepseekV4MLAAttention(DeepseekV4Attention):
                 positions: torch.Tensor) -> torch.Tensor:
         """Inverse-RoPE + wo_a (per-group bmm) + wo_b output projection.
         """
-        t = o.shape[0]
-        o_f = o.view(t, self.n_local_heads, self.head_dim)
         mesh = get_vllm_model_wrapper_context().mesh
-        o_ref = torch_view(
-            sharded_rope(
-                rope_kernel.rope,
-                mesh,
-                jax_view(o_f),
-                jax_view(positions),
-                jax_view(self.rotary_emb.cos_sin_cache),
+        # fused_reverse_rope_wo_a_projection assume data parallelism
+        # for the attention layer.
+        z = jax.shard_map(
+            functools.partial(
+                fused_reverse_rope_wo_a_projection,
+                head_dim=self.head_dim,
                 inverse=True,
-            ))
-
-        # --- wo_a: per-group batched matmul [t, g, d] x [d, g, r] -> [t, g, r].
-        o_ref = o_ref.view(t, self.n_local_groups, -1)  # [t, g, d]
-        hidden_dim = o_ref.shape[-1]
-        wo_a_weight = self.wo_a.weight.view(hidden_dim, self.n_local_groups,
-                                            self.o_lora_rank)
-        wo_a_scale = self.wo_a.weight_scale.view(self.n_local_groups,
-                                                 self.o_lora_rank)
-        z = jnp.einsum(
-            "tgd,dgr->tgr",
-            jax_view(o_ref),
-            jax_view(wo_a_weight),
-            preferred_element_type=jnp.float32) * jax_view(wo_a_scale).astype(
-                jnp.bfloat16)[None, ...]
+                quantize_activations=True,
+            ),
+            mesh=mesh,
+            in_specs=(
+                P(ShardingAxisName.ATTN_DATA),  # o
+                P(ShardingAxisName.ATTN_DATA),  # positions
+                P(),  # cos_sin_cache (replicated)
+                P(),  # wo_a
+                P(),  # wo_a_scale
+            ),
+            out_specs=P(ShardingAxisName.ATTN_DATA),
+            check_vma=False,
+        )(
+            jax_view(o),
+            jax_view(positions),
+            jax_view(self.rotary_emb.cos_sin_cache),
+            jax_view(self.wo_a.weight),
+            jax_view(self.wo_a.weight_scale),
+        )
 
         # --- wo_b: RowParallelLinear back to hidden_size (returns (out, bias)).
-        out = self.wo_b(torch_view(z.astype(jnp.bfloat16).reshape(t, -1)))
+        out = self.wo_b(torch_view(z))
         if isinstance(out, tuple):
             out = out[0]
         return out
@@ -463,7 +467,7 @@ class VllmDeepseekV4MLAAttention(DeepseekV4Attention):
                     # TODO: tune num_kv_pages_per_block & num_queries_per_block
                     num_kv_pages_per_block=(2, 2, 2),
                     num_queries_per_block=(1, 32, 32),
-                    q_compute_block_size=2,
+                    q_compute_block_size=4,
                     unnormalized_output=False if swa_only else True,
                 ))
 


### PR DESCRIPTION
[DSv4] fused reverse-rope + fp8-quant + wo-a batch-matmul kernel

before this PR:
https://screenshot-v2.corp.google.com/7fnsc3kigau2o (~304us)
The reshape from (num_tokens, num_heads, head_dim) -> (num_tokens, num_groups, heads_per_group * head_dim) is very costly.

after this PR:
https://screenshot-v2.corp.google.com/59nb2hso4dtog (~74us)

Roofline of this fused op is about 34us.


Quality verified:
MMLU: https://paste.googleplex.com/6592322820243456 
MMLU Pro: https://paste.googleplex.com/4992211245727744 
