### PR TITLE
[do not review] Cap transformers below 5.15.0 to fix Gemma4 CI breakage

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,11 @@ gcsfs==2026.1.0
 hypothesis==6.151.9
 sortedcontainers==2.4.0
 # Upstream pins to 5.5.3 https://github.com/vllm-project/vllm/blob/de3fe8dc62f3d77eb8dab8125ca90436f606bccb/requirements/test/nightly-torch.txt#L32
-transformers>=5.8.0
+# transformers 5.15.0 turns Gemma4 head_dim into a per-layer attribute: reading it off
+# the global config raises AmbiguousGlobalPerLayerAttributeError, both in vLLM's
+# Gemma4ModelArchConfigConvertor.get_head_size (fixed upstream in
+# https://github.com/vllm-project/vllm/pull/49797, not yet in our LKG) and in
+# tpu_inference/models/jax/gemma4.py which reads config.head_dim/global_head_dim.
+# TODO(cuiq): remove the cap once the vLLM LKG includes #49797 and the JAX Gemma4
+# model reads per-layer configs.
+transformers>=5.8.0,<5.15.0


### PR DESCRIPTION
## What broke

Since 2026-08-10 ~10:30 UTC, every freshly built CI image fails

```
tests/models/jax/test_gemma4.py::TestGemma4ForConditionalGeneration::test_model_loading[skip_layers_model_loader_for_test-0-1-google/gemma-4-31B-it]
```

on both tpu6e and tpu7x with:

```
transformers.integrations.heterogeneity.configuration_utils.AmbiguousGlobalPerLayerAttributeError:
'head_dim' is a per-layer attribute and may vary across layers.
```

First seen in nightly build 24024 (tpu7x); both platforms red since build 24040, and it fails PR pre-commit builds too (e.g. 24051).

## Root cause

transformers **5.15.0** (released 2026-08-10 10:27 UTC) makes Gemma4 `head_dim` a per-layer attribute; reading it off the global config now raises. No tpu-inference or vLLM commit is at fault: builds 24001 and 24024 ran the **same** tpu-inference commit (`a5596b27f`) and the **same** vLLM LKG (`f5bb701fa`) — 24001 passed, 24024 failed. Within 24024, the tpu6e job ran before the 5.15.0 release and passed; the tpu7x job ran after and failed. Both vLLM (`transformers >= 5.5.3`) and this repo (`transformers >= 5.8.0`) set only a floor, so rebuilt images silently picked up 5.15.0 under the same image tag.

## Why a cap instead of supporting 5.15.0

Two independent breaks, verified locally on tpu7x:

| vLLM | transformers | result |
|---|---|---|
| `f5bb701fa` (current LKG) | 5.14.1 | test **passes** |
| `f5bb701fa` (current LKG) | 5.15.0 | exact CI failure in vLLM `Gemma4ModelArchConfigConvertor.get_head_size` |
| `70b84f0bcb` (includes vllm#49797 fix) | 5.15.0 | still **fails**, now in `tpu_inference/models/jax/gemma4.py` (`config.head_dim` / `config.global_head_dim` reads) |

So 5.15.0 support requires both advancing the vLLM LKG past [vllm#49797](https://github.com/vllm-project/vllm/pull/49797) (merged 2026-08-10, not in `f5bb701fa` and not in `83ad767eed` of #3358) **and** making the JAX Gemma4 model read per-layer configs. The cap restores CI green now; a TODO in requirements.txt tracks removing it.

The Dockerfile installs vLLM's requirements before this repo's `requirements.txt`, so the cap takes effect as a downgrade in the later layer — verified with pip on top of an environment that already has 5.15.0: it resolves to 5.14.1.
