### PR TITLE
Replay recorded rollout traces in the agentic benchmark

### DIFF
--- a/scripts/vllm/benchmarking/agentic_benchmark/README.md
+++ b/scripts/vllm/benchmarking/agentic_benchmark/README.md
@@ -95,16 +95,3 @@ One JSON object per line, one line per trajectory:
 | `prompt_len` | Initial prompt length in tokens. Taken from the first stream of each group. |
 | `out_lens` | Assistant tokens generated on each turn, in order. Its length sets the turn count. |
 | `obs_lens` | Environment observation tokens appended after each turn, in order. |
-
-Every field is used during replay; there are none to ignore. No prompt or
-completion text is needed, so a trace of 1,024 trajectories is only a few
-hundred KB and carries no task content.
-
-To build one from RL rollout dumps, walk each trajectory's assistant-token mask
-and record the length of each alternating run: runs of generated tokens become
-`out_lens`, the runs between them become `obs_lens`, and the leading run of
-non-generated tokens is `prompt_len`. Truncate to the unpadded trajectory length
-first, or trailing padding is counted as one enormous observation. While
-building, check that `prompt_len + sum(out_lens) + sum(obs_lens)` equals the
-recorded trajectory length for every row; that catches both the padding mistake
-and any off-by-one in the run extraction.

--- a/scripts/vllm/benchmarking/agentic_benchmark/README.md
+++ b/scripts/vllm/benchmarking/agentic_benchmark/README.md
@@ -78,7 +78,7 @@ python benchmarks/benchmark_agentic.py \
 
 ## 3. Replaying a Recorded Rollout Trace
 
-Pass `--trace-file` to replay measured trajectories. 
+Pass `--trace-file` to replay measured trajectories.
 
 ### Trace file format
 

--- a/scripts/vllm/benchmarking/agentic_benchmark/README.md
+++ b/scripts/vllm/benchmarking/agentic_benchmark/README.md
@@ -78,29 +78,14 @@ python benchmarks/benchmark_agentic.py \
 
 ## 3. Replaying a Recorded Rollout Trace
 
-The flags above sample turn counts and lengths from uniform distributions. Real
-agent rollouts do not look like that: turn count is a *cap* that most
-trajectories reach rather than a spread, assistant turns are short tool calls,
-and environment observations are large and heavy tailed. Measured on SWE-agent
-rollouts of `Qwen3.5-397B-A17B`:
-
-| quantity | uniform default | real rollouts (min / median / max) |
-| --- | --- | --- |
-| assistant turns | `uniform(5, 50)` | 12 / **30** / 30 |
-| output tokens per turn | `uniform(200, 1000)` | 3 / **82** / 9,076 |
-| observation tokens per turn | `uniform(10, 100)` | 23 / **220** / 26,625 |
-| initial prompt | `uniform(2k, 8k)` | 7,546 / **7,650** / 7,753 |
-
-Pass `--trace-file` to replay measured trajectories instead. The offered load is
-then exactly the recorded one and is identical on every run, which makes small
-throughput differences between server configurations readable.
+Pass `--trace-file` to replay measured trajectories. 
 
 ### Trace file format
 
 One JSON object per line, one line per trajectory:
 
 ```json
-{"group": 0, "stream": 0, "prompt_len": 7570, "turns": 30, "final_len": 37975, "reward": 1.0, "out_lens": [399, 65, 57], "obs_lens": [23, 942, 2126]}
+{"group": 0, "stream": 0, "prompt_len": 7570, "out_lens": [399, 65, 57], "obs_lens": [23, 942, 2126]}
 ```
 
 | field | meaning |
@@ -110,9 +95,8 @@ One JSON object per line, one line per trajectory:
 | `prompt_len` | Initial prompt length in tokens. Taken from the first stream of each group. |
 | `out_lens` | Assistant tokens generated on each turn, in order. Its length sets the turn count. |
 | `obs_lens` | Environment observation tokens appended after each turn, in order. |
-| `turns`, `final_len`, `reward` | Optional, for filtering and validation. Ignored during replay. |
 
