### PR TITLE
Make pause/resume work on TPU

### DIFF
--- a/.buildkite/rl/rl_integration.yml
+++ b/.buildkite/rl/rl_integration.yml
@@ -41,6 +41,38 @@ steps:
         .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_rl_integration_CorrectnessTest
 
   # ------------------------------------------------------------------
+  # Pause/resume tests (nightly)
+  #
+  # Covers the weight-sync window an async RL trainer relies on: mode="keep"
+  # freezing in-flight rollouts without corrupting them, requests submitted
+  # during a pause surviving to resume, and cache_salt rotation stopping a new
+  # policy from reusing the previous policy's KV. Nightly rather than
+  # per-push because it stands up its own AsyncLLM engine.
+  # ------------------------------------------------------------------
+  - label: "${TPU_VERSION:-tpu6e} Pause/resume tests for rl_integration"
+    key: "${TPU_VERSION:-tpu6e}_rl_integration_PauseResumeTest"
+    soft_fail: true
+    if: build.env("NIGHTLY") == "1"
+    agents:
+      queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    commands:
+      - .buildkite/scripts/run_in_docker.sh python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_rl_pause_resume.py
+  - label: "${TPU_VERSION:-tpu6e} Record pause/resume test result for rl_integration"
+    key: "${TPU_VERSION:-tpu6e}_record_rl_integration_PauseResumeTest"
+    depends_on: "${TPU_VERSION:-tpu6e}_rl_integration_PauseResumeTest"
+    if: build.env("NIGHTLY") == "1"
+    env:
+      CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
+      CI_TARGET: "rl_integration"
+      CI_STAGE: "PauseResumeTest"
+      CI_CATEGORY: "rl support matrix"
+    agents:
+      queue: cpu
+    commands:
+      - |
+        .buildkite/scripts/record_step_result.sh ${TPU_VERSION:-tpu6e}_rl_integration_PauseResumeTest
+
+  # ------------------------------------------------------------------
   # Performance tests
   # ------------------------------------------------------------------
   - label: "${TPU_VERSION:-tpu6e} Performance tests for rl_integration"

--- a/.buildkite/rl/rl_integration.yml
+++ b/.buildkite/rl/rl_integration.yml
@@ -64,7 +64,7 @@ steps:
     env:
       CI_TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       CI_TARGET: "rl_integration"
-      CI_STAGE: "PauseResumeTest"
+      CI_STAGE: "Single-Host CorrectnessTest"
       CI_CATEGORY: "rl support matrix"
     agents:
       queue: cpu

--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -581,19 +581,28 @@ class TestDPScheduler:
                                            mock_structured_output_manager)
 
         scheduler._send_command = MagicMock()
-        scheduler._get_result = MagicMock(return_value=None)
+        # Rank workers answer FINISH_REQUESTS with the (request_id,
+        # client_index) pairs they actually finished; EngineCoreProc needs
+        # them to send abort outputs.
+        scheduler._get_result = MagicMock(
+            side_effect=lambda rank, _cmd: [(f"req{rank + 1}", rank)])
 
         scheduler.assigned_dp_rank = {"req1": 0, "req2": 1, "req3": 0}
 
         # Test with list of requests
-        scheduler.finish_requests(["req1", "req2"],
-                                  finished_status="completed")
+        finished = scheduler.finish_requests(["req1", "req2"],
+                                             finished_status="completed")
 
         # Verify FINISH_REQUESTS commands were sent to correct ranks
         scheduler._send_command.assert_any_call(
             0, SchedulerCommand.FINISH_REQUESTS, (["req1"], "completed"))
         scheduler._send_command.assert_any_call(
             1, SchedulerCommand.FINISH_REQUESTS, (["req2"], "completed"))
