### PR TITLE
Lower the TPU KV cache geometry into Raiden's byte-span pool IR

### DIFF
--- a/tests/distributed/test_kv_pool_layout.py
+++ b/tests/distributed/test_kv_pool_layout.py
@@ -1,0 +1,731 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Offline validation of the KV byte-span lowering against a real controller.
+
+No TPU and no model: the reshard control plane runs as a sidecar process, and
+stand-in worker listeners record the plan it dispatches instead of moving
+bytes. That plans a TP4-prefill -> TP2-decode reshard with *different page
+sizes* on both sides, and the byte accounting is checked against the
+controller's own arithmetic rather than against a second derivation of this
+module's.
+
+Everything below the plan tests is pure lowering and needs no control plane.
+"""
+
+import json
+import math
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+
+import pytest
+
+raiden_controller = pytest.importorskip(
+    "tpu_sync.rpc.raiden_controller",
+    reason="tpu-raiden is not installed in this environment",
+)
+raiden_service_pb2 = pytest.importorskip(
+    "tpu_sync.rpc.raiden_service_pb2",
+    reason="tpu-raiden is not installed in this environment",
+)
+
+from tpu_inference.distributed import kv_pool_layout as kvpl  # noqa: E402
+from tpu_inference.distributed.raiden_reshard_client import \
+    ReshardRequestBlockClient  # noqa: E402
+
+# Raiden serves the reshard control plane from a standalone binary that no
+# wheel ships and that ``build.sh`` does not build by default, so a source
+# checkout built with ``//tpu_sync/kv_cache/reshard:reshard_sidecar`` is what
+# makes the plan tests below runnable.
+_SIDECAR_BINARY = "reshard_sidecar"
+_SIDECAR_ENV = "TPU_KV_RESHARD_SIDECAR"
+
+# Qwen3-0.6B-shaped attention, truncated to a few layers to keep the plan
+# small. bf16 => packing 2; head_dim 128 is already 128-aligned.
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+PACKING = 2
+DTYPE_BITS = 16
+DTYPE_TAG = "bfloat16"
+# align_to(NUM_KV_HEADS * 2, PACKING) // PACKING
+HEAD_GROUPS = 8
+GROUP_BYTES = PACKING * HEAD_DIM * DTYPE_BITS // 8  # 512
+NUM_LAYERS = 4
+NUM_BLOCKS = 64
+
+FINGERPRINT = kvpl.layout_fingerprint(
+    num_layers=NUM_LAYERS,
+    num_kv_heads=NUM_KV_HEADS,
+    head_dim=HEAD_DIM,
+    dtype_tag=DTYPE_TAG,
+)
+
+
+def _recv_exactly(sock, count):
+    buf = b""
+    while len(buf) < count:
+        chunk = sock.recv(count - len(buf))
+        if not chunk:
+            return None
+        buf += chunk
+    return buf
+
+
+class _RecordingWorker:
+    """A control-plane listener that records the plan the controller sends.
+
+    The controller arms the receiver and fires each sender over the framed
+    ``ControlRequest`` wire at the address the work unit registered, and
+    returns once every worker has acked. Acking without touching a TPU is
+    enough to get the whole plan out of it.
+    """
+
+    def __init__(self):
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.bind(("127.0.0.1", 0))
+        self._server.listen(16)
+        self._server.settimeout(0.2)
+        self.address = f"127.0.0.1:{self._server.getsockname()[1]}"
+        self.requests = []
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._server.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            with conn:
+                try:
+                    header = _recv_exactly(conn, 4)
+                    if header is None:
+                        continue
+                    payload = _recv_exactly(conn,
+                                            int.from_bytes(header, "big"))
+                    if payload is None:
+                        continue
+                    req = raiden_service_pb2.ControlRequest()
+                    req.ParseFromString(payload)
+                    self.requests.append(req)
+                    body = raiden_service_pb2.ControlResponse(
+                        success=True).SerializeToString()
+                    conn.sendall(len(body).to_bytes(4, "big") + body)
+                except OSError:
+                    pass
+
+    def close(self):
+        self._stop.set()
+        self._thread.join(timeout=5)
+        self._server.close()
+
+    @property
+    def start_transfer(self):
+        """The single START_TRANSFER this worker was sent."""
+        commands = [
+            req.start_transfer_request for req in self.requests
+            if req.command == raiden_service_pb2.ControlRequest.
+            COMMAND_START_TRANSFER
+        ]
+        assert len(commands) == 1, f"expected 1 START_TRANSFER, got {commands}"
+        return commands[0]
+
+
+def _find_sidecar_binary():
+    """Env var, then $PATH, then the Bazel output of a Raiden checkout."""
+    candidates = [os.environ.get(_SIDECAR_ENV), shutil.which(_SIDECAR_BINARY)]
+    import tpu_sync  # Raiden is a namespace package, so __file__ is None.
+    for entry in list(getattr(tpu_sync, "__path__", ())):
+        candidates.append(
+            os.path.join(os.path.dirname(entry), "bazel-bin", "tpu_sync",
+                         "kv_cache", "reshard", _SIDECAR_BINARY))
+    for candidate in candidates:
+        if candidate and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+@pytest.fixture(scope="module")
+def controller_address():
+    """A reshard control plane, shared by every plan test in this module."""
+    binary = _find_sidecar_binary()
+    if binary is None:
+        pytest.skip(
+            f"No executable {_SIDECAR_BINARY}: build "
+            f"//tpu_sync/kv_cache/reshard:{_SIDECAR_BINARY} in a Raiden "
+            f"checkout or set ${_SIDECAR_ENV}")
+
+    handle, ready_file = tempfile.mkstemp(prefix="reshard_", suffix=".ready")
+    os.close(handle)
+    os.unlink(ready_file)
+    process = subprocess.Popen([
+        binary, "--port=0", "--advertise-host=127.0.0.1",
+        f"--ready-file={ready_file}"
+    ])
+    try:
+        deadline = time.monotonic() + 60.0
+        ready = None
+        while ready is None and time.monotonic() < deadline:
+            assert process.poll() is None, (
+                f"sidecar exited with {process.returncode} before binding")
+            try:
+                with open(ready_file, "r") as f:
+                    line = f.read().strip()
+                if line:
+                    ready = json.loads(line)
+            except (FileNotFoundError, json.JSONDecodeError):
+                time.sleep(0.05)
+        assert ready is not None, "sidecar never published its ready file"
+        yield ready["address"]
+    finally:
+        process.terminate()
+        process.wait(timeout=30)
+        if os.path.exists(ready_file):
+            os.unlink(ready_file)
+
+
+def _geometry(*, tp, rank, page_tokens, head_groups=HEAD_GROUPS):
+    return kvpl.AttentionKVGeometry(
+        num_layers=NUM_LAYERS,
+        num_blocks=NUM_BLOCKS,
+        page_tokens=page_tokens,
+        head_groups=head_groups,
+        head_groups_local=head_groups // tp,
+        packing=PACKING,
+        padded_head_dim=HEAD_DIM,
+        dtype_bits=DTYPE_BITS,
+        transfer_rank=rank,
+        transfer_parallelism=tp,
+        dtype_tag=DTYPE_TAG,
+    )
+
+
+class _Plan:
+    """The dispatched plan, read back off the worker listeners.
+
+    The receiver is sent every source's schedule keyed by that source's
+    ordinal among the ranks feeding it; each sender is sent its own schedule
+    under key 0. Both views come from the controller, so the fields below are
+    its arithmetic, not a second copy of the lowering's.
+    """
+
+    def __init__(self, dst_worker, src_workers, src_units):
+        receiver = dst_worker.start_transfer
+        self.src_units = [
+            _to_raiden_id(unit) for unit in receiver.src_units
+        ]
+        group = receiver.pool_groups[0]
+        self.dst_device_block_ids = list(group.dst_device_block_ids)
+        self.dst_expected_extent_bytes = list(group.dst_expected_extent_bytes)
+        self.transfer_pool_indices = list(receiver.transfer_pool_indices)
+        self.expected_block_count = receiver.expected_block_count
+
+        # A sender that owns none of this destination's heads is dropped from
+        # the plan and never dispatched.
+        self.shard_push_schedules = {}
+        for unit, worker in zip(src_units, src_workers):
+            if not worker.requests:
+                continue
+            schedules = worker.start_transfer.shard_push_schedules
+            self.shard_push_schedules[unit] = schedules
+
+        # Recover the receiver's key for each sender by matching the schedule
+        # it was armed with against the one that sender was fired with. That
+        # key is what the receiver scatters a push under, so it is the field a
+        # wrong source ordinal corrupts silently.
+        self.src_schedule_keys = {}
+        for unit, schedules in self.shard_push_schedules.items():
+            blob = schedules[0].SerializeToString()
+            for key, armed in receiver.shard_push_schedules.items():
+                if armed.SerializeToString() == blob:
+                    self.src_schedule_keys[unit] = key
+                    break
+
+    @property
+    def entries(self):
+        for schedules in self.shard_push_schedules.values():
+            for schedule in schedules.values():
+                yield from schedule.entries
+
+
+def _to_raiden_id(proto):
+    return raiden_controller.RaidenId(
+        job_name=proto.job_name,
+        job_replica_id=proto.job_replica_id,
+        data_name=proto.data_name,
+        data_replica_idx=proto.data_replica_idx,
+    )
+
+
+_REQUEST_COUNTER = [0]
+
+
+def _plan_one_destination(
+    controller_address,
+    *,
+    num_tokens,
+    src_tp,
+    dst_tp,
+    src_page,
+    dst_page,
+    dst_rank,
+    src_fingerprint=FINGERPRINT,
+    dst_fingerprint=FINGERPRINT,
+    workers_out=None,
+):
+    """Registers both meshes and drives the plan for one decode rank."""
+    facade = raiden_controller.RaidenControllerClientFacade(controller_address)
+    blocks = ReshardRequestBlockClient(controller_address)
+
+    src_geoms = [
+        _geometry(tp=src_tp, rank=r, page_tokens=src_page)
+        for r in range(src_tp)
+    ]
+    dst_geoms = [
+        _geometry(tp=dst_tp, rank=d, page_tokens=dst_page)
+        for d in range(dst_tp)
+    ]
+
+    _REQUEST_COUNTER[0] += 1
+    generation = _REQUEST_COUNTER[0]
+
+    src_workers = [_RecordingWorker() for _ in src_geoms]
+    dst_workers = [_RecordingWorker() for _ in dst_geoms]
+    if workers_out is not None:
+        workers_out.extend(src_workers + dst_workers)
+
+    try:
+        # The work-unit directory is keyed by RaidenId and the sidecar outlives
+        # any one test, so the geometry goes in the id: a later test's TP2
+        # source must not inherit a TP4 registration.
+        src_units = []
+        for rank, geometry in enumerate(src_geoms):
+            unit = raiden_controller.RaidenId(
+                job_name="prefill",
+                job_replica_id=f"engine-tp{src_tp}p{src_page}-rank{rank}",
+                data_name="kv.fa",
+                data_replica_idx=0,
+            )
+            src_units.append(unit)
+            facade.register_work_unit(
+                unit,
+                [f"10.0.0.{rank + 1}:8000"],
+                control_plane_rpc_address=src_workers[rank].address,
+                pool_manifest=kvpl.build_pool_manifest(geometry),
+                layout_fingerprint=src_fingerprint,
+                page_tokens=geometry.page_tokens,
+                transfer_parallelism=geometry.transfer_parallelism,
+                transfer_rank=geometry.transfer_rank,
+            )
+
+        dst_units = []
+        for rank, geometry in enumerate(dst_geoms):
+            unit = raiden_controller.RaidenId(
+                job_name="decode",
+                job_replica_id=f"engine-tp{dst_tp}p{dst_page}-rank{rank}",
+                data_name="kv.fa",
+                data_replica_idx=0,
+            )
+            dst_units.append(unit)
+            facade.register_work_unit(
+                unit,
+                [f"10.1.0.{rank + 1}:8000"],
+                control_plane_rpc_address=dst_workers[rank].address,
+                pool_manifest=kvpl.build_pool_manifest(geometry),
+                layout_fingerprint=dst_fingerprint,
+                page_tokens=geometry.page_tokens,
+                transfer_parallelism=geometry.transfer_parallelism,
+                transfer_rank=geometry.transfer_rank,
+            )
+
+        # One (req_id, uuid) pair per destination rank: a registration is keyed
+        # (req_id, unit) and its spans address a single destination's byte
+        # space. The generation keeps tests from colliding in the registry.
+        req_id = f"request-{generation}-d{dst_rank}"
+        uuid = 1000 * generation + dst_rank
+        src_blocks_per_rank = math.ceil(num_tokens / src_page)
+        src_block_ids = [[
+            10 + rank * src_blocks_per_rank + i
+            for i in range(src_blocks_per_rank)
+        ] for rank in range(src_tp)]
+
+        for rank, geometry in enumerate(src_geoms):
+            entries = kvpl.build_request_span_entries(
+                geometry,
+                dst_geoms[dst_rank],
+                src_block_ids=src_block_ids[rank],
+                num_tokens=num_tokens,
+            )
+            blocks.register_request_blocks(
+                req_id,
+                uuid,
+                src_units[rank],
+                src_block_ids[rank],
+                pool_spans=entries,
+            )
+
+        dst_ids = list(range(40, 40 + math.ceil(num_tokens / dst_page)))
+        facade.coordinate_transfer(
+            src_units=src_units,
+            dst_units=[dst_units[dst_rank]],
+            req_id=req_id,
+            use_block_chunks=True,
+            is_sender=True,
+            uuid=uuid,
+            src_controller_address=controller_address,
+            dst_mem_type=raiden_controller.RaidenMemoryType.HBM,
+            dst_device_block_ids=dst_ids,
+            num_tokens=num_tokens,
+            transfer_pool_tags=[kvpl.KV_POOL_TAG],
+        )
+        plan = _Plan(dst_workers[dst_rank], src_workers, src_units)
+    finally:
+        if workers_out is None:
+            for worker in src_workers + dst_workers:
+                worker.close()
+    return controller_address, dst_workers, src_units, dst_units, dst_ids, plan
+
+
+def _scheduled_bytes(plan):
+    """Sums the size field of every emitted shard-push entry."""
+    return sum(entry.size_bytes * max(entry.count, 1)
+               for entry in plan.entries)
+
+
+# --- end-to-end plans --------------------------------------------------------
+
+
+@pytest.mark.parametrize("dst_rank", [0, 1])
+def test_tp4_to_tp2_differing_page_sizes_plans_with_exact_bytes(
+        controller_address, dst_rank):
+    """The end-to-end case: the plan builds and the byte accounting is exact."""
+    num_tokens = 256
+    _, _, src_units, _, dst_ids, plan = _plan_one_destination(
+        controller_address,
+        num_tokens=num_tokens,
+        src_tp=4,
+        dst_tp=2,
+        src_page=128,
+        dst_page=64,
+        dst_rank=dst_rank,
+    )
+
+    dst_per_token = (HEAD_GROUPS // 2) * GROUP_BYTES  # 2048
+    src_per_token = (HEAD_GROUPS // 4) * GROUP_BYTES  # 1024
+    assert dst_per_token == 2 * src_per_token
+
+    # Every byte of this decode rank's slice arrives exactly once.
+    assert _scheduled_bytes(plan) == num_tokens * dst_per_token
+    assert sum(plan.dst_expected_extent_bytes) == num_tokens * dst_per_token
+
+    # Only the two prefill ranks owning this decode rank's heads participate;
+    # the other two registered empty spans and were dropped.
+    expected = [src_units[2 * dst_rank], src_units[2 * dst_rank + 1]]
+    assert plan.src_units == expected
+
+    assert plan.dst_device_block_ids == dst_ids
+    assert plan.transfer_pool_indices == list(range(NUM_LAYERS))
+
+    # One shard per work unit, so dst_shard_idx is a constant, not a route.
+    for shards in plan.shard_push_schedules.values():
+        assert list(shards) == [0]
+        for schedule in shards.values():
+            assert {entry.dst_shard_idx for entry in schedule.entries} == {0}
+
+
+def test_both_decode_ranks_together_cover_the_whole_request(
+        controller_address):
+    """Summed over decode ranks, the plans move the full KV footprint."""
+    num_tokens = 256
+    total = sum(
+        _scheduled_bytes(
+            _plan_one_destination(controller_address,
+                                  num_tokens=num_tokens,
+                                  src_tp=4,
+                                  dst_tp=2,
+                                  src_page=128,
+                                  dst_page=64,
+                                  dst_rank=d)[5]) for d in range(2))
+    assert total == num_tokens * HEAD_GROUPS * GROUP_BYTES
+
+
+def test_partial_final_destination_page_is_allowed(controller_address):
+    """num_tokens need not be a multiple of the destination page size."""
+    num_tokens = 200  # 200 = 3*64 + 8, and 200 = 1*128 + 72
+    _, _, _, _, dst_ids, plan = _plan_one_destination(
+        controller_address,
+        num_tokens=num_tokens,
+        src_tp=4,
+        dst_tp=2,
+        src_page=128,
+        dst_page=64,
+        dst_rank=0,
+    )
+    assert len(dst_ids) == 4
+    dst_per_token = (HEAD_GROUPS // 2) * GROUP_BYTES
+    assert _scheduled_bytes(plan) == num_tokens * dst_per_token
+    # Only the last page is partial.
+    extents = plan.dst_expected_extent_bytes
+    assert extents[:-1] == [64 * dst_per_token] * 3
+    assert extents[-1] == 8 * dst_per_token
+
+
+# --- negative and structural checks -----------------------------------------
+
+
+def test_fingerprint_mismatch_is_rejected_before_any_worker_rpc(
+        controller_address):
+    workers = []
+    try:
+        with pytest.raises(RuntimeError, match="fingerprint"):
+            _plan_one_destination(
+                controller_address,
+                num_tokens=256,
+                src_tp=4,
+                dst_tp=2,
+                src_page=128,
+                dst_page=64,
+                dst_rank=0,
+                dst_fingerprint="a-different-model",
+                workers_out=workers,
+            )
+        # Nothing was armed and nothing was fired: planning rejects the pair
+        # before a single worker hears about the transfer.
+        assert [worker.requests for worker in workers] == [[]] * len(workers)
+    finally:
+        for worker in workers:
+            worker.close()
+
+
+def test_fingerprint_ignores_tp_degree_and_page_size():
+    """The two axes this work makes heterogeneous must not be in it."""
+    base = dict(num_layers=NUM_LAYERS,
+                num_kv_heads=NUM_KV_HEADS,
+                head_dim=HEAD_DIM,
+                dtype_tag=DTYPE_TAG)
+    assert kvpl.layout_fingerprint(**base) == FINGERPRINT
+    assert kvpl.layout_fingerprint(**{**base, "num_layers": 5}) != FINGERPRINT
+    assert kvpl.layout_fingerprint(**{**base, "head_dim": 64}) != FINGERPRINT
+    assert kvpl.layout_fingerprint(**{
+        **base, "dtype_tag": "float8_e4m3"
+    }) != FINGERPRINT
+
+
+def test_contributing_src_ranks_partition_by_head_range():
+    src = [_geometry(tp=4, rank=r, page_tokens=128) for r in range(4)]
+    dst = [_geometry(tp=2, rank=d, page_tokens=64) for d in range(2)]
+    assert kvpl.contributing_src_ranks(src, dst[0]) == [0, 1]
+    assert kvpl.contributing_src_ranks(src, dst[1]) == [2, 3]
+
+
+def test_head_reshard_emits_strided_spans():
+    """TP4 -> TP2 interleaves, so spans must carry count and strides."""
+    src = _geometry(tp=4, rank=1, page_tokens=128)
+    dst = _geometry(tp=2, rank=0, page_tokens=64)
+    registration = kvpl.build_request_spans(src,
+                                            dst,
+                                            src_block_ids=[10, 11],
+                                            num_tokens=256)
+    assert registration.dst_space_version == 0
+    assert registration.declared_bytes == 256 * (HEAD_GROUPS //
+                                                 4) * GROUP_BYTES
+    # Runs are bounded by both page sizes: 256 tokens / min(128, 64) = 4.
+    assert len(registration.spans) == 4
+    for span in registration.spans:
+        assert span.count == 64
+        assert span.size_bytes == (HEAD_GROUPS // 4) * GROUP_BYTES
+        assert span.src_stride_bytes == (HEAD_GROUPS // 4) * GROUP_BYTES
+        assert span.dst_stride_bytes == (HEAD_GROUPS // 2) * GROUP_BYTES
+        # Rank 1 is the upper half of decode rank 0's token slot.
+        assert span.dst_offset_bytes % span.dst_stride_bytes == (
+            HEAD_GROUPS // 4) * GROUP_BYTES
+
+
+def test_symmetric_geometry_coalesces_to_contiguous_spans():
+    """Equal TP and page size must not pay the per-token entry cost."""
+    src = _geometry(tp=2, rank=0, page_tokens=64)
+    dst = _geometry(tp=2, rank=0, page_tokens=64)
+    registration = kvpl.build_request_spans(src,
+                                            dst,
+                                            src_block_ids=[10, 11, 12, 13],
+                                            num_tokens=256)
+    assert len(registration.spans) == 4
+    for span in registration.spans:
+        assert span.count == 1
+        assert span.src_stride_bytes == 0
+        assert span.dst_stride_bytes == 0
+        assert span.size_bytes == 64 * (HEAD_GROUPS // 2) * GROUP_BYTES
+
+
+def test_symmetric_tp_with_differing_page_size_still_plans(controller_address):
+    """Isolates the page-size axis from the TP axis."""
+    num_tokens = 256
+    _, _, src_units, _, _, plan = _plan_one_destination(
+        controller_address,
+        num_tokens=num_tokens,
+        src_tp=2,
+        dst_tp=2,
+        src_page=128,
+        dst_page=64,
+        dst_rank=1,
+    )
+    assert plan.src_units == [src_units[1]]
+    assert _scheduled_bytes(plan) == num_tokens * (HEAD_GROUPS //
+                                                   2) * GROUP_BYTES
+
+
+def test_nonlinear_alignment_padding_is_rejected():
+    """F3: padding is computed on the local head count, so it need not scale."""
+    src = _geometry(tp=4, rank=0, page_tokens=128, head_groups=8)
+    dst = _geometry(tp=2, rank=0, page_tokens=64, head_groups=12)
+    with pytest.raises(ValueError, match="total head-group extent"):
+        kvpl.head_group_overlap(src, dst)
+
+
+def test_non_contributing_rank_registers_no_spans():
+    src = _geometry(tp=4, rank=3, page_tokens=128)
+    dst = _geometry(tp=2, rank=0, page_tokens=64)
+    assert kvpl.build_request_span_entries(src,
+                                           dst,
+                                           src_block_ids=[10, 11],
+                                           num_tokens=256) == []
+    with pytest.raises(ValueError, match="owns no heads"):
+        kvpl.build_request_spans(src,
+                                 dst,
+                                 src_block_ids=[10, 11],
+                                 num_tokens=256)
+
+
+def test_pool_manifest_is_one_dense_pool_per_layer():
+    geometry = _geometry(tp=4, rank=0, page_tokens=128)
+    pools = kvpl.build_pool_manifest(geometry)
+    assert len(pools) == NUM_LAYERS
+    for layer_idx, pool in enumerate(pools):
+        pool.validate()
+        assert pool.tag == kvpl.KV_POOL_TAG
+        assert pool.storage_index == layer_idx
+        assert pool.dtype_tag == DTYPE_TAG
+        # A local shard is dense: live bytes fill the whole block stride.
+        assert pool.live_bytes_per_block == pool.block_stride_bytes
+        assert pool.block_stride_bytes == 128 * (HEAD_GROUPS //
+                                                 4) * GROUP_BYTES
+
+
+# --- source schedule keys ----------------------------------------------------
+#
+# The receiver picks which source's schedule to scatter a push with using the
+# sender's Raiden node_id alone, and the controller keys those schedules by the
+# source's ordinal among the ranks feeding that destination. If the connector
+# leaves node_id at Raiden's default of 0, every rank's bytes land in the first
+# rank's head slots: the plan still validates and the byte totals are still
+# exact, so nothing errors and the model emits garbage. These lock our
+# derivation against the controller's own.
+
+
+@pytest.mark.parametrize("dst_rank", [0, 1])
+def test_schedule_key_matches_the_controller_tp4_to_tp2(
+        controller_address, dst_rank):
+    _, _, src_units, _, _, plan = _plan_one_destination(
+        controller_address,
+        num_tokens=256,
+        src_tp=4,
+        src_page=128,
+        dst_tp=2,
+        dst_page=64,
+        dst_rank=dst_rank,
+    )
+    for rank, unit in enumerate(src_units):
+        if unit not in plan.src_schedule_keys:
+            continue  # contributes nothing to this destination
+        assert plan.src_schedule_keys[unit] == kvpl.source_schedule_key(
+            rank, 4, 2)
+
+
+def test_schedule_key_matches_the_controller_tp4_to_tp1(controller_address):
+    _, _, src_units, _, _, plan = _plan_one_destination(
+        controller_address,
+        num_tokens=256,
+        src_tp=4,
+        src_page=128,
+        dst_tp=1,
+        dst_page=64,
+        dst_rank=0,
+    )
+    # Every rank contributes, so the ordinal is the global rank.
+    assert [plan.src_schedule_keys[unit] for unit in src_units] == [0, 1, 2, 3]
+    for rank, unit in enumerate(src_units):
+        assert plan.src_schedule_keys[unit] == kvpl.source_schedule_key(
+            rank, 4, 1)
+
+
+@pytest.mark.parametrize("src_tp,dst_tp", [(1, 1), (2, 2), (4, 4), (4, 2),
+                                           (4, 1), (2, 1), (1, 2), (2, 4)])
+def test_schedule_key_is_the_ordinal_among_contributors(src_tp, dst_tp):
+    """Derived the same way the controller derives it, for every shape."""
+    src = [
+        _geometry(tp=src_tp, rank=r, page_tokens=128) for r in range(src_tp)
+    ]
+    for dst_rank in range(dst_tp):
+        dst = _geometry(tp=dst_tp, rank=dst_rank, page_tokens=64)
+        contributors = kvpl.contributing_src_ranks(src, dst)
+        for ordinal, rank in enumerate(contributors):
+            assert kvpl.source_schedule_key(rank, src_tp, dst_tp) == ordinal
+
+
+def test_symmetric_geometry_keeps_the_default_key():
+    """One source per destination means the ordinal is always 0."""
+    for tp in (1, 2, 4):
+        for rank in range(tp):
+            assert kvpl.source_schedule_key(rank, tp, tp) == 0
+
+
+def test_dst_uuid_separates_a_requests_destinations():
+    """A source keys its active plan by uuid, so one per destination rank.
+
+    Reusing one uuid makes every source that feeds more than one destination
+    reject all but the first with ALREADY_EXISTS -- the remaining ranks then
+    wait forever on a push that was never armed.
+    """
+    base = 0x3_FFFF_FFFF_FFFF
+    keys = {kvpl.dst_uuid(base, rank) for rank in range(8)}
+    assert len(keys) == 8
+
+
+def test_dst_uuid_stays_within_the_uuids_width():
+    """`get_uuid` trims to 50 bits so vLLM's encoder and Go agree on it."""
+    for base in (0, 1, (1 << 50) - 1):
+        for rank in range(8):
+            tagged = kvpl.dst_uuid(base, rank)
+            assert 0 <= tagged <= max(base, (1 << 50) - 1)
+            assert tagged.bit_length() <= 50
+
+
+def test_dst_uuid_keeps_one_request_recognisable():
+    """Only the low bits move, so sibling transfers stay visibly related."""
+    base = 0x2_ABCD_EF01_2345
+    for rank in range(4):
+        assert kvpl.dst_uuid(base, rank) >> 8 == base >> 8
+
+
+def test_dst_uuid_rejects_a_rank_it_cannot_encode():
+    with pytest.raises(ValueError):
+        kvpl.dst_uuid(1 << 40, 256)