-`out_lens` and `obs_lens` are the only required per-turn fields. No prompt or
+Every field is used during replay; there are none to ignore. No prompt or
 completion text is needed, so a trace of 1,024 trajectories is only a few
 hundred KB and carries no task content.
 
@@ -120,28 +104,7 @@ To build one from RL rollout dumps, walk each trajectory's assistant-token mask
 and record the length of each alternating run: runs of generated tokens become
 `out_lens`, the runs between them become `obs_lens`, and the leading run of
 non-generated tokens is `prompt_len`. Truncate to the unpadded trajectory length
-first, or trailing padding is counted as one enormous observation. A trace is
-correct when `prompt_len + sum(out_lens) + sum(obs_lens)` equals the recorded
-trajectory length for every row.
-
-### Global prefix
-
-Real agents share a system prompt and tool definitions across *every*
-trajectory, not just within a group — 6,476 tokens in the rollouts above, with
-roughly 1,100 more shared per problem. Pass `--global-prefix-len` to reproduce
-that; without it, groups share nothing with each other and prefix caching is
-understated.
-
-```bash
-python benchmark_agentic.py \
-    --model Qwen/Qwen3.5-397B-A17B-FP8 \
-    --model-path-or-id Qwen/Qwen3.5-397B-A17B-FP8 \
-    --trace-file trace.jsonl \
-    --global-prefix-len 6476 \
-    --num-groups 16 \
-    --concurrency 16
-```
-
-`--num-groups` limits how much of the trace is replayed; omit it to replay every
-group. Concurrency is counted in groups, so `--concurrency 16` with a group size
-of 16 runs 256 concurrent streams.
+first, or trailing padding is counted as one enormous observation. While
+building, check that `prompt_len + sum(out_lens) + sum(obs_lens)` equals the
+recorded trajectory length for every row; that catches both the padding mistake
+and any off-by-one in the run extraction.