+
+        # And that what the ranks reported is passed back to the caller.
+        assert sorted(
+            (r.request_id, r.client_index) for r in finished) == [("req1", 0),
+                                                                  ("req2", 1)]
 
     def test_get_num_unfinished_requests(self, mock_vllm_config,
                                          mock_kv_cache_config,

--- a/tests/e2e/test_rl_pause_resume.py
+++ b/tests/e2e/test_rl_pause_resume.py
@@ -60,8 +60,7 @@ PROMPT = ("Count from one to forty, writing each number as a word, "
 # complete blocks, so anything shorter than block_size (64 on TPU by default)
 # reports zero cached tokens no matter how the salt behaves, and the
 # comparison silently becomes 0 > 0.
-SALT_PROMPT = "Reference material: " + " ".join(
-    f"item{i}" for i in range(400))
+SALT_PROMPT = "Reference material: " + " ".join(f"item{i}" for i in range(400))
 
 
 @pytest.fixture(scope="module")
@@ -224,9 +223,8 @@ class TestCacheSaltIsolatesPolicies:
                                        cache_salt=salt_b)
 
             assert warm is not None, "engine did not report num_cached_tokens"
-            assert warm > cold, (
-                f"prefix caching is not working at all "
-                f"(cold={cold}, warm={warm})")
+            assert warm > cold, (f"prefix caching is not working at all "
+                                 f"(cold={cold}, warm={warm})")
             assert rotated < warm, (
                 f"rotating cache_salt did not invalidate reuse "
                 f"(salt B cached={rotated}, salt A warm cached={warm}); a new "
@@ -235,5 +233,33 @@ class TestCacheSaltIsolatesPolicies:
                 f"the prompt does not re-cache under the new salt "
                 f"(cached={warm_b}); the drop above may have been eviction "
                 f"rather than the salt")
+
+        loop.run_until_complete(scenario())
+
+
+class TestPauseWithCacheClear:
+    """clear_cache=True reaches reset_encoder_cache over collective_rpc.
+
+    That RPC resolves by name and is issued regardless of modality, so before
+    TPUWorker grew the method this failed on every TPU model, text-only
+    included, with `NotImplementedError: Method 'reset_encoder_cache' is not
+    implemented.` Verified by deleting the method and re-running this test.
+    Placed last: it aborts in-flight work and wipes the prefix cache, which
+    would disturb the tests above.
+    """
+
+    def test_pause_clear_cache_then_engine_still_serves(self, loop, engine):
+
+        async def scenario():
+            await engine.pause_generation(mode="abort", clear_cache=True)
+            assert await engine.is_paused()
+            await engine.resume_generation()
+            assert not await engine.is_paused()
+
+            token_ids, _ = await _collect(engine,
+                                          "after-cache-clear",
+                                          max_tokens=8)
+            assert len(token_ids) == 8, (
+                "engine did not serve correctly after a cache-clearing pause")
 
         loop.run_until_complete(scenario())

--- a/tests/e2e/test_rl_pause_resume.py
+++ b/tests/e2e/test_rl_pause_resume.py
@@ -23,19 +23,15 @@
 #   1. mode="keep" freezes in-flight work without corrupting it -- the tokens
 #      produced across a pause match an uninterrupted run exactly.
 #   2. Requests submitted during a pause are queued, not aborted.
-#   3. Rotating cache_salt stops a new policy from reusing the old policy's
-#      blocks, while leaving reuse within a policy intact.
+#   3. clear_cache=True completes instead of failing on a missing worker RPC.
 #
-# (3) is the invariant the whole design rests on and nothing in the engine
-# enforces it: cache_salt is a per-request field the caller supplies, and the
-# engine's weight_version never reaches the block hasher. If it silently
-# stopped working, an RL run would keep producing plausible rewards computed
-# against stale KV.
+# cache_salt behaviour is deliberately not retested here: the block hasher and
+# block pool are vLLM code this repo reuses unmodified, and upstream covers it
+# in tests/v1/core/test_prefix_caching.py.
 
 from __future__ import annotations
 
 import asyncio
-import uuid
 
 import pytest
 from vllm import SamplingParams
@@ -55,12 +51,6 @@ PAUSE_HOLD_S = 3.0
 
 PROMPT = ("Count from one to forty, writing each number as a word, "
           "separated by commas.")
-
-# The salt test needs a prompt spanning several KV blocks: vLLM only caches
-# complete blocks, so anything shorter than block_size (64 on TPU by default)
-# reports zero cached tokens no matter how the salt behaves, and the
-# comparison silently becomes 0 > 0.
-SALT_PROMPT = "Reference material: " + " ".join(f"item{i}" for i in range(400))
 
 
 @pytest.fixture(scope="module")
@@ -91,20 +81,12 @@ def engine(loop):
 async def _collect(engine: AsyncLLM,
                    request_id: str,
                    prompt: str = PROMPT,
-                   max_tokens: int = GEN_TOKENS,
-                   cache_salt: str | None = None):
-    """Runs one request to completion, returning (token_ids, num_cached).
-
-    cache_salt rides on the prompt dict (`TextPrompt.cache_salt`); AsyncLLM's
-    generate() has no such keyword.
-    """
+                   max_tokens: int = GEN_TOKENS):
+    """Runs one request to completion, returning (token_ids, num_cached)."""
     params = SamplingParams(temperature=0.0, max_tokens=max_tokens)
