### PR TITLE
ci(kube): run pipeline_jax on Kubernetes through the workload launcher

### DIFF
--- a/.buildkite/kubernetes/README.md
+++ b/.buildkite/kubernetes/README.md
@@ -1,0 +1,138 @@
+# TPU steps on Kubernetes
+
+`pipeline_kube.yaml` is `pipeline_jax.yml` run on GKE. Every TPU step goes
+through one path: the launcher submits a workload and streams it back.
+
+```yaml
+- label: "unit tests"
+  agents:
+    queue: kube
+  plugins:
+    - kubernetes:
+        podTemplate: tpu-launcher
+  command: .buildkite/kubernetes/run.sh v6e-8-2x4 pytest tests/
+```
+
+The step names a **profile** and a command. `run.sh` resolves the image and
+the tokens, names the environment to forward, picks the manifest, and hands
+off to `/opt/launcher/launch`, which lives in the launcher image the cluster
+publishes (see `ci-infra`, `terraform/gcp_old/tpu-inference/k8s`).
+
+The split is deliberate. The *shape* of a job lives here, next to the tests it
+runs, so changing it is a normal PR. The *facts about the hardware* - chip
+count, topology, node labels, queue names, deadlines - come from a profile
+registry generated in `ci-infra` from the same tfvars that create the node
+pools and the Kueue queues. Manifests reference them as `${CHIPS}`,
+`${TOPOLOGY}` and so on, so a profile cannot change region, reservation or chip
+count without the queues following, and no placement detail is restated here to
+go stale. `/opt/launcher/launch --profile bogus -- true` lists the profiles.
+
+## Why a launcher even for one pod
+
+agent-stack-k8s can only create a `batch/v1` Job, and a Job cannot span hosts,
+so multi-host slices and cross-host prefill/decode need a launcher regardless.
+Routing single-pod work through it too keeps one code path and, more
+importantly, keeps the Buildkite agent *outside* the Kueue workload:
+
+- **No `retry:` for preemption.** Kueue evicts the workload; the agent is on a
+  CPU pod it does not manage, so the step log pauses and resumes instead of the
+  build failing with a lost agent.
+- **No chips held while waiting.** Admission and node scale-up cost a CPU pod,
+  not a TPU.
+
+## Manifests
+
+`manifests/test.yaml` is one pod on one host holding every chip on the node.
+It mounts the two caches the cluster publishes as PersistentVolumeClaims -
+`jax-cache` (compilation cache) at `/cache/jax` and `hf-cache` (model weights)
+at the HF hub path - which are GCS FUSE mounts on buckets in the cluster's own
+region. A claim named `jax-cache` means the local cache wherever the pod is
+dispatched, so the manifest carries no bucket name. The gcsfuse file cache in
+front of them is a RAM-backed `emptyDir` sized per machine type
+(`${FUSE_CACHE_SIZE}`, from the profile).
+
+`WORKLOAD_MANIFEST` in `run.sh` picks a different manifest for a shape that
+needs one; everything else stays the same. **Write your own** - the launcher
+submits any `Job` or `JobSet` in this repo. When writing a JobSet, the axis
+matters:
+
+| You want | Express it as |
+|---|---|
+| Distinct roles (prefill, decode, benchmark) | one `replicatedJob` each, `replicas: 1`, `parallelism: 1` |
+| N interchangeable independent pods | one `replicatedJob`, `replicas: N`, `parallelism: 1` |
+| The hosts of one multi-host TPU slice | one `replicatedJob`, `replicas: 1`, `parallelism: <hosts>`, `completionMode: Indexed` |
+
+`replicas` creates separate Jobs; `parallelism` creates pods *inside* one Job.
+Only the last row wants `parallelism > 1`: the pods are hosts of one slice and
+their index within the Job is what identifies each host.
+
+What the launcher fills in: `metadata.name`, `namespace`, the Kueue queue
+label, correlation labels, the `ownerReference`, and the `args` of the
+container named `workload`. Everything else is yours; `${CHIPS}`,
+`${TOPOLOGY}`, `${ACCELERATOR_LABEL}`, `${NUM_HOSTS}`, `${MAX_RUNTIME}`,
+`${FUSE_CACHE_SIZE}`, `${IMAGE}`, `${WORKLOAD_NAME}` and `${KUEUE_QUEUE}` pull
+values from the named profile. The step's own environment is substituted too,
+so a manifest can pin something like `${BUILDKITE_COMMIT}`.
+
+Referencing a name is how you require it. The profile names are always defined,
+so a `${NAME}` left over after they are applied is a name nothing provides - a
+typo, or a variable since removed - and the launcher refuses to submit, listing
+what was asked for. (Write `$$` for a literal dollar; a bare `$` is a template
+error.) Kubernetes would catch most of these anyway - an unresolved `${NAME}` is
+not a valid quantity, integer or label value - but it accepts one in a plain
+string like an env `value:` without complaint.
+
+`${ACCELERATOR_LABEL}`, `${TOPOLOGY}` and `${CHIPS}` are required outright: a
+manifest that never mentions them is rejected. Unlike the names above,
+hardcoding placement fails *silently* - the workload still requests TPU chips,
+so Kueue admits it against the profile's quota and the pod lands on whatever
+pool has room. That is a different topology than the profile promised, or the
+right one by luck, and nothing in the run looks wrong.
+
+Because the manifest is repo-controlled it is validated before submission. The
+workload namespace enforces PodSecurity `baseline`, which rejects privileged
+containers, `hostPath` volumes and host networking outright; the launcher adds
+what admission cannot judge - the manifest may not name a different Kueue
+queue than `--profile` resolves to, a workload pod may not run as a service
+account the cluster has not published for workloads, and the image must come
+from an allow-listed registry.
+
+## Running the suite
+
+`run.sh` is this repo's counterpart to `scripts/run_in_docker.sh`. The mapping:
+
+| bare metal | kubernetes |
+|---|---|
+| `agents: { queue: tpu_v6e_8_queue }` | `run.sh v6e-8-2x4 ...` |
+| `run_in_docker.sh bash <script>` | `bash <script>` - the pod is the container |
+| `-e NAME` on `docker run` | `FORWARD` list in `run.sh`, once |
+| `vllm-tpu:$BUILDKITE_COMMIT` local tag | the same image from Artifact Registry |
+
+Two things worth knowing:
+
+- **Forwarding is by name.** `run.sh` forwards every `BUILDKITE_*` variable
+  (except the command, the plugin list and the agent's local Job API socket)
+  plus a named list of test variables; an unset name is skipped rather than
+  injected empty. `BUILDKITE_AGENT_ACCESS_TOKEN` is among them, which is what
+  lets a workload run `buildkite-agent artifact upload` itself - the agent is
+  in a different pod, so `artifact_paths` cannot see test output.
+- **Tokens come from Buildkite and Secret Manager, not Kubernetes Secrets.**
+  `HF_TOKEN` is the Buildkite cluster secret; the Test Engine analytics token
+  is read from Secret Manager. Neither is applied to a cluster.
+
+The image is built once by `build_docker` on the `cpu` queue and its exact
+tag handed to the TPU steps through `buildkite-agent meta-data`. Setting
+`WORKLOAD_IMAGE` on the build pins one instead and skips the build.
+
+```bash
+bk build create --pipeline tpu-commons/kube-dev --branch <branch>            # the per-push suite
+bk build create --pipeline tpu-commons/kube-dev --branch <branch> --env NIGHTLY=1
+bk build create --pipeline tpu-commons/kube-dev --branch <branch> --env SKIP_PART2=1
+```
+
+`VLLM_XLA_CHECK_RECOMPILATION=1` is set on every step, as `run_in_docker.sh`
+does: it is what makes JAX persist small and quick compilations, without which
+a compilation cache built here plateaus at about twice the warm time. The
+cache namespace (`CACHE_NAMESPACE`, default `jax0.11.0_tputpu6e`) is
+overridable per build, which is how a cold cache is measured without
+disturbing the real one.

--- a/.buildkite/kubernetes/manifests/test.yaml
+++ b/.buildkite/kubernetes/manifests/test.yaml
@@ -1,0 +1,157 @@
+# One TPU step: one pod on one host, holding every chip on the node.
+#
+# The command comes from the launcher (`launch --profile P -- <command>`),
+# chip count, topology and node labels from the profile it names, and the two
+# caches from PersistentVolumeClaims the cluster publishes: jax-cache is the
+# compilation cache and hf-cache the model weights, both GCS FUSE mounts on
+# regional buckets. A claim named jax-cache means the local cache in every
+# region, so this manifest is correct wherever the pod is dispatched.
+apiVersion: batch/v1
+kind: Job
+spec:
+  parallelism: 1
+  completions: 1
+  # No retry for a test that failed - Buildkite already has its result - but
+  # a pod the infrastructure took away (node lost, autoscaler) is replaced for
+  # as long as activeDeadlineSeconds allows: DisruptionTarget is ignored, and
+  # only the workload container's own exit code fails the Job.
+  backoffLimit: 0
+  podFailurePolicy:
+    rules:
+      - action: Ignore
+        onPodConditions:
+          - type: DisruptionTarget
+      - action: FailJob
+        onExitCodes:
+          containerName: workload
+          operator: NotIn
+          values: [0]
+  activeDeadlineSeconds: ${MAX_RUNTIME}
+  template:
+    metadata:
+      annotations:
+        # Without this GKE does not inject the sidecar and the csi volumes
+        # below never mount.
+        gke-gcsfuse/volumes: "true"
+        # Do not let the autoscaler reclaim this node underneath a running
+        # test. Job pods are evictable by default, so once the rest of a build
+        # drains, the last long step is a lone pod on an otherwise idle node -
+        # exactly what OPTIMIZE_UTILIZATION consolidates away, and it presents
+        # as a job that vanished rather than as an eviction.
+        cluster-autoscaler.kubernetes.io/safe-to-evict: "false"
+        # Headroom for metadata prefetch on both mounts. GKE's guidance is
+        # 512Mi or higher; 2Gi because the compilation cache prefix holds tens
+        # of thousands of entries and a prefetch that runs out of memory falls
+        # back to a lookup per miss.
+        gke-gcsfuse/metadata-prefetch-memory-limit: "2Gi"
+        # Unlimited sidecar CPU and memory. Parallel downloads are the whole
+        # reason a multi-gigabyte checkpoint arrives in one pass rather than
+        # eight sequential ones, and they are CPU-bound; the default limits
+        # throttle exactly the work we tuned for. Permitted on Standard
+        # clusters only, which these are.
+        gke-gcsfuse/cpu-limit: "0"
+        gke-gcsfuse/memory-limit: "0"
+    spec:
+      restartPolicy: Never
+      # The identity the cache buckets authorise, published by ci-infra
+      # alongside the claims below.
+      #
+      # Named rather than left as `default`, which every pod without this field
+      # runs as. Granting cache writes to `default` would extend them to
+      # anything scheduled in this namespace, and the launcher accepts whatever
+      # image a step names - allowed_image_repos is still empty.
+      serviceAccountName: tpu-workload
+      nodeSelector:
+        cloud.google.com/gke-tpu-accelerator: ${ACCELERATOR_LABEL}
+        cloud.google.com/gke-tpu-topology: ${TOPOLOGY}
+      tolerations:
+        - key: "google.com/tpu"
+          operator: "Equal"
+          value: "present"
+          effect: "NoSchedule"
+      containers:
+        - name: workload
+          image: ${IMAGE}
+          command: ["/bin/bash", "-lc"]
+          workingDir: /workspace/tpu_inference
+          env:
+            # Only what is the same for every test. Everything else arrives
+            # through `--env`, which skips names the step did not set - unlike
+            # template substitution, which cannot express "leave this unset" and
+            # renders MODEL_IMPL_TYPE="" where tpu_inference wants it absent.
+            - name: HF_HOME
+              value: /workspace/.cache/huggingface
+            # Unbuffered, so output reaches the log as it happens rather
+            # than in blocks when a pipe flushes.
+            - name: PYTHONUNBUFFERED
+              value: "1"
+            # Both names for the same reason run_in_docker.sh sets both: the
+            # first stops vLLM's CompilationManager substituting its default,
+            # the second catches tests that never go through it.
+            - name: VLLM_XLA_CACHE_PATH
+              value: /cache/jax
+            - name: JAX_COMPILATION_CACHE_DIR
+              value: /cache/jax
+          resources:
+            limits:
+              google.com/tpu: "${CHIPS}"
+            requests:
+              google.com/tpu: "${CHIPS}"
+          volumeMounts:
+            - name: dshm
+              mountPath: /dev/shm
+            - name: jax-cache
+              mountPath: /cache/jax
+            - name: hf-cache
+              mountPath: /workspace/.cache/huggingface/hub
+      volumes:
+        # Backing store for the gcsfuse file cache, in RAM.
+        #
+        # Sized by the launcher from the profile's machine type: half of host
+        # memory, which is 80Gi on ct6e-standard-1t's 176 GB and 670Gi on
+        # ct6e-standard-8t's 1440 GB. One fixed number cannot serve both - it
+        # is either unsafe on the smallest shape or leaves most of the largest
+        # idle. GKE's own gcsfuse profiles use 0.7 of allocatable; half is
+        # deliberately below that, because tmpfs writes count against the
+        # container and the tests need room of their own.
+        #
+        # A sizeLimit, not a reservation: tmpfs holds only what is written, so
+        # the larger figures cost nothing until the cache fills.
+        #
+        # Without this volume the sidecar falls back to 5GiB of ephemeral
+        # storage and fileCacheCapacity becomes a cheque it cannot cash - build
+        # 239 spent 113.6m of part2 loading checkpoints that way, against 8.8m
+        # with a cache that fits.
+        - name: gke-gcsfuse-cache
+          emptyDir:
+            medium: Memory
+            sizeLimit: ${FUSE_CACHE_SIZE}
+        # JAX and vLLM use shared memory heavily; the 64MB default is far too
+        # small and fails in ways that look like unrelated crashes.
+        - name: dshm
+          emptyDir:
+            medium: Memory
+            sizeLimit: 16Gi
+        # Both caches are claims, not mounts.
+        #
+        # The bucket is regional - a cache in another region costs 502ms per
+        # miss against 36ms in-region - so its name differs per cluster. Naming
+        # it here would put a bucket in every manifest, pipeline and step. The
+        # PersistentVolume behind these claims holds it instead, created by
+        # ci-infra alongside the cluster, and the claim names are identical
+        # everywhere.
+        #
+        # It also survives MultiKueue placing this Job in a different region
+        # than it was submitted from: the claim resolves at mount time, in
+        # whichever cluster the pod actually landed in. An inline volume is
+        # rendered before submission, when that is not yet known.
+        #
+        # Tuning lives in the PV too - as a proper list rather than the
+        # comma-separated string an inline volume needs, which folded YAML has
+        # silently corrupted before.
+        - name: jax-cache
+          persistentVolumeClaim:
+            claimName: jax-cache
+        - name: hf-cache
+          persistentVolumeClaim:
+            claimName: hf-cache

--- a/.buildkite/kubernetes/run.sh
+++ b/.buildkite/kubernetes/run.sh
@@ -1,0 +1,203 @@
+#!/usr/bin/env bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The Kubernetes counterpart of scripts/run_in_docker.sh.
+#
+#   .buildkite/kubernetes/run.sh <profile> <command> [args...]
+#
+# run_in_docker.sh picks the image, mounts the caches and forwards a long -e
+# list to a container on a long-lived VM. Here the pod is the container and the
+# profile decides the hardware, so what is left is resolving the image and the
+# token and naming what to forward - which is the same for every step, and the
+# reason this is a script rather than 23 copies of it in the pipeline.
+#
+# All of it lives here rather than in the launcher: `ci-image` is this repo's
+# metadata key and MODEL_IMPL_TYPE is this repo's variable. The launcher should
+# not have to know either to schedule a pod.
+set -euo pipefail
+
+if [[ $# -lt 2 ]]; then
+  echo "usage: $0 <profile> <command> [args...]" >&2
+  exit 2
+fi
+
+profile="$1"
+shift
+
+# The build step publishes the exact tag it pushed. Reading it back beats
+# recomputing it from commit hashes in every step, which is how they drift.
+WORKLOAD_IMAGE="${WORKLOAD_IMAGE:-$(buildkite-agent meta-data get ci-image 2>/dev/null || true)}"
+export WORKLOAD_IMAGE
+
+# From the Buildkite cluster secret, not a Kubernetes Secret. Fetching it
+# through the agent is also what adds it to the log redactor.
+HF_TOKEN="${HF_TOKEN:-$(buildkite-agent secret get "${HF_SECRET_KEY:-HF_TOKEN}")}"
+export HF_TOKEN
+
+# Buildkite Test Engine, the same way. On bare metal this arrives from the
+# agent environment on the VM; the agent-stack pods have no equivalent, so
+# every run so far has logged "No BUILDKITE_ANALYTICS_TOKEN environment
+# variable present" and Test Engine has received nothing. The name is already
+# in FORWARD below - what was missing is the value.
+#
+# Absent is not fatal: the collector warns and the tests still run. So a
+# missing secret must not fail the step, and an empty value must not be
+# exported - FORWARD skips names that are unset, but an exported empty string
+# is set, and would be injected as empty rather than skipped.
+if [ -z "${BUILDKITE_ANALYTICS_TOKEN:-}" ]; then
+  # GCP Secret Manager rather than the agent's own secret store, because that
+  # is where this token lives. The launcher image ships gcloud and the pod's
+  # service account is the identity; the grant is on the single secret rather
+  # than the project.
+  #
+  # Trailing newline stripped: `gcloud secrets versions access` emits the
+  # payload verbatim, and a token with a newline on the end is rejected in a
+  # way that looks like a bad token rather than a formatting problem.
+  _analytics_token="$(gcloud secrets versions access latest \
+    --secret="${ANALYTICS_SECRET_ID:-tpu_commons_buildkite_analytics_token}" \
+    --project="${ANALYTICS_SECRET_PROJECT:-cloud-tpu-inference-test}" \
+    2>/dev/null | tr -d '\r\n' || true)"
+  if [ -n "$_analytics_token" ]; then
+    export BUILDKITE_ANALYTICS_TOKEN="$_analytics_token"
+  else
+    echo "run.sh: could not read the Test Engine token from Secret Manager" \
+         "(${ANALYTICS_SECRET_PROJECT:-cloud-tpu-inference-test}/" \
+         "${ANALYTICS_SECRET_ID:-tpu_commons_buildkite_analytics_token});" \
+         "Test Engine will receive no results from this step" >&2
+  fi
+  unset _analytics_token
+fi
+
+# Mirrors the -e list in run_in_docker.sh, so a test sees the same environment
+# on either platform.
+#
+# The BUILDKITE_* names are no longer listed here - they are enumerated from
+# the environment below, because this list drifted and lost
+# BUILDKITE_ANALYTICS_TOKEN once already. What stays here is everything else:
+# names a step sets that no convention would find.
+#
+# Named rather than forwarded wholesale so the pod's environment is a decision
+# rather than an accident. A name the step has not set is skipped rather than
+# injected empty - ${...} substitution cannot express that, and tpu_inference
+# rejects MODEL_IMPL_TYPE="" where it wants the variable absent.
+FORWARD=(
+  # Secrets and identity
+  HF_TOKEN GITHUB_CI_BOT_TOKEN
+  # Model and backend selection
+  TPU_VERSION MODEL_IMPL_TYPE TPU_BACKEND_TYPE NEW_MODEL_DESIGN
+  QUANTIZATION USE_PREBUILT_IMAGE SKIP_ACCURACY_TESTS BVT_ONLY
+  NUM_PRECOMPILE_WORKERS VLLM_LOG_LEVEL VLLM_XLA_CHECK_RECOMPILATION
+  # --env wins over the manifest, so a step that sets these replaces the
+  # defaults derived below; one that does not is unaffected.
+  JAX_COMPILATION_CACHE_DIR VLLM_XLA_CACHE_PATH
+  # Test parameters
+  TEST_MODEL TEST_MODE TEST_LORA_TP TENSOR_PARALLEL_SIZE
+  MINIMUM_ACCURACY_THRESHOLD MINIMUM_THROUGHPUT_THRESHOLD
+  MODEL INPUT_LEN OUTPUT_LEN PREFIX_LEN MAX_MODEL_LEN
+  MAX_NUM_SEQS MAX_NUM_BATCHED_TOKENS NUM_PROMPTS RANDOM_SEED
+  MAX_CONCURRENCY REQUEST_RATE TIMEOUT_SECONDS COMPILATION_CONFIG
+  USE_CHAT_TEMPLATE BENCH_DATASET USE_BATCHED_RPA_KERNEL
+  GPU_MEMORY_UTILIZATION GCS_BUCKET HOST_NAME
+)
+
+# What the BUILDKITE_* sweep above carries, recorded because it is no longer
+# visible as a list:
+#
+#   BUILDKITE_AGENT_ACCESS_TOKEN and _ENDPOINT let the workload call
+#   buildkite-agent itself - artifact upload, meta-data, annotate, and the OIDC
+#   token bktec authenticates with. It is the only thing that can see its own
+#   output files: unlike bare metal, where run_in_docker.sh bind-mounts results
+#   into the agent's checkout for `artifact_paths` to glob, a pod shares no
+#   filesystem with the agent. Not a widening of trust - the step's own
+#   commands already run with this token, from the same repo as the test.
+#
+#   BUILDKITE_ANALYTICS_TOKEN and BUILDKITE_TEST_ENGINE_* are what Test Engine
+#   reports through. BUILDKITE_PARALLEL_JOB and _COUNT are how bktec knows
+#   which shard it is; they are unset on a step without `parallelism:`, and
+#   unset names are skipped.
+
+
+# Every BUILDKITE_* the agent sets, plus the named list above.
+#
+# The list used to carry the BUILDKITE_ names too, and kept losing them:
+# BUILDKITE_ANALYTICS_TOKEN went missing once and Test Engine silently received
+# nothing for months, and the BUILDKITE_TEST_ENGINE_* names were only there
+# because someone added them in advance. Enumerating the environment cannot
+# drift; a hand-maintained list of a hundred names will.
+#
+# Still only names that are actually set, so the "absent rather than empty"
+# property the list was written for is unchanged.
+#
+# Two are held back deliberately:
+#
+#   BUILDKITE_COMMAND is this step's own script. Forwarding it into the
+#   container invites something to re-execute the launcher from inside the
+#   workload it launched.
+#   BUILDKITE_PLUGINS is a JSON blob describing agent-side plugins, which mean
+#   nothing in the pod and can be large enough to bloat the pod spec.
+#   BUILDKITE_AGENT_JOB_API_SOCKET and _TOKEN address a unix socket the agent
+#   opens for its own job. The docker plugin can mount that socket into a
+#   container because the container shares the host; our workload pod is on
+#   another cluster entirely, so the path can never resolve. Forwarding it is
+#   worse than omitting it: the CLI currently fails with "socket empty or
+#   undefined", which names the problem, where a path that exists in the
+#   variable but not on disk fails as a connection error.
+FORWARD_DENY="BUILDKITE_COMMAND BUILDKITE_PLUGINS BUILDKITE_AGENT_JOB_API_SOCKET BUILDKITE_AGENT_JOB_API_TOKEN"
+
+env_args=()
+seen=" "
+for name in $(compgen -v | grep '^BUILDKITE_' | sort); do
+  case " $FORWARD_DENY " in *" $name "*) continue ;; esac
+  env_args+=(--env "$name")
+  seen="$seen$name "
+done
+for name in "${FORWARD[@]}"; do
+  case "$seen" in *" $name "*) continue ;; esac
+  env_args+=(--env "$name")
+  seen="$seen$name "
+done
+
+# Persist every compiled module, as bare metal does. run_in_docker.sh passes
+# -e VLLM_XLA_CHECK_RECOMPILATION=1 on every step; besides failing a test that
+# recompiles at runtime, it is what makes CompilationManager lower JAX's
+# persistent-cache thresholds to -1, so small and quick compilations are
+# written too. Without it a cache this side builds plateaus at about twice
+# the seeded time, however many suites run.
+export VLLM_XLA_CHECK_RECOMPILATION="${VLLM_XLA_CHECK_RECOMPILATION:-1}"
+
+# The cache namespace, and the two paths derived from it. Bare metal builds the
+# same string from the versions it has to hand - jax${JAX_VERSION}_tpu${TPU_VERSION}
+# - so it follows a JAX bump automatically. This is a literal, which means a
+# bump silently points us at a namespace nobody writes any more: a cold cache,
+# no error, 2-3x slower. Deriving it from the image is the real fix.
+#
+# Overridable per build, which is how a cold cache is measured without
+# disturbing the real one.
+export CACHE_NAMESPACE="${CACHE_NAMESPACE:-jax0.11.0_tputpu6e}"
+export JAX_COMPILATION_CACHE_DIR="/cache/jax/${CACHE_NAMESPACE}"
+export VLLM_XLA_CACHE_PATH="${JAX_COMPILATION_CACHE_DIR}"
+
+# The workload manifest: one pod on one host with the two cache claims the
+# cluster publishes mounted at /cache/jax and the HF hub path. WORKLOAD_MANIFEST
+# names a different object for a shape that needs one - a slice across hosts
+# is a JobSet, not a Job - while keeping everything else here (image, tokens,
+# forwarded env) identical.
+manifest="${WORKLOAD_MANIFEST:-.buildkite/kubernetes/manifests/test.yaml}"
+
+exec /opt/launcher/launch \
+  --profile "$profile" \
+  "${env_args[@]}" \
+  --manifest "$manifest" \
+  -- "$@"

--- a/.buildkite/pipeline_kube.yaml
+++ b/.buildkite/pipeline_kube.yaml
@@ -1,0 +1,472 @@
+# TPU steps on Kubernetes, via the workload launcher.
+#
+# pipeline_jax.yml, run on GKE. Each step names a profile and a command; chip
+# count, topology, Kueue queue and deadlines come from the cluster-side profile
+# registry in ci-infra, so nothing about placement is repeated here. Step keys
+# match pipeline_jax so the two files read side by side; steps that only exist
+# for tpu7x are absent, and steps gated on NIGHTLY stay gated.
+#
+# The image is built once by build_docker and read back through Buildkite
+# metadata; WORKLOAD_IMAGE pins one instead and skips the build. SKIP_PART2=1
+# leaves the longest step out, for iterating on anything that is not part2.
+#
+# No `retry:` for preemption. The agent runs on a CPU pod outside the Kueue
+# workload, so an eviction pauses the step log rather than losing the agent.
+
+# No pipeline-level env: a name in that block wins over one passed to
+# `bk build create --env`, so anything defaulted there could not be overridden
+# per build. run.sh defaults CACHE_NAMESPACE and the cache paths instead.
+
+# soft_fail matches pipeline_jax: one failing test should not hide the rest.
+#
+# One timeout for every step, covering waiting as well as running, because
+# Buildkite adds no queue time of its own - the agent pod starts at once and
+# then waits inside the step. A hung test is bounded separately by the
+# workload's activeDeadlineSeconds, which the queue cannot consume.
+.tpu_step: &tpu_step
+  depends_on: "build_docker"
+  soft_fail: true
+  timeout_in_minutes: 480
+  agents:
+    queue: "kube"
+  plugins:
+    - kubernetes:
+        podTemplate: tpu-launcher
+        # Blobless. Every step clones this repo only to read run.sh and a
+        # manifest - the workload needs none of it, the image already has the
+        # tree - and that clone was ~36s of the ~3.4m before each pod starts.
+        # Blobs are fetched on demand, so the working tree stays complete.
+        checkout:
+          cloneFlags: -v --filter=blob:none
+          fetchFlags: -v --prune --filter=blob:none
+
+steps:
+  # Same builder as pipeline_dev.yml: a CPU agent, not a TPU one, and not
+  # through the launcher - a docker build is not a TPU workload.
+  - label: ":docker: Build and push CI image"
+    key: "build_docker"
+    # Skipped when the build names its own image: a pinned WORKLOAD_IMAGE means
+    # run.sh never reads the ci-image metadata this step publishes. Buildkite
+    # treats a skipped dependency as satisfied, so the TPU steps still run.
+    if: "build.env('WORKLOAD_IMAGE') == null"
+    timeout_in_minutes: 90
+    agents:
+      queue: "cpu"
+    env:
+      TPU_VERSION: "tpu6e"
+    commands:
+      - |
+        if [[ -n "$${CI_IMAGE:-}" ]]; then
+          buildkite-agent meta-data set ci-image "$$CI_IMAGE"
+          exit 0
+        fi
+        # setup_docker_env.sh refuses to build without this: the image tag
+        # includes the vLLM commit, and omitting it lets pipelines overwrite
+        # each other's image for the same tpu-inference commit. The real
+        # pipelines set it in bootstrap; this one has none.
+        source .buildkite/scripts/configs/pipeline_config.sh
+        VLLM_COMMIT_HASH="$${VLLM_COMMIT_HASH:-$$(get_vllm_commit_hash)}"
+        buildkite-agent meta-data set "VLLM_COMMIT_HASH" "$$VLLM_COMMIT_HASH"
+        source .buildkite/scripts/setup_docker_env.sh
+        setup_environment "vllm-tpu" "false" "true"
+        buildkite-agent meta-data set ci-image "$$EXPORTED_CI_CACHE_IMAGE"
+
+  # ------------------------------------------------------------ single chip ---
+  # Fourteen of these against a two-chip nominal quota, so most are borrowing
+  # and are the first reclaimed when an eight-chip step arrives.
+
+  - label: ":kubernetes: E2E MLPerf | JAX models"
+    key: "tpu6e_test_0"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
+
+  - label: ":kubernetes: E2E MLPerf | JAX models, quantized"
+    key: "tpu6e_test_1"
+    if: "build.env('NIGHTLY') == '1'"
+    env:
+      TPU_VERSION: "tpu6e"
+      QUANTIZATION: "True"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
+
+  - label: ":kubernetes: E2E MLPerf | JAX new models"
+    key: "tpu6e_test_2"
+    if: "build.env('NIGHTLY') == '1'"
+    env:
+      TPU_VERSION: "tpu6e"
+      NEW_MODEL_DESIGN: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
+
+  - label: ":kubernetes: E2E MLPerf | JAX + vLLM models"
+    key: "tpu6e_test_3"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+      MODEL_IMPL_TYPE: "vllm"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
+
+  - label: ":kubernetes: E2E speculative decoding"
+    key: "tpu6e_test_6"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        # Per-push runs the BVT subset; nightly runs the full matrix.
+        if [ "$${NIGHTLY:-0}" = "1" ]; then export BVT_ONLY=; else export BVT_ONLY=1; fi
+        .buildkite/kubernetes/run.sh v6e-1-1x1 \
+            python3 -m pytest -s -v -x /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py
+
+  - label: ":kubernetes: JAX unit tests part1"
+    key: "tpu6e_test_7_1"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 bash -c '
+          python3 -m pytest -s -v -x \
+            /workspace/tpu_inference/tests/layers/vllm/backends/test_flash_attn.py \
+            /workspace/tpu_inference/tests/layers/vllm/test_awq.py \
+            /workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_moe.py \
+            /workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_w8a8_fp8.py \
+            /workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_w8a8_int8.py \
+            --cov-config=/workspace/tpu_inference/.coveragerc --cov tpu_inference --cov-report=
+          rc=$$?
+          cp .coverage .coverage.part1.tpu6e && buildkite-agent artifact upload .coverage.part1.tpu6e
+          exit $$rc
+        '
+
+  - label: ":kubernetes: JAX unit tests part2"
+    key: "tpu6e_test_7_2"
+    # The longest step in the suite at ~79m, which is also bare metal's figure,
+    # and the one that sets the build's makespan. SKIP_PART2=1 leaves it out,
+    # which halves a run when the thing being checked is not part2.
+    if: "build.env('SKIP_PART2') != '1'"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 bash -c '
+          python3 -m pytest -s -v -x /workspace/tpu_inference/tests/ \
+          --ignore=/workspace/tpu_inference/tests/layers/vllm/backends/test_flash_attn.py \
+          --ignore=/workspace/tpu_inference/tests/layers/vllm/test_awq.py \
+          --ignore=/workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_moe.py \
+          --ignore=/workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_w8a8_fp8.py \
+          --ignore=/workspace/tpu_inference/tests/layers/vllm/test_compressed_tensors_w8a8_int8.py \
+          --ignore=/workspace/tpu_inference/tests/kernels \
+          --ignore=/workspace/tpu_inference/tests/lora \
+          --ignore=/workspace/tpu_inference/tests/e2e \
+          --ignore=/workspace/tpu_inference/tpu_inference/mock \
+          --ignore=/workspace/tpu_inference/tests/models/jax/test_deepseek_v3.py \
+          --ignore=/workspace/tpu_inference/tests/offload/tpu_offload_multi_request_accuracy_test.py \
+          --ignore=/workspace/tpu_inference/tests/offload/tpu_offload_accuracy_test.py \
+          --ignore=/workspace/tpu_inference/tests/offload/tpu_offload_performance_test.py \
+          --ignore=/workspace/tpu_inference/tests/core/test_dp_group_sampling_prefix_cache.py \
+          --ignore=/workspace/tpu_inference/tests/runner/test_async_logprobs.py \
+          --ignore=/workspace/tpu_inference/tests/runner/test_processed_logprobs.py \
+          --ignore=/workspace/tpu_inference/tests/runner/test_moe_expert_ids.py \
+            --cov-config=/workspace/tpu_inference/.coveragerc --cov tpu_inference --cov-report=
+          rc=$$?
+          cp .coverage .coverage.part2.tpu6e && buildkite-agent artifact upload .coverage.part2.tpu6e
+          exit $$rc
+        '
+
+  # pipeline_jax's tpu6e_test_7_3. A CPU step: it downloads the two coverage
+  # files the TPU steps uploaded and reports on them, so it needs no chips and
+  # does not go through the launcher.
+  #
+  # The upload side is where this differs from bare metal. There, artifact_paths
+  # collects the file from the agent's working directory, because the agent runs
+  # on the TPU VM. Here the agent is in the launcher pod and the file is written
+  # in the workload pod, which the agent cannot see - so the test uploads it
+  # itself with the buildkite-agent CLI the CI image now ships.
+  - label: ":kubernetes: JAX unit tests combine and report"
+    key: "tpu6e_test_7_3"
+    depends_on:
+      - "tpu6e_test_7_1"
+      - "tpu6e_test_7_2"
+    # SKIP_PART2 leaves part2's file absent rather than this step unrunnable:
+    # a skipped dependency counts as satisfied, and the combine takes whatever
+    # files arrived.
+    soft_fail: true
+    agents:
+      queue: "kube"
+    commands:
+      - |
+        # pip, not the pex that pipeline_jax uses. pex 2.1.151 declares
+        # python <3.13 and this image is on 3.14, so it cannot bootstrap -
+        # "Failed to find compatible interpreter", which is what builds 255
+        # through 260 all died on. pex exists there to avoid installing into a
+        # long-lived VM's interpreter; a pod is thrown away after the step, so
+        # the reason does not apply.
+        pip install --quiet --break-system-packages coverage \
+          || pip install --quiet coverage
+        python3 -m coverage --version
+      - buildkite-agent artifact download ".coverage.part*" .
+      - |
+        # Maps the container's path back onto the checkout, so the report
+        # attributes coverage to files that exist here.
+        printf '[paths]\nsource =\n    .\n    /workspace/tpu_inference/\n' > .coveragerc
+      - |
+        set -o pipefail
+        files=$$(ls .coverage.part* 2>/dev/null)
+        if [ -z "$$files" ]; then
+          echo "no coverage files were uploaded; nothing to combine" >&2
+          exit 1
+        fi
+        echo "combining: $$files"
+        # shellcheck disable=SC2086
+        python3 -m coverage combine $$files
+        python3 -m coverage report --fail-under=68
+        EXIT_CODE=$$?
+        rm -f .coverage.part* .coveragerc .coverage
+        exit $$EXIT_CODE
+
+  - label: ":kubernetes: JAX unit tests | kernels"
+    key: "tpu6e_test_8"
+    # Same gate as pipeline_jax: nightly, or opted into by name. The opt-in
+    # is what lets a kernel change run these without a full nightly.
+    if: "(build.env('NIGHTLY') == '1' || build.env('RUN_KERNEL_TESTS') == '1')"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 \
+            python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels \
+              --ignore=/workspace/tpu_inference/tests/kernels/ragged_paged_attention_kernel_v2_test.py \
+              --ignore=/workspace/tpu_inference/tests/kernels/ragged_kv_cache_update_v2_test.py \
+              --ignore=/workspace/tpu_inference/tests/kernels/collectives \
+              --ignore=/workspace/tpu_inference/tests/kernels/spmm_v1_test.py
+
+  - label: ":kubernetes: lora e2e | single chip, test_lora"
+    key: "tpu6e_test_10_1"
+    if: "build.env('NIGHTLY') == '1'"
+    env:
+      TPU_VERSION: "tpu6e"
+      MODEL_IMPL_TYPE: "vllm"
+      TPU_BACKEND_TYPE: "jax"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_lora.py
+
+  - label: ":kubernetes: lora e2e | single chip, test_lora_adapter"
+    key: "tpu6e_test_10_2"
+    if: "build.env('NIGHTLY') == '1'"
+    env:
+      TPU_VERSION: "tpu6e"
+      MODEL_IMPL_TYPE: "vllm"
+      TPU_BACKEND_TYPE: "jax"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_lora_adapter.py
+
+  - label: ":kubernetes: lora unit tests | single chip"
+    key: "tpu6e_test_15"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 bash -c \
+            'python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_bgmv.py &&
+             python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_layers.py'
+
+  - label: ":kubernetes: Runai streamer | JAX UniProcExecutor"
+    key: "tpu6e_test_27"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_jax_uni_proc_executor
+
+  - label: ":kubernetes: Runai streamer | Torchax UniProcExecutor"
+    key: "tpu6e_test_28"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_torchax_uni_proc_executor
+
+  - label: ":kubernetes: Accuracy | Qwen2.5-VL-7B-Instruct"
+    key: "tpu6e_test_33"
+    env:
+      TPU_VERSION: "tpu6e"
+      TEST_MODEL: "Qwen/Qwen2.5-VL-7B-Instruct"
+      TENSOR_PARALLEL_SIZE: "1"
+      MINIMUM_ACCURACY_THRESHOLD: "0.72"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-1-1x1 bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh
+
+  # ------------------------------------------------------------- eight chip ---
+  # Only one fits at a time, so these serialise and each squeezes the
+  # single-chip steps down to their nominal two chips.
+
+  - label: ":kubernetes: E2E MLPerf | Llama4"
+    key: "tpu6e_test_4"
+    if: "build.env('NIGHTLY') == '1'"
+    env:
+      TPU_VERSION: "tpu6e"
+      NEW_MODEL_DESIGN: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-8-2x4 bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
+
+  - label: ":kubernetes: JAX unit tests | collective kernels"
+    key: "tpu6e_test_9"
+    if: "(build.env('NIGHTLY') == '1' || build.env('RUN_KERNEL_COLLECTIVES_TESTS') == '1')"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-8-2x4 python3 -m pytest -s -v -x /workspace/tpu_inference/tests/kernels/collectives
+
+  - label: ":kubernetes: E2E MLPerf | JAX + vLLM, multi chip"
+    key: "tpu6e_test_11"
+    if: "build.env('NIGHTLY') == '1'"
+    env:
+      TPU_VERSION: "tpu6e"
+      MODEL_IMPL_TYPE: "vllm"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-8-2x4 bash /workspace/tpu_inference/tests/e2e/benchmarking/mlperf.sh
+
+  - label: ":kubernetes: lora e2e | multi chip"
+    key: "tpu6e_test_13"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+      TEST_LORA_TP: "True"
+      VLLM_LOG_LEVEL: "INFO"
+      MODEL_IMPL_TYPE: "vllm"
+      TPU_BACKEND_TYPE: "jax"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-8-2x4 python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_lora.py
+
+  - label: ":kubernetes: lora unit tests | multi chip"
+    key: "tpu6e_test_16"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+      VLLM_LOG_LEVEL: "INFO"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-8-2x4 python3 -m pytest -s -v -x /workspace/tpu_inference/tests/lora/test_layers.py
+
+  - label: ":kubernetes: Runai streamer | Torchax RayDistributedExecutor"
+    key: "tpu6e_test_29"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-8-2x4 python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_runai_model_streamer_loader.py::test_correctness_torchax_ray_distributed_executor
+
+  - label: ":kubernetes: E2E | Single host DCN P/D disaggregation"
+    key: "tpu6e_test_34"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+      MODEL: "Qwen/Qwen3-0.6B"
+      INPUT_LEN: "512"
+      OUTPUT_LEN: "128"
+      NUM_PROMPTS: "200"
+      REQUEST_RATE: "4"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-8-2x4 bash /workspace/tpu_inference/examples/disagg/run_disagg_single_host.sh
+
+  # pipeline_jax's tpu6e_test_25, which runs on bare metal as eight docker
+  # containers on one 8-chip VM. "Multi-host" there means eight TPU processes,
+  # not eight machines: every container uses --network host and addresses the
+  # others as 127.0.0.1, so a pod holding all 8 chips is the same environment
+  # with the container boundaries removed. run_disagg_multi_host_pod.sh is that
+  # script with `docker run` replaced by a background process.
+  #
+  # Not a JobSet. A JobSet is for a slice spanning several nodes; this needs
+  # one v6e-8.
+  - label: ":kubernetes: E2E | Multihost DCN P/D disaggregation"
+    key: "tpu6e_test_25"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+      MODEL: "Qwen/Qwen3-0.6B"
+      INPUT_LEN: "1024"
+      OUTPUT_LEN: "1024"
+      NUM_PROMPTS: "100"
+      RANDOM_SEED: "10"
+      MAX_CONCURRENCY: "10"
+      TEST_MODE: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-8-2x4 bash /workspace/tpu_inference/examples/disagg/run_disagg_multi_host_pod.sh
+
+  - label: ":kubernetes: E2E | MPMD data parallelism"
+    key: "tpu6e_test_35"
+    env:
+      TPU_VERSION: "tpu6e"
+      USE_PREBUILT_IMAGE: "1"
+      NEW_MODEL_DESIGN: "1"
+    <<: *tpu_step
+    commands:
+      - |
+        .buildkite/kubernetes/run.sh v6e-8-2x4 bash -c '
+            set -eu
+            MODEL=meta-llama/Llama-3.1-8B-Instruct
+            TPU_MULTIPROCESS_DP=1 \
+              VLLM_ENGINE_READY_TIMEOUT_S=60000 \
+              MODEL_IMPL_TYPE=flax_nnx \
+              vllm serve $$MODEL \
+                --port 8000 \
+                --data-parallel-size 4 \
+                --tensor-parallel-size 1 \
+                --max-model-len 1024 \
+                --no-enable-prefix-caching \
+                --gpu-memory-utilization 0.9 &
+            trap "kill %1 2>/dev/null || true" EXIT
+            for _ in $$(seq 1 180); do
+              curl -fs localhost:8000/health > /dev/null && break || sleep 10
+            done
+            curl -fsS http://localhost:8000/v1/completions \
+              -X POST \
+              -H "Content-Type: application/json" \
+              -d "{\"model\": \"$$MODEL\", \"prompt\": \"San Francisco is a\", \"max_tokens\": 50}"
+          '

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,6 +42,26 @@ RUN apt-get update && apt-get install -y \
     g++ \
     && rm -rf /var/lib/apt/lists/*
 
+# buildkite-agent, for `artifact upload` from inside the test container.
+#
+# On bare metal the agent runs on the TPU VM, so a step's artifact_paths uploads
+# from the agent's own working directory. Under Kubernetes the agent is in a
+# different pod from the test and cannot see what the test wrote, so the test
+# uploads its own artifacts. BUILDKITE_AGENT_ACCESS_TOKEN, BUILDKITE_BUILD_ID
+# and BUILDKITE_JOB_ID are already forwarded into the workload pod, which is
+# what `artifact upload` needs.
+#
+# Only the CLI is wanted. Nothing here should ever run `buildkite-agent start`:
+# this container is a workload, not an agent.
+#
+# Copied from the official image rather than downloaded: the binary is a
+# static Go executable, so it works on this base unchanged, and the pin is
+# an image tag rather than a URL. Pinned because the version is part of what
+# the image is, and an unpinned pull makes two builds of the same commit
+# differ.
+COPY --from=buildkite/agent:3.137.0 /usr/local/bin/buildkite-agent /usr/local/bin/buildkite-agent
+RUN buildkite-agent --version
+
 # Conditionally install google-cloud-cli for benchmarking infrastructure
 RUN if [ "$BM_INFRA" = "true" ]; then \
         apt-get update && apt-get install -y gnupg curl \

--- a/examples/disagg/run_disagg_multi_host_pod.sh
+++ b/examples/disagg/run_disagg_multi_host_pod.sh
@@ -1,0 +1,281 @@
+#!/bin/bash
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Multi-host DCN disaggregation, run as processes in one pod.
+#
+# The same test as run_disagg_multi_host.sh, which starts one docker container
+# per TPU process. That script cannot run here: it drives `docker run`, and a
+# workload pod has no docker daemon and runs under PodSecurity `baseline`,
+# which rejects the --privileged it asks for.
+#
+# The conversion is small, because "multi-host" here means multiple TPU
+# processes rather than multiple machines. All eight containers already run
+# --network host and address each other as 127.0.0.1, so a pod - one network
+# namespace, all 8 chips of a ct6e-standard-8t - is the same environment with
+# the container boundaries removed. `docker run` becomes a background process
+# and `docker exec` becomes a plain command.
+#
+#   prefill  4 processes, chips 0-3, Ray cluster on 8100, vLLM on 8400
+#   decode   4 processes, chips 4-7, Ray cluster on 9100, vLLM on 9400
+#   proxy    1 process, port 8000, no chips
+#
+# Two things the container boundary was providing for free, which have to be
+# arranged explicitly now:
+#
+#   Ray temp dirs, one per process. A Ray node keeps its session directory and
+#   its raylet and plasma sockets under --temp-dir, so two raylets sharing one
+#   collide. The docker script gets this free from the mount namespace: even
+#   with --network host, each container has a private /tmp.
+#
+#   Process identity. TPU_VISIBLE_CHIPS, CLOUD_TPU_TASK_ID and TPU_PROCESS_PORT
+#   differ per process and were per-container env. Here they are set per
+#   command, which is why each `ray start` is wrapped in `env`.
+
+# shellcheck disable=all
+set -e
+
+MODEL=${MODEL:="Qwen/Qwen3-0.6B"}
+TPU_VERSION=${TPU_VERSION:=tpu6e}
+INPUT_LEN=${INPUT_LEN:=128}
+OUTPUT_LEN=${OUTPUT_LEN:=20}
+NUM_PROMPTS=${NUM_PROMPTS:=100}
+RANDOM_SEED=${RANDOM_SEED:=10}
+MAX_CONCURRENCY=${MAX_CONCURRENCY:=10}
+# 1 benchmark, 2 correctness, 3 both. Same meaning as the docker script.
+TEST_MODE=${TEST_MODE:=1}
+
+LOG_DIR=${LOG_DIR:-$HOME/logs}
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+
+# v6e has 4 chips per instance; tpu7x has 2. Mirrors run_disagg_multi_host.sh.
+NUM_HOSTS_PER_INSTANCE=4
+TPU_PROCESS_BOUNDS="2,2,1"
+PREFILL_TPU_PORTS=(8476 8477 8478 8479)
+DECODE_TPU_PORTS=(9476 9477 9478 9479)
+if [ "$TPU_VERSION" = "tpu7x" ]; then
+  NUM_HOSTS_PER_INSTANCE=2
+  TPU_PROCESS_BOUNDS="1,2,1"
+  PREFILL_TPU_PORTS=(8476 8477)
+  DECODE_TPU_PORTS=(9476 9477)
+fi
+
+PREFILL_RAY_PORT=8100
+DECODE_RAY_PORT=9100
+PREFILL_VLLM_PORT=8400
+DECODE_VLLM_PORT=9400
+PROXY_PORT=8000
+COMMON_SIDE_PORT=8900
+
+PIDS=()
+
+dump_logs() {
+  echo "--- Script exiting, displaying logs ---"
+  for f in prefill.txt decode.txt proxy.txt benchmark.txt correctness.txt; do
+    echo "--- $LOG_DIR/$f ---"
+    [ -f "$LOG_DIR/$f" ] && cat "$LOG_DIR/$f" || echo "File not found."
+  done
+  echo "--- ray ---"
+  for d in /tmp/ray-prefill* /tmp/ray-decode*; do
+    [ -d "$d" ] && find "$d" -name "raylet.err" -exec tail -20 {} + 2>/dev/null || true
+  done
+  echo "--- End of logs ---"
+}
+
+cleanup() {
+  set +e
+  dump_logs
+  # Ray first: it supervises the per-chip workers, and killing it before the
+  # vLLM servers avoids a page of connection errors in the logs above.
+  ray stop --force >/dev/null 2>&1
+  for pid in "${PIDS[@]}"; do kill "$pid" 2>/dev/null; done
+  sleep 3
+  for pid in "${PIDS[@]}"; do kill -9 "$pid" 2>/dev/null; done
+  pkill -9 -f "vllm serve" 2>/dev/null
+  pkill -9 -f toy_proxy_server 2>/dev/null
+  rm -f /tmp/libtpu_lockfile
+}
+trap cleanup EXIT
+
+# Wait for an HTTP service, failing early if the process behind it died. The
+# docker script did this with `docker exec ... kill -0`; here the PID is ours.
+wait_for_server() {
+  local port=$1 pid=$2 name=$3 log=$4
+  echo "Waiting for $name on port $port (pid $pid)..."
+  local end=$((SECONDS + 900))
+  while [ $SECONDS -lt $end ]; do
+    # 127.0.0.1, not localhost: localhost resolves to ::1 first and the pod
+    # has no IPv6 loopback, which is what broke single-host disagg on kube.
+    if curl -fs --max-time 5 "127.0.0.1:${port}/health" >/dev/null; then
+      echo "=== $name healthy on port $port ==="
+      return 0
+    fi
+    if ! kill -0 "$pid" 2>/dev/null; then
+      echo "Error: $name (pid $pid) died before becoming healthy." >&2
+      [ -f "$log" ] && tail -80 "$log"
+      return 1
+    fi
+    sleep 2
+  done
+  echo "Error: $name did not become healthy within the timeout." >&2
+  [ -f "$log" ] && tail -80 "$log"
+  return 1
+}
+
+check_failed_requests() {
+  local failed
+  failed=$(grep "Failed requests:" "$1" | awk '{print $3}' || true)
+  if [ -z "$failed" ]; then
+    echo "Error: no 'Failed requests:' line in the benchmark output." >&2
+    return 1
+  fi
+  if [ "$failed" -gt 0 ]; then
+    echo "Error: benchmark reported $failed failed requests." >&2
+    return 1
+  fi
+  echo "Success: benchmark reported $failed failed requests."
+}
+
+mkdir -p "$LOG_DIR"
+rm -f "$LOG_DIR"/{prefill,decode,proxy,benchmark,correctness}.txt
+rm -rf /tmp/ray-prefill* /tmp/ray-decode* /tmp/libtpu_lockfile
+ray stop --force >/dev/null 2>&1 || true
+
+# One Ray cluster per instance, then the vLLM server that drives it.
+#
+# `ray start --block` stays in the foreground, so each process goes to the
+# background here - the docker script got the same effect from `docker run -d`.
+start_instance() {
+  local role=$1 ray_port=$2 chip_base=$3 kv_base=$4 tmpdir=$5 vllm_port=$6 kv_role=$7
+  shift 7
+  local ports=("$@")
+  local addrs=()
+  for p in "${ports[@]}"; do addrs+=("127.0.0.1:$p"); done
+  local joined
+  joined=$(IFS=, ; echo "${addrs[*]}")
+
+  for ((i=0; i<NUM_HOSTS_PER_INSTANCE; i++)); do
+    # One temp dir per process, not per cluster. A Ray node keeps its session
+    # directory, raylet socket and plasma socket under --temp-dir, so raylets
+    # sharing one collide and workers attach to the wrong raylet, and the
+    # prefill workers deadlock in xla_bridge backend init racing for one chip.
+    #
+    # The docker script gets this from the mount namespace: --network host
+    # shares the network but each container still has a private /tmp, so every
+    # raylet already had its own /tmp/ray. That is also what a real Ray cluster
+    # looks like - one session dir per node. Only the network was ever shared.
+    local cmd="ray start --block --temp-dir=${tmpdir}-${i}"
+    if [ "$i" -eq 0 ]; then
+      cmd="$cmd --head --port=${ray_port}"
+      [ "$role" = "decode" ] && cmd="$cmd --min-worker-port=20000 --max-worker-port=29999"
+    else
+      cmd="$cmd --address=127.0.0.1:${ray_port}"
+    fi
+    env \
+      # 0, not the 1 run.sh exports for every other step. This test sets
+      # SKIP_JAX_PRECOMPILE=1, so the first real request necessarily compiles,
+      # and the check exists to fail a run that does exactly that: every
+      # request fails with "JAX compilation occurred".
+      #
+      # Bare metal never sees it: `docker run` passes an explicit env list that
+      # omits the flag, so the containers start clean. Processes in a pod
+      # inherit the pod's environment instead. run_disagg_single_host.sh sets
+      # it to 0 for the same reason.
+      VLLM_XLA_CHECK_RECOMPILATION=0 \
+      TPU_MULTIHOST_BACKEND=ray \
+      TPU_NODE_ID="${i}" \
+      TPU_KV_TRANSFER_PORT="$(( kv_base + i ))" \
+      TPU_SIDE_CHANNEL_PORT="$(( COMMON_SIDE_PORT + i ))" \
+      RAY_DEDUP_LOGS=0 \
+      SKIP_JAX_PRECOMPILE=1 \
+      TPU_CHIPS_PER_PROCESS_BOUNDS="1,1,1" \
+      TPU_PROCESS_BOUNDS="${TPU_PROCESS_BOUNDS}" \
+      TPU_VISIBLE_CHIPS="$(( chip_base + i ))" \
+      CLOUD_TPU_TASK_ID="${i}" \
+      TPU_PROCESS_ADDRESSES="${joined}" \
+      TPU_PROCESS_PORT="${ports[$i]}" \
+      $cmd >>"$LOG_DIR/ray-${role}.txt" 2>&1 &
+    PIDS+=($!)
+    sleep 1
+  done
+
+  echo "--- started $role Ray cluster: ${NUM_HOSTS_PER_INSTANCE} processes, chips ${chip_base}-$(( chip_base + NUM_HOSTS_PER_INSTANCE - 1 )) ---"
+
+  # vLLM attaches to node 0 of that cluster, exactly as `docker exec ...-0` did.
+  env \
+    VLLM_XLA_CHECK_RECOMPILATION=0 \
+    TPU_MULTIHOST_BACKEND=ray \
+    TPU_NODE_ID=0 \
+    TPU_KV_TRANSFER_PORT="${kv_base}" \
+    TPU_SIDE_CHANNEL_PORT="${COMMON_SIDE_PORT}" \
+    RAY_ADDRESS="127.0.0.1:${ray_port}" \
+    RAY_DEDUP_LOGS=0 \
+    SKIP_JAX_PRECOMPILE=1 \
+    TPU_CHIPS_PER_PROCESS_BOUNDS="1,1,1" \
+    TPU_PROCESS_BOUNDS="${TPU_PROCESS_BOUNDS}" \
+    TPU_VISIBLE_CHIPS="${chip_base}" \
+    CLOUD_TPU_TASK_ID=0 \
+    TPU_PROCESS_ADDRESSES="${joined}" \
+    TPU_PROCESS_PORT="${ports[0]}" \
+    vllm serve "$MODEL" \
+      --port "${vllm_port}" \
+      --gpu-memory-utilization 0.8 \
+      --no-enable-prefix-caching \
+      --max-num-batched-tokens 1024 \
+      --tensor-parallel-size "${NUM_HOSTS_PER_INSTANCE}" \
+      --kv-transfer-config "{\"kv_connector\":\"TPUConnector\",\"kv_connector_module_path\":\"tpu_inference.distributed.tpu_connector\",\"kv_role\":\"${kv_role}\"}" \
+      >"$LOG_DIR/${role}.txt" 2>&1 &
+  PIDS+=($!)
+  eval "${role^^}_VLLM_PID=$!"
+}
+
+start_instance prefill "$PREFILL_RAY_PORT" 0 8200 /tmp/ray-prefill \
+  "$PREFILL_VLLM_PORT" kv_producer "${PREFILL_TPU_PORTS[@]}"
+start_instance decode "$DECODE_RAY_PORT" "$NUM_HOSTS_PER_INSTANCE" 9200 /tmp/ray-decode \
+  "$DECODE_VLLM_PORT" kv_consumer "${DECODE_TPU_PORTS[@]}"
+
+wait_for_server "$PREFILL_VLLM_PORT" "$PREFILL_VLLM_PID" "prefill vllm" "$LOG_DIR/prefill.txt"
+wait_for_server "$DECODE_VLLM_PORT" "$DECODE_VLLM_PID" "decode vllm" "$LOG_DIR/decode.txt"
+
+# 127.0.0.1 rather than localhost: localhost resolves to ::1 first, and the
+# pod has no IPv6 loopback. That is what broke single-host disagg on kube.
+python3 "$SCRIPT_DIR/toy_proxy_server.py" --host 127.0.0.1 --port "$PROXY_PORT" \
+  >"$LOG_DIR/proxy.txt" 2>&1 &
+PROXY_PID=$!
+PIDS+=($PROXY_PID)
+wait_for_server "$PROXY_PORT" "$PROXY_PID" "toy_proxy_server" "$LOG_DIR/proxy.txt"
+
+if [ "$TEST_MODE" = "1" ] || [ "$TEST_MODE" = "3" ]; then
+  echo "--- benchmark ---"
+  vllm bench serve \
+    --backend vllm --host 127.0.0.1 --port "$PROXY_PORT" --model "$MODEL" \
+    --dataset-name random --random-input-len "$INPUT_LEN" \
+    --random-output-len "$OUTPUT_LEN" --num-prompts "$NUM_PROMPTS" \
+    --request-rate inf --max-concurrency "$MAX_CONCURRENCY" \
+    --trust-remote-code --seed "$RANDOM_SEED" \
+    >"$LOG_DIR/benchmark.txt" 2>&1
+  check_failed_requests "$LOG_DIR/benchmark.txt"
+fi
+
+if [ "$TEST_MODE" = "2" ] || [ "$TEST_MODE" = "3" ]; then
+  echo "--- correctness ---"
+  python3 "$SCRIPT_DIR/test_disagg_correctness.py" \
+    --baseline_url "http://127.0.0.1:${DECODE_VLLM_PORT}/v1/completions" \
+    --disagg_url "http://127.0.0.1:${PROXY_PORT}/v1/completions" \
+    --model "$MODEL" --num_requests "$NUM_PROMPTS" \
+    --input_length "$INPUT_LEN" --output_length "$OUTPUT_LEN" \
+    >"$LOG_DIR/correctness.txt" 2>&1
+fi
+
+echo "--- done ---"

--- a/examples/disagg/run_disagg_single_host.sh
+++ b/examples/disagg/run_disagg_single_host.sh
@@ -39,6 +39,13 @@ print_logs_on_exit() {
       echo "File not found."
     fi
 
+    echo "--- Contents of $LOG_DIR/proxy_0.txt ---"
+    if [ -f "$LOG_DIR/proxy_0.txt" ]; then
+      cat "$LOG_DIR/proxy_0.txt"
+    else
+      echo "File not found."
+    fi
+
     echo "--- Contents of $LOG_DIR/benchmark_0.txt ---"
     if [ -f "$LOG_DIR/benchmark_0.txt" ]; then
       cat "$LOG_DIR/benchmark_0.txt"
@@ -234,13 +241,21 @@ echo "starting proxy server"
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 # Start proxy server
 python $SCRIPT_DIR/toy_proxy_server.py \
---host localhost \
+--host 127.0.0.1 \
 --port 8000 \
 --prefiller-hosts ${PREFILL_HOSTS[@]} \
 --prefiller-ports ${PREFILL_PORTS[@]} \
 --decoder-hosts ${DECODE_HOSTS[@]} \
 --decoder-ports ${DECODE_PORTS[@]} \
 > $LOG_DIR/proxy_0.txt 2>&1 &
+PROXY_PID=$!
+
+# Wait for the proxy the same way we wait for prefill and decode. Without
+# this the benchmark below opens port 8000 while uvicorn is still importing,
+# and every request fails with ECONNREFUSED - 200 of 200, reported as failed
+# requests rather than as a proxy that was not up yet.
+echo "Waiting for proxy on port 8000 to start..."
+wait_for_server 8000 $PROXY_PID
 
 # run benchmark for both disagg and non-disagg
 LOG_FILE="$LOG_DIR/benchmark_0.txt"

--- a/tests/e2e/benchmarking/bench_utils.sh
+++ b/tests/e2e/benchmarking/bench_utils.sh
@@ -52,7 +52,15 @@ waitForServerReady() {
             exit 1
         fi
 
-        if grep -Eq "$error_regex" "$LOG_FILE"; then
+        # Warnings are not fatal, even when they quote an exception. JAX reports
+        # a cache entry it could not write as
+        #   UserWarning: Error writing persistent compilation cache entry for
+        #   'jit_sample': OSError: [Errno 116] Stale file handle
+        # which matches "OSError:" above and killed a healthy server. Anchoring
+        # the patterns instead would not work: engine output is prefixed, so a
+        # real traceback arrives as "(EngineCore pid=375) OSError: ...", never
+        # at the start of a line.
+        if grep -E "$error_regex" "$LOG_FILE" | grep -qv "Warning:"; then
             echo "FATAL ERROR DETECTED: The server log contains a fatal error pattern."
             # Call cleanup and exit (cleanup must be handled by the calling script's trap)
             exit 1

--- a/tests/models/jax/test_gemma4.py
+++ b/tests/models/jax/test_gemma4.py
@@ -131,16 +131,27 @@ class TestGemma4ForConditionalGeneration:
             )
         assert jax_output is not None
 
+    # model_name is the innermost parametrize on purpose, so that it varies
+    # slowest and all four pp configurations for one checkpoint run together.
+    #
+    # Stacked parametrize varies the topmost decorator fastest, so with
+    # model_name on top these sixteen cases ran round-robin - 31B, 26B-A4B,
+    # 31B-FP8, 26B-A4B-FP8, then back to 31B, four times over. Each checkpoint
+    # was therefore fetched four separate times, always with the other three
+    # in between, which is the worst possible order for a cache: whatever holds
+    # 31B has been evicted by the other three before 31B comes round again,
+    # and this block dominated the step's checkpoint-loading time. Grouped,
+    # each checkpoint is fetched once and reused three times.
+    @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
+                                                       (3, 4)])
+    @pytest.mark.parametrize("load_format",
+                             ["skip_layers_model_loader_for_test"])
     @pytest.mark.parametrize("model_name", [
         "google/gemma-4-31B-it",
         "google/gemma-4-26B-A4B-it",
         "RedHatAI/gemma-4-31B-it-FP8-Dynamic",
         "RedHatAI/gemma-4-26B-A4B-it-FP8-Dynamic",
     ])
-    @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
-                                                       (3, 4)])
-    @pytest.mark.parametrize("load_format",
-                             ["skip_layers_model_loader_for_test"])
     def test_model_loading(
             self,
             model_name,

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -15,6 +15,12 @@ def test_getattr_without_cache(monkeypatch: pytest.MonkeyPatch):
     assert envs.JAX_PLATFORMS == "tpu"
     assert envs.PHASED_PROFILING_DIR == "/tmp/profiling"
 
+    # Unset rather than assumed unset: on GKE the TPU device plugin injects
+    # TPU_ACCELERATOR_TYPE, TPU_WORKER_ID and friends into every TPU pod, so
+    # these are already populated there. libtpu needs them, so the environment
+    # is right and the assumption was wrong.
+    monkeypatch.delenv("TPU_NAME", raising=False)
+    monkeypatch.delenv("TPU_ACCELERATOR_TYPE", raising=False)
     assert envs.TPU_NAME is None
     assert envs.TPU_ACCELERATOR_TYPE is None
     monkeypatch.setenv("TPU_NAME", "my-tpu")


### PR DESCRIPTION
Runs `pipeline_jax.yml` on GKE. Every TPU step goes through the workload launcher from [ci-infra#467](https://github.com/vllm-project/ci-infra/pull/467) on the infrastructure from [ci-infra#438](https://github.com/vllm-project/ci-infra/pull/438); nothing here runs until both are applied.

## What it does

`pipeline_kube.yaml` is `pipeline_jax.yml` with each TPU step naming a **profile** and a command:

```yaml
- label: "unit tests"
  agents: { queue: kube }
  plugins: [{ kubernetes: { podTemplate: tpu-launcher } }]
  command: .buildkite/kubernetes/run.sh v6e-8-2x4 pytest tests/
```

`run.sh` resolves the image and tokens, forwards the environment, picks the manifest and hands off to `/opt/launcher/launch`, which submits a Job that Kueue admits against the profile's quota on a TPU node pool built from the reservation on demand, streams the pod's log back, and mirrors its exit code. Step keys match `pipeline_jax` so the files read side by side; steps that exist only for tpu7x are absent, `NIGHTLY` gating is kept.

| bare metal | kubernetes |
|---|---|
| `agents: { queue: tpu_v6e_8_queue }` | `run.sh v6e-8-2x4 ...` |
| `run_in_docker.sh bash <script>` | `bash <script>` - the pod is the container |
| `-e NAME` on `docker run` | `FORWARD` list in `run.sh`, once |
| `vllm-tpu:$BUILDKITE_COMMIT` local tag | the same image from Artifact Registry |

## Files

- `.buildkite/pipeline_kube.yaml` - the pipeline. `WORKLOAD_IMAGE` pins an image and skips the build; `SKIP_PART2=1` leaves the longest step out.
- `.buildkite/kubernetes/run.sh` - the counterpart of `scripts/run_in_docker.sh`: image, tokens, forwarded env, cache namespace, manifest.
- `.buildkite/kubernetes/manifests/test.yaml` - one pod on one host, every chip on the node, the two cache claims mounted (`jax-cache` at `/cache/jax`, `hf-cache` at the HF hub path), RAM-backed gcsfuse file cache sized per machine type. Retries a pod the infrastructure took away (`DisruptionTarget`), never a failed test.
- `docker/Dockerfile` - adds the `buildkite-agent` CLI, copied from the pinned official `buildkite/agent` image. The agent is in a different pod from the test, so `artifact_paths` cannot see test output; the test uploads its own coverage shards.
- `examples/disagg/run_disagg_multi_host_pod.sh` - `tpu6e_test_25`, the eight-process single-host disaggregation test, with `docker run` replaced by background processes in one pod, since there is no docker in a pod (each Ray node gets its own `--temp-dir`; `VLLM_XLA_CHECK_RECOMPILATION=0` set explicitly, since pod processes inherit the step's environment where containers did not).
- Test-side fixes that help bare metal too: `test_gemma4.py` loads each large checkpoint once instead of round-robin (checkpoint loading in part2 fell from 23.8 to 8.8 min); `bench_utils.sh` stops treating a `UserWarning` quoting `OSError` as fatal; `test_envs.py` unsets `TPU_NAME`/`TPU_ACCELERATOR_TYPE` rather than assuming them absent (GKE injects them); `run_disagg_single_host.sh` waits for the proxy before benchmarking.

## Verified

- Five consecutive full-suite runs (kube-dev builds 255-260) on one pinned image: 16/16 TPU steps pass; summed per-step median execution 169.4 min against 176.5 min on bare metal; in-pod setup 0.1 min against 2-3 min; coverage upload, combine and Test Engine reporting working.
- A compilation cache filled only from Kubernetes reaches bare metal's warm time on speculative decoding (28.0 vs 27.8 min) with `VLLM_XLA_CHECK_RECOMPILATION=1`, which `run_in_docker.sh` already sets on every step.
- Cross-host JobSet was validated separately on a four-host v6e slice (build 272) and is deliberately not in this PR, which covers the v6e `pipeline_jax` suite only.
