### PR TITLE
[DSv4] avoid params being copied in fwd pass

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -75,6 +75,8 @@ if TYPE_CHECKING:
     LORA_MODULE_PATH: str = ""
     SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES: str = "auto"
     SLICE_ROPE_CACHE: bool = False
+    ROPE_CACHE_ROW_MAJOR: bool = True
+    HASH_TABLE_ROW_MAJOR: bool = False
     MIN_TOKEN_BUCKET: int = 16
     MOE_ROUTE_PADDING_TO_EXPERT0: bool = False
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
@@ -447,6 +449,17 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # positions can exceed max_model_len.
     "SLICE_ROPE_CACHE":
     env_bool("SLICE_ROPE_CACHE", default=False),
+    # Set the rotary cos_sin_cache in the row-major TPU layout at
+    # load time. XLA picks the transposed layout {0,1} for narrow tables (the
+    # 64-wide DeepSeek rope cache) to avoid lane padding, and then has to copy
+    # the whole table back to {1,0} inside the step function on every forward
+    # pass. Trades 2x HBM for that buffer for the per-step copy.
+    "ROPE_CACHE_ROW_MAJOR":
+    env_bool("ROPE_CACHE_ROW_MAJOR", default=True),
+    # similar to ROPE_CACHE_ROW_MAJOR, but for the hash-MoE routing table
+    # (`*.routed_experts.hash_indices_table`, [vocab_size, num_experts_per_tok]).
+    "HASH_TABLE_ROW_MAJOR":
+    env_bool("HASH_TABLE_ROW_MAJOR", default=False),
     "MLA_TRANSPOSE_KV_CACHE":
     env_bool("MLA_TRANSPOSE_KV_CACHE", default=False),
     # Minimum max num of batched tokens.

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -75,7 +75,7 @@ if TYPE_CHECKING:
     LORA_MODULE_PATH: str = ""
     SC_ALLREDUCE_ALLGATHER_OFFLOAD_MIN_BYTES: str = "auto"
     SLICE_ROPE_CACHE: bool = False
-    ROPE_CACHE_ROW_MAJOR: bool = True
+    ROPE_CACHE_ROW_MAJOR: bool = False
     HASH_TABLE_ROW_MAJOR: bool = False
     MIN_TOKEN_BUCKET: int = 16
     MOE_ROUTE_PADDING_TO_EXPERT0: bool = False
@@ -455,7 +455,7 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # the whole table back to {1,0} inside the step function on every forward
     # pass. Trades 2x HBM for that buffer for the per-step copy.
     "ROPE_CACHE_ROW_MAJOR":
-    env_bool("ROPE_CACHE_ROW_MAJOR", default=True),
+    env_bool("ROPE_CACHE_ROW_MAJOR", default=False),
     # similar to ROPE_CACHE_ROW_MAJOR, but for the hash-MoE routing table
     # (`*.routed_experts.hash_indices_table`, [vocab_size, num_experts_per_tok]).
     "HASH_TABLE_ROW_MAJOR":

--- a/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_compressor.py
+++ b/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_compressor.py
@@ -110,6 +110,21 @@ class VllmDeepseekCompressor(DeepseekCompressor):
             super().__init__(*args, **kwargs)
         finally:
             dsv4_compressor.CompressorStateCache = orig_state_cache