-    prompt_arg: str | dict = prompt
-    if cache_salt is not None:
-        prompt_arg = {"prompt": prompt, "cache_salt": cache_salt}
     token_ids: list[int] = []
     num_cached = None
-    async for out in engine.generate(prompt_arg, params, request_id):
+    async for out in engine.generate(prompt, params, request_id):
         token_ids = list(out.outputs[0].token_ids)
         num_cached = out.num_cached_tokens
     return token_ids, num_cached
@@ -183,56 +165,6 @@ class TestRequestsSubmittedWhilePaused:
             await engine.resume_generation()
             token_ids, _ = await asyncio.wait_for(task, timeout=120)
             assert len(token_ids) == 16
-
-        loop.run_until_complete(scenario())
-
-
-class TestCacheSaltIsolatesPolicies:
-    """Rotating cache_salt is what fences a new policy off from old KV."""
-
-    def test_salt_rotation_drops_reuse_and_same_salt_keeps_it(
-            self, loop, engine):
-
-        async def scenario():
-            # Unique per run: with fixed salts a warm pool from an earlier
-            # run would make the cold step look like a hit and invert the
-            # whole comparison.
-            run_id = uuid.uuid4().hex[:8]
-            salt_a, salt_b = f"policy-vA-{run_id}", f"policy-vB-{run_id}"
-            prompt = SALT_PROMPT
-
-            _, cold = await _collect(engine,
-                                     "salt-a-cold",
-                                     prompt=prompt,
-                                     max_tokens=8,
-                                     cache_salt=salt_a)
-            _, warm = await _collect(engine,
-                                     "salt-a-warm",
-                                     prompt=prompt,
-                                     max_tokens=8,
-                                     cache_salt=salt_a)
-            _, rotated = await _collect(engine,
-                                        "salt-b",
-                                        prompt=prompt,
-                                        max_tokens=8,
-                                        cache_salt=salt_b)
-            _, warm_b = await _collect(engine,
-                                       "salt-b-warm",
-                                       prompt=prompt,
-                                       max_tokens=8,
-                                       cache_salt=salt_b)
-
-            assert warm is not None, "engine did not report num_cached_tokens"
-            assert warm > cold, (f"prefix caching is not working at all "
-                                 f"(cold={cold}, warm={warm})")
-            assert rotated < warm, (
-                f"rotating cache_salt did not invalidate reuse "
-                f"(salt B cached={rotated}, salt A warm cached={warm}); a new "
-                f"policy would read KV computed under the old one")
-            assert warm_b > rotated, (
-                f"the prompt does not re-cache under the new salt "
-                f"(cached={warm_b}); the drop above may have been eviction "
-                f"rather than the salt")
 
         loop.run_until_complete(scenario())
 