--- a/tpu_inference/distributed/kv_pool_layout.py
+++ b/tpu_inference/distributed/kv_pool_layout.py
@@ -1,0 +1,690 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lowers this worker's KV cache geometry into Raiden's byte-span pool IR.
+
+Raiden's reshard pipeline is geometry-neutral: the controller validates and
+re-keys byte spans, but it never derives them. Every mapping from "my mesh,
+my page size, my head shard" to bytes is the caller's job -- see
+``tpu_raiden/api/torch/pool_layout.py``:
+
+    callers (e.g. the TPU vLLM connector) derive them from their own model
+    and kernel layouts.
+
+This module is that derivation. It produces two things:
+
+  * :func:`build_pool_manifest` -- the static, per-worker declaration of
+    where the live KV bytes sit inside each attention page. Registered once
+    at worker init via ``register_work_unit(pool_manifest=...)``.
+  * :func:`build_request_spans` -- the per-request, per-(src rank, dst rank)
+    byte spans that say which of *my* bytes land where in *your* pages.
+    Registered per request via ``register_request_blocks(pool_spans=...)``.
+
+Because the two sides may run different tensor-parallel degrees and
+different page sizes, neither side's page layout is assumed by the other.
+The only thing that must agree is :func:`layout_fingerprint`, which covers
+the model-invariant parts and deliberately excludes TP degree and page size
+-- those are precisely what differ.
+
+Scope:
+
+  * Attention (``fa``) pools only. MLA and Mamba/GDN state pools raise.
+  * No context parallelism (``KV_CONTEXT`` mesh product must be 1).
+  * ``BATCH`` unsharded, so a rank's local page is dense and contiguous.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import math
+from typing import Any, List, Optional, Sequence, Tuple
+
+from tpu_raiden.api.torch.pool_layout import PoolSpec, RegionSpec
+from tpu_sync.rpc.raiden_controller import RaidenId
+
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+# Raiden pool tag for flash-attention KV pages. Must match on both sides;
+# the controller filters plans by tag and treats it as an opaque string.
+KV_POOL_TAG = "fa"
+
+# `data_name` for every KV work unit. The controller keys pool identity on
+# (tag, dtype_tag), so this is only a human-readable discriminator.
+KV_DATA_NAME = "kv.fa"
+
+
+@dataclasses.dataclass(frozen=True)
+class PoolByteSpan:
+    """One (source -> destination) byte range of a rank's declaration.
+
+    Mirrors ``PoolByteSpan`` in Raiden's ``controller_service.proto``; field
+    names match so the encoder can copy them across without a mapping table.
+    A ``count`` above one repeats the range uniformly, advancing each side by
+    its own stride, which is how a head slice interleaved through a
+    token-major page is expressed without one entry per token.
+    """
+
+    src_block_ordinal: int
+    src_offset_bytes: int
+    dst_block_index: int
+    dst_offset_bytes: int
+    size_bytes: int
+    src_stride_bytes: int = 0
+    dst_stride_bytes: int = 0
+    count: int = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class PoolSpanRegistration:
+    """One rank's byte declaration for one pool tag, for one request.
+
+    ``declared_bytes`` is cross-checked against the sum of the spans, and
+    over all contributing ranks against the destination's byte coverage, so
+    a rank that owns none of a destination's heads still registers with an
+    empty span list rather than staying silent.
+    """
+
+    tag: str
+    block_ids: Tuple[int, ...]
+    spans: Tuple[PoolByteSpan, ...]
+    declared_bytes: int
+    # 0: ``dst_block_index`` indexes the transfer's destination block list and
+    # ``dst_offset_bytes`` is page-local. 1 is destination-page-agnostic and
+    # cannot express a strided head slice, so this lowering always emits 0.
+    dst_space_version: int = 0
+
+
+@dataclasses.dataclass(frozen=True)
+class AttentionKVGeometry:
+    """One worker's byte-level view of its attention KV cache.
+
+    All ``*_bytes`` fields describe the worker's **local** shard, which is
+    what Raiden actually reads and writes. The logical (unsharded) array is
+    only used to derive them.
+
+    The kernel page layout is token-major, head-minor::
+
+        (num_blocks, page_tokens, head_groups, packing, padded_head_dim)
+           dim 0        dim 1        dim 2 (sharded)  dim 3      dim 4
+
+    so within one page the bytes run ``token 0 [all local head groups] |
+    token 1 [...] | ...``. That ordering is why a TP4 source contributes an
+    interleaved half of every destination token slot rather than one
+    contiguous run -- see :func:`build_request_spans`.
+    """
+
+    num_layers: int
+    num_blocks: int
+    page_tokens: int
+    # Global (unsharded) dim-2 extent, and this rank's slice of it.
+    head_groups: int
+    head_groups_local: int
+    packing: int
+    padded_head_dim: int
+    dtype_bits: int
+    # Position of this worker within the KV_HEAD mesh axis.
+    transfer_rank: int
+    transfer_parallelism: int
+    dtype_tag: str
+
+    def __post_init__(self):
+        if self.transfer_parallelism <= 0:
+            raise ValueError("transfer_parallelism must be positive")
+        if not 0 <= self.transfer_rank < self.transfer_parallelism:
+            raise ValueError(
+                f"transfer_rank {self.transfer_rank} is out of range for "
+                f"parallelism {self.transfer_parallelism}")
+        if self.head_groups != self.head_groups_local * self.transfer_parallelism:
+            raise ValueError(
+                f"head_groups {self.head_groups} is not "
+                f"{self.head_groups_local} x {self.transfer_parallelism}")
+
+    @property
+    def group_bytes(self) -> int:
+        """Bytes of one head group for one token."""
+        return self.packing * self.padded_head_dim * self.dtype_bits // 8
+
+    @property
+    def per_token_bytes(self) -> int:
+        """Local bytes occupied by one token slot in one page."""
+        return self.head_groups_local * self.group_bytes
+
+    @property
+    def block_live_bytes(self) -> int:
+        """Local live bytes in one page."""
+        return self.page_tokens * self.per_token_bytes
+
+    @property
+    def head_group_range(self) -> Tuple[int, int]:
+        """This rank's half-open slice of the global head-group axis."""
+        start = self.transfer_rank * self.head_groups_local
+        return (start, start + self.head_groups_local)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def geometry_to_dict(geometry: AttentionKVGeometry) -> dict:
+    """JSON-safe form, for carrying a rank's geometry in ``kv_transfer_params``.
+
+    The destination is the side that builds the spans -- it is the only side
+    that knows both geometries -- so the producer publishes its own geometry
+    in the handshake and the consumer reconstitutes it here.
+    """
+    return dataclasses.asdict(geometry)
+
+
+def geometry_from_dict(payload: dict) -> AttentionKVGeometry:
+    """Inverse of :func:`geometry_to_dict`. Validates via ``__post_init__``."""
+    fields = {f.name for f in dataclasses.fields(AttentionKVGeometry)}
+    unknown = set(payload) - fields
+    _require(not unknown, f"Unknown geometry fields in handshake: {unknown}")
+    return AttentionKVGeometry(**payload)
+
+
+def work_unit_id(role: str, rank: int, instance: str = "") -> RaidenId:
+    """The Raiden work-unit identity of one KV shard.
+
+    One unit per **device shard**, not per process. A JAX vLLM worker is a
+    single process holding N chips, but Raiden's byte-span planner requires
+    one data-plane endpoint per work unit
+    (``raiden_controller.py``: "Pool reshard planning requires one data-plane
+    endpoint per work unit") and always emits ``dst_shard_idx = 0``. So each
+    local shard gets its own ``KVCacheManager``, its own endpoint, and its own
+    unit -- which is also exactly the shape
+    :func:`contributing_src_ranks` assumes.
+
+    ``job_replica_id`` must be the rank rendered as an int-parseable string:
+    when several single-shard sources feed one destination, the controller
+    facade keys the push schedules by ``int(src_unit.job_replica_id)``.
+
+    ``instance`` separates engines that share a role and a controller. The
+    controller's work-unit registry is keyed by the whole id, so two decode
+    engines of the same parallelism would otherwise register the same units
+    and the second would take over the first's endpoints -- every push then
+    lands on one engine and the other's loads never complete. Rank alone
+    cannot separate them: both engines hold ranks 0..TP-1. Pass a tag that is
+    stable across an engine's own processes and distinct between engines; see
+    :func:`engine_instance_tag`.
+    """
+    _require(rank >= 0, f"rank must be non-negative, got {rank}")
+    return RaidenId(
+        job_name=role if not instance else f"{role}@{instance}",
+        job_replica_id=str(int(rank)),
+        data_name=KV_DATA_NAME,
+        data_replica_idx=int(rank),
+    )
+
+
+def engine_instance_tag(host: str, transfer_port: int | str) -> str:
+    """A per-engine tag for :func:`work_unit_id`.
+
+    The data-plane host and base transfer port identify an engine uniquely --
+    two engines on one host must already differ in port to coexist -- and both
+    are read from the same configuration in the scheduler and the worker, so
+    the two processes derive the same tag without having to exchange one.
+    """
+    return f"{host}:{transfer_port}"
+
+
+def unit_to_dict(unit: RaidenId) -> dict:
+    """JSON-safe form of a work-unit id, for the handshake."""
+    return {
+        "job_name": unit.job_name,
+        "job_replica_id": unit.job_replica_id,
+        "data_name": unit.data_name,
+        "data_replica_idx": int(unit.data_replica_idx),
+    }
+
+
+def unit_from_dict(payload: dict) -> RaidenId:
+    """Inverse of :func:`unit_to_dict`."""
+    return RaidenId(
+        job_name=str(payload["job_name"]),
+        job_replica_id=str(payload["job_replica_id"]),
+        data_name=str(payload["data_name"]),
+        data_replica_idx=int(payload["data_replica_idx"]),
+    )
+
+
+def dst_req_id(req_id: str, dst_rank: int) -> str:
+    """Per-destination-rank request id.
+
+    The controller's registration store is keyed ``(req_id, unit)`` while a
+    span set addresses exactly one destination's byte space, so a request
+    fanning out to K decode ranks needs K distinct req_ids -- reusing one
+    would have each destination's spans overwrite the last.
+    """
+    return f"{req_id}#d{int(dst_rank)}"
+
+
+_DST_RANK_MASK = 0xFF
+
+
+def dst_uuid(uuid: int, dst_rank: int) -> int:
+    """Per-destination-rank plan uuid.
+
+    A source registers one active plan per transfer, keyed by uuid, and
+    rejects a repeat with ``ALREADY_EXISTS``. Whenever a source feeds more
+    than one destination -- any geometry with ``src_parallelism <
+    dst_parallelism``, and every source in a partial fan-in such as 4 -> 2 --
+    that same source registers K plans, so the uuid has to distinguish them
+    just as :func:`dst_req_id` distinguishes the registrations.
+
+    The rank goes in the low bits rather than being mixed in, so a uuid stays
+    recognisably one request's across its destinations. That spends 8 of the
+    uuid's 50 bits, which only has to keep *in-flight* requests apart.
+    """
+    _require(0 <= dst_rank <= _DST_RANK_MASK,
+             f"dst_rank {dst_rank} does not fit in {_DST_RANK_MASK:#x}")
+    return (int(uuid) & ~_DST_RANK_MASK) | int(dst_rank)
+
+
+def geometry_from_mesh(
+    mesh: Any,
+    *,
+    num_blocks: int,
+    block_size: int,
+    num_kv_heads: int,
+    head_dim: int,
+    kv_dtype: Any,
+    num_layers: int,
+    transfer_rank: int,
+    use_mla: bool = False,
+) -> AttentionKVGeometry:
+    """Derives the local byte geometry from a live mesh.
+
+    Reuses the runner's own shape helper rather than recomputing the kernel
+    layout, so a kernel change cannot silently desynchronise the manifest
+    from the actual allocation.
+    """
+    # Imported lazily: this pulls vLLM and the attention kernels, which the
+    # pure-arithmetic paths below do not need.
+    from jax._src import dtypes
+
+    from tpu_inference import utils
+    from tpu_inference.layers.common.sharding import ShardingAxisName
+    from tpu_inference.runner.kv_cache import get_kv_cache_shape_with_mesh
+    from tpu_inference.utils import to_jax_dtype
+
+    if use_mla:
+        raise NotImplementedError(
+            "MLA KV pools are out of scope: the latent cache has no KV_HEAD "
+            "axis, so head-slice resharding is not defined for it")
+
+    context_cnt = utils.get_mesh_shape_product(mesh,
+                                               ShardingAxisName.KV_CONTEXT)
+    _require(
+        context_cnt == 1,
+        f"Context parallelism (KV_CONTEXT={context_cnt}) is out of scope; a "
+        "page would then hold a strided token subset")
+    model_cnt = utils.get_mesh_shape_product(mesh, ShardingAxisName.KV_HEAD)
+
+    jax_dtype = to_jax_dtype(kv_dtype)
+    shape = get_kv_cache_shape_with_mesh(
+        mesh=mesh,
+        total_num_pages=num_blocks,
+        block_size=block_size,
+        actual_num_kv_heads=num_kv_heads,
+        actual_head_dim=head_dim,
+        kv_dtype=jax_dtype,
+        use_mla=False,
+    )
+    _, page_tokens, head_groups, packing, padded_head_dim = shape
+    _require(
+        head_groups % model_cnt == 0,
+        f"Head-group extent {head_groups} is not divisible by the KV_HEAD "
+        f"mesh product {model_cnt}")
+
+    return AttentionKVGeometry(
+        num_layers=num_layers,
+        num_blocks=num_blocks,
+        page_tokens=int(page_tokens),
+        head_groups=int(head_groups),
+        head_groups_local=int(head_groups) // model_cnt,
+        packing=int(packing),
+        padded_head_dim=int(padded_head_dim),
+        dtype_bits=int(dtypes.itemsize_bits(jax_dtype)),
+        transfer_rank=int(transfer_rank),
+        transfer_parallelism=int(model_cnt),
+        dtype_tag=str(jax_dtype.__name__ if hasattr(jax_dtype, "__name__"
+                                                    ) else jax_dtype),
+    )
+
+
+def layout_fingerprint(
+    *,
+    num_layers: int,
+    num_kv_heads: int,
+    head_dim: int,
+    dtype_tag: str,
+    use_mla: bool = False,
+) -> str:
+    """Stable identity of the parts of the layout that must agree.
+
+    The controller rejects a transfer whose source and destination
+    fingerprints differ (``raiden_controller.py``: "Layout fingerprint
+    mismatch between source and destination"), before any worker RPC.
+
+    Deliberately excluded: **tensor-parallel degree** and **page size**.
+    Those are exactly the axes this work makes heterogeneous, so folding
+    them in would reject every transfer we care about. Padding and packing
+    are excluded too because they are functions of ``head_dim`` and the
+    dtype, which are included.
+    """
+    payload = "|".join([
+        "tpu-inference.kv.v1",
+        f"layers={int(num_layers)}",
+        f"kv_heads={int(num_kv_heads)}",
+        f"head_dim={int(head_dim)}",
+        f"dtype={dtype_tag}",
+        f"mla={int(bool(use_mla))}",
+    ])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+
+
+def build_pool_manifest(geometry: AttentionKVGeometry) -> List[PoolSpec]:
+    """One :class:`PoolSpec` per attention layer, in layer order.
+
+    The controller matches pools **positionally** by ``(tag, dtype_tag)``
+    against the destination manifest, so both sides must publish the same
+    number of pools in the same order. Layer count is model-invariant, so
+    that is compatible with differing TP and page size.
+
+    A rank's local shard is dense -- ``BATCH`` is unsharded and there is no
+    context parallelism -- so each block is one contiguous live region and
+    ``block_stride_bytes == live bytes``.
+    """
+    per_token = geometry.per_token_bytes
+    return [
+        PoolSpec(
+            tag=KV_POOL_TAG,
+            storage_index=layer_idx,
+            base_offset_bytes=0,
+            block_stride_bytes=geometry.block_live_bytes,
+            num_blocks=geometry.num_blocks,
+            dtype_tag=geometry.dtype_tag,
+            regions=(RegionSpec(
+                name=KV_POOL_TAG,
+                offset_bytes=0,
+                stride_bytes=per_token,
+                unit_bytes=per_token,
+                num_units=geometry.page_tokens,
+                units_per_stride=1,
+            ), ),
+        ) for layer_idx in range(geometry.num_layers)
+    ]
+
+
+def head_group_overlap(
+    src: AttentionKVGeometry,
+    dst: AttentionKVGeometry,
+) -> Optional[Tuple[int, int]]:
+    """Half-open global head-group range that ``src`` owes ``dst``.
+
+    Returns ``None`` when the two ranks share no heads, i.e. this source
+    contributes nothing to this destination and must be left out of the
+    transfer's ``src_units`` entirely.
+    """
+    _require(
+        src.head_groups == dst.head_groups,
+        "Source and destination disagree on the total head-group extent "
+        f"({src.head_groups} vs {dst.head_groups}). Alignment padding is "
+        "computed on the *local* head count, so it does not always scale "
+        "linearly with TP degree; this reshard is not well defined.")
+    _require(
+        src.group_bytes == dst.group_bytes,
+        f"Head-group byte size differs ({src.group_bytes} vs "
+        f"{dst.group_bytes}); dtype or head_dim padding disagree")
+
+    src_start, src_end = src.head_group_range
+    dst_start, dst_end = dst.head_group_range
+    start = max(src_start, dst_start)
+    end = min(src_end, dst_end)
+    return (start, end) if start < end else None
+
+
+def contributing_src_ranks(
+    src_geometries: Sequence[AttentionKVGeometry],
+    dst: AttentionKVGeometry,
+) -> List[int]:
+    """Indices of the source ranks that own any of ``dst``'s heads.
+
+    Every transfer targets exactly one destination rank (Raiden's byte-span
+    planner allows one shard per work unit and one destination unit per
+    plan, so ``dst_shard_idx`` is always 0 and a TP2 decode is two separate
+    work units). Passing a non-contributing source rank would leave a hole
+    in that rank's declared coverage and fail the controller's
+    exactly-once destination coverage check.
+    """
+    return [
+        index for index, src in enumerate(src_geometries)
+        if head_group_overlap(src, dst) is not None
+    ]
+
+
+def source_schedule_key(
+    transfer_rank: int,
+    transfer_parallelism: int,
+    dst_parallelism: int,
+) -> int:
+    """The Raiden ``node_id`` a source rank must carry to be routed correctly.
+
+    A pool-reshard push carries the sender's ``node_id`` in its wire header
+    (``block_transport.cc``: ``header.remote_id = block_delegate_->node_id()``)
+    and the receiver uses it, and only it, to pick which source's schedule to
+    scatter the payload with (``kv_cache_manager_base.cc``:
+    ``found_src_shard = sender_node_id``). The controller keys those schedules
+    by the source's **ordinal among the ranks that actually contribute to this
+    destination** (``raiden_controller.py``: ``src_schedule_keys = {unit:
+    ordinal for ordinal, unit in enumerate(active_src_units)}``), not by its
+    global ``transfer_rank``.
+
+    So ``node_id`` must be that ordinal. Leaving it at Raiden's default of 0 is
+    silently correct while exactly one source feeds each destination -- which
+    is every symmetric geometry -- and silently
+    *wrong* the moment two do: all the pushes resolve to the first source's
+    schedule, so every rank's bytes land in the first rank's head slots and the
+    rest of the destination keeps stale KV. Nothing errors; the plan validates,
+    the byte totals are exact, and the model emits garbage.
+
+    Under uniform tensor parallelism the ordinal is a property of the source
+    rank alone, so it can be fixed at worker init: destination ``d`` is fed by
+    the contiguous run of sources ``[d * P // D, (d+1) * P // D)`` when
+    ``P >= D``, and by the single source ``d * P // D`` when ``P < D``. The
+    ordering is derived here from :func:`contributing_src_ranks` rather than
+    open-coded, so it cannot drift from the spans it has to agree with.
+    """
+    _require(
+        0 <= transfer_rank < transfer_parallelism,
+        f"transfer_rank {transfer_rank} out of range for "
+        f"parallelism {transfer_parallelism}")
+    _require(dst_parallelism > 0, "dst_parallelism must be positive")
+
+    # Any extent both sides divide evenly routes identically to the real one,
+    # because ownership is the rank's equal share of it.
+    extent = transfer_parallelism * dst_parallelism // math.gcd(
+        transfer_parallelism, dst_parallelism)
+    src_geometries = [
+        _routing_geometry(rank, transfer_parallelism, extent)
+        for rank in range(transfer_parallelism)
+    ]
+    for dst_rank in range(dst_parallelism):
+        dst = _routing_geometry(dst_rank, dst_parallelism, extent)
+        contributors = contributing_src_ranks(src_geometries, dst)
+        if transfer_rank in contributors:
+            return contributors.index(transfer_rank)
+    raise ValueError(
+        f"Source rank {transfer_rank}/{transfer_parallelism} feeds no "
+        f"destination rank of a {dst_parallelism}-way decode; the head-group "
+        "extent is not divisible by both parallelisms")
+
+
+def _routing_geometry(rank: int, parallelism: int,
+                      extent: int) -> AttentionKVGeometry:
+    """A geometry that carries only what head-group routing depends on.
+
+    Head-group ownership is fixed by ``(transfer_rank, transfer_parallelism)``
+    and the global extent; page size, dtype and layer count do not enter it.
+    Using the smallest extent both parallelisms divide keeps this independent
+    of the model, so a producer can compute its schedule key before it has
+    ever seen the consumer's geometry.
+    """
+    return AttentionKVGeometry(
+        num_layers=1,
+        num_blocks=1,
+        page_tokens=1,
+        head_groups=extent,
+        head_groups_local=extent // parallelism,
+        packing=1,
+        padded_head_dim=1,
+        dtype_bits=16,
+        transfer_rank=rank,
+        transfer_parallelism=parallelism,
+        dtype_tag="bfloat16",
+    )
+
+
+def build_request_span_entries(
+    src: AttentionKVGeometry,
+    dst: AttentionKVGeometry,
+    *,
+    src_block_ids: Sequence[int],
+    num_tokens: int,
+) -> List[PoolSpanRegistration]:
+    """``register_request_blocks(pool_spans=...)`` payload for one rank pair.
+
+    Empty when this source owes this destination nothing. Register it anyway:
+    the transfer must list **every** source rank in ``src_units`` because the
+    controller requires ``transfer_rank`` values contiguous from zero
+    (``raiden_controller.py``: "Source transfer_rank values must be contiguous
+    from zero"), and it raises "Missing producer block registration" for any
+    listed unit without a registration under the transfer's uuid. Ranks that
+    contribute nothing therefore register an empty span list and are dropped
+    from ``active_src_units`` when the plan is built.
+
+    Because the registration store is keyed ``(req_id, unit)`` and a set of
+    spans addresses one destination's byte space, a request fanning out to
+    several decode ranks needs **a distinct req_id (and uuid) per destination
+    rank** -- otherwise the second registration overwrites the first.
+    """
+    if head_group_overlap(src, dst) is None:
+        return []
+    return [
+        build_request_spans(src,
+                            dst,
+                            src_block_ids=src_block_ids,
+                            num_tokens=num_tokens)
+    ]
+
+
+def build_request_spans(
+    src: AttentionKVGeometry,
+    dst: AttentionKVGeometry,
+    *,
+    src_block_ids: Sequence[int],
+    num_tokens: int,
+) -> PoolSpanRegistration:
+    """Byte spans carrying one source rank's share of one request to one
+    destination rank.
+
+    Under pure tensor parallelism every rank holds *all* tokens for its own
+    head slice, so source page ``o`` covers tokens
+    ``[o * src.page_tokens, (o+1) * src.page_tokens)`` and destination page
+    ``k`` covers ``[k * dst.page_tokens, (k+1) * dst.page_tokens)``. A run of
+    consecutive tokens that stays inside one page on both sides becomes a
+    single uniformly strided span.
+
+    The spans are emitted in the **v0** (page-indexed) form, not the
+    ``dst_space_version=1`` global-compact form. v1 requires every span to
+    be a plain contiguous range with no repeats, which cannot express a head
+    reshard: because pages are token-major, a TP4 source owns an interleaved
+    slice of every destination token slot, not one contiguous run. v1 stays
+    correct for the token-split (context-parallel) case, which this path is
+    not.
+    """
+    _require(num_tokens > 0, "num_tokens must be positive")
+    overlap = head_group_overlap(src, dst)
+    if overlap is None:
+        raise ValueError(
+            f"Source rank {src.transfer_rank}/{src.transfer_parallelism} owns "
+            f"no heads of destination rank "
+            f"{dst.transfer_rank}/{dst.transfer_parallelism}; it must be "
+            "excluded from src_units rather than declaring empty spans")
+    overlap_start, overlap_end = overlap
+
+    group_bytes = src.group_bytes
+    # Bytes this pair moves per token, and where they sit in each token slot.
+    width = (overlap_end - overlap_start) * group_bytes
+    src_in_token = (overlap_start - src.head_group_range[0]) * group_bytes
+    dst_in_token = (overlap_start - dst.head_group_range[0]) * group_bytes
+    src_token_bytes = src.per_token_bytes
+    dst_token_bytes = dst.per_token_bytes
+
+    expected_blocks = -(-num_tokens // src.page_tokens)  # ceil
+    _require(
+        len(src_block_ids) == expected_blocks,
+        f"Expected {expected_blocks} source block ids for {num_tokens} tokens "
+        f"at page_tokens={src.page_tokens}, got {len(src_block_ids)}")
+
+    spans: List[PoolByteSpan] = []
+    token = 0
+    while token < num_tokens:
+        src_block, src_token_off = divmod(token, src.page_tokens)
+        dst_block, dst_token_off = divmod(token, dst.page_tokens)
+        run = min(
+            num_tokens - token,
+            src.page_tokens - src_token_off,
+            dst.page_tokens - dst_token_off,
+        )
+        src_offset = src_token_off * src_token_bytes + src_in_token
+        dst_offset = dst_token_off * dst_token_bytes + dst_in_token
+
+        if width == src_token_bytes and width == dst_token_bytes:
+            # Same head slice on both sides: the strided form degenerates to
+            # one contiguous copy. Emitting it that way keeps the symmetric
+            # TP-N -> TP-N path cheap (one entry per run, not one per token).
+            spans.append(
+                PoolByteSpan(
+                    src_block_ordinal=src_block,
+                    src_offset_bytes=src_offset,
+                    dst_block_index=dst_block,
+                    dst_offset_bytes=dst_offset,
+                    size_bytes=width * run,
+                ))
+        else:
+            spans.append(
+                PoolByteSpan(
+                    src_block_ordinal=src_block,
+                    src_offset_bytes=src_offset,
+                    dst_block_index=dst_block,
+                    dst_offset_bytes=dst_offset,
+                    size_bytes=width,
+                    src_stride_bytes=src_token_bytes,
+                    dst_stride_bytes=dst_token_bytes,
+                    count=run,
+                ))
+        token += run
+
+    return PoolSpanRegistration(
+        tag=KV_POOL_TAG,
+        block_ids=tuple(int(block_id) for block_id in src_block_ids),
+        spans=tuple(spans),
+        declared_bytes=num_tokens * width,
+        dst_space_version=0,
+    )

--- a/tpu_inference/distributed/raiden_reshard_client.py
+++ b/tpu_inference/distributed/raiden_reshard_client.py
@@ -1,0 +1,150 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Client for the reshard control plane's request-block registration.
+
+Raiden serves the reshard control plane -- the work-unit directory, the
+request-block registry, the plan builder and receiver arming -- from its C++
+reshard store. Two of the three commands this connector needs have Python
+clients in ``tpu_sync.rpc.raiden_controller``: ``register_work_unit`` and
+``coordinate_transfer``. Request-block registration does not, and its Python
+client is a torch extension binding, so the producer's byte-span declarations
+are encoded here instead.
+
+The encoding is not a reimplementation of anything: ``ControllerRequest`` with
+``COMMAND_REGISTER_REQUEST_BLOCKS`` over a 4-byte big-endian length frame is
+the same envelope the other two commands use, on the same port, so this shares
+``connect_socket`` with them and inherits its address parsing, IPv6 handling
+and connect retry.
+"""
+
+import typing
+from typing import Any
+
+_IMPORT_ERROR = None
+try:
+    from tpu_sync.rpc import controller_service_pb2, raiden_service_pb2
+    from tpu_sync.rpc.raiden_controller import connect_socket
+except Exception as _exc:  # pylint: disable=broad-except
+    controller_service_pb2 = None
+    raiden_service_pb2 = None
+    connect_socket = None
+    _IMPORT_ERROR = _exc
+
+# Matches the connect and read timeout the controller client uses for the
+# coordinate call, which blocks for the whole transfer.
+_DEFAULT_TIMEOUT_S = 300.0
+
+
+class ReshardRequestBlockClient:
+    """Registers a producer rank's byte-span declarations for one request.
+
+    One instance is cheap and holds no connection; each call opens and closes
+    its own socket, which is what the surrounding controller client does.
+    """
+
+    def __init__(self,
+                 controller_address: str,
+                 timeout_s: float = _DEFAULT_TIMEOUT_S):
+        if _IMPORT_ERROR is not None:
+            raise RuntimeError(
+                "tpu_sync.rpc is unavailable, so the reshard control plane "
+                f"cannot be reached: {_IMPORT_ERROR}")
+        self._address = controller_address
+        self._timeout_s = timeout_s
+
+    def register_request_blocks(
+        self,
+        req_id: str,
+        uuid: int,
+        unit: Any,
+        block_ids: typing.Sequence[int],
+        pool_spans: typing.Sequence[Any] = (),
+    ) -> None:
+        """Declares which of this rank's bytes land where, for one request.
+
+        Args:
+            req_id: Request identity the plan is keyed by, together with
+                ``uuid``. One destination rank per ``req_id``.
+            uuid: Plan identity. A source keys its active plan by uuid, so
+                each destination rank of a fan-out needs a distinct one.
+            unit: The registering producer rank's ``RaidenId``.
+            block_ids: The producer blocks holding this request's KV.
+            pool_spans: Per-tag span entries from
+                ``kv_pool_layout.build_request_span_entries``. Empty for a
+                rank that owns none of this destination's heads -- the
+                controller still requires it to register.
+        """
+        block_req = controller_service_pb2.RegisterRequestBlocksRequest(
+            req_id=req_id,
+            uuid=uuid,
+            unit=raiden_service_pb2.RaidenIdProto(
+                job_name=unit.job_name,
+                job_replica_id=unit.job_replica_id,
+                data_name=unit.data_name,
+                data_replica_idx=unit.data_replica_idx,
+            ),
+            block_ids=list(block_ids),
+        )
+        for entry in pool_spans:
+            entry_proto = block_req.pool_spans.add(
+                tag=str(entry.tag),
+                block_ids=[int(block_id) for block_id in entry.block_ids],
+                declared_bytes=int(entry.declared_bytes),
+                dst_space_version=int(getattr(entry, "dst_space_version", 0)),
+            )
+            for span in entry.spans:
+                entry_proto.spans.add(
+                    src_block_ordinal=int(span.src_block_ordinal),
+                    src_offset_bytes=int(span.src_offset_bytes),
+                    dst_block_index=int(span.dst_block_index),
+                    dst_offset_bytes=int(span.dst_offset_bytes),
+                    size_bytes=int(span.size_bytes),
+                    src_stride_bytes=int(span.src_stride_bytes),
+                    dst_stride_bytes=int(span.dst_stride_bytes),
+                    count=int(span.count),
+                )
+        req = controller_service_pb2.ControllerRequest(
+            command=controller_service_pb2.ControllerRequest.
+            COMMAND_REGISTER_REQUEST_BLOCKS,
+            register_request_blocks_request=block_req,
+        )
+        self._send(req)
+
+    def _send(self, req: Any) -> Any:
+        sock = connect_socket(self._address, timeout=self._timeout_s)
+        try:
+            payload = req.SerializeToString()
+            sock.sendall(len(payload).to_bytes(4, "big") + payload)
+            resp_len = int.from_bytes(_recv_exactly(sock, 4), "big")
+            resp = controller_service_pb2.ControllerResponse()
+            resp.ParseFromString(_recv_exactly(sock, resp_len))
+            if not resp.success:
+                raise RuntimeError(
+                    "Reshard control plane rejected register_request_blocks: "
+                    f"{resp.message}")
+            return resp
+        finally:
+            sock.close()
+
+
+def _recv_exactly(sock, count: int) -> bytes:
+    buf = b""
+    while len(buf) < count:
+        chunk = sock.recv(count - len(buf))
+        if not chunk:
+            raise RuntimeError(
+                "Reshard control plane closed the connection after "
+                f"{len(buf)} of {count} bytes")
+        buf += chunk
+    return buf


### PR DESCRIPTION
# Description

## Problem

Raiden plans a KV transfer as byte spans over pools, and it deliberately does not re-derive the caller's layout — `tpu_raiden/api/torch/pool_layout.py` says so directly: "callers (e.g. the TPU vLLM connector) derive them from their own model and kernel layouts." Nothing in tpu-inference produced that description, so the TPU connector could only use Raiden's index-matched block pull, which requires prefill and decode to run the same tensor-parallel degree and the same page size.

## Approach

Add the lowering as a standalone module of pure functions over the mesh and the KV cache shape. **Nothing imports it in this PR** — the connector change that does is P5, stacked on this branch. Splitting them is deliberate: this module is arithmetic with an executable specification, worth reviewing on its own, and combining the two would make a single review out of roughly 2,600 lines.

Scope is attention pools with the `BATCH` axis unsharded and no context parallelism. MLA and Mamba/GDN state pools raise rather than guess.

## What changed

`tpu_inference/distributed/kv_pool_layout.py` (new):

- **`layout_fingerprint()`** covers the model-invariant parts — dtype, head dim, KV head count, layer count, MLA flag — and deliberately excludes TP degree and page size, which are precisely what may differ between the two sides. The controller rejects a mismatch before any worker RPC.
- **`build_pool_manifest()`** describes one attention pool per layer over the local shard's live bytes, taking the shape from the runner's own KV cache geometry rather than recomputing it.
- **`build_request_span_entries()`** packs a rank's owned bytes dense rank-major into the request-global compact byte space and splits them at both sides' page boundaries. Spans are emitted in strided form, not the page-split form: pages are token-major, so a source rank owns an interleaved slice of every destination token slot rather than a contiguous run, and the page-split form rejects a stride. The page-split form stays correct for a pure token split, which isn't this case.
- **`source_schedule_key()`** reproduces offline the ordinal the controller uses to key each source's push schedule. This is the subtle one: a receiver resolves an arriving push by the sender's Raiden `node_id` alone, but the controller keys schedules by the source's ordinal among the ranks contributing to that destination — which is not the transfer rank. A source that reports the transport's default 0 has its bytes scattered with another rank's schedule, silently — an exact byte total and a validated plan, because the receiver-side coverage check validates the plan, not the wire. The key derives from the same `contributing_src_ranks()` the spans are built from, so the two can't drift apart. At equal parallelism the ordinal is always 0, which is why a symmetric path never needs it.
- **`dst_uuid()`** and **`engine_instance_tag()`** keep one request's destinations, and two engines of the same role, from colliding. A source registers one active plan per transfer keyed by uuid and rejects a repeat with `ALREADY_EXISTS`, so one source feeding K destinations needs K uuids; the controller's work-unit registry is keyed by the whole `RaidenId`, so two engines of the same parallelism both holding ranks 0..TP-1 would otherwise overwrite each other's endpoints.

# Tests

`tests/distributed/test_kv_pool_layout.py` — 20 test functions, no TPU and no wire traffic, driving an in-process `RaidenController` through `register_work_unit`, `register_request_blocks`, and plan construction:

```bash
pytest tests/distributed/test_kv_pool_layout.py
```

The central fixture is TP4 page 128 → TP2 page 64 over 256 tokens: 4 strided spans per contributing rank, Σ `ShardPushEntryProto` bytes = 524288 = 256 × 2048, head fan-in {0,1}→dst0 and {2,3}→dst1, both destination ranks together covering the whole request exactly once. Around it: a partial final destination page is allowed; a fingerprint mismatch is rejected before any worker RPC; the fingerprint ignores TP degree and page size; a head reshard emits strided spans while a symmetric geometry coalesces to contiguous ones; non-linear alignment padding is rejected; a non-contributing rank registers an empty span list; and `source_schedule_key()` is asserted equal to the controller's own `plan.src_schedule_keys` at TP4→TP2 and TP4→TP1 — which is what makes it a specification rather than a second guess.

The 20 tests were run on a v6e-8 with tpu-raiden built from source, and all pass. `pre-commit run --all-files` passes with a clean tree afterwards.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
