### PR TITLE
Feed sample() logits in the model's native dtype (+4.7% greedy decode throughput)

### DIFF
--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -242,6 +242,51 @@ class TestProcessedLogprobs:
 
         assert np.allclose(raw_logprobs, processed, atol=1e-6)
 
+    def test_sample_greedy_native_dtype_matches_f32(self):
+        """Greedy sampling is dtype-invariant: bf16 -> f32 widening is exact,
+        so feeding logits in the model's native dtype (#3127) cannot change
+        the selected tokens, and the returned logits stay f32."""
+        logits_bf16 = jax.random.normal(jax.random.PRNGKey(42), (8, 64),
+                                        dtype=jnp.float32).astype(jnp.bfloat16)
+        logits_f32 = logits_bf16.astype(jnp.float32)
+
+        metadata = self._make_sampling_metadata(8, do_sampling=False)
+        fake_mesh = self._get_fake_mesh()
+        tokens_native, ret_logits_native = sample(jax.random.PRNGKey(0),
+                                                  fake_mesh, logits_bf16,
+                                                  metadata)
+        tokens_wide, ret_logits_wide = sample(jax.random.PRNGKey(0), fake_mesh,
+                                              logits_f32, metadata)
+
+        assert np.array_equal(np.array(tokens_native), np.array(tokens_wide))
+        assert ret_logits_native.dtype == jnp.float32
+        assert ret_logits_wide.dtype == jnp.float32
+        assert np.array_equal(np.array(ret_logits_native),
+                              np.array(ret_logits_wide))
+
+    def test_sample_do_sampling_native_dtype_matches_f32(self):
+        """Same dtype-invariance for the sampled path: the transforms and
+        categorical draw run on the f32-widened logits either way, so a bf16
+        input with the same key selects identical tokens and returns
+        identical f32 processed logits."""
+        logits_bf16 = jax.random.normal(jax.random.PRNGKey(42), (8, 64),
+                                        dtype=jnp.float32).astype(jnp.bfloat16)
+        logits_f32 = logits_bf16.astype(jnp.float32)
+
+        metadata = self._make_sampling_metadata(8, do_sampling=True)
+        fake_mesh = self._get_fake_mesh()
+        tokens_native, ret_logits_native = sample(jax.random.PRNGKey(0),
+                                                  fake_mesh, logits_bf16,
+                                                  metadata)
+        tokens_wide, ret_logits_wide = sample(jax.random.PRNGKey(0), fake_mesh,
+                                              logits_f32, metadata)
+
+        assert np.array_equal(np.array(tokens_native), np.array(tokens_wide))
+        assert ret_logits_native.dtype == jnp.float32
+        assert ret_logits_wide.dtype == jnp.float32
+        assert np.array_equal(np.array(ret_logits_native),
+                              np.array(ret_logits_wide))
+
 
 class TestComputePromptLogprobs:
 

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -123,6 +123,10 @@ def sample(
             logits, NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
 
     greedy_tokens = jnp.argmax(logits, axis=-1)
+    # Widen only after the argmax: bf16 -> f32 widening is exact so the
+    # argmax result is unchanged, and placing the convert here makes it the
+    # output materialization on the greedy path -- without it XLA must insert
+    # a full-vocab copy of the aliased input (see #3127).
     logits = logits.astype(jnp.float32)
     if not tpu_sampling_metadata.do_sampling:
         ret_tokens = greedy_tokens

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -962,8 +962,11 @@ class CompilationManager:
             # function.
             sampling_metadata_sharding = NamedSharding(
                 self.runner.mesh, PartitionSpec(ShardingAxisName.ATTN_DATA))
+            # Like the sharding above, the dummy's dtype must match the
+            # logits that compute_logits_fn produces at serving time -- the
+            # jit cache is keyed on dtype as well.
             logits = self._create_dummy_tensor((num_reqs, hsize),
-                                               jnp.float32,
+                                               self.runner.model_config.dtype,
                                                sharding=logits_sharding)
             for do_sampling in (True, False):
                 for logprobs in (True, False):

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -2002,7 +2002,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         processed_bonus_logits = None
         if spec_decode_metadata is None:
-            logits = logits.astype(jnp.float32)
+            # Logits enter sample() in the model's native dtype; the f32
+            # widening happens inside sample() after the argmax. The sampling
+            # precompile menu is keyed on this dtype (_precompile_sampling),
+            # so a dtype change here must be mirrored there.
             with self.maybe_forbid_compile:
                 next_tokens, processed_logits = sample(
                     step_rng,
@@ -2042,7 +2045,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 key=rejection_rng,
             )
 
-        logits = logits.astype(jnp.float32)
+        if tpu_sampling_metadata.logprobs:
+            # Only the logprobs consumers below need f32 logits; skip the
+            # full-vocab widening otherwise.
+            logits = logits.astype(jnp.float32)
         if full_logits is not None:
             full_logits = full_logits.astype(jnp.float32)
         with self.maybe_forbid_compile:


### PR DESCRIPTION
## Problem

The non spec decode branch of `_sample_from_logits` converts logits to fp32 before calling `sample()`. On the greedy path this one conversion costs three ways. It dispatches as its own program outside any jit, so nothing can fuse with it. Because `sample()` then returns its input unchanged, XLA inserts a full vocabulary copy to materialize the aliased output. And the argmax reads fp32 instead of bf16, twice the bytes it needs. On v5e-1 with gemma-2b at batch 512 these three ops take about 3.5 ms of a 28 ms decode step, consistent with the report in #3127.

## Change

Three parts that must land together. `sample()` now takes logits in the model's native dtype and widens to fp32 only after the argmax, so the widening doubles as the output materialization and the aliasing copy disappears. The runner keeps the post sample fp32 conversion only when logprobs are requested, since the logprobs computation is the only consumer that needs it. The dummy in `_precompile_sampling` switches to the model dtype, so the AOT compiled programs stay keyed to what serving actually feeds them. The two external patches described in #3127 skipped this last step and regressed TTFT by 4.4x, which is why the menu change is part of the same commit rather than a follow up. The spec decode branch already feeds `sample()` native dtype logits, so this aligns the non spec path with existing behavior.

The numerics are unchanged by construction. Widening bf16 to fp32 is exact, so moving the argmax before the widening cannot change which token wins, and the temperature, top k and top p transforms still run in fp32 exactly as before.

## Validation

All measurements on v5e-1 with gemma-2b (bf16, vocab 256000) at batch 512, greedy, identical serving flags for both rounds. Both rounds ran under `VLLM_XLA_CHECK_RECOMPILATION=1`, which turns any steady state compilation into a hard error; none occurred.

Per step cost of the three ops, from XProf HLO Op Stats:

| op | baseline | this PR |
|---|---|---|
| `copy.2`, aliasing copy of the returned logits | 1,562.0 us | eliminated |
| convert bf16 to fp32 | 1,236.7 us, standalone dispatch outside jit (`tpu_runner.py:2005`) | 1,236.2 us, output materialization inside `jit(sample)` (`sampling.py:130`) |
| argmax `iota_reduce_fusion` | 696.2 us, fp32 input | 426.4 us, bf16 input |
| total | 3,494.9 us | 1,662.6 us |

The remaining conversion is the fp32 output materialization inside `jit(sample)` and is no longer a separate dispatch. Net saving is about 1.8 ms per decode step.

Serving benchmarks with `vllm bench serve`, 512 prompts, temperature 0, request rate inf:

| metric | baseline | this PR |
|---|---|---|
| decode heavy (input 128, output 512), median TPOT | 28.18 ms | 27.06 ms |
| decode heavy, output throughput | 16,832 tok/s | 17,626 tok/s (+4.7%) |
| decode heavy, median ITL | 27.40 ms | 25.95 ms |
| prefill heavy (input 512, output 128), median TTFT | 4,181.8 ms | 4,071.1 ms |
| prefill heavy, P99 TTFT | 8,814.3 ms | 8,605.4 ms |

TTFT is the sentinel for precompile menu misses, the failure mode that sank both external attempts in #3127. It stays flat.

Greedy outputs are bit identical: 64 prompts with 128 generated tokens each produced identical token id dumps before and after the change.

Two new unit tests assert that `sample()` returns identical tokens and identical fp32 logits for bf16 and fp32 inputs, on both the greedy and the sampled path. This test file has two pre-existing failures on v5e (tolerances calibrated against CPU numerics vs TPU transcendental precision); they fail identically at the base commit and are unrelated to this change.

## Follow ups

About 1.2 ms per step remains in the fp32 output materialization. It can be skipped when logprobs are off, since the menu is statically keyed on the logprobs flag, but that changes the return dtype contract of `sample()` and deserves its own review. The decode loop has the same conversion inside its own self contained jit trace, where XLA can already fuse it. An explicit `head_dtype` override via hf-overrides would mis-key the menu; the spec decode select menus already assume the model dtype, so that edge is equally unsupported on both paths today.

Fixes #3127