--- a/tests/e2e/test_rl_pause_resume.py
+++ b/tests/e2e/test_rl_pause_resume.py
@@ -1,0 +1,239 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# End-to-end tests for the pause/resume window an async RL trainer uses to
+# swap policy weights, driven through AsyncLLM.
+#
+# The loop under test: batches k and k+1 are in flight, k finishes, the engine
+# is paused, weights are synced, the engine resumes. Batch k+1 legitimately
+# spans two policies; batch k+2 must not reuse KV computed under the old one.
+#
+# What each test pins down:
+#   1. mode="keep" freezes in-flight work without corrupting it -- the tokens
+#      produced across a pause match an uninterrupted run exactly.
+#   2. Requests submitted during a pause are queued, not aborted.
+#   3. Rotating cache_salt stops a new policy from reusing the old policy's
+#      blocks, while leaving reuse within a policy intact.
+#
+# (3) is the invariant the whole design rests on and nothing in the engine
+# enforces it: cache_salt is a per-request field the caller supplies, and the
+# engine's weight_version never reaches the block hasher. If it silently
+# stopped working, an RL run would keep producing plausible rewards computed
+# against stale KV.
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+
+import pytest
+from vllm import SamplingParams
+from vllm.engine.arg_utils import AsyncEngineArgs
+from vllm.v1.engine.async_llm import AsyncLLM
+
+MODEL_NAME = "meta-llama/Llama-3.2-1B-Instruct"
+MAX_MODEL_LEN = 2048
+MAX_NUM_SEQS = 32
+
+# Long enough that the pause lands mid-generation rather than after the
+# request has already finished.
+GEN_TOKENS = 64
+PAUSE_AFTER_TOKENS = 8
+# How long to hold the pause while asserting nothing advances.
+PAUSE_HOLD_S = 3.0
+
+PROMPT = ("Count from one to forty, writing each number as a word, "
+          "separated by commas.")
+
+# The salt test needs a prompt spanning several KV blocks: vLLM only caches
+# complete blocks, so anything shorter than block_size (64 on TPU by default)
+# reports zero cached tokens no matter how the salt behaves, and the
+# comparison silently becomes 0 > 0.
+SALT_PROMPT = "Reference material: " + " ".join(
+    f"item{i}" for i in range(400))
+
+
+@pytest.fixture(scope="module")
+def loop():
+    loop = asyncio.new_event_loop()
+    yield loop
+    loop.close()
+
+
+@pytest.fixture(scope="module")
+def engine(loop):
+    """One AsyncLLM for the module; each test drives it on the shared loop."""
+
+    async def _build() -> AsyncLLM:
+        return AsyncLLM.from_engine_args(
+            AsyncEngineArgs(
+                model=MODEL_NAME,
+                max_model_len=MAX_MODEL_LEN,
+                max_num_seqs=MAX_NUM_SEQS,
+                enable_prefix_caching=True,
+            ))
+
+    eng = loop.run_until_complete(_build())
+    yield eng
+    eng.shutdown()
+
+
+async def _collect(engine: AsyncLLM,
+                   request_id: str,
+                   prompt: str = PROMPT,
+                   max_tokens: int = GEN_TOKENS,
+                   cache_salt: str | None = None):
+    """Runs one request to completion, returning (token_ids, num_cached).
+
+    cache_salt rides on the prompt dict (`TextPrompt.cache_salt`); AsyncLLM's
+    generate() has no such keyword.
+    """
+    params = SamplingParams(temperature=0.0, max_tokens=max_tokens)
+    prompt_arg: str | dict = prompt
+    if cache_salt is not None:
+        prompt_arg = {"prompt": prompt, "cache_salt": cache_salt}
+    token_ids: list[int] = []
+    num_cached = None
+    async for out in engine.generate(prompt_arg, params, request_id):
+        token_ids = list(out.outputs[0].token_ids)
+        num_cached = out.num_cached_tokens
+    return token_ids, num_cached
+
+
+class TestPauseKeepPreservesGeneration:
+    """mode="keep" must freeze in-flight work, not drop or corrupt it."""
+
+    def test_generation_across_pause_matches_uninterrupted_run(
+            self, loop, engine):
+
+        async def scenario():
+            baseline, _ = await _collect(engine, "baseline")
+            assert len(baseline) == GEN_TOKENS, (
+                f"baseline stopped early ({len(baseline)} tokens); the pause "
+                f"would not land mid-generation")
+
+            produced: list[int] = []
+            observed: dict[str, int] = {}
+
+            async def pauser():
+                while len(produced) < PAUSE_AFTER_TOKENS:
+                    await asyncio.sleep(0.01)
+                    if len(produced) >= GEN_TOKENS:
+                        break
+                await engine.pause_generation(mode="keep", clear_cache=False)
+                assert await engine.is_paused()
+                observed["at_pause"] = len(produced)
+                await asyncio.sleep(PAUSE_HOLD_S)
+                observed["after_hold"] = len(produced)
+                await engine.resume_generation()
+                assert not await engine.is_paused()
+
+            task = asyncio.create_task(pauser())
+            params = SamplingParams(temperature=0.0, max_tokens=GEN_TOKENS)
+            async for out in engine.generate(PROMPT, params, "paused"):
+                produced[:] = list(out.outputs[0].token_ids)
+            await task
+
+            assert observed["at_pause"] < GEN_TOKENS, (
+                "request finished before the pause; increase GEN_TOKENS")
+            # The freeze itself: no forward progress while paused.
+            assert observed["after_hold"] == observed["at_pause"], (
+                f"generation advanced during the pause: "
+                f"{observed['at_pause']} -> {observed['after_hold']} tokens")
+            # The request was frozen, not aborted.
+            assert len(produced) == GEN_TOKENS, (
+                f"request did not finish after resume "
+                f"({len(produced)}/{GEN_TOKENS} tokens)")
+            # And freezing did not corrupt it.
+            assert produced == baseline, (
+                "tokens generated across a pause differ from an "
+                "uninterrupted run")
+
+        loop.run_until_complete(scenario())
+
+
+class TestRequestsSubmittedWhilePaused:
+    """A pause defers new work; it must not reject or abort it."""
+
+    def test_request_added_during_pause_completes_after_resume(
+            self, loop, engine):
+
+        async def scenario():
+            await engine.pause_generation(mode="keep", clear_cache=False)
+            assert await engine.is_paused()
+
+            task = asyncio.create_task(
+                _collect(engine, "queued-during-pause", max_tokens=16))
+            # Give it time to be admitted and sit in the waiting queue.
+            await asyncio.sleep(PAUSE_HOLD_S)
+            assert not task.done(), (
+                "a request submitted during a pause produced output before "
+                "resume")
+
+            await engine.resume_generation()
+            token_ids, _ = await asyncio.wait_for(task, timeout=120)
+            assert len(token_ids) == 16
+
+        loop.run_until_complete(scenario())
+
+
+class TestCacheSaltIsolatesPolicies:
+    """Rotating cache_salt is what fences a new policy off from old KV."""
+
+    def test_salt_rotation_drops_reuse_and_same_salt_keeps_it(
+            self, loop, engine):
+
+        async def scenario():
+            # Unique per run: with fixed salts a warm pool from an earlier
+            # run would make the cold step look like a hit and invert the
+            # whole comparison.
+            run_id = uuid.uuid4().hex[:8]
+            salt_a, salt_b = f"policy-vA-{run_id}", f"policy-vB-{run_id}"
+            prompt = SALT_PROMPT
+
+            _, cold = await _collect(engine,
+                                     "salt-a-cold",
+                                     prompt=prompt,
+                                     max_tokens=8,
+                                     cache_salt=salt_a)
+            _, warm = await _collect(engine,
+                                     "salt-a-warm",
+                                     prompt=prompt,
+                                     max_tokens=8,
+                                     cache_salt=salt_a)
+            _, rotated = await _collect(engine,
+                                        "salt-b",
+                                        prompt=prompt,
+                                        max_tokens=8,
+                                        cache_salt=salt_b)
+            _, warm_b = await _collect(engine,
+                                       "salt-b-warm",
+                                       prompt=prompt,
+                                       max_tokens=8,
+                                       cache_salt=salt_b)
+
+            assert warm is not None, "engine did not report num_cached_tokens"
+            assert warm > cold, (
+                f"prefix caching is not working at all "
+                f"(cold={cold}, warm={warm})")
+            assert rotated < warm, (
+                f"rotating cache_salt did not invalidate reuse "
+                f"(salt B cached={rotated}, salt A warm cached={warm}); a new "
+                f"policy would read KV computed under the old one")
+            assert warm_b > rotated, (
+                f"the prompt does not re-cache under the new salt "
+                f"(cached={warm_b}); the drop above may have been eviction "
+                f"rather than the salt")
+
+        loop.run_until_complete(scenario())