--- a/scripts/vllm/benchmarking/agentic_benchmark/README.md
+++ b/scripts/vllm/benchmarking/agentic_benchmark/README.md
@@ -73,3 +73,75 @@ python benchmarks/benchmark_agentic.py \
     --env-len-max 20 \
     --concurrency 16
 ```
+
+---
+
+## 3. Replaying a Recorded Rollout Trace
+
+The flags above sample turn counts and lengths from uniform distributions. Real
+agent rollouts do not look like that: turn count is a *cap* that most
+trajectories reach rather than a spread, assistant turns are short tool calls,
+and environment observations are large and heavy tailed. Measured on SWE-agent
+rollouts of `Qwen3.5-397B-A17B`:
+
+| quantity | uniform default | real rollouts (min / median / max) |
+| --- | --- | --- |
+| assistant turns | `uniform(5, 50)` | 12 / **30** / 30 |
+| output tokens per turn | `uniform(200, 1000)` | 3 / **82** / 9,076 |
+| observation tokens per turn | `uniform(10, 100)` | 23 / **220** / 26,625 |
+| initial prompt | `uniform(2k, 8k)` | 7,546 / **7,650** / 7,753 |
+
+Pass `--trace-file` to replay measured trajectories instead. The offered load is
+then exactly the recorded one and is identical on every run, which makes small
+throughput differences between server configurations readable.
+
+### Trace file format
+
+One JSON object per line, one line per trajectory:
+
+```json
+{"group": 0, "stream": 0, "prompt_len": 7570, "turns": 30, "final_len": 37975, "reward": 1.0, "out_lens": [399, 65, 57], "obs_lens": [23, 942, 2126]}
+```
+
+| field | meaning |
+| --- | --- |
+| `group` | Problem index. Streams sharing a `group` share one initial prompt, which is what exercises prefix caching. |
+| `stream` | Generation index within the group, `0..G-1`. |
+| `prompt_len` | Initial prompt length in tokens. Taken from the first stream of each group. |
+| `out_lens` | Assistant tokens generated on each turn, in order. Its length sets the turn count. |
+| `obs_lens` | Environment observation tokens appended after each turn, in order. |
+| `turns`, `final_len`, `reward` | Optional, for filtering and validation. Ignored during replay. |
+
+`out_lens` and `obs_lens` are the only required per-turn fields. No prompt or
+completion text is needed, so a trace of 1,024 trajectories is only a few
+hundred KB and carries no task content.
+
+To build one from RL rollout dumps, walk each trajectory's assistant-token mask
+and record the length of each alternating run: runs of generated tokens become
+`out_lens`, the runs between them become `obs_lens`, and the leading run of
+non-generated tokens is `prompt_len`. Truncate to the unpadded trajectory length
+first, or trailing padding is counted as one enormous observation. A trace is
+correct when `prompt_len + sum(out_lens) + sum(obs_lens)` equals the recorded
+trajectory length for every row.
+
+### Global prefix
+
+Real agents share a system prompt and tool definitions across *every*
+trajectory, not just within a group — 6,476 tokens in the rollouts above, with
+roughly 1,100 more shared per problem. Pass `--global-prefix-len` to reproduce
+that; without it, groups share nothing with each other and prefix caching is
+understated.
+
+```bash
+python benchmark_agentic.py \
+    --model Qwen/Qwen3.5-397B-A17B-FP8 \
+    --model-path-or-id Qwen/Qwen3.5-397B-A17B-FP8 \
+    --trace-file trace.jsonl \
+    --global-prefix-len 6476 \
+    --num-groups 16 \
+    --concurrency 16
+```
+
+`--num-groups` limits how much of the trace is replayed; omit it to replay every
+group. Concurrency is counted in groups, so `--concurrency 16` with a group size
+of 16 runs 256 concurrent streams.

--- a/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
+++ b/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
@@ -58,37 +58,27 @@ def get_percentile(data: List[float], percentile: float) -> float:
 
 def make_token_text(tokenizer: AutoTokenizer, num_tokens: int,
                     rng: random.Random) -> str:
-    """Builds text that encodes to num_tokens tokens.
+    """Builds text of about num_tokens tokens.
 
-    decode() then encode() is not an identity, so the round trip is corrected
-    until the length matches. Callers rely on the exact length because the
-    prompt lengths replayed from a trace are the measured ones.
+    Decoding random ids and re-encoding overshoots by roughly 5%, so the text
+    is trimmed back once. That lands within a token or two, which is close
+    enough; no caller needs an exact length.
 
     Args:
-        tokenizer: Tokenizer used to decode and re-encode.
-        num_tokens: Target token count.
+        tokenizer: Tokenizer used to decode the sampled ids.
+        num_tokens: Approximate token count.
         rng: Random source, so shared spans can be reproduced exactly.
 
     Returns:
-        str: Text of the requested token length.
+        str: Generated text.
     """
     if num_tokens <= 0:
         return ""
     # Safe token ID range, avoiding special control characters.
     ids = [rng.randint(1000, 50000) for _ in range(num_tokens)]
     text = tokenizer.decode(ids, skip_special_tokens=True)
-    for _ in range(8):
-        cur = len(tokenizer.encode(text, add_special_tokens=False))
-        if cur == num_tokens:
-            break
-        if cur > num_tokens:
-            keep = tokenizer.encode(text,
-                                    add_special_tokens=False)[:num_tokens]
-            text = tokenizer.decode(keep, skip_special_tokens=True)
-        else:
-            extra = [rng.randint(1000, 50000) for _ in range(num_tokens - cur)]
-            text += tokenizer.decode(extra, skip_special_tokens=True)
-    return text
+    trimmed = tokenizer.encode(text, add_special_tokens=False)[:num_tokens]
+    return tokenizer.decode(trimmed, skip_special_tokens=True)
 
 
 def generate_initial_prompt(tokenizer: AutoTokenizer,
@@ -109,22 +99,6 @@ def generate_initial_prompt(tokenizer: AutoTokenizer,
 
 def build_initial_prompt(tokenizer: AutoTokenizer, global_prefix: str,
                          total_len: int, group_idx: int) -> str:
-    """Builds a group's initial prompt as global_prefix + group-specific text.
-
-    Every group receives the identical global_prefix string, so all
-    trajectories share it as a token prefix, while the remainder is shared
-    only by the streams within one group. This reproduces the two-level
-    sharing that drives prefix cache behaviour in real agent rollouts.
-
-    Args:
-        tokenizer: Tokenizer used to size the group-specific portion.
-        global_prefix: Text shared by every trajectory (may be empty).
-        total_len: Desired total prompt length in tokens.
-        group_idx: Group index, seeding the group-specific portion.
-
-    Returns:
-        str: The group's initial prompt.
-    """
     global_len = len(tokenizer.encode(
         global_prefix, add_special_tokens=False)) if global_prefix else 0
     remainder = max(0, total_len - global_len)
@@ -572,8 +546,6 @@ async def main_async(args: argparse.Namespace):
     trace_groups: List[List[Dict[str, Any]]] | None = None
     if args.trace_file:
         trace_groups = load_trace(args.trace_file)
-        # Unset means replay the whole trace, rather than the synthetic
-        # default of 2 groups, which would silently truncate it.
         if args.num_groups is not None:
             trace_groups = trace_groups[:args.num_groups]
         turns = sum(

--- a/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
+++ b/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
@@ -56,6 +56,41 @@ def get_percentile(data: List[float], percentile: float) -> float:
     return sorted_data[lower]
 
 
+def make_token_text(tokenizer: AutoTokenizer, num_tokens: int,
+                    rng: random.Random) -> str:
+    """Builds text that encodes to num_tokens tokens.
+
+    decode() then encode() is not an identity, so the round trip is corrected
+    until the length matches. Callers rely on the exact length because the
+    prompt lengths replayed from a trace are the measured ones.
+
+    Args:
+        tokenizer: Tokenizer used to decode and re-encode.
+        num_tokens: Target token count.
+        rng: Random source, so shared spans can be reproduced exactly.
+
+    Returns:
+        str: Text of the requested token length.
+    """
+    if num_tokens <= 0:
+        return ""
+    # Safe token ID range, avoiding special control characters.
+    ids = [rng.randint(1000, 50000) for _ in range(num_tokens)]
+    text = tokenizer.decode(ids, skip_special_tokens=True)
+    for _ in range(8):
+        cur = len(tokenizer.encode(text, add_special_tokens=False))
+        if cur == num_tokens:
+            break
+        if cur > num_tokens:
+            keep = tokenizer.encode(text,
+                                    add_special_tokens=False)[:num_tokens]
+            text = tokenizer.decode(keep, skip_special_tokens=True)
+        else:
+            extra = [rng.randint(1000, 50000) for _ in range(num_tokens - cur)]
+            text += tokenizer.decode(extra, skip_special_tokens=True)
+    return text
+
+
 def generate_initial_prompt(tokenizer: AutoTokenizer,
                             args: argparse.Namespace) -> str:
     """Generates a random initial prompt of a specific token length.
@@ -69,9 +104,58 @@ def generate_initial_prompt(tokenizer: AutoTokenizer,
     """
     length = random.randint(args.initial_prompt_len_min,
                             args.initial_prompt_len_max)
-    # Using safe token ID range to avoid special control characters
-    token_ids = [random.randint(1000, 50000) for _ in range(length)]
-    return tokenizer.decode(token_ids, skip_special_tokens=True)
+    return make_token_text(tokenizer, length, random)
+
+
+def build_initial_prompt(tokenizer: AutoTokenizer, global_prefix: str,
+                         total_len: int, group_idx: int) -> str:
+    """Builds a group's initial prompt as global_prefix + group-specific text.
+
+    Every group receives the identical global_prefix string, so all
+    trajectories share it as a token prefix, while the remainder is shared
+    only by the streams within one group. This reproduces the two-level
+    sharing that drives prefix cache behaviour in real agent rollouts.
+
+    Args:
+        tokenizer: Tokenizer used to size the group-specific portion.
+        global_prefix: Text shared by every trajectory (may be empty).
+        total_len: Desired total prompt length in tokens.
+        group_idx: Group index, seeding the group-specific portion.
+
+    Returns:
+        str: The group's initial prompt.
+    """
+    global_len = len(tokenizer.encode(
+        global_prefix, add_special_tokens=False)) if global_prefix else 0
+    remainder = max(0, total_len - global_len)
+    group_text = make_token_text(tokenizer, remainder,
+                                 random.Random(1_000_000 + group_idx))
+    if not global_prefix:
+        return group_text
+    return global_prefix + "\n" + group_text
+
+
+def load_trace(path: str) -> List[List[Dict[str, Any]]]:
+    """Loads a rollout trace, returning per-group lists of trajectory specs.
+
+    Args:
+        path: Path to the JSONL trace.
+
+    Returns:
+        List[List[Dict[str, Any]]]: Trajectories grouped by "group", each
+        inner list sorted by "stream".
+    """
+    groups: Dict[Any, List[Dict[str, Any]]] = {}
+    with open(path) as f:
+        for line in f:
+            line = line.strip()
+            if not line:
+                continue
+            rec = json.loads(line)
+            groups.setdefault(rec["group"], []).append(rec)
+    for specs in groups.values():
+        specs.sort(key=lambda r: r.get("stream", 0))
+    return [groups[k] for k in sorted(groups)]
 
 
 async def run_grpo_stream(
@@ -83,6 +167,7 @@ async def run_grpo_stream(
     stream_idx: int,
     group_idx: int,
     args: argparse.Namespace,
+    spec: Dict[str, Any] | None = None,
 ) -> List[Dict[str, Any]]:
     """Runs a single GRPO stream as a multi-turn conversation.
 
@@ -99,7 +184,10 @@ async def run_grpo_stream(
     Returns:
         List[Dict[str, Any]]: Statistics of each turn in the stream.
     """
-    num_turns = random.randint(args.turns_min, args.turns_max)
+    out_lens = spec.get("out_lens") if spec else None
+    obs_lens = spec.get("obs_lens") if spec else None
+    num_turns = (len(out_lens) if out_lens is not None else random.randint(
+        args.turns_min, args.turns_max))
     messages = [
         {
             "role": "system",
@@ -114,7 +202,11 @@ async def run_grpo_stream(
     stats = []
 
     for turn in range(1, num_turns + 1):
-        max_tokens = random.randint(args.output_len_min, args.output_len_max)
+        if out_lens is not None:
+            max_tokens = out_lens[turn - 1]
+        else:
+            max_tokens = random.randint(args.output_len_min,
+                                        args.output_len_max)
         payload = {
             "model": model,
             "messages": messages,
@@ -211,12 +303,12 @@ async def run_grpo_stream(
             }
 
             # Simulate environment response of 10-100 tokens
-            env_len = random.randint(args.env_len_min, args.env_len_max)
-            env_token_ids = [
-                random.randint(1000, 50000) for _ in range(env_len)
-            ]
-            env_text = tokenizer.decode(env_token_ids,
-                                        skip_special_tokens=True)
+            if obs_lens is not None:
+                idx = turn - 1
+                env_len = obs_lens[idx] if idx < len(obs_lens) else 0
+            else:
+                env_len = random.randint(args.env_len_min, args.env_len_max)
+            env_text = make_token_text(tokenizer, env_len, random)
 
             messages.append({"role": "user", "content": env_text})
             turn_stat["env_tokens"] = len(tokenizer.encode(env_text))
@@ -256,6 +348,8 @@ async def run_group(
     tokenizer: AutoTokenizer,
     group_idx: int,
     args: argparse.Namespace,
+    global_prefix: str = "",
+    specs: List[Dict[str, Any]] | None = None,
 ) -> List[Dict[str, Any]]:
     """Runs a single GRPO group of G parallel streams.
 
@@ -270,13 +364,27 @@ async def run_group(
     Returns:
         List[Dict[str, Any]]: Accumulated stats of all streams in the group.
     """
-    initial_prompt = generate_initial_prompt(tokenizer, args)
+    if specs:
+        target_len = specs[0].get("prompt_len") or args.initial_prompt_len_max
+        initial_prompt = build_initial_prompt(tokenizer, global_prefix,
+                                              target_len, group_idx)
+        num_streams = len(specs)
+    elif global_prefix:
+        target_len = random.randint(args.initial_prompt_len_min,
+                                    args.initial_prompt_len_max)
+        initial_prompt = build_initial_prompt(tokenizer, global_prefix,
+                                              target_len, group_idx)
+        num_streams = args.group_size
+    else:
+        initial_prompt = generate_initial_prompt(tokenizer, args)
+        num_streams = args.group_size
+
     initial_prompt_len = len(tokenizer.encode(initial_prompt))
-    print(f"Group {group_idx}: Starting {args.group_size} streams with "
+    print(f"Group {group_idx}: Starting {num_streams} streams with "
           f"shared initial prompt of {initial_prompt_len} tokens...")
 
     tasks = []
-    for stream_idx in range(args.group_size):
+    for stream_idx in range(num_streams):
         tasks.append(
             run_grpo_stream(
                 session,
@@ -287,6 +395,7 @@ async def run_group(
                 stream_idx,
                 group_idx,
                 args,
+                specs[stream_idx] if specs else None,
             ))
 
     results = await asyncio.gather(*tasks)
@@ -460,19 +569,45 @@ async def main_async(args: argparse.Namespace):
             print("Please ensure vLLM serve was started before running.")
             sys.exit(1)
 
+    trace_groups: List[List[Dict[str, Any]]] | None = None
+    if args.trace_file:
+        trace_groups = load_trace(args.trace_file)
+        if args.num_groups and args.num_groups < len(trace_groups):
+            trace_groups = trace_groups[:args.num_groups]
+        turns = sum(
+            len(s.get("out_lens", [])) for g in trace_groups for s in g)
+        streams = sum(len(g) for g in trace_groups)
+        print(f"Replaying trace {args.trace_file}: {len(trace_groups)} groups,"
+              f" {streams} streams, {turns:,} turns")
+
+    global_prefix = ""
+    if args.global_prefix_len > 0:
+        global_prefix = make_token_text(tokenizer, args.global_prefix_len,
+                                        random.Random(0))
+        got = len(tokenizer.encode(global_prefix, add_special_tokens=False))
+        print(f"Global prefix shared by every trajectory: {got} tokens")
+
     semaphore = asyncio.Semaphore(args.concurrency)
 
-    async def worker(group_idx: int, session: aiohttp.ClientSession):
+    async def worker(group_idx: int,
+                     session: aiohttp.ClientSession,
+                     specs: List[Dict[str, Any]] | None = None):
         async with semaphore:
             return await run_group(session, url, args.model, tokenizer,
-                                   group_idx, args)
+                                   group_idx, args, global_prefix, specs)
 
     start_time = time.perf_counter()
 
     async with make_client_session() as session:
-        group_tasks = [
-            worker(i, session) for i in range(1, args.num_groups + 1)
-        ]
+        if trace_groups is not None:
+            group_tasks = [
+                worker(i + 1, session, specs)
+                for i, specs in enumerate(trace_groups)
+            ]
+        else:
+            group_tasks = [
+                worker(i, session) for i in range(1, args.num_groups + 1)
+            ]
         results = await asyncio.gather(*group_tasks)
 
     end_time = time.perf_counter()
@@ -569,6 +704,26 @@ def main():
         type=int,
         default=100,
         help="Maximum simulated environment response length in tokens.",
+    )
+    parser.add_argument(
+        "--trace-file",
+        type=str,
+        default=None,
+        help="Replay a recorded rollout trace (JSONL) instead of sampling "
+        "turn counts and lengths. Each row is one trajectory: "
+        '{"group", "stream", "prompt_len", "out_lens", "obs_lens"}. '
+        "Overrides --turns-*, --output-len-*, --env-len-* and "
+        "--initial-prompt-len-*.",
+    )
+    parser.add_argument(
+        "--global-prefix-len",
+        type=int,
+        default=0,
+        help="Tokens of prompt shared by *every* trajectory, mimicking the "
+        "system prompt and tool definitions of a real agent. The remainder "
+        "of each initial prompt is shared only within a group. Real "
+        "SWE-agent rollouts measure ~6476 tokens global and ~1100 "
+        "per-group.",
     )
     parser.add_argument(
         "--concurrency",

--- a/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
+++ b/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
@@ -60,10 +60,6 @@ def make_token_text(tokenizer: AutoTokenizer, num_tokens: int,
                     rng: random.Random) -> str:
     """Builds text of about num_tokens tokens.
 
-    Decoding random ids and re-encoding overshoots by roughly 5%, so the text
-    is trimmed back once. That lands within a token or two, which is close
-    enough; no caller needs an exact length.
-
     Args:
         tokenizer: Tokenizer used to decode the sampled ids.
         num_tokens: Approximate token count.

--- a/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
+++ b/scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py
@@ -572,7 +572,9 @@ async def main_async(args: argparse.Namespace):
     trace_groups: List[List[Dict[str, Any]]] | None = None
     if args.trace_file:
         trace_groups = load_trace(args.trace_file)
-        if args.num_groups and args.num_groups < len(trace_groups):
+        # Unset means replay the whole trace, rather than the synthetic
+        # default of 2 groups, which would silently truncate it.
+        if args.num_groups is not None:
             trace_groups = trace_groups[:args.num_groups]
         turns = sum(
             len(s.get("out_lens", [])) for g in trace_groups for s in g)
@@ -605,8 +607,9 @@ async def main_async(args: argparse.Namespace):
                 for i, specs in enumerate(trace_groups)
             ]
         else:
+            num_groups = 2 if args.num_groups is None else args.num_groups
             group_tasks = [
-                worker(i, session) for i in range(1, args.num_groups + 1)
+                worker(i, session) for i in range(1, num_groups + 1)
             ]
         results = await asyncio.gather(*group_tasks)
 
@@ -647,8 +650,9 @@ def main():
     parser.add_argument(
         "--num-groups",
         type=int,
-        default=2,
-        help="Number of GRPO groups (requests) to simulate.",
+        default=None,
+        help="Number of GRPO groups (requests) to simulate. Defaults to 2, "
+        "or to every group in --trace-file when replaying a trace.",
     )
     parser.add_argument(
         "--group-size",


### PR DESCRIPTION
## Problem

This pull request enables the replay of recorded rollout traces in the agentic benchmark. 

example usage: 

```
python benchmark_agentic.py \
  --model Qwen/Qwen3.5-397B-A17B-FP8 \
  --trace-file /tmp/gbs1024_trace_file.jsonl \
  --global-prefix-len 6476 \
  --num-groups 16 \
  --concurrency 16
```

The changes include:

* Added support for a `--trace-file` argument to replay recorded rollout traces, allowing for deterministic benchmarking using pre-recorded prompt and output lengths.  
* Implemented the `load_trace` function to parse trace files and group trajectories for replay. 
* Added a `--global-prefix-len` argument and logic to generate a prompt prefix shared across all trajectories, mimicking real-world agent system prompts and tool definitions.  

## Trace file format

One JSON object per line, one line per trajectory:

```json
{"group": 0, "stream": 0, "prompt_len": 7570, "out_lens": [399, 65, 57], "obs_lens": [23, 942, 2126]}
```

| field | meaning |
| --- | --- |
| `group` | Problem index. Streams sharing a `group` share one initial prompt, which is what exercises prefix caching. |
| `stream` | Generation index within the group, `0..G-1`. |
| `prompt_len` | Initial prompt length in tokens. Taken from the first stream of each group. |
| `out_lens` | Assistant tokens generated on each turn, in order. Its length sets the turn count. |
| `obs_lens` | Environment observation tokens appended after each turn, in order. |