+        self._wkv_wgate_transposed = False
+
+    def transpose_wkv_wgate(self) -> None:
+        """Stores ``fused_wkv_wgate.weight`` transposed, once, at load time.
+
+        vLLM lays linear weights out as [out_features, in_features], but the
+        compress-and-store kernel consumes them as
+        [hidden_size, 2 * coff * head_dim].
+        """
+        if self._wkv_wgate_transposed:
+            return
+        weight = self.fused_wkv_wgate.weight.data.t().contiguous()
+        self.fused_wkv_wgate.weight = torch.nn.Parameter(weight,
+                                                         requires_grad=False)
+        self._wkv_wgate_transposed = True
 
     # pylint: disable=unused-argument
     def forward(
@@ -223,9 +238,10 @@ class VllmDeepseekCompressor(DeepseekCompressor):
                 outs.append(new_state_cache)
             return tuple(outs) if len(outs) > 1 else outs[0]
 
+        assert self._wkv_wgate_transposed
         operands = (
             jax_view(hidden_states),
-            jax_view(self.fused_wkv_wgate.weight).T,
+            jax_view(self.fused_wkv_wgate.weight),
             jax_view(self.ape),
             jax_view(self.norm.weight),
             jax_view(rotary_emb.cos_sin_cache),

--- a/tpu_inference/models/vllm/experimental/deepseek_v4.py
+++ b/tpu_inference/models/vllm/experimental/deepseek_v4.py
@@ -35,6 +35,8 @@ from vllm.sequence import IntermediateTensors
 
 from tpu_inference.layers.vllm.custom_ops.experimental.deepseek_v4.deepseek_v4_attention import \
     VllmDeepseekV4MLAAttention
+from tpu_inference.layers.vllm.custom_ops.experimental.deepseek_v4.deepseek_v4_compressor import \
+    VllmDeepseekCompressor
 from tpu_inference.layers.vllm.interface.moe import FusedMoEFactory
 
 
@@ -800,6 +802,15 @@ class DeepseekV4ForCausalLM(nn.Module, SupportsPP):
         loader = AutoWeightsLoader(self, skip_substrs=["mtp."])
         loaded_params = loader.load_weights(weights,
                                             mapper=self.hf_to_vllm_mapper)
+
+        # Post-load weight surgery goes here.
+        # The TPU compress-and-store kernel wants ``fused_wkv_wgate`` as
+        # [hidden_size, 2 * coff * head_dim]; transpose it once here instead of
+        # on every forward pass.
+        for module in self.modules():
+            if isinstance(module, VllmDeepseekCompressor):
+                module.transpose_wkv_wgate()
+
         return loaded_params
 
     def get_expert_mapping(self) -> list[tuple[str, str, int, str]]:

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -27,6 +27,7 @@ import torch.nn
 import torchax
 import vllm.envs as vllm_envs
 from flax.typing import PRNGKey
+from jax.experimental.layout import Format, Layout
 from jax.sharding import Mesh, NamedSharding, PartitionSpec
 from torchax.interop import jax_view, torch_view
 from torchax.ops.mappings import TORCH_DTYPE_TO_JAX, t2j
@@ -72,6 +73,35 @@ from tpu_inference.runner.mm_encoder_jit_manager import (
     MMEncoderJITManager, maybe_create_mm_encoder_jit_manager)
 
 logger = init_logger(__name__)
+
+
+def _to_row_major(arr: jax.Array, key: str) -> jax.Array:
+    """Materializes ``arr`` in row-major layout.
+
+    XLA:TPU picks the layout of a device array from its shape alone. For a
+    narrow 2-D table -- the rope ``cos_sin_cache`` ([max_position, 64]), the
+    hash-MoE ``hash_indices_table`` ([vocab_size, 6]) -- the minor-most
+    dimension would be padded out to a full 128-lane tile, so XLA prefers the
+    transposed layout {0,1}, which needs no padding. Consumers of the table
+    (the rope kernels and any other custom call, an XLA gather) want the
+    default {1,0}, so the compiler inserts a ``copy(t[N,c]{0,1}) -> t[N,c]{1,0}``
+    of the whole table into the step function -- on every forward pass.
+    Committing the buffer in {1,0} at load time moves that relayout to load
+    time; the buffer then pays the lane padding permanently (2x HBM for a
+    64-wide f32 table, 21x for a 6-wide one).
+    """
+    fmt = getattr(arr, "format", None)
+    if fmt is None or fmt.layout is None:
+        return arr
+    row_major = Layout(tuple(range(arr.ndim)))
+    if fmt.layout.major_to_minor == row_major.major_to_minor:
+        return arr
+    out = jax.device_put(arr, Format(row_major, arr.sharding))
+    logger.info(
+        "Relaid out %s %s from layout %s to %s at load time to avoid a "
+        "per-step XLA layout copy", key, arr.shape, fmt.layout.major_to_minor,
+        row_major.major_to_minor)
+    return out
 
 
 class _VllmRunner(torch.nn.Module):
@@ -258,19 +288,29 @@ class VllmModelWrapper:
         # positions are 1-D and bounded by max_model_len (standard text RoPE);
         # MRoPE video positions are structural and can exceed max_model_len, so
         # skip the slice there to avoid an out-of-bounds cos_sin_cache gather.
-        if envs.SLICE_ROPE_CACHE and \
-                not self.vllm_config.model_config.uses_mrope:
-            max_len = self.vllm_config.model_config.max_model_len
+        slice_rope_cache = envs.SLICE_ROPE_CACHE and \
+            not self.vllm_config.model_config.uses_mrope
+        max_len = self.vllm_config.model_config.max_model_len
+        for key, val in list(params_and_buffers.items()):
+            if not key.endswith("rotary_emb.cos_sin_cache"):
+                continue
+            arr = jax_view(val)
+            if slice_rope_cache and arr.shape[0] > max_len:
+                arr = arr[:max_len]
+                logger.info(
+                    "Sliced rope cache %s rows %d -> %d. Assumes "
+                    "positions are 1-D and bounded by max_model_len "
+                    "(%d); MRoPE (video) can exceed it and is excluded", key,
+                    jax_view(val).shape[0], max_len, max_len)
+            if envs.ROPE_CACHE_ROW_MAJOR:
+                arr = _to_row_major(arr, key)
+            params_and_buffers[key] = torch_view(arr)
+
+        if envs.HASH_TABLE_ROW_MAJOR:
             for key, val in list(params_and_buffers.items()):
-                if key.endswith("rotary_emb.cos_sin_cache"):
-                    arr = jax_view(val)
-                    if arr.shape[0] > max_len:
-                        params_and_buffers[key] = torch_view(arr[:max_len])
-                        logger.info(
-                            "Sliced rope cache %s rows %d -> %d. Assumes "
-                            "positions are 1-D and bounded by max_model_len "
-                            "(%d); MRoPE (video) can exceed it and is excluded",
-                            key, arr.shape[0], max_len, max_len)
+                if key.endswith("hash_indices_table"):
+                    params_and_buffers[key] = torch_view(
+                        _to_row_major(jax_view(val), key))
 
         self._pooler: Pooler | None = self.model.pooler
 


### PR DESCRIPTION
[DSv4] avoid params being copied in fwd pass

3 params were being copied in the forward pass before:
* cos_sin_cache for ROPE
* MOE tid_to_eid-hash-table for the bottom 3 layers of MOE
* compressor's projection weigthts.

For `cos_sin_cache` & `tid_to_eid-hash-table`, copy is due to the last dim of the array is not multiple of 128; XLA chose a column-major layout (to avoid padding, thus save space); in each forward pass, XLA's relayout (to row major layout) trigger a copy;
* to avoid copy, added environment variable to force a row-major layout for those 2 arrays at model loading time.

For compressor's projection weights;
* explicitly perform a weight matrix tranpose at the end of weight loading so that we don't need to call ".T" within each forward pass.


Quality validated:
MMLU: https://paste.googleplex.com/6592322820243456 
MMLU Pro: https://paste.googleplex.com/4992211245727744 