--- a/tests/e2e/test_rl_pause_resume.py
+++ b/tests/e2e/test_rl_pause_resume.py
@@ -23,15 +23,19 @@
 #   1. mode="keep" freezes in-flight work without corrupting it -- the tokens
 #      produced across a pause match an uninterrupted run exactly.
 #   2. Requests submitted during a pause are queued, not aborted.
-#   3. clear_cache=True completes instead of failing on a missing worker RPC.
+#   3. Rotating cache_salt stops a new policy from reusing the old policy's
+#      blocks, while leaving reuse within a policy intact.
 #
-# cache_salt behaviour is deliberately not retested here: the block hasher and
-# block pool are vLLM code this repo reuses unmodified, and upstream covers it
-# in tests/v1/core/test_prefix_caching.py.
+# (3) is the invariant the whole design rests on and nothing in the engine
+# enforces it: cache_salt is a per-request field the caller supplies, and the
+# engine's weight_version never reaches the block hasher. If it silently
+# stopped working, an RL run would keep producing plausible rewards computed
+# against stale KV.
 
 from __future__ import annotations
 
 import asyncio
+import uuid
 
 import pytest
 from vllm import SamplingParams
@@ -51,6 +55,12 @@ PAUSE_HOLD_S = 3.0
 
 PROMPT = ("Count from one to forty, writing each number as a word, "
           "separated by commas.")
