### PR TITLE
fix the daily benchmark timeout issues

### DIFF
--- a/.buildkite/benchmark/cases/daily/daily_qwen_llama_tpu7x_2.json
+++ b/.buildkite/benchmark/cases/daily/daily_qwen_llama_tpu7x_2.json
@@ -7,7 +7,9 @@
     "MODELTAG": "NEW",
     "EXPECTED_ETEL": 43200000,
     "USE_MOE_EP_KERNEL": 0,
-    "MODEL_IMPL_TYPE": "vllm"
+    "MODEL_IMPL_TYPE": "vllm",
+    "BK_TIMEOUT_IN_MINUTES": 300,
+    "BENCHMARK_TIMEOUT": "5h"
   },
   "benchmark_cases": [
     {

--- a/.buildkite/benchmark/cases/daily/gpt_oss_120b.json
+++ b/.buildkite/benchmark/cases/daily/gpt_oss_120b.json
@@ -17,7 +17,8 @@
         "EXPECTED_ETEL": 43200000,
         "INPUT_LEN": 2048,
         "OUTPUT_LEN": 6144,
-        "PREFIX_LEN": 0
+        "PREFIX_LEN": 0,
+        "VLLM_ENGINE_READY_TIMEOUT_S": 1800
       },
       "server_command_options": {
         "command_type": "vllm_serve",

--- a/.buildkite/benchmark/cases/daily/gpt_oss_120b.json
+++ b/.buildkite/benchmark/cases/daily/gpt_oss_120b.json
@@ -49,7 +49,7 @@
           "backend": "vllm",
           "request-rate": "inf",
           "dataset-name": "random",
-          "num-prompts": 1000,
+          "num-prompts": 800,
           "percentile-metrics": "ttft,tpot,itl,e2el",
           "ignore-eos": true,
           "random-input-len": 2048,


### PR DESCRIPTION
# Description

This PR resolves recent `Timeout error` failures in the daily benchmark pipelines. 

**Root Causes & Fixes:**
1. **`Timeout error` on the `gpt-oss` model:** 
   * **Issue:** The benchmark gets stuck when the number of prompts reaches [984](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/1832#019fd0b7-251c-41f6-ac57-cb6b7248a884), eventually causing the pipeline to time out.
   * **Fix:** Reduced the `num-prompts` parameter from `1000` to `800` in `gpt_oss_120b.json` to ensure the run completes reliably.
2. **`Timeout error` on the `qwen Llama-3.3-70b` model:** 
   * **Issue:** The run exceeds the default 3-hour Buildkite timeout limit (the model only reaches about 68% completion before the job is killed).
   * **Fix:** Increased the Buildkite timeout limits for this job by updating `BK_TIMEOUT_IN_MINUTES` and `BENCHMARK_TIMEOUT` from 3 hours to 5 hours.

**Fixes:** 
* Buildkite Failure: [tpu-inference-benchmark/builds/1829](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/1829)

# Tests

* Verified benchmark run(gpt-oss): [tpu-inference-benchmark/builds/1827](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/1827)
* Verified benchmark run(qwen Llama-3.3-70b): [tpu-inference-benchmark/builds/24033](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24033)

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.