### PR TITLE
[releases/v0.27.0] Pin transformers to 5.14.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,7 @@ gcsfs==2026.1.0
 hypothesis==6.151.9
 sortedcontainers==2.4.0
 # Upstream pins to 5.5.3 https://github.com/vllm-project/vllm/blob/de3fe8dc62f3d77eb8dab8125ca90436f606bccb/requirements/test/nightly-torch.txt#L32
-transformers>=5.8.0
+# 5.15.0 makes per-layer attrs (e.g. head_dim) raise on global access, which
+# breaks gemma-4 config handling in the pinned vLLM; hold at the last known
+# good version for this release.
+transformers==5.14.1


### PR DESCRIPTION
transformers 5.15.0 (released 2026-08-10) makes per-layer attributes such as `head_dim` raise `AmbiguousGlobalPerLayerAttributeError` on global access. The vLLM pinned by this release (`f5bb701fa`) reads `config.head_dim` globally for gemma-4 (`vllm/transformers_utils/model_arch_config_convertor.py`), so any fresh docker build now fails `tests/models/jax/test_gemma4*.py` at collection of the model config (first seen in main builds 24024/24080, onset matching the 5.15.0 release time).

The nightly that validated this cut ([#24008](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24008), green) was built with 5.14.1 — the last good version. Pin it on the release branch so future release builds stay reproducible. main is being fixed separately (transformers cap + LKG advance past the upstream vLLM fix).