+
+# The salt test needs a prompt spanning several KV blocks: vLLM only caches
+# complete blocks, so anything shorter than block_size (64 on TPU by default)
+# reports zero cached tokens no matter how the salt behaves, and the
+# comparison silently becomes 0 > 0.
+SALT_PROMPT = "Reference material: " + " ".join(f"item{i}" for i in range(400))
 
 
 @pytest.fixture(scope="module")
@@ -81,12 +91,20 @@ def engine(loop):
 async def _collect(engine: AsyncLLM,
                    request_id: str,
                    prompt: str = PROMPT,
-                   max_tokens: int = GEN_TOKENS):
-    """Runs one request to completion, returning (token_ids, num_cached)."""
+                   max_tokens: int = GEN_TOKENS,
+                   cache_salt: str | None = None):
+    """Runs one request to completion, returning (token_ids, num_cached).
+
+    cache_salt rides on the prompt dict (`TextPrompt.cache_salt`); AsyncLLM's
+    generate() has no such keyword.
+    """
     params = SamplingParams(temperature=0.0, max_tokens=max_tokens)
+    prompt_arg: str | dict = prompt
+    if cache_salt is not None:
+        prompt_arg = {"prompt": prompt, "cache_salt": cache_salt}
     token_ids: list[int] = []
     num_cached = None
-    async for out in engine.generate(prompt, params, request_id):
+    async for out in engine.generate(prompt_arg, params, request_id):
         token_ids = list(out.outputs[0].token_ids)
         num_cached = out.num_cached_tokens
     return token_ids, num_cached
@@ -165,6 +183,56 @@ class TestRequestsSubmittedWhilePaused:
             await engine.resume_generation()
             token_ids, _ = await asyncio.wait_for(task, timeout=120)
             assert len(token_ids) == 16
+
+        loop.run_until_complete(scenario())
+
+
+class TestCacheSaltIsolatesPolicies:
+    """Rotating cache_salt is what fences a new policy off from old KV."""
+
+    def test_salt_rotation_drops_reuse_and_same_salt_keeps_it(
+            self, loop, engine):
+
+        async def scenario():
+            # Unique per run: with fixed salts a warm pool from an earlier
+            # run would make the cold step look like a hit and invert the
+            # whole comparison.
+            run_id = uuid.uuid4().hex[:8]
+            salt_a, salt_b = f"policy-vA-{run_id}", f"policy-vB-{run_id}"
+            prompt = SALT_PROMPT
+
+            _, cold = await _collect(engine,
+                                     "salt-a-cold",
+                                     prompt=prompt,
+                                     max_tokens=8,
+                                     cache_salt=salt_a)
+            _, warm = await _collect(engine,
+                                     "salt-a-warm",
+                                     prompt=prompt,
+                                     max_tokens=8,
+                                     cache_salt=salt_a)
+            _, rotated = await _collect(engine,
+                                        "salt-b",
+                                        prompt=prompt,
+                                        max_tokens=8,
+                                        cache_salt=salt_b)
+            _, warm_b = await _collect(engine,
+                                       "salt-b-warm",
+                                       prompt=prompt,
+                                       max_tokens=8,
+                                       cache_salt=salt_b)
+
+            assert warm is not None, "engine did not report num_cached_tokens"
+            assert warm > cold, (f"prefix caching is not working at all "
+                                 f"(cold={cold}, warm={warm})")
+            assert rotated < warm, (
+                f"rotating cache_salt did not invalidate reuse "
+                f"(salt B cached={rotated}, salt A warm cached={warm}); a new "
+                f"policy would read KV computed under the old one")
+            assert warm_b > rotated, (
+                f"the prompt does not re-cache under the new salt "
+                f"(cached={warm_b}); the drop above may have been eviction "
+                f"rather than the salt")
 
         loop.run_until_complete(scenario())
 

