### PR TITLE
examples/disagg: make the correctness check measure KV correctness

### DIFF
--- a/examples/disagg/numerics_control.py
+++ b/examples/disagg/numerics_control.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Measure the mismatch rate a disaggregated run cannot beat.
+
+Comparing a disaggregated deployment's text against a single-node baseline
+cannot on its own tell a corrupted KV handoff from greedy decoding flipping a
+near-tied argmax. These two controls remove the KV transfer from the picture
+entirely: every byte of KV is computed locally by the engine that uses it, so
+any mismatch they report is attributable to the shape of the prefill alone.
+
+  C1  chunking control. Two identical servers differing only in
+      --max-num-batched-tokens (unchunked vs chunked). Same weights, same block
+      size, no prefix caching, no disaggregation. A mismatch here means that
+      splitting a prefill across forward passes is by itself enough to change
+      the output.
+
+  C2  prefix-cache control. One server with prefix caching on. The same prompt
+      is sent twice: the first call prefills all N tokens, the second reuses the
+      cached KV -- bit-identical by construction -- and recomputes only the
+      tail. Identical bytes, different query-chunk shape.
+
+Reading the result. A disaggregated run changes the execution path at least as
+much as these controls do, so it cannot be expected to beat them. If the
+controls sit near the disaggregated rate, the mismatches are argmax instability
+and the transfer is not implicated. If the controls are near zero while the
+disaggregated rate is not, the transferred bytes are suspect.
+
+Prompt distribution dominates both. Prompts of random single letters leave the
+top two logits routinely tied to within a bf16 ULP, so they flip under any
+change of execution path; prose does not.
+"""
+
+import argparse
+import json
+import sys
+
+from pd_probe import (build_prompt_ids, compare_logprobs, completion,
+                      first_top_logprobs)
+from transformers import AutoTokenizer
+
+
+def run_pair(url_a,
+             url_b,
+             model,
+             tok,
+             lengths,
+             styles,
+             n,
+             out_len,
+             label,
+             same_server_twice=False):
+    """Compare two endpoints (or one endpoint called twice) over the sweep."""
+    rows = []
+    for style in styles:
+        for n_tok in lengths:
+            mism = tok1_mm = 0
+            deltas = []
+            for i in range(n):
+                # Distinct seed space per control, so C2's "fresh" call really is
+                # a cache miss rather than a prompt the sweep already warmed.
+                seed = hash((label, style, n_tok, i)) & 0xFFFFFFFF
+                ids = build_prompt_ids(tok, n_tok, style, seed)
+                try:
+                    a = completion(url_a, model, ids, out_len, None)
+                    b = completion(url_b, model, ids, out_len, None)
+                    if a["choices"][0]["text"] != b["choices"][0]["text"]:
+                        mism += 1
+                    la = completion(url_a, model, ids, 1, 5)
+                    lb = completion(url_b, model, ids, 1, 5)
+                    ta, topa = first_top_logprobs(la)
+                    tb, topb = first_top_logprobs(lb)
+                    if ta != tb:
+                        tok1_mm += 1
+                    deltas.append(compare_logprobs(topa, topb)[1])
+                except Exception as e:  # noqa: BLE001
+                    print(f"  [{label} {style} {n_tok} #{i}] error: {e!r}")
+            med = sorted(deltas)[len(deltas) // 2] if deltas else float("nan")
+            rows.append((label, style, n_tok, mism, tok1_mm, n, med))
+            print(f"{label:<14} {style:<10} {n_tok:>5}  text_mm={mism}/{n}  "
+                  f"tok1_mm={tok1_mm}/{n}  med_lp_delta={med:.2e}")
+    return rows
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--unchunked-url", required=True, help="C1 server A")
+    ap.add_argument("--chunked-url", required=True, help="C1 server B")
+    ap.add_argument("--prefixcache-url", required=True, help="C2 server")
+    ap.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    ap.add_argument("--lengths", default="128,256,384,512")
+    ap.add_argument("--num-prompts", type=int, default=8)
+    ap.add_argument("--output-length", type=int, default=32)
+    ap.add_argument("--style",
+                    choices=["gibberish", "text", "both"],
+                    default="both")
+    ap.add_argument("--json-out", default=None)
+    args = ap.parse_args()
+
+    lengths = [int(x) for x in args.lengths.split(",") if x.strip()]
+    styles = ["gibberish", "text"] if args.style == "both" else [args.style]
+    tok = AutoTokenizer.from_pretrained(args.model)
+
+    print("=== C1: unchunked vs chunked prefill (no disagg, no transfer) ===")
+    r1 = run_pair(args.unchunked_url, args.chunked_url, args.model, tok,
+                  lengths, styles, args.num_prompts, args.output_length,
+                  "C1-chunking")
+
+    print("\n=== C2: prefix-cache miss vs hit on one server "
+          "(bit-identical KV, different query shape) ===")
+    r2 = run_pair(args.prefixcache_url,
+                  args.prefixcache_url,
+                  args.model,
+                  tok,
+                  lengths,
+                  styles,
+                  args.num_prompts,
+                  args.output_length,
+                  "C2-prefixcache",
+                  same_server_twice=True)
+
+    def rate(rows):
+        m = sum(r[3] for r in rows)
+        t = sum(r[5] for r in rows)
+        return m / t if t else float("nan"), m, t
+
+    c1, m1, t1 = rate(r1)
+    c2, m2, t2 = rate(r2)
+    print("\n=== Control summary ===")
+    print(f"C1 chunking      mismatch rate: {c1:.3f}  ({m1}/{t1})")
+    print(f"C2 prefix-cache  mismatch rate: {c2:.3f}  ({m2}/{t2})")
+    print(
+        "\nCompare these against the disaggregated rate measured on the same "
+        "model and prompts.\nA comparable rate means argmax instability, not a "
+        "transfer fault; a near-zero rate\nhere alongside a much higher "
+        "disaggregated rate means the transferred bytes are\nworth "
+        "investigating.")
+
+    if args.json_out:
+        with open(args.json_out, "w") as f:
+            json.dump({"c1": r1, "c2": r2}, f, indent=1)
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/disagg/pd_probe.py
+++ b/examples/disagg/pd_probe.py
@@ -1,0 +1,310 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Localise a disaggregated-vs-baseline output difference.
+
+When a disaggregated deployment's text differs from a single-node baseline, the
+cause is either the transferred KV or greedy decoding flipping a near-tied
+argmax. Text equality alone cannot tell them apart. This probe posts the prompt
+as an explicit list of token ids -- which the OpenAI completions API accepts --
+so the token count is exact rather than whatever a word-count happened to
+tokenize to, and runs two measurements over it.
+
+Measurement A -- block-alignment sweep.
+  The producer drops the trailing partial block (tpu_connector.request_finished:
+  `computed_block_ids = block_ids if all_full else block_ids[:-1]`) and the
+  consumer independently derives the same boundary via
+  round_down(len(prompt), block_size). At a prompt length that is an exact
+  multiple of block_size the decoder therefore has *zero* tail to recompute; at
+  any other length it recomputes the remainder. Mismatches confined to
+  non-multiples point at the recomputed tail; mismatches at exact multiples too
+  point at the transferred bytes.
+
+Measurement B -- first-token logprobs.
+  Sub-ULP drift shows up as near-tied top-1/top-2 logits with the two endpoints
+  agreeing to ~1e-3. Wrong KV shows up as a large delta whatever the tie
+  structure. One call per endpoint settles which of the two is happening,
+  without any KV-level tooling.
+
+Prompt distribution is a variable, not a constant. --style gibberish emits
+random single letters, whose top two logits are routinely tied to within a bf16
+ULP; --style text uses prose. Running both quantifies how much of a rate is an
+artefact of the prompts.
+"""
+
+import argparse
+import json
+import math
+import random
+import sys
+from collections import defaultdict
+
+import requests
+from transformers import AutoTokenizer
+
+# Real prose, so that --style text exercises a normal (non-near-tied) logit
+# distribution. Content is irrelevant; it only has to tokenize to enough tokens.
+_PROSE = """
+The history of computing hardware spans the development of machines able to
+automate calculation. Early aids such as the abacus gave way to mechanical
+calculators, and then to programmable machines whose behaviour was determined by
+stored instructions rather than by physical rearrangement. The shift from vacuum
+tubes to transistors, and then to integrated circuits, reduced cost and power draw
+by orders of magnitude while raising reliability. Later, the separation of memory
+from arithmetic became the dominant constraint on performance, and much of the
+subsequent design effort went into hiding the latency of that separation through
+caches, pipelining, and speculative execution. Accelerators returned to a different
+tradeoff, spending area on arithmetic throughput and on very wide memory interfaces,
+and pushing the burden of scheduling back onto the compiler and the programmer.
+"""
+
+
+def build_prompt_ids(tok, num_tokens: int, style: str, seed: int) -> list[int]:
+    """Return exactly `num_tokens` token ids."""
+    rng = random.Random(seed)
+    if style == "gibberish":
+        # Random single lowercase letters joined by spaces: the near-tie-rich
+        # distribution. Over-generate, then truncate to an exact token count.
+        words = [
+            rng.choice("abcdefghijklmnopqrstuvwxyz")
+            for _ in range(num_tokens * 2 + 32)
+        ]
+        text = " ".join(words)
+    else:
+        # Rotate the starting point so prompts differ between samples.
+        body = " ".join(_PROSE.split())
+        reps = math.ceil((num_tokens * 8) / max(len(body), 1)) + 1
+        text = " ".join([body] * reps)
+        off = rng.randrange(0, max(len(body), 1))
+        text = text[off:]
+
+    ids = tok.encode(text, add_special_tokens=False)
+    if len(ids) < num_tokens:
+        raise RuntimeError(
+            f"only produced {len(ids)} tokens, needed {num_tokens}")
+    return ids[:num_tokens]
+
+
+def post(url: str, payload: dict, timeout: int = 600) -> dict:
+    r = requests.post(url, json=payload, timeout=timeout)
+    r.raise_for_status()
+    return r.json()
+
+
+def completion(url: str, model: str, ids: list[int], max_tokens: int,
+               logprobs: int | None) -> dict:
+    payload = {
+        "model": model,
+        "prompt": ids,
+        "max_tokens": max_tokens,
+        "temperature": 0.0,
+        "stream": False,
+    }
+    if logprobs is not None:
+        payload["logprobs"] = logprobs
+    return post(url, payload)
+
+
+def first_top_logprobs(resp: dict) -> tuple[str, dict[str, float]]:
+    """(sampled token, {token: logprob}) for the first generated position."""
+    lp = resp["choices"][0].get("logprobs")
+    if not lp:
+        raise RuntimeError(
+            "endpoint returned no logprobs; is `logprobs` supported?")
+    top = lp.get("top_logprobs") or []
+    toks = lp.get("tokens") or []
+    if not top or not toks:
+        raise RuntimeError(f"malformed logprobs payload: {lp}")
+    return toks[0], dict(top[0])
+
+
+def compare_logprobs(base: dict[str, float],
+                     disagg: dict[str, float]) -> tuple[float, float]:
+    """(baseline top1-top2 gap, max |delta| over tokens common to both)."""
+    ordered = sorted(base.values(), reverse=True)
+    gap = (ordered[0] - ordered[1]) if len(ordered) > 1 else float("inf")
+    shared = set(base) & set(disagg)
+    delta = max((abs(base[t] - disagg[t]) for t in shared),
+                default=float("nan"))
+    return gap, delta
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--baseline-url", required=True)
+    ap.add_argument("--disagg-url", required=True)
+    ap.add_argument("--model", default="Qwen/Qwen3-0.6B")
+    ap.add_argument("--block-size", type=int, default=128)
+    ap.add_argument("--lengths",
+                    type=str,
+                    default="64,127,128,129,192,200,255,256,257,384,512",
+                    help="exact prompt token counts to sweep")
+    ap.add_argument("--num-prompts",
+                    type=int,
+                    default=10,
+                    help="prompts per length")
+    ap.add_argument("--output-length", type=int, default=32)
+    ap.add_argument("--style",
+                    choices=["gibberish", "text", "both"],
+                    default="both")
+    ap.add_argument("--json-out", type=str, default=None)
+    args = ap.parse_args()
+
+    lengths = [int(x) for x in args.lengths.split(",") if x.strip()]
+    styles = ["gibberish", "text"] if args.style == "both" else [args.style]
+
+    print(f"model={args.model} block_size={args.block_size}")
+    print(f"baseline={args.baseline_url}")
+    print(f"disagg  ={args.disagg_url}")
+    tok = AutoTokenizer.from_pretrained(args.model)
+
+    records = []
+    # (style, length) -> counters
+    agg: dict[tuple[str, int], dict] = defaultdict(lambda: {
+        "n": 0,
+        "text_mismatch": 0,
+        "tok1_mismatch": 0,
+        "gaps": [],
+        "deltas": []
+    })
+
+    for style in styles:
+        for n_tok in lengths:
+            for i in range(args.num_prompts):
+                seed = hash((style, n_tok, i)) & 0xFFFFFFFF
+                ids = build_prompt_ids(tok, n_tok, style, seed)
+                rec = {
+                    "style": style,
+                    "num_tokens": n_tok,
+                    "sample": i,
+                    "aligned": n_tok % args.block_size == 0
+                }
+
+                # --- Measurement A: greedy text equality -------------------
+                try:
+                    b = completion(args.baseline_url, args.model, ids,
+                                   args.output_length, None)
+                    d = completion(args.disagg_url, args.model, ids,
+                                   args.output_length, None)
+                    bt = b["choices"][0]["text"]
+                    dt = d["choices"][0]["text"]
+                    rec["text_match"] = (bt == dt)
+                    if bt != dt:
+                        common = 0
+                        for cb, cd in zip(bt, dt):
+                            if cb != cd:
+                                break
+                            common += 1
+                        rec["common_prefix_chars"] = common
+                        rec["baseline_text"] = bt
+                        rec["disagg_text"] = dt
+                except Exception as e:  # noqa: BLE001
+                    rec["text_error"] = repr(e)
+
+                # --- Measurement B: first-token logprobs -------------------
+                try:
+                    bl = completion(args.baseline_url, args.model, ids, 1, 5)
+                    dl = completion(args.disagg_url, args.model, ids, 1, 5)
+                    b_tok, b_top = first_top_logprobs(bl)
+                    d_tok, d_top = first_top_logprobs(dl)
+                    gap, delta = compare_logprobs(b_top, d_top)
+                    rec.update({
+                        "tok1_match": b_tok == d_tok,
+                        "baseline_top2_gap": gap,
+                        "logprob_max_delta": delta,
+                        "baseline_tok1": b_tok,
+                        "disagg_tok1": d_tok
+                    })
+                except Exception as e:  # noqa: BLE001
+                    rec["logprob_error"] = repr(e)
+
+                records.append(rec)
+                a = agg[(style, n_tok)]
+                a["n"] += 1
+                if rec.get("text_match") is False:
+                    a["text_mismatch"] += 1
+                if rec.get("tok1_match") is False:
+                    a["tok1_mismatch"] += 1
+                if isinstance(rec.get("baseline_top2_gap"), float):
+                    a["gaps"].append(rec["baseline_top2_gap"])
+                if isinstance(rec.get("logprob_max_delta"), float):
+                    a["deltas"].append(rec["logprob_max_delta"])
+
+    # --- Report ------------------------------------------------------------
+    def med(xs):
+        return float("nan") if not xs else sorted(xs)[len(xs) // 2]
+
+    print(
+        "\n=== Measurement A/B by prompt length "
+        f"(block_size={args.block_size}; 'aligned' = whole prompt transferred, "
+        "decoder recomputes nothing) ===")
+    hdr = (f"{'style':<10} {'tokens':>7} {'aligned':>8} {'text_mm':>9} "
+           f"{'tok1_mm':>9} {'med top2 gap':>13} {'med lp delta':>13}")
+    print(hdr)
+    print("-" * len(hdr))
+    for style in styles:
+        for n_tok in lengths:
+            a = agg[(style, n_tok)]
+            if not a["n"]:
+                continue
+            print(f"{style:<10} {n_tok:>7} "
+                  f"{str(n_tok % args.block_size == 0):>8} "
+                  f"{a['text_mismatch']:>4}/{a['n']:<4} "
+                  f"{a['tok1_mismatch']:>4}/{a['n']:<4} "
+                  f"{med(a['gaps']):>13.5f} {med(a['deltas']):>13.2e}")
+
+    # --- Verdict -----------------------------------------------------------
+    aligned = [r for r in records if r["aligned"]]
+    unaligned = [r for r in records if not r["aligned"]]
+
+    def mm_rate(rs):
+        seen = [r for r in rs if "text_match" in r]
+        return (sum(1 for r in seen if not r["text_match"]) /
+                len(seen)) if seen else float("nan")
+
+    all_deltas = [
+        r["logprob_max_delta"] for r in records
+        if isinstance(r.get("logprob_max_delta"), float)
+        and not math.isnan(r["logprob_max_delta"])
+    ]
+    mismatch_gaps = [
+        r["baseline_top2_gap"] for r in records if r.get("tok1_match") is False
+        and isinstance(r.get("baseline_top2_gap"), float)
+    ]
+
+    print("\n=== Summary ===")
+    print(f"mismatch rate, block-aligned prompts   : {mm_rate(aligned):.3f} "
+          f"(n={len(aligned)})")
+    print(f"mismatch rate, unaligned prompts       : {mm_rate(unaligned):.3f} "
+          f"(n={len(unaligned)})")
+    print(f"max first-token logprob delta (all)    : "
+          f"{max(all_deltas) if all_deltas else float('nan'):.3e}")
+    print(f"median top1-top2 gap where tok1 flipped: {med(mismatch_gaps):.5f} "
+          f"(n={len(mismatch_gaps)})")
+    print(
+        "\nRead: a near-zero aligned rate, a tiny logprob delta and a near-zero "
+        "top2 gap at the\n      flips mean the differences are argmax "
+        "instability under a changed prefill shape.\n      A non-zero aligned "
+        "rate, or a large logprob delta, means the transferred KV is\n      "
+        "worth investigating.")
+
+    if args.json_out:
+        with open(args.json_out, "w") as f:
+            json.dump(records, f, indent=1)
+        print(f"\nper-prompt records -> {args.json_out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/examples/disagg/test_disagg_correctness.py
+++ b/examples/disagg/test_disagg_correctness.py
@@ -11,28 +11,92 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+"""Greedy-output correctness check: disaggregated P/D against a single-node baseline.
+
+Prompts are built as an explicit list of token ids, which the completions API
+accepts, so the token count of a prompt is exact. That matters because every
+boundary in the connector is expressed in tokens and blocks: `request_finished()`
+drops the trailing partial block and `get_num_new_matched_tokens()` mirrors it with
+`round_down(len(prompt), block_size)`. A prompt specified in words leaves the token
+count unknown and variable.
+
+Prompts default to real prose. Random-letter prompts are off-manifold, and the
+model's top-1 and top-2 logits are then frequently tied to within a bfloat16 ULP, so
+greedy argmax is settled by float noise. Controls that contain no KV transfer at all
+-- unchunked versus chunked prefill on two identical servers, and prefix-cache miss
+versus hit on a single server, where the reused KV is bit-identical by construction
+-- mismatch at a comparable rate on that distribution. Greedy text equality over
+random letters therefore measures argmax stability under any change of execution
+path, not KV correctness. `--prompt_style gibberish` is kept for that stability
+probe; pair it with a non-zero `--max_mismatch_rate`.
+
+For the same reason a mismatch rate of exactly zero is not achievable in general, so
+`--max_mismatch_rate` (default 0.0) is a floor you can raise. `--control_url` is the
+better option: it measures this run's own instability floor, on the same model,
+prompts and hardware, and gates on `disagg <= floor`.
+
+The shape of a failure says more than its rate. A transfer fault diverges at
+character 0 and at a rate near 1.0; argmax instability diverges deep into the
+continuation at a few percent. Each mismatch is reported with the number of leading
+characters the two outputs share, for that reason.
+
+To diagnose a failure rather than merely detect one, `pd_probe.py` gives per-length
+mismatch rates and first-token logprob deltas across the block boundary, and
+`numerics_control.py` runs the same comparison with the KV transfer removed.
+"""
 
 import argparse
 import json
 import logging
+import math
 import random
-import string
 
 import requests
 
+# Real prose, so the default probe distribution is on-manifold and the model is
+# confident. The content is irrelevant; it only has to tokenize to enough tokens.
+_PROSE = """
+The history of computing hardware spans the development of machines able to
+automate calculation. Early aids such as the abacus gave way to mechanical
+calculators, and then to programmable machines whose behaviour was determined by
+stored instructions rather than by physical rearrangement. The shift from vacuum
+tubes to transistors, and then to integrated circuits, reduced cost and power draw
+by orders of magnitude while raising reliability. Later, the separation of memory
+from arithmetic became the dominant constraint on performance, and much of the
+subsequent design effort went into hiding the latency of that separation through
+caches, pipelining, and speculative execution. Accelerators returned to a different
+tradeoff, spending area on arithmetic throughput and on very wide memory interfaces,
+and pushing the burden of scheduling back onto the compiler and the programmer.
+"""
 
-def generate_prompt(num_words):
-    """Generates a random prompt with a specified number of words."""
-    words = [random.choice(string.ascii_lowercase) for _ in range(num_words)]
-    return " ".join(words)
+
+def build_prompt_ids(tokenizer, num_tokens, style, seed):
+    """Return exactly `num_tokens` token ids, so block boundaries are addressable."""
+    rng = random.Random(seed)
+    if style == "gibberish":
+        words = [
+            rng.choice("abcdefghijklmnopqrstuvwxyz")
+            for _ in range(num_tokens * 2 + 32)
+        ]
+        text = " ".join(words)
+    else:
+        body = " ".join(_PROSE.split())
+        reps = math.ceil((num_tokens * 8) / max(len(body), 1)) + 1
+        # Rotate the starting point so that successive prompts differ.
+        text = " ".join([body] * reps)[rng.randrange(0, max(len(body), 1)):]
+
+    ids = tokenizer.encode(text, add_special_tokens=False)
+    if len(ids) < num_tokens:
+        raise RuntimeError(f"produced {len(ids)} tokens, needed {num_tokens}")
+    return ids[:num_tokens]
 
 
-def send_request(url, prompt, model_name, output_length):
+def send_request(url, prompt_ids, model_name, output_length):
     """Sends a request to the LLM and returns the response."""
     headers = {"Content-Type": "application/json"}
     data = {
         "model": model_name,
-        "prompt": prompt,
+        "prompt": prompt_ids,
         "max_tokens": output_length,
         "temperature": 0.0,
     }
@@ -49,37 +113,87 @@ def send_request(url, prompt, model_name, output_length):
 
 def main(args):
     """Main function to run the correctness test."""
+    from transformers import AutoTokenizer
+    tokenizer = AutoTokenizer.from_pretrained(args.model)
+
     mismatches = 0
+    control_mismatches = 0
     for i in range(args.num_requests):
         logging.info(f"Sending request {i+1}/{args.num_requests}...")
-        prompt = generate_prompt(args.input_length)
+        prompt_ids = build_prompt_ids(tokenizer, args.input_length,
+                                      args.prompt_style, i)
 
-        baseline_response = send_request(args.baseline_url, prompt, args.model,
-                                         args.output_length)
-        disagg_response = send_request(args.disagg_url, prompt, args.model,
+        baseline_response = send_request(args.baseline_url, prompt_ids,
+                                         args.model, args.output_length)
+        disagg_response = send_request(args.disagg_url, prompt_ids, args.model,
                                        args.output_length)
+
+        if args.control_url:
+            # The floor for this run. Send the same prompt to the control server
+            # twice: the first call is a cache miss and prefills all N tokens, the
+            # second is a hit and recomputes only the tail from the cached -- and
+            # therefore bit-identical -- KV. Comparing the two isolates the change
+            # of execution path with the byte question settled a priori, which is
+            # the closest transfer-free analogue of what the disagg decoder does.
+            # (Comparing the control against the baseline instead would just be two
+            # independent cold prefills, which agree, and would measure nothing.)
+            control_miss = send_request(args.control_url, prompt_ids,
+                                        args.model, args.output_length)
+            control_hit = send_request(args.control_url, prompt_ids,
+                                       args.model, args.output_length)
+            if control_miss != control_hit:
+                control_mismatches += 1
 
         if baseline_response != disagg_response:
             mismatches += 1
+            common = 0
+            for cb, cd in zip(baseline_response, disagg_response):
+                if cb != cd:
+                    break
+                common += 1
             logging.info(f"  MISMATCH FOUND for prompt {i+1}:")
-            logging.info(f"    Prompt: {prompt[:100]}...")
+            # Where they diverge is the useful part: divergence at character 0
+            # points at the handoff, divergence deep into the continuation points
+            # at drift accumulated during decode.
+            logging.info(f"    Diverged after {common} identical characters")
             logging.info(f"    Baseline: {baseline_response}")
             logging.info(f"    Disagg:   {disagg_response}")
         else:
             logging.info(f"  Responses match for prompt {i+1}.")
 
+    rate = mismatches / args.num_requests if args.num_requests else 0.0
     logging.info("\n--- Test Summary ---")
+    logging.info(f"style={args.prompt_style} input_tokens={args.input_length} "
+                 f"output_tokens={args.output_length}")
     if mismatches == 0:
         logging.info("All responses matched! The services are consistent.")
     else:
         logging.info(
-            f"{mismatches}/{args.num_requests} requests had mismatched responses."
-        )
-        if mismatches > args.num_requests * 0.5:  # If more than 50% mismatches, raise an exception
-            raise Exception(
-                "More than 50% of responses mismatched. There may be a significant issue."
-            )
+            f"{mismatches}/{args.num_requests} requests had mismatched "
+            f"responses (rate {rate:.3f}).")
+    threshold = args.max_mismatch_rate
+    if args.control_url:
+        control_rate = (control_mismatches /
+                        args.num_requests if args.num_requests else 0.0)
+        logging.info(
+            f"control (cache miss vs hit) mismatch rate, this run's floor: "
+            f"{control_mismatches}/{args.num_requests} "
+            f"({control_rate:.3f})")
+        # Gate relative to the floor actually measured here, not to an absolute
+        # constant: greedy argmax is not stable to execution-path changes even
+        # when the KV is bit-identical, and how unstable depends on the model,
+        # the prompt distribution and the hardware.
+        threshold = max(threshold, control_rate)
     logging.info("--------------------")
+
+    if rate > threshold:
+        raise Exception(
+            f"Mismatch rate {rate:.3f} exceeds threshold {threshold:.3f}. Use "
+            f"pd_probe.py to localise it across the block boundary, and "
+            f"numerics_control.py to establish this run's noise floor, before "
+            f"concluding the KV transfer is at fault. A real transfer bug "
+            f"diverges at character 0 and at a rate near 1.0; divergence deep "
+            f"into the continuation at a few percent is argmax instability.")
 
 
 if __name__ == "__main__":
@@ -91,12 +205,37 @@ if __name__ == "__main__":
                         help="Number of requests to send.")
     parser.add_argument("--input_length",
                         type=int,
-                        default=100,
-                        help="Length of each input prompt in words.")
+                        default=256,
+                        help="Exact length of each input prompt, in tokens.")
     parser.add_argument("--output_length",
                         type=int,
-                        default=20,
-                        help="Length of each output response in words.")
+                        default=32,
+                        help="Number of tokens to generate per response.")
+    parser.add_argument(
+        "--prompt_style",
+        type=str,
+        default="text",
+        choices=["text", "gibberish"],
+        help="'text' is real prose and is the correctness gate. "
+        "'gibberish' is random letters: an argmax-stability probe "
+        "that even bit-identical-KV controls fail, so pair it "
+        "with a non-zero --max_mismatch_rate.")
+    parser.add_argument("--max_mismatch_rate",
+                        type=float,
+                        default=0.0,
+                        help="Raise if the mismatch rate exceeds this. Note "
+                        "that a rate of exactly 0 is not always achievable "
+                        "even with bit-identical KV; prefer --control_url.")
+    parser.add_argument("--control_url",
+                        type=str,
+                        default=None,
+                        help="Optional endpoint used to measure this run's "
+                        "instability floor. It must be a server started with "
+                        "--enable-prefix-caching: each prompt is sent to it "
+                        "twice, so the second call recomputes only the tail "
+                        "from bit-identical cached KV, and any disagreement "
+                        "between the two is argmax instability with the KV "
+                        "held constant. The gate becomes disagg <= floor.")
     parser.add_argument("--baseline_url",
                         type=str,
                         default="http://localhost:9400/v1/completions",


### PR DESCRIPTION
# Description

## Problem

`examples/disagg/test_disagg_correctness.py` is supposed to catch a bad KV handoff between the prefill and decode instances. It can't, for three reasons:

- **Prompts are random single lowercase letters joined by spaces.** That distribution is off-manifold: the model's top-1 and top-2 logits are frequently tied to within a bfloat16 ULP, so the argmax is settled by float noise, not by the KV. On a v6e-8 with `Qwen/Qwen3-0.6B`, symmetric TP1 with equal block size mismatches 16/50 — but a control that transfers no KV at all mismatches at the same rate:

  | path | KV bytes | mismatch rate |
  |---|---|---|
  | unchunked vs. chunked prefill, two identical servers | computed independently | 7/64 |
  | prefix-cache miss vs. hit, one server | identical by construction | 9/64 |
  | disaggregated reference | transferred | 0.125–0.203 |

  The second row is decisive: vLLM reuses cached blocks verbatim, so the KV cannot differ, yet 14% of continuations still diverge. A path with no transfer at all fails the check at the same rate as the disaggregated one — a failure here never proved a fault in the transfer.

- **Prompt length is counted in whitespace-separated words**, not tokens. Every boundary the connector cares about is a token/block boundary, so an unknown token count makes an alignment fault indistinguishable from ordinary prompt-length variance.

- **It only raises above a 50% mismatch rate**, so it can't enforce a strict limit.

## Approach

Post prompts as an explicit list of token ids, which pins the token count exactly and makes block boundaries addressable, and default to prose instead of gibberish. That alone takes the same symmetric run from 16/50 to 1/50.

The residual can't be removed — greedy output isn't stable across a change of execution path even with identical KV bytes, and the prefix-cache control reproduces the same residual with bit-identical KV. A fixed limit of zero is unachievable, and any other fixed number is a guess tied to this model, this prompt distribution, and this hardware. So the gate is relative instead: `--control_url` points at a server with `--enable-prefix-caching`, sends each prompt there twice — a cache miss, then a hit reusing identical KV — and requires `disagg_rate <= control_floor`, both measured in the same run. Mismatch reports now include the number of leading characters the two outputs share: a transport fault diverges near character 0; argmax instability diverges deep into the continuation.

Two new diagnostics ship alongside the fix, for whenever this gate goes red in a later change:

- **`pd_probe.py`** sweeps exact prompt lengths across the block boundary and reports the per-length mismatch rate and first-token logprob delta — separating a fault in the recomputed tail from a fault in the transferred bytes.
- **`numerics_control.py`** runs the two transfer-free controls in the table above, establishing the noise floor before anything is called a bug.

## What changed

- `examples/disagg/test_disagg_correctness.py` — token-id prompts, prose default, `--max_mismatch_rate` (default 0.0) replacing the 50% threshold, `--control_url` for the relative gate, character-offset mismatch reporting. `--prompt_style gibberish` is retained as an explicit stability probe.
- `examples/disagg/pd_probe.py` (new) — block-alignment sweep + first-token logprob deltas.
- `examples/disagg/numerics_control.py` (new) — the two transfer-free noise-floor controls.

**Breaking change:** `--input_length` now counts tokens, not words. Its default moves from 100 to 256, and `--output_length` from 20 to 32. An existing invocation still runs; it just produces a shorter prompt than before.

# Tests

Hardware: v6e-8 in `us-east5-a`. Model: `Qwen/Qwen3-0.6B`.

```bash
# disaggregated deployment; port 9400 is the decode instance, used as the single-node baseline
PREFILLER_TP_SIZE=1 DECODER_TP_SIZE=1 bash examples/disagg/run_disagg_single_host.sh

# control server that measures the floor
vllm serve Qwen/Qwen3-0.6B --port 9500 \
  --enable-prefix-caching --block-size 128 --gpu-memory-utilization 0.3

python examples/disagg/test_disagg_correctness.py \
  --num_requests 50 --control_url http://localhost:9500/v1/completions
```

```
style=text input_tokens=256 output_tokens=32
1/50 requests had mismatched responses (rate 0.020).
control (cache miss vs hit) mismatch rate, this run's floor: 1/50 (0.020)
exit code: 0
```

The one remaining mismatch diverges 63 characters into the continuation, at a high-entropy branch point decided below bf16 resolution.

A block-alignment sweep over 96 prompts rules out a fault in the recomputed tail: block-aligned prompts, where the decoder recomputes nothing, mismatch *more* often (0.203) than unaligned ones (0.125) — the opposite of what a tail fault would predict.

```bash
python examples/disagg/pd_probe.py \
  --baseline-url http://localhost:9400/v1/completions \
  --disagg-url   http://localhost:8000/v1/completions
```

`numerics_control.py` needs two more servers, identical except for `--max-num-batched-tokens`, to measure the chunking control:

```bash
vllm serve Qwen/Qwen3-0.6B --port 9600 --no-enable-prefix-caching \
  --block-size 128 --max-num-batched-tokens 8192 --gpu-memory-utilization 0.3
vllm serve Qwen/Qwen3-0.6B --port 9601 --no-enable-prefix-caching \
  --block-size 128 --max-num-batched-tokens 256 --gpu-memory-utilization 0.3

python examples/disagg/numerics_control.py \
  --unchunked-url    http://localhost:9600/v1/completions \
  --chunked-url      http://localhost:9601/v1/completions \
  --prefixcache-url  http://localhost:9500/v1/completions
```

No regression in serving on the same deployment: `vllm bench serve --num-prompts 200 --request-rate 4` gives 200 succeeded / 0 failed, 3.97 req/s, median TTFT 37.92 ms, median TPOT 2.93 ms.

`pre-commit run --all-files` passes. These are example scripts and aren't collected by the test suite.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.