--- a/tests/e2e/test_rl_pause_resume.py
+++ b/tests/e2e/test_rl_pause_resume.py
@@ -25,12 +25,6 @@
 #   2. Requests submitted during a pause are queued, not aborted.
 #   3. Rotating cache_salt stops a new policy from reusing the old policy's
 #      blocks, while leaving reuse within a policy intact.
-#
-# (3) is the invariant the whole design rests on and nothing in the engine
-# enforces it: cache_salt is a per-request field the caller supplies, and the
-# engine's weight_version never reaches the block hasher. If it silently
-# stopped working, an RL run would keep producing plausible rewards computed
-# against stale KV.
 
 from __future__ import annotations
 

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -25,7 +25,7 @@ from enum import Enum
 from multiprocessing import Process
 from multiprocessing.connection import Connection, wait
 from time import time
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 import cloudpickle
 import numpy as np
@@ -74,6 +74,17 @@ class SchedulerCommand(Enum):
     SET_PAUSE_STATE = "set_pause_state"
     GET_PAUSE_STATE = "get_pause_state"
     SHUTDOWN = "shutdown"
+
+
+class FinishedRequestInfo(NamedTuple):
+    """The part of a finished `Request` that has to cross the DP boundary.
+
+    `EngineCoreProc._send_abort_outputs` reads exactly these two attributes, so
+    this is a drop-in stand-in for `Request` there without pickling the whole
+    object back from a rank scheduler process.
+    """
+    request_id: str
+    client_index: int
 
 
 class SchedulerWorkerError(Exception):
@@ -203,8 +214,10 @@ def _scheduler_worker_process(
 
                 case SchedulerCommand.FINISH_REQUESTS:
                     request_ids, finished_status = data
-                    scheduler.finish_requests(request_ids, finished_status)
-                    _send_result(None)  # Signal completion
+                    finished = scheduler.finish_requests(
+                        request_ids, finished_status)
+                    _send_result([(r.request_id, r.client_index)
+                                  for r in (finished or [])])
 
                 case SchedulerCommand.UPDATE_DRAFT_TOKEN_IDS:
                     draft_token_ids = data
@@ -1300,7 +1313,8 @@ class DPScheduler(SchedulerInterface):
         for req_id in finished_req_ids:
             self.assigned_dp_rank.pop(req_id, None)
 
-    def finish_requests(self, request_ids, finished_status) -> None:
+    def finish_requests(self, request_ids,
+                        finished_status) -> List[FinishedRequestInfo]:
         """Forward request finish signals to the appropriate DP rank schedulers."""
         if isinstance(request_ids, str):
             request_ids = [request_ids]
@@ -1310,12 +1324,17 @@ class DPScheduler(SchedulerInterface):
             ]
 
         # If any request is still held in the pending queue, drop it.
+        finished: List[FinishedRequestInfo] = []
         if self._pending_new_requests:
             request_id_set = set(request_ids)
-            self._pending_new_requests = [
-                r for r in self._pending_new_requests
-                if r.request_id not in request_id_set
-            ]
+            kept = []
+            for r in self._pending_new_requests:
+                if r.request_id in request_id_set:
+                    finished.append(
+                        FinishedRequestInfo(r.request_id, r.client_index))
+                else:
+                    kept.append(r)
+            self._pending_new_requests = kept
 
         # Route finish signals to appropriate schedulers
         rank_request_ids = defaultdict(list)
@@ -1329,7 +1348,12 @@ class DPScheduler(SchedulerInterface):
         for rank, req_ids in rank_request_ids.items():
             self._send_command(rank, SchedulerCommand.FINISH_REQUESTS,
                                (req_ids, finished_status))
-            self._get_result(rank, SchedulerCommand.FINISH_REQUESTS)
+        for rank in rank_request_ids:
+            finished.extend(
+                FinishedRequestInfo(req_id, client_index)
+                for req_id, client_index in self._get_result(
+                    rank, SchedulerCommand.FINISH_REQUESTS))
+        return finished
 
     def get_num_unfinished_requests(self) -> int:
         """Get total number of unfinished requests across all DP ranks.

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1317,6 +1317,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
     def reinitialize_kv_cache(self) -> None:
         self.kv_cache_manager.reinitialize_kv_cache()
 
+    def reset_encoder_cache(self) -> None:
+        self.encoder_cache.clear()
+
     def capture_model(self) -> None:
         self.compilation_manager.capture_model()
 

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -776,6 +776,22 @@ class TPUWorker(WorkerBase):
     def reinitialize_kv_cache(self) -> None:
         self.model_runner.reinitialize_kv_cache()
 
+    def reset_encoder_cache(self) -> None:
+        self.model_runner.reset_encoder_cache()
+
+    def sleep(self, level: int = 1) -> None:
+        raise NotImplementedError(
+            "Sleep mode is not supported on TPU: there is no analogue of "
+            "CUDA's virtual-memory allocator for offloading weights. Use "
+            "`pause_generation()` to stop scheduling (equivalent to sleep "
+            "level 0), and the weight-update session "
+            "(`start_weight_update`/`finish_weight_update`) to release and "
+            "restore KV cache memory.")
+
+    def wake_up(self, tags: list[str] | None = None) -> None:
+        raise NotImplementedError(
+            "Sleep mode is not supported on TPU; see TPUWorker.sleep.")
+
     def add_lora(self, lora_request: Any) -> bool:
         return self.model_runner.add_lora(lora_request)
 


### PR DESCRIPTION
## What

This PR enables the Pause/Resume feature on TPU. Motivation is off-policy RL: batches `k` and `k+1` are in flight, `k` finishes, we pause the engine, sync weights, and resume — with `k+1` paused rather than restarted.

Added E2E nightly test. 

## The fixes

- **`reset_encoder_cache` on `TPUWorker` / `TPUModelRunner`.** vLLM defines this on `gpu_worker.Worker` rather than `WorkerBase`, so `TPUWorker` inherits nothing. `EngineCore._reset_caches()` — reached by every
`pause_generation(clear_cache=True)` — calls `collective_rpc("reset_encoder_cache")`, so the call raises `AttributeError`.

- **`DPScheduler.finish_requests` now returns what it finished.** vLLM's `Scheduler.finish_requests` returns `list[Request]`, and `EngineCoreProc.pause_scheduler` relies on it:

```python
aborted_reqs = self.scheduler.finish_requests(None, RequestStatus.FINISHED_ABORTED)
self._send_abort_outputs(aborted_reqs)   # this is what notifies clients
```

`DPScheduler` returned `None`. `_send_abort_outputs(None)` is falsy-guarded, so there is no crash — it simply notifies nobody, and every aborted request's client waits forever. `pause_generation(mode="abort")` hangs the fleet under data parallelism, which is the default mode.

- `sleep` / `wake_up` raise `NotImplementedError`.

## Usage 


```
VLLM_SERVER_DEV_MODE=1 \      # required — /pause, /resume, /update_weight_version live under dev
vllm serve <model> \
  --enable-prefix-caching \
  --enable-prompt-tokens-details   # else cached_tokens is silently absent
```

HTTP flow

```
BASE=http://localhost:8000

# 1. Freeze. keep = in-flight rollouts stay resident with their KV.
#    clear_cache=false = do NOT preempt them / wipe the pool.
curl -sX POST "$BASE/pause?mode=keep&clear_cache=false"
curl -s "$BASE/is_paused"          # {"is_paused":true}

# 2. Sync weights.
#    Either write weights out-of-band (tunix / Raiden), or call 
#    /start_weight_update and pass free_kv_cache=False 
#    explicitly rather than via the route.

# 3. Resume. Frozen rollouts continue exactly where they stopped.
curl -sX POST "$BASE/resume"

# 4. This is what actually fences off the old policy: every request issued
#    from now on carries the new salt.
curl -sX POST "$BASE/v1/chat/completions" \
     -H 'Content-Type: application/json' \
     -d '{"model":"...","messages":[...],"cache_salt":"policy-v1"}'
```

Python / AsyncLLM

```
await engine.pause_generation(mode="keep", clear_cache=False)

# ... weight sync. E.g.
# await engine.collective_rpc("start_weight_update",
#                             kwargs={"free_kv_cache": False})

await engine.resume_generation()

# every subsequent request:
engine.generate(prompt, sampling_params, request_id,
                ... )   # with cache_salt="policy-v1" on the request
```
