### PR TITLE
Support prefill and decode at different TP degrees and page sizes

### DIFF
--- a/examples/disagg/run_disagg_single_host.sh
+++ b/examples/disagg/run_disagg_single_host.sh
@@ -45,6 +45,11 @@ print_logs_on_exit() {
     else
       echo "File not found."
     fi
+
+    if [ -f "$LOG_DIR/controller_0.txt" ]; then
+      echo "--- Contents of $LOG_DIR/controller_0.txt ---"
+      cat "$LOG_DIR/controller_0.txt"
+    fi
   else
     echo "Log directory '$LOG_DIR' not found."
   fi
@@ -65,13 +70,83 @@ NUM_PREFILL_INSTANCES=1
 NUM_DECODE_INSTANCES=1
 TPU_VERSION=${TPU_VERSION:=tpu7x}
 if [ "${TPU_VERSION:-}" = "tpu7x" ]; then
-    PREFILLER_TP_SIZE=2
-    DECODER_TP_SIZE=2
+    PREFILLER_TP_SIZE=${PREFILLER_TP_SIZE:=2}
+    DECODER_TP_SIZE=${DECODER_TP_SIZE:=2}
 else
-    PREFILLER_TP_SIZE=1
-    DECODER_TP_SIZE=1
+    PREFILLER_TP_SIZE=${PREFILLER_TP_SIZE:=1}
+    DECODER_TP_SIZE=${DECODER_TP_SIZE:=1}
 fi
+
+# Which physical chips each side gets, and the process grid over them. Not
+# every subset is valid: libtpu requires a chip's index_on_host to match its
+# position, so only single chips and axis-aligned blocks initialize. The grid
+# is derived from how many chips the side was given, not from its TP degree --
+# a chip may hold more than one core. Override *_CHIP_BOUNDS when the default
+# guess does not match the host's grid.
+PREFILL_CHIPS=${PREFILL_CHIPS:="0"}
+DECODE_CHIPS=${DECODE_CHIPS:="1"}
+chip_count() {
+  local IFS=','
+  # shellcheck disable=SC2086
+  set -- $1
+  echo $#
+}
+chip_bounds() {
+  case "$1" in
+    1) echo "1,1,1" ;;
+    2) echo "1,2,1" ;;
+    4) echo "2,2,1" ;;
+    8) echo "2,4,1" ;;
+    *) echo "1,$1,1" ;;
+  esac
+}
+PREFILL_CHIP_COUNT=$(chip_count "$PREFILL_CHIPS")
+DECODE_CHIP_COUNT=$(chip_count "$DECODE_CHIPS")
+PREFILL_CHIP_BOUNDS=${PREFILL_CHIP_BOUNDS:=$(chip_bounds $PREFILL_CHIP_COUNT)}
+DECODE_CHIP_BOUNDS=${DECODE_CHIP_BOUNDS:=$(chip_bounds $DECODE_CHIP_COUNT)}
+
+# KV page size per side. They may differ only on the controller path below;
+# the symmetric connector index-matches blocks and requires them equal.
+# Decode is left unset by default so the platform picks its own page size.
+PREFILL_BLOCK_SIZE=${PREFILL_BLOCK_SIZE:=128}
+DECODE_BLOCK_SIZE=${DECODE_BLOCK_SIZE:-}
+
+# Connector selection. The default is the stock symmetric connector, so this
+# script's behaviour is unchanged unless you ask for something else.
+KV_CONNECTOR_MODULE=${KV_CONNECTOR_MODULE:="tpu_inference.distributed.tpu_connector"}
+
+# Controller path: route the transfer through Raiden's byte-span reshard
+# planner instead of the index-matched pull, which is what allows the two
+# sides to differ in TP degree and page size. Requires the raiden connector.
+KV_CONTROLLER=${KV_CONTROLLER:=0}
+KV_CONTROLLER_PORT=${KV_CONTROLLER_PORT:=9700}
+PREFILL_LISTENER_PORT=${PREFILL_LISTENER_PORT:=9800}
+DECODE_LISTENER_PORT=${DECODE_LISTENER_PORT:=9900}
+if [ "$KV_CONTROLLER" != "0" ]; then
+  KV_CONNECTOR_MODULE=${KV_CONNECTOR_MODULE_OVERRIDE:="tpu_inference.distributed.tpu_raiden_connector"}
+  KV_CONTROLLER_ADDRESS="localhost:$KV_CONTROLLER_PORT"
+elif { [ -n "$DECODE_BLOCK_SIZE" ] && [ "$PREFILL_BLOCK_SIZE" != "$DECODE_BLOCK_SIZE" ]; } ||
+     [ "$PREFILLER_TP_SIZE" != "$DECODER_TP_SIZE" ]; then
+  echo "Error: prefill and decode geometries differ (TP $PREFILLER_TP_SIZE vs $DECODER_TP_SIZE," \
+       "block $PREFILL_BLOCK_SIZE vs ${DECODE_BLOCK_SIZE:-<platform default>}) but KV_CONTROLLER=0." \
+       "The symmetric connector index-matches blocks and would transfer the wrong bytes." >&2
+  exit 1
+fi
+
+# The raiden connector needs the decode side's TP degree while the prefill
+# engine is planning, so it rides along with the other connector options.
+# The stock connector gets exactly the transfer config it always got.
+KV_EXTRA_CONFIG=""
+case "$KV_CONNECTOR_MODULE" in
+  *tpu_raiden_connector)
+    KV_EXTRA_CONFIG=",\"kv_connector_extra_config\":{\"decode_tp_size\":$DECODER_TP_SIZE}"
+    ;;
+esac
+
 echo "TPU_VERSION=${TPU_VERSION:-<unset>} | PREFILLER_TP_SIZE=$PREFILLER_TP_SIZE | DECODER_TP_SIZE=$DECODER_TP_SIZE"
+echo "chips: prefill=[$PREFILL_CHIPS] ($PREFILL_CHIP_BOUNDS) decode=[$DECODE_CHIPS] ($DECODE_CHIP_BOUNDS)"
+echo "block_size: prefill=$PREFILL_BLOCK_SIZE decode=${DECODE_BLOCK_SIZE:-<platform default>} | connector=$KV_CONNECTOR_MODULE"
+echo "controller=${KV_CONTROLLER_ADDRESS:-<disabled>}"
 
 PREFILL_HOSTS=()
 PREFILL_PORTS=()
@@ -116,9 +191,11 @@ cleanup_instances() {
   echo "Cleaning up any running vLLM instances..."
   pkill -f "vllm" || true
   pkill -f "toy_proxy_server" || true
+  pkill -f "raiden_controller_sidecar" || true
   sleep 5
   pkill -9 -f "vllm" || true
   pkill -9 -f "toy_proxy_server" || true
+  pkill -9 -f "raiden_controller_sidecar" || true
   fuser -k -9 /dev/vfio/* || true
   fuser -k -9 /dev/accel* || true
   rm -rf /tmp/jax_cache_* || true
@@ -133,10 +210,49 @@ if [ ! -d $LOG_DIR ]; then
   mkdir -p $LOG_DIR
 else
   # Delete old log files to avoid printing stale logs at the end
-  rm -f $LOG_DIR/prefill_0.txt $LOG_DIR/decode_0.txt $LOG_DIR/benchmark_0.txt $LOG_DIR/proxy_0.txt
+  rm -f $LOG_DIR/prefill_0.txt $LOG_DIR/decode_0.txt $LOG_DIR/benchmark_0.txt $LOG_DIR/proxy_0.txt \
+        $LOG_DIR/controller_0.txt
 fi
 
 cleanup_instances
+
+# Start the Raiden controller sidecar. It owns the plan and moves no data, so
+# one process serves the pair; it lives outside the engines because they own
+# TPU chips and restart far more often than the control plane does.
+if [ "$KV_CONTROLLER" != "0" ]; then
+  JAX_PLATFORMS=cpu python -m tpu_inference.distributed.raiden_controller_sidecar \
+    --port $KV_CONTROLLER_PORT > $LOG_DIR/controller_0.txt 2>&1 &
+  CONTROLLER_PID=$!
+  timeout 60 bash -c "
+    until grep -q RAIDEN_CONTROLLER_PORT $LOG_DIR/controller_0.txt; do
+      if ! kill -0 $CONTROLLER_PID 2>/dev/null; then
+        echo 'Error: Raiden controller sidecar failed to start!' >&2
+        exit 1
+      fi
+      sleep 1
+    done"
+  echo "Raiden controller sidecar up on $KV_CONTROLLER_ADDRESS (PID $CONTROLLER_PID)"
+fi
+
+# libtpu takes a whole-host advisory lock at /tmp/libtpu_lockfile as soon as a
+# process claims more than one chip, so the second engine aborts with "The TPU
+# is already in use by process with pid N" even though the two TPU_VISIBLE_CHIPS
+# sets are disjoint. One chip per side does not trip it, which is why TP1 -> TP1
+# needs none of this. Dropping the file between the two launches is the
+# workaround libtpu's own error message points at: prefill keeps its open inode,
+# decode creates a fresh one, and `fuser /dev/vfio/*` confirms the two processes
+# end up holding disjoint iommu groups.
+#
+# Only do this when the chip sets really are disjoint -- that lock is the only
+# thing stopping two engines from claiming the same chip.
+PARTITION_NEEDS_LOCK_RELEASE=0
+if [ "$PREFILL_CHIPS" != "$DECODE_CHIPS" ] &&
+   { [ "$PREFILL_CHIP_COUNT" -gt 1 ] || [ "$DECODE_CHIP_COUNT" -gt 1 ]; }; then
+  PARTITION_NEEDS_LOCK_RELEASE=1
+  # Clear any lock left behind by a crashed run, so the wait below observes the
+  # file prefill is about to create rather than a stale one.
+  rm -f /tmp/libtpu_lockfile
+fi
 
 # Start prefill instances
 for i in $(seq 0 $((NUM_PREFILL_INSTANCES-1))); do
@@ -149,12 +265,14 @@ for i in $(seq 0 $((NUM_PREFILL_INSTANCES-1))); do
     # os.environ[TPU_PROCESS_BOUNDS] = "1,1,1"
     # os.environ[TPU_VISIBLE_CHIPS] = "0,1,2,3"
 
-    TPU_CHIPS_PER_PROCESS_BOUNDS=1,1,1 \
+    TPU_CHIPS_PER_PROCESS_BOUNDS=$PREFILL_CHIP_BOUNDS \
     TPU_PROCESS_BOUNDS=1,1,1 \
-    TPU_VISIBLE_CHIPS=0 \
+    TPU_VISIBLE_CHIPS=$PREFILL_CHIPS \
     \
     TPU_KV_TRANSFER_PORT=$KV_PORT \
     TPU_SIDE_CHANNEL_PORT=$SIDE_PORT \
+    TPU_KV_CONTROLLER_ADDRESS=${KV_CONTROLLER_ADDRESS:-} \
+    TPU_KV_LISTENER_PORT=$((PREFILL_LISTENER_PORT + i * 16)) \
     SKIP_JAX_PRECOMPILE=1 \
     VLLM_XLA_CHECK_RECOMPILATION=0 \
     VLLM_XLA_CACHE_PATH="/tmp/jax_cache_$PORT" \
@@ -166,10 +284,10 @@ for i in $(seq 0 $((NUM_PREFILL_INSTANCES-1))); do
     --port $PORT \
     --gpu-memory-utilization 0.3 \
     --max-num-batched-tokens 1024 \
-    --block-size 128 \
+    --block-size $PREFILL_BLOCK_SIZE \
     --no-enable-prefix-caching \
     --tensor-parallel-size $PREFILLER_TP_SIZE \
-    --kv-transfer-config "{\"kv_connector\":\"TPUConnector\",\"kv_connector_module_path\":\"tpu_inference.distributed.tpu_connector\",\"kv_role\":\"kv_producer\"}" \
+    --kv-transfer-config "{\"kv_connector\":\"TPUConnector\",\"kv_connector_module_path\":\"$KV_CONNECTOR_MODULE\",\"kv_role\":\"kv_producer\"$KV_EXTRA_CONFIG}" \
     > $LOG_DIR/prefill_$i.txt 2>&1 &
 
     PREFILL_HOSTS+=("localhost")
@@ -177,6 +295,16 @@ for i in $(seq 0 $((NUM_PREFILL_INSTANCES-1))); do
     PREFILL_PIDS+=($!)
 done
 
+if [ "$PARTITION_NEEDS_LOCK_RELEASE" = "1" ]; then
+  # Wait for prefill to take the lock, then drop the file so decode can take
+  # one of its own. Prefill keeps its open inode, so its own lock is unaffected.
+  echo "waiting for prefill to claim the TPU, then releasing the whole-host lock"
+  for _ in $(seq 1 300); do
+    [ -e /tmp/libtpu_lockfile ] && break
+    sleep 1
+  done
+  rm -f /tmp/libtpu_lockfile
+fi
 
 # Start decode instances
 for i in $(seq 0 $((NUM_DECODE_INSTANCES-1))); do
@@ -190,12 +318,14 @@ for i in $(seq 0 $((NUM_DECODE_INSTANCES-1))); do
     # os.environ[TPU_PROCESS_BOUNDS] = "1,1,1"
     # os.environ[TPU_VISIBLE_CHIPS] = "4,5,6,7"
 
-    TPU_CHIPS_PER_PROCESS_BOUNDS=1,1,1 \
+    TPU_CHIPS_PER_PROCESS_BOUNDS=$DECODE_CHIP_BOUNDS \
     TPU_PROCESS_BOUNDS=1,1,1 \
-    TPU_VISIBLE_CHIPS=1 \
+    TPU_VISIBLE_CHIPS=$DECODE_CHIPS \
     \
     TPU_KV_TRANSFER_PORT=$KV_PORT \
     TPU_SIDE_CHANNEL_PORT=$SIDE_PORT \
+    TPU_KV_CONTROLLER_ADDRESS=${KV_CONTROLLER_ADDRESS:-} \
+    TPU_KV_LISTENER_PORT=$((DECODE_LISTENER_PORT + i * 16)) \
     SKIP_JAX_PRECOMPILE=1 \
     VLLM_XLA_CHECK_RECOMPILATION=0 \
     VLLM_XLA_CACHE_PATH="/tmp/jax_cache_$PORT" \
@@ -208,8 +338,9 @@ for i in $(seq 0 $((NUM_DECODE_INSTANCES-1))); do
     --gpu-memory-utilization 0.3 \
     --no-enable-prefix-caching \
     --max-num-batched-tokens 1024 \
+    ${DECODE_BLOCK_SIZE:+--block-size $DECODE_BLOCK_SIZE} \
     --tensor-parallel-size $DECODER_TP_SIZE \
-    --kv-transfer-config "{\"kv_connector\":\"TPUConnector\",\"kv_connector_module_path\":\"tpu_inference.distributed.tpu_connector\",\"kv_role\":\"kv_consumer\"}" \
+    --kv-transfer-config "{\"kv_connector\":\"TPUConnector\",\"kv_connector_module_path\":\"$KV_CONNECTOR_MODULE\",\"kv_role\":\"kv_consumer\"}" \
     > $LOG_DIR/decode_$i.txt 2>&1 &
 
     DECODE_HOSTS+=("localhost")

--- a/tests/distributed/test_kv_pool_layout.py
+++ b/tests/distributed/test_kv_pool_layout.py
@@ -1,0 +1,731 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Offline validation of the KV byte-span lowering against a real controller.
+
+No TPU and no model: the reshard control plane runs as a sidecar process, and
+stand-in worker listeners record the plan it dispatches instead of moving
+bytes. That plans a TP4-prefill -> TP2-decode reshard with *different page
+sizes* on both sides, and the byte accounting is checked against the
+controller's own arithmetic rather than against a second derivation of this
+module's.
+
+Everything below the plan tests is pure lowering and needs no control plane.
+"""
+
+import json
+import math
+import os
+import shutil
+import socket
+import subprocess
+import tempfile
+import threading
+import time
+
+import pytest
+
+raiden_controller = pytest.importorskip(
+    "tpu_sync.rpc.raiden_controller",
+    reason="tpu-raiden is not installed in this environment",
+)
+raiden_service_pb2 = pytest.importorskip(
+    "tpu_sync.rpc.raiden_service_pb2",
+    reason="tpu-raiden is not installed in this environment",
+)
+
+from tpu_inference.distributed import kv_pool_layout as kvpl  # noqa: E402
+from tpu_inference.distributed.raiden_reshard_client import \
+    ReshardRequestBlockClient  # noqa: E402
+
+# Raiden serves the reshard control plane from a standalone binary that no
+# wheel ships and that ``build.sh`` does not build by default, so a source
+# checkout built with ``//tpu_sync/kv_cache/reshard:reshard_sidecar`` is what
+# makes the plan tests below runnable.
+_SIDECAR_BINARY = "reshard_sidecar"
+_SIDECAR_ENV = "TPU_KV_RESHARD_SIDECAR"
+
+# Qwen3-0.6B-shaped attention, truncated to a few layers to keep the plan
+# small. bf16 => packing 2; head_dim 128 is already 128-aligned.
+NUM_KV_HEADS = 8
+HEAD_DIM = 128
+PACKING = 2
+DTYPE_BITS = 16
+DTYPE_TAG = "bfloat16"
+# align_to(NUM_KV_HEADS * 2, PACKING) // PACKING
+HEAD_GROUPS = 8
+GROUP_BYTES = PACKING * HEAD_DIM * DTYPE_BITS // 8  # 512
+NUM_LAYERS = 4
+NUM_BLOCKS = 64
+
+FINGERPRINT = kvpl.layout_fingerprint(
+    num_layers=NUM_LAYERS,
+    num_kv_heads=NUM_KV_HEADS,
+    head_dim=HEAD_DIM,
+    dtype_tag=DTYPE_TAG,
+)
+
+
+def _recv_exactly(sock, count):
+    buf = b""
+    while len(buf) < count:
+        chunk = sock.recv(count - len(buf))
+        if not chunk:
+            return None
+        buf += chunk
+    return buf
+
+
+class _RecordingWorker:
+    """A control-plane listener that records the plan the controller sends.
+
+    The controller arms the receiver and fires each sender over the framed
+    ``ControlRequest`` wire at the address the work unit registered, and
+    returns once every worker has acked. Acking without touching a TPU is
+    enough to get the whole plan out of it.
+    """
+
+    def __init__(self):
+        self._server = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        self._server.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        self._server.bind(("127.0.0.1", 0))
+        self._server.listen(16)
+        self._server.settimeout(0.2)
+        self.address = f"127.0.0.1:{self._server.getsockname()[1]}"
+        self.requests = []
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._serve, daemon=True)
+        self._thread.start()
+
+    def _serve(self):
+        while not self._stop.is_set():
+            try:
+                conn, _ = self._server.accept()
+            except socket.timeout:
+                continue
+            except OSError:
+                return
+            with conn:
+                try:
+                    header = _recv_exactly(conn, 4)
+                    if header is None:
+                        continue
+                    payload = _recv_exactly(conn,
+                                            int.from_bytes(header, "big"))
+                    if payload is None:
+                        continue
+                    req = raiden_service_pb2.ControlRequest()
+                    req.ParseFromString(payload)
+                    self.requests.append(req)
+                    body = raiden_service_pb2.ControlResponse(
+                        success=True).SerializeToString()
+                    conn.sendall(len(body).to_bytes(4, "big") + body)
+                except OSError:
+                    pass
+
+    def close(self):
+        self._stop.set()
+        self._thread.join(timeout=5)
+        self._server.close()
+
+    @property
+    def start_transfer(self):
+        """The single START_TRANSFER this worker was sent."""
+        commands = [
+            req.start_transfer_request for req in self.requests
+            if req.command == raiden_service_pb2.ControlRequest.
+            COMMAND_START_TRANSFER
+        ]
+        assert len(commands) == 1, f"expected 1 START_TRANSFER, got {commands}"
+        return commands[0]
+
+
+def _find_sidecar_binary():
+    """Env var, then $PATH, then the Bazel output of a Raiden checkout."""
+    candidates = [os.environ.get(_SIDECAR_ENV), shutil.which(_SIDECAR_BINARY)]
+    import tpu_sync  # Raiden is a namespace package, so __file__ is None.
+    for entry in list(getattr(tpu_sync, "__path__", ())):
+        candidates.append(
+            os.path.join(os.path.dirname(entry), "bazel-bin", "tpu_sync",
+                         "kv_cache", "reshard", _SIDECAR_BINARY))
+    for candidate in candidates:
+        if candidate and os.access(candidate, os.X_OK):
+            return candidate
+    return None
+
+
+@pytest.fixture(scope="module")
+def controller_address():
+    """A reshard control plane, shared by every plan test in this module."""
+    binary = _find_sidecar_binary()
+    if binary is None:
+        pytest.skip(
+            f"No executable {_SIDECAR_BINARY}: build "
+            f"//tpu_sync/kv_cache/reshard:{_SIDECAR_BINARY} in a Raiden "
+            f"checkout or set ${_SIDECAR_ENV}")
+
+    handle, ready_file = tempfile.mkstemp(prefix="reshard_", suffix=".ready")
+    os.close(handle)
+    os.unlink(ready_file)
+    process = subprocess.Popen([
+        binary, "--port=0", "--advertise-host=127.0.0.1",
+        f"--ready-file={ready_file}"
+    ])
+    try:
+        deadline = time.monotonic() + 60.0
+        ready = None
+        while ready is None and time.monotonic() < deadline:
+            assert process.poll() is None, (
+                f"sidecar exited with {process.returncode} before binding")
+            try:
+                with open(ready_file, "r") as f:
+                    line = f.read().strip()
+                if line:
+                    ready = json.loads(line)
+            except (FileNotFoundError, json.JSONDecodeError):
+                time.sleep(0.05)
+        assert ready is not None, "sidecar never published its ready file"
+        yield ready["address"]
+    finally:
+        process.terminate()
+        process.wait(timeout=30)
+        if os.path.exists(ready_file):
+            os.unlink(ready_file)
+
+
+def _geometry(*, tp, rank, page_tokens, head_groups=HEAD_GROUPS):
+    return kvpl.AttentionKVGeometry(
+        num_layers=NUM_LAYERS,
+        num_blocks=NUM_BLOCKS,
+        page_tokens=page_tokens,
+        head_groups=head_groups,
+        head_groups_local=head_groups // tp,
+        packing=PACKING,
+        padded_head_dim=HEAD_DIM,
+        dtype_bits=DTYPE_BITS,
+        transfer_rank=rank,
+        transfer_parallelism=tp,
+        dtype_tag=DTYPE_TAG,
+    )
+
+
+class _Plan:
+    """The dispatched plan, read back off the worker listeners.
+
+    The receiver is sent every source's schedule keyed by that source's
+    ordinal among the ranks feeding it; each sender is sent its own schedule
+    under key 0. Both views come from the controller, so the fields below are
+    its arithmetic, not a second copy of the lowering's.
+    """
+
+    def __init__(self, dst_worker, src_workers, src_units):
+        receiver = dst_worker.start_transfer
+        self.src_units = [
+            _to_raiden_id(unit) for unit in receiver.src_units
+        ]
+        group = receiver.pool_groups[0]
+        self.dst_device_block_ids = list(group.dst_device_block_ids)
+        self.dst_expected_extent_bytes = list(group.dst_expected_extent_bytes)
+        self.transfer_pool_indices = list(receiver.transfer_pool_indices)
+        self.expected_block_count = receiver.expected_block_count
+
+        # A sender that owns none of this destination's heads is dropped from
+        # the plan and never dispatched.
+        self.shard_push_schedules = {}
+        for unit, worker in zip(src_units, src_workers):
+            if not worker.requests:
+                continue
+            schedules = worker.start_transfer.shard_push_schedules
+            self.shard_push_schedules[unit] = schedules
+
+        # Recover the receiver's key for each sender by matching the schedule
+        # it was armed with against the one that sender was fired with. That
+        # key is what the receiver scatters a push under, so it is the field a
+        # wrong source ordinal corrupts silently.
+        self.src_schedule_keys = {}
+        for unit, schedules in self.shard_push_schedules.items():
+            blob = schedules[0].SerializeToString()
+            for key, armed in receiver.shard_push_schedules.items():
+                if armed.SerializeToString() == blob:
+                    self.src_schedule_keys[unit] = key
+                    break
+
+    @property
+    def entries(self):
+        for schedules in self.shard_push_schedules.values():
+            for schedule in schedules.values():
+                yield from schedule.entries
+
+
+def _to_raiden_id(proto):
+    return raiden_controller.RaidenId(
+        job_name=proto.job_name,
+        job_replica_id=proto.job_replica_id,
+        data_name=proto.data_name,
+        data_replica_idx=proto.data_replica_idx,
+    )
+
+
+_REQUEST_COUNTER = [0]
+
+
+def _plan_one_destination(
+    controller_address,
+    *,
+    num_tokens,
+    src_tp,
+    dst_tp,
+    src_page,
+    dst_page,
+    dst_rank,
+    src_fingerprint=FINGERPRINT,
+    dst_fingerprint=FINGERPRINT,
+    workers_out=None,
+):
+    """Registers both meshes and drives the plan for one decode rank."""
+    facade = raiden_controller.RaidenControllerClientFacade(controller_address)
+    blocks = ReshardRequestBlockClient(controller_address)
+
+    src_geoms = [
+        _geometry(tp=src_tp, rank=r, page_tokens=src_page)
+        for r in range(src_tp)
+    ]
+    dst_geoms = [
+        _geometry(tp=dst_tp, rank=d, page_tokens=dst_page)
+        for d in range(dst_tp)
+    ]
+
+    _REQUEST_COUNTER[0] += 1
+    generation = _REQUEST_COUNTER[0]
+
+    src_workers = [_RecordingWorker() for _ in src_geoms]
+    dst_workers = [_RecordingWorker() for _ in dst_geoms]
+    if workers_out is not None:
+        workers_out.extend(src_workers + dst_workers)
+
+    try:
+        # The work-unit directory is keyed by RaidenId and the sidecar outlives
+        # any one test, so the geometry goes in the id: a later test's TP2
+        # source must not inherit a TP4 registration.
+        src_units = []
+        for rank, geometry in enumerate(src_geoms):
+            unit = raiden_controller.RaidenId(
+                job_name="prefill",
+                job_replica_id=f"engine-tp{src_tp}p{src_page}-rank{rank}",
+                data_name="kv.fa",
+                data_replica_idx=0,
+            )
+            src_units.append(unit)
+            facade.register_work_unit(
+                unit,
+                [f"10.0.0.{rank + 1}:8000"],
+                control_plane_rpc_address=src_workers[rank].address,
+                pool_manifest=kvpl.build_pool_manifest(geometry),
+                layout_fingerprint=src_fingerprint,
+                page_tokens=geometry.page_tokens,
+                transfer_parallelism=geometry.transfer_parallelism,
+                transfer_rank=geometry.transfer_rank,
+            )
+
+        dst_units = []
+        for rank, geometry in enumerate(dst_geoms):
+            unit = raiden_controller.RaidenId(
+                job_name="decode",
+                job_replica_id=f"engine-tp{dst_tp}p{dst_page}-rank{rank}",
+                data_name="kv.fa",
+                data_replica_idx=0,
+            )
+            dst_units.append(unit)
+            facade.register_work_unit(
+                unit,
+                [f"10.1.0.{rank + 1}:8000"],
+                control_plane_rpc_address=dst_workers[rank].address,
+                pool_manifest=kvpl.build_pool_manifest(geometry),
+                layout_fingerprint=dst_fingerprint,
+                page_tokens=geometry.page_tokens,
+                transfer_parallelism=geometry.transfer_parallelism,
+                transfer_rank=geometry.transfer_rank,
+            )
+
+        # One (req_id, uuid) pair per destination rank: a registration is keyed
+        # (req_id, unit) and its spans address a single destination's byte
+        # space. The generation keeps tests from colliding in the registry.
+        req_id = f"request-{generation}-d{dst_rank}"
+        uuid = 1000 * generation + dst_rank
+        src_blocks_per_rank = math.ceil(num_tokens / src_page)
+        src_block_ids = [[
+            10 + rank * src_blocks_per_rank + i
+            for i in range(src_blocks_per_rank)
+        ] for rank in range(src_tp)]
+
+        for rank, geometry in enumerate(src_geoms):
+            entries = kvpl.build_request_span_entries(
+                geometry,
+                dst_geoms[dst_rank],
+                src_block_ids=src_block_ids[rank],
+                num_tokens=num_tokens,
+            )
+            blocks.register_request_blocks(
+                req_id,
+                uuid,
+                src_units[rank],
+                src_block_ids[rank],
+                pool_spans=entries,
+            )
+
+        dst_ids = list(range(40, 40 + math.ceil(num_tokens / dst_page)))
+        facade.coordinate_transfer(
+            src_units=src_units,
+            dst_units=[dst_units[dst_rank]],
+            req_id=req_id,
+            use_block_chunks=True,
+            is_sender=True,
+            uuid=uuid,
+            src_controller_address=controller_address,
+            dst_mem_type=raiden_controller.RaidenMemoryType.HBM,
+            dst_device_block_ids=dst_ids,
+            num_tokens=num_tokens,
+            transfer_pool_tags=[kvpl.KV_POOL_TAG],
+        )
+        plan = _Plan(dst_workers[dst_rank], src_workers, src_units)
+    finally:
+        if workers_out is None:
+            for worker in src_workers + dst_workers:
+                worker.close()
+    return controller_address, dst_workers, src_units, dst_units, dst_ids, plan
+
+
+def _scheduled_bytes(plan):
+    """Sums the size field of every emitted shard-push entry."""
+    return sum(entry.size_bytes * max(entry.count, 1)
+               for entry in plan.entries)
+
+
+# --- end-to-end plans --------------------------------------------------------
+
+
+@pytest.mark.parametrize("dst_rank", [0, 1])
+def test_tp4_to_tp2_differing_page_sizes_plans_with_exact_bytes(
+        controller_address, dst_rank):
+    """The end-to-end case: the plan builds and the byte accounting is exact."""
+    num_tokens = 256
+    _, _, src_units, _, dst_ids, plan = _plan_one_destination(
+        controller_address,
+        num_tokens=num_tokens,
+        src_tp=4,
+        dst_tp=2,
+        src_page=128,
+        dst_page=64,
+        dst_rank=dst_rank,
+    )
+
+    dst_per_token = (HEAD_GROUPS // 2) * GROUP_BYTES  # 2048
+    src_per_token = (HEAD_GROUPS // 4) * GROUP_BYTES  # 1024
+    assert dst_per_token == 2 * src_per_token
+
+    # Every byte of this decode rank's slice arrives exactly once.
+    assert _scheduled_bytes(plan) == num_tokens * dst_per_token
+    assert sum(plan.dst_expected_extent_bytes) == num_tokens * dst_per_token
+
+    # Only the two prefill ranks owning this decode rank's heads participate;
+    # the other two registered empty spans and were dropped.
+    expected = [src_units[2 * dst_rank], src_units[2 * dst_rank + 1]]
+    assert plan.src_units == expected
+
+    assert plan.dst_device_block_ids == dst_ids
+    assert plan.transfer_pool_indices == list(range(NUM_LAYERS))
+
+    # One shard per work unit, so dst_shard_idx is a constant, not a route.
+    for shards in plan.shard_push_schedules.values():
+        assert list(shards) == [0]
+        for schedule in shards.values():
+            assert {entry.dst_shard_idx for entry in schedule.entries} == {0}
+
+
+def test_both_decode_ranks_together_cover_the_whole_request(
+        controller_address):
+    """Summed over decode ranks, the plans move the full KV footprint."""
+    num_tokens = 256
+    total = sum(
+        _scheduled_bytes(
+            _plan_one_destination(controller_address,
+                                  num_tokens=num_tokens,
+                                  src_tp=4,
+                                  dst_tp=2,
+                                  src_page=128,
+                                  dst_page=64,
+                                  dst_rank=d)[5]) for d in range(2))
+    assert total == num_tokens * HEAD_GROUPS * GROUP_BYTES
+
+
+def test_partial_final_destination_page_is_allowed(controller_address):
+    """num_tokens need not be a multiple of the destination page size."""
+    num_tokens = 200  # 200 = 3*64 + 8, and 200 = 1*128 + 72
+    _, _, _, _, dst_ids, plan = _plan_one_destination(
+        controller_address,
+        num_tokens=num_tokens,
+        src_tp=4,
+        dst_tp=2,
+        src_page=128,
+        dst_page=64,
+        dst_rank=0,
+    )
+    assert len(dst_ids) == 4
+    dst_per_token = (HEAD_GROUPS // 2) * GROUP_BYTES
+    assert _scheduled_bytes(plan) == num_tokens * dst_per_token
+    # Only the last page is partial.
+    extents = plan.dst_expected_extent_bytes
+    assert extents[:-1] == [64 * dst_per_token] * 3
+    assert extents[-1] == 8 * dst_per_token
+
+
+# --- negative and structural checks -----------------------------------------
+
+
+def test_fingerprint_mismatch_is_rejected_before_any_worker_rpc(
+        controller_address):
+    workers = []
+    try:
+        with pytest.raises(RuntimeError, match="fingerprint"):
+            _plan_one_destination(
+                controller_address,
+                num_tokens=256,
+                src_tp=4,
+                dst_tp=2,
+                src_page=128,
+                dst_page=64,
+                dst_rank=0,
+                dst_fingerprint="a-different-model",
+                workers_out=workers,
+            )
+        # Nothing was armed and nothing was fired: planning rejects the pair
+        # before a single worker hears about the transfer.
+        assert [worker.requests for worker in workers] == [[]] * len(workers)
+    finally:
+        for worker in workers:
+            worker.close()
+
+
+def test_fingerprint_ignores_tp_degree_and_page_size():
+    """The two axes this work makes heterogeneous must not be in it."""
+    base = dict(num_layers=NUM_LAYERS,
+                num_kv_heads=NUM_KV_HEADS,
+                head_dim=HEAD_DIM,
+                dtype_tag=DTYPE_TAG)
+    assert kvpl.layout_fingerprint(**base) == FINGERPRINT
+    assert kvpl.layout_fingerprint(**{**base, "num_layers": 5}) != FINGERPRINT
+    assert kvpl.layout_fingerprint(**{**base, "head_dim": 64}) != FINGERPRINT
+    assert kvpl.layout_fingerprint(**{
+        **base, "dtype_tag": "float8_e4m3"
+    }) != FINGERPRINT
+
+
+def test_contributing_src_ranks_partition_by_head_range():
+    src = [_geometry(tp=4, rank=r, page_tokens=128) for r in range(4)]
+    dst = [_geometry(tp=2, rank=d, page_tokens=64) for d in range(2)]
+    assert kvpl.contributing_src_ranks(src, dst[0]) == [0, 1]
+    assert kvpl.contributing_src_ranks(src, dst[1]) == [2, 3]
+
+
+def test_head_reshard_emits_strided_spans():
+    """TP4 -> TP2 interleaves, so spans must carry count and strides."""
+    src = _geometry(tp=4, rank=1, page_tokens=128)
+    dst = _geometry(tp=2, rank=0, page_tokens=64)
+    registration = kvpl.build_request_spans(src,
+                                            dst,
+                                            src_block_ids=[10, 11],
+                                            num_tokens=256)
+    assert registration.dst_space_version == 0
+    assert registration.declared_bytes == 256 * (HEAD_GROUPS //
+                                                 4) * GROUP_BYTES
+    # Runs are bounded by both page sizes: 256 tokens / min(128, 64) = 4.
+    assert len(registration.spans) == 4
+    for span in registration.spans:
+        assert span.count == 64
+        assert span.size_bytes == (HEAD_GROUPS // 4) * GROUP_BYTES
+        assert span.src_stride_bytes == (HEAD_GROUPS // 4) * GROUP_BYTES
+        assert span.dst_stride_bytes == (HEAD_GROUPS // 2) * GROUP_BYTES
+        # Rank 1 is the upper half of decode rank 0's token slot.
+        assert span.dst_offset_bytes % span.dst_stride_bytes == (
+            HEAD_GROUPS // 4) * GROUP_BYTES
+
+
+def test_symmetric_geometry_coalesces_to_contiguous_spans():
+    """Equal TP and page size must not pay the per-token entry cost."""
+    src = _geometry(tp=2, rank=0, page_tokens=64)
+    dst = _geometry(tp=2, rank=0, page_tokens=64)
+    registration = kvpl.build_request_spans(src,
+                                            dst,
+                                            src_block_ids=[10, 11, 12, 13],
+                                            num_tokens=256)
+    assert len(registration.spans) == 4
+    for span in registration.spans:
+        assert span.count == 1
+        assert span.src_stride_bytes == 0
+        assert span.dst_stride_bytes == 0
+        assert span.size_bytes == 64 * (HEAD_GROUPS // 2) * GROUP_BYTES
+
+
+def test_symmetric_tp_with_differing_page_size_still_plans(controller_address):
+    """Isolates the page-size axis from the TP axis."""
+    num_tokens = 256
+    _, _, src_units, _, _, plan = _plan_one_destination(
+        controller_address,
+        num_tokens=num_tokens,
+        src_tp=2,
+        dst_tp=2,
+        src_page=128,
+        dst_page=64,
+        dst_rank=1,
+    )
+    assert plan.src_units == [src_units[1]]
+    assert _scheduled_bytes(plan) == num_tokens * (HEAD_GROUPS //
+                                                   2) * GROUP_BYTES
+
+
+def test_nonlinear_alignment_padding_is_rejected():
+    """F3: padding is computed on the local head count, so it need not scale."""
+    src = _geometry(tp=4, rank=0, page_tokens=128, head_groups=8)
+    dst = _geometry(tp=2, rank=0, page_tokens=64, head_groups=12)
+    with pytest.raises(ValueError, match="total head-group extent"):
+        kvpl.head_group_overlap(src, dst)
+
+
+def test_non_contributing_rank_registers_no_spans():
+    src = _geometry(tp=4, rank=3, page_tokens=128)
+    dst = _geometry(tp=2, rank=0, page_tokens=64)
+    assert kvpl.build_request_span_entries(src,
+                                           dst,
+                                           src_block_ids=[10, 11],
+                                           num_tokens=256) == []
+    with pytest.raises(ValueError, match="owns no heads"):
+        kvpl.build_request_spans(src,
+                                 dst,
+                                 src_block_ids=[10, 11],
+                                 num_tokens=256)
+
+
+def test_pool_manifest_is_one_dense_pool_per_layer():
+    geometry = _geometry(tp=4, rank=0, page_tokens=128)
+    pools = kvpl.build_pool_manifest(geometry)
+    assert len(pools) == NUM_LAYERS
+    for layer_idx, pool in enumerate(pools):
+        pool.validate()
+        assert pool.tag == kvpl.KV_POOL_TAG
+        assert pool.storage_index == layer_idx
+        assert pool.dtype_tag == DTYPE_TAG
+        # A local shard is dense: live bytes fill the whole block stride.
+        assert pool.live_bytes_per_block == pool.block_stride_bytes
+        assert pool.block_stride_bytes == 128 * (HEAD_GROUPS //
+                                                 4) * GROUP_BYTES
+
+
+# --- source schedule keys ----------------------------------------------------
+#
+# The receiver picks which source's schedule to scatter a push with using the
+# sender's Raiden node_id alone, and the controller keys those schedules by the
+# source's ordinal among the ranks feeding that destination. If the connector
+# leaves node_id at Raiden's default of 0, every rank's bytes land in the first
+# rank's head slots: the plan still validates and the byte totals are still
+# exact, so nothing errors and the model emits garbage. These lock our
+# derivation against the controller's own.
+
+
+@pytest.mark.parametrize("dst_rank", [0, 1])
+def test_schedule_key_matches_the_controller_tp4_to_tp2(
+        controller_address, dst_rank):
+    _, _, src_units, _, _, plan = _plan_one_destination(
+        controller_address,
+        num_tokens=256,
+        src_tp=4,
+        src_page=128,
+        dst_tp=2,
+        dst_page=64,
+        dst_rank=dst_rank,
+    )
+    for rank, unit in enumerate(src_units):
+        if unit not in plan.src_schedule_keys:
+            continue  # contributes nothing to this destination
+        assert plan.src_schedule_keys[unit] == kvpl.source_schedule_key(
+            rank, 4, 2)
+
+
+def test_schedule_key_matches_the_controller_tp4_to_tp1(controller_address):
+    _, _, src_units, _, _, plan = _plan_one_destination(
+        controller_address,
+        num_tokens=256,
+        src_tp=4,
+        src_page=128,
+        dst_tp=1,
+        dst_page=64,
+        dst_rank=0,
+    )
+    # Every rank contributes, so the ordinal is the global rank.
+    assert [plan.src_schedule_keys[unit] for unit in src_units] == [0, 1, 2, 3]
+    for rank, unit in enumerate(src_units):
+        assert plan.src_schedule_keys[unit] == kvpl.source_schedule_key(
+            rank, 4, 1)
+
+
+@pytest.mark.parametrize("src_tp,dst_tp", [(1, 1), (2, 2), (4, 4), (4, 2),
+                                           (4, 1), (2, 1), (1, 2), (2, 4)])
+def test_schedule_key_is_the_ordinal_among_contributors(src_tp, dst_tp):
+    """Derived the same way the controller derives it, for every shape."""
+    src = [
+        _geometry(tp=src_tp, rank=r, page_tokens=128) for r in range(src_tp)
+    ]
+    for dst_rank in range(dst_tp):
+        dst = _geometry(tp=dst_tp, rank=dst_rank, page_tokens=64)
+        contributors = kvpl.contributing_src_ranks(src, dst)
+        for ordinal, rank in enumerate(contributors):
+            assert kvpl.source_schedule_key(rank, src_tp, dst_tp) == ordinal
+
+
+def test_symmetric_geometry_keeps_the_default_key():
+    """One source per destination means the ordinal is always 0."""
+    for tp in (1, 2, 4):
+        for rank in range(tp):
+            assert kvpl.source_schedule_key(rank, tp, tp) == 0
+
+
+def test_dst_uuid_separates_a_requests_destinations():
+    """A source keys its active plan by uuid, so one per destination rank.
+
+    Reusing one uuid makes every source that feeds more than one destination
+    reject all but the first with ALREADY_EXISTS -- the remaining ranks then
+    wait forever on a push that was never armed.
+    """
+    base = 0x3_FFFF_FFFF_FFFF
+    keys = {kvpl.dst_uuid(base, rank) for rank in range(8)}
+    assert len(keys) == 8
+
+
+def test_dst_uuid_stays_within_the_uuids_width():
+    """`get_uuid` trims to 50 bits so vLLM's encoder and Go agree on it."""
+    for base in (0, 1, (1 << 50) - 1):
+        for rank in range(8):
+            tagged = kvpl.dst_uuid(base, rank)
+            assert 0 <= tagged <= max(base, (1 << 50) - 1)
+            assert tagged.bit_length() <= 50
+
+
+def test_dst_uuid_keeps_one_request_recognisable():
+    """Only the low bits move, so sibling transfers stay visibly related."""
+    base = 0x2_ABCD_EF01_2345
+    for rank in range(4):
+        assert kvpl.dst_uuid(base, rank) >> 8 == base >> 8
+
+
+def test_dst_uuid_rejects_a_rank_it_cannot_encode():
+    with pytest.raises(ValueError):
+        kvpl.dst_uuid(1 << 40, 256)

--- a/tests/distributed/test_tpu_raiden_connector_controller.py
+++ b/tests/distributed/test_tpu_raiden_connector_controller.py
@@ -1,0 +1,605 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""The connector's controller path, with the controller mocked.
+
+Covers the orchestration only -- that the right units, spans, tags and block
+ids reach the controller, and that a request is reported finished exactly when
+every destination rank's transfer is. Whether those spans tile the
+destination's byte space exactly is the job of
+`tests/distributed/test_kv_pool_layout.py`, which drives a real
+`RaidenController`.
+
+The symmetric fall-through is asserted here too: with no `src_units` in the
+handshake the connector must still take the index-matched `start_read` path,
+so a producer and a consumer can be upgraded independently.
+"""
+
+import os
+import unittest
+from concurrent.futures import ThreadPoolExecutor, wait
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+pytest.importorskip("tpu_sync.rpc.raiden_controller")
+
+from tpu_inference.distributed import kv_pool_layout as kvpl  # noqa: E402
+from tpu_inference.distributed import tpu_raiden_connector as trc  # noqa: E402
+
+CONTROLLER = "10.0.0.1:9700"
+NUM_LAYERS = 4
+NUM_BLOCKS = 64
+HEAD_GROUPS = 8
+PACKING = 2
+HEAD_DIM = 128
+DTYPE_BITS = 16
+DTYPE_TAG = "bfloat16"
+
+
+def _geometry(*, rank: int, parallelism: int, page_tokens: int):
+    return kvpl.AttentionKVGeometry(
+        num_layers=NUM_LAYERS,
+        num_blocks=NUM_BLOCKS,
+        page_tokens=page_tokens,
+        head_groups=HEAD_GROUPS,
+        head_groups_local=HEAD_GROUPS // parallelism,
+        packing=PACKING,
+        padded_head_dim=HEAD_DIM,
+        dtype_bits=DTYPE_BITS,
+        transfer_rank=rank,
+        transfer_parallelism=parallelism,
+        dtype_tag=DTYPE_TAG,
+    )
+
+
+class _RecordingFacade:
+    """Stands in for `RaidenControllerClientFacade`."""
+
+    def __init__(self, address, log):
+        self.address = address
+        self._log = log
+
+    def coordinate_transfer(self, **kwargs):
+        self._log.append(("coordinate", kwargs))
+        return True
+
+
+class _RecordingBlockClient:
+    """Stands in for `ReshardRequestBlockClient`.
+
+    Shares the caller's log with `_RecordingFacade` so the declaration and
+    the coordination it precedes stay in one ordered sequence.
+    """
+
+    def __init__(self, address, log):
+        self.address = address
+        self._log = log
+
+    def register_request_blocks(self,
+                                req_id,
+                                uuid,
+                                unit,
+                                block_ids,
+                                pool_spans=()):
+        self._log.append(
+            ("register", req_id, unit, tuple(block_ids), tuple(pool_spans)))
+
+
+class MockVllmConfig:
+
+    def __init__(self,
+                 *,
+                 is_producer: bool,
+                 block_size: int,
+                 tp_size: int,
+                 extra_config: dict | None = None):
+        self.kv_transfer_config = MagicMock()
+        self.kv_transfer_config.is_kv_producer = is_producer
+        # Real dict semantics, not a MagicMock: the connector reads its
+        # options through `get_from_extra_config(key, default)` and has to see
+        # the default when a key is absent.
+        self.kv_transfer_config.kv_connector_extra_config = dict(extra_config
+                                                                 or {})
+        self.kv_transfer_config.get_from_extra_config = (
+            self.kv_transfer_config.kv_connector_extra_config.get)
+        self.cache_config = MagicMock()
+        self.cache_config.block_size = block_size
+        self.model_config = MagicMock()
+        self.model_config.max_model_len = 4096
+        self.parallel_config = MagicMock()
+        self.parallel_config.tensor_parallel_size = tp_size
+
+
+def _scheduler(*,
+               is_producer,
+               block_size=128,
+               tp_size=4,
+               env=None,
+               extra_config=None):
+    with patch.dict(os.environ, env or {}, clear=False):
+        return trc.TPUConnectorScheduler(
+            MockVllmConfig(is_producer=is_producer,
+                           block_size=block_size,
+                           tp_size=tp_size,
+                           extra_config=extra_config))
+
+
+def _finished_request(req_id="req-0", num_computed_tokens=261):
+    request = MagicMock()
+    request.request_id = req_id
+    request.status = trc.RequestStatus.FINISHED_LENGTH_CAPPED
+    request.num_computed_tokens = num_computed_tokens
+    return request
+
+
+class TestSchedulerHandshake(unittest.TestCase):
+
+    def test_symmetric_handshake_is_unchanged_without_a_controller(self):
+        scheduler = _scheduler(is_producer=True,
+                               env={"TPU_KV_CONTROLLER_ADDRESS": ""})
+        self.assertFalse(scheduler.use_controller)
+        _, params = scheduler.request_finished(_finished_request(),
+                                               [10, 11, 12])
+        self.assertEqual(
+            set(params),
+            {"uuid", "remote_block_ids", "remote_host", "remote_port"})
+
+    def test_controller_handshake_lists_every_source_rank(self):
+        scheduler = _scheduler(is_producer=True,
+                               tp_size=4,
+                               env={
+                                   "TPU_KV_CONTROLLER_ADDRESS": CONTROLLER,
+                                   "TPU_KV_DECODE_TP_SIZE": "2",
+                               })
+        geometry = _geometry(rank=0, parallelism=4, page_tokens=128)
+        with patch.object(trc.dist_utils,
+                          "get_local_kv_geometry",
+                          return_value=kvpl.geometry_to_dict(geometry)):
+            delay, params = scheduler.request_finished(_finished_request(),
+                                                       [10, 11, 12])
+
+        self.assertTrue(delay)
+        # Every source rank is listed, contributing or not: the controller
+        # requires transfer_rank contiguous from zero.
+        self.assertEqual(
+            [unit["data_replica_idx"] for unit in params["src_units"]],
+            [0, 1, 2, 3])
+        self.assertEqual(params["src_controller"], CONTROLLER)
+        # 261 computed tokens at page 128: the trailing partial block is
+        # dropped, so exactly two whole source pages are transferred.
+        self.assertEqual(params["remote_block_ids"], [10, 11])
+        self.assertEqual(params["num_tokens"], 2 * 128)
+        # One req_id per *destination* rank: the controller's registration
+        # store is keyed (req_id, unit), so reusing one would have the second
+        # destination's spans overwrite the first's.
+        self.assertEqual(params["dst_req_ids"], ["req-0#d0", "req-0#d1"])
+        self.assertEqual(kvpl.geometry_from_dict(params["src_geometry"]),
+                         geometry)
+
+    def test_two_engines_of_a_role_register_distinct_units(self):
+        # Two decode engines of the same parallelism both hold ranks 0..TP-1,
+        # so rank alone cannot separate them: without the instance tag they
+        # register byte-identical ids, the controller's registry keeps only
+        # the last endpoints, and every push lands on one engine while the
+        # other's loads never complete.
+        first = kvpl.engine_instance_tag("10.0.1.1", 7200)
+        second = kvpl.engine_instance_tag("10.0.2.2", 7200)
+        self.assertNotEqual(first, second)
+        for rank in range(4):
+            a = kvpl.work_unit_id(trc._DECODE_ROLE, rank, first)
+            b = kvpl.work_unit_id(trc._DECODE_ROLE, rank, second)
+            self.assertNotEqual(a, b)
+            # The controller keys push schedules by int(job_replica_id), so
+            # the tag must never leak into that field.
+            for unit in (a, b):
+                self.assertEqual(int(unit.job_replica_id), rank)
+                self.assertEqual(unit.data_replica_idx, rank)
+
+    def test_handshake_units_match_what_the_worker_registers(self):
+        # The scheduler names the producer's units in the handshake while its
+        # workers register them from another process. Both derive the tag from
+        # the same configuration, so they must agree without exchanging one.
+        env = {
+            "TPU_KV_CONTROLLER_ADDRESS": CONTROLLER,
+            "TPU_KV_TRANSFER_PORT": "7100",
+        }
+        scheduler = _scheduler(is_producer=True, tp_size=4, env=env)
+        geometry = _geometry(rank=0, parallelism=4, page_tokens=128)
+        with patch.dict(os.environ, env, clear=False), \
+             patch.object(trc.dist_utils, "get_host_ip",
+                          return_value="10.0.3.3"), \
+             patch.object(trc.dist_utils, "get_local_kv_geometry",
+                          return_value=kvpl.geometry_to_dict(geometry)):
+            scheduler.instance_tag = kvpl.engine_instance_tag(
+                trc.dist_utils.get_host_ip(),
+                trc.dist_utils.get_kv_transfer_port())
+            _, params = scheduler.request_finished(_finished_request(),
+                                                   [10, 11, 12])
+            worker_tag = kvpl.engine_instance_tag(
+                trc.dist_utils.get_host_ip(),
+                int(trc.dist_utils.get_kv_transfer_port()))
+
+        self.assertEqual(
+            [kvpl.unit_from_dict(unit) for unit in params["src_units"]], [
+                kvpl.work_unit_id(trc._PREFILL_ROLE, rank, worker_tag)
+                for rank in range(4)
+            ])
+
+    def test_missing_worker_geometry_is_a_loud_error(self):
+        scheduler = _scheduler(is_producer=True,
+                               env={"TPU_KV_CONTROLLER_ADDRESS": CONTROLLER})
+        with patch.object(trc.dist_utils,
+                          "get_local_kv_geometry",
+                          return_value=None):
+            with self.assertRaisesRegex(RuntimeError, "never published"):
+                scheduler.request_finished(_finished_request(), [10, 11, 12])
+
+    def test_decode_rank_count_mismatch_is_rejected(self):
+        scheduler = _scheduler(is_producer=False,
+                               tp_size=2,
+                               env={"TPU_KV_CONTROLLER_ADDRESS": CONTROLLER})
+        params = {
+            "src_units": [{}, {}, {}, {}],
+            "dst_req_ids": ["a", "b", "c", "d"],
+        }
+        with self.assertRaisesRegex(ValueError, r'"decode_tp_size": 2'):
+            scheduler._controller_load_fields(params)
+
+    def test_decode_tp_size_is_read_from_the_connector_extra_config(self):
+        """The peer's TP degree is a connector option, not a TPU-only env var.
+
+        It rides in `--kv-transfer-config` alongside `kv_connector` and
+        `kv_role`, so a recipe written for another backend's connector ports
+        without moving settings into the environment.
+        """
+        scheduler = _scheduler(is_producer=True,
+                               tp_size=4,
+                               env={
+                                   "TPU_KV_CONTROLLER_ADDRESS": CONTROLLER,
+                                   "TPU_KV_DECODE_TP_SIZE": "",
+                               },
+                               extra_config={"decode_tp_size": 2})
+        self.assertEqual(scheduler.num_decode_ranks, 2)
+
+        geometry = _geometry(rank=0, parallelism=4, page_tokens=128)
+        with patch.object(trc.dist_utils,
+                          "get_local_kv_geometry",
+                          return_value=kvpl.geometry_to_dict(geometry)):
+            _, params = scheduler.request_finished(_finished_request(),
+                                                   [10, 11, 12])
+        # One destination request id per decode rank, from the declared width.
+        self.assertEqual(len(params["dst_req_ids"]), 2)
+
+    def test_extra_config_wins_over_the_environment_fallback(self):
+        scheduler = _scheduler(is_producer=True,
+                               tp_size=4,
+                               env={
+                                   "TPU_KV_CONTROLLER_ADDRESS": CONTROLLER,
+                                   "TPU_KV_DECODE_TP_SIZE": "8",
+                               },
+                               extra_config={"decode_tp_size": 2})
+        self.assertEqual(scheduler.num_decode_ranks, 2)
+
+    def test_environment_fallback_still_applies_when_unset(self):
+        scheduler = _scheduler(is_producer=True,
+                               tp_size=4,
+                               env={
+                                   "TPU_KV_CONTROLLER_ADDRESS": CONTROLLER,
+                                   "TPU_KV_DECODE_TP_SIZE": "8",
+                               },
+                               extra_config={})
+        self.assertEqual(scheduler.num_decode_ranks, 8)
+
+    def test_symmetric_is_assumed_when_neither_is_set(self):
+        scheduler = _scheduler(is_producer=True,
+                               tp_size=4,
+                               env={
+                                   "TPU_KV_CONTROLLER_ADDRESS": CONTROLLER,
+                                   "TPU_KV_DECODE_TP_SIZE": "",
+                               },
+                               extra_config={})
+        self.assertEqual(scheduler.num_decode_ranks, 4)
+
+    def test_matched_tokens_follow_the_producer_not_our_page_size(self):
+        """The two sides must agree on how much prefix actually arrives.
+
+        The producer drops its own trailing partial block, so it sends
+        `round_down(len(prompt), P.block_size)`. Re-deriving that from the
+        decode block size answers differently for any prompt that is not a
+        multiple of both, and the excess would be decoded against KV nobody
+        ever wrote.
+        """
+        scheduler = _scheduler(is_producer=False,
+                               block_size=64,
+                               tp_size=1,
+                               env={"TPU_KV_CONTROLLER_ADDRESS": CONTROLLER})
+        request = MagicMock()
+        request.prompt_token_ids = [0] * 200
+        request.kv_transfer_params = {"num_tokens": 128}
+        count, is_async = scheduler.get_num_new_matched_tokens(request, 0)
+        # round_down(200, 64) would say 192; the producer only sent 128.
+        self.assertEqual(count, 128)
+        self.assertTrue(is_async)
+
+    def test_matched_tokens_round_the_producer_count_to_our_pages(self):
+        """A decode page coarser than the prefill page truncates further."""
+        scheduler = _scheduler(is_producer=False,
+                               block_size=128,
+                               tp_size=1,
+                               env={"TPU_KV_CONTROLLER_ADDRESS": CONTROLLER})
+        request = MagicMock()
+        request.prompt_token_ids = [0] * 200
+        request.kv_transfer_params = {"num_tokens": 192}
+        count, _ = scheduler.get_num_new_matched_tokens(request, 0)
+        self.assertEqual(count, 128)
+
+    def test_matched_tokens_unchanged_on_the_symmetric_path(self):
+        """No `num_tokens` in the handshake means the legacy derivation."""
+        scheduler = _scheduler(is_producer=False,
+                               block_size=128,
+                               tp_size=1,
+                               env={"TPU_KV_CONTROLLER_ADDRESS": ""})
+        request = MagicMock()
+        request.prompt_token_ids = [0] * 300
+        request.kv_transfer_params = {"uuid": 1}
+        count, _ = scheduler.get_num_new_matched_tokens(request, 0)
+        self.assertEqual(count, 256)
+
+    def test_load_without_controller_fields_falls_through(self):
+        scheduler = _scheduler(is_producer=False,
+                               env={"TPU_KV_CONTROLLER_ADDRESS": CONTROLLER})
+        self.assertEqual(scheduler._controller_load_fields({"uuid": 1}), {})
+
+
+class TestWorkerControllerPath(unittest.TestCase):
+
+    def _worker(self,
+                *,
+                dst_parallelism=2,
+                dst_page_tokens=64,
+                is_producer=False):
+        with patch.dict(os.environ, {"TPU_KV_CONTROLLER_ADDRESS": CONTROLLER},
+                        clear=False):
+            worker = trc.TPUConnectorWorker(
+                MockVllmConfig(is_producer=is_producer,
+                               block_size=dst_page_tokens,
+                               tp_size=dst_parallelism))
+        self.assertTrue(worker.use_controller)
+        worker.shard_geometries = [
+            _geometry(rank=rank,
+                      parallelism=dst_parallelism,
+                      page_tokens=dst_page_tokens)
+            for rank in range(dst_parallelism)
+        ]
+        worker.shard_units = [
+            kvpl.work_unit_id(trc._DECODE_ROLE, rank)
+            for rank in range(dst_parallelism)
+        ]
+        worker.shard_managers = [MagicMock() for _ in range(dst_parallelism)]
+        for manager in worker.shard_managers:
+            manager.poll_stats.return_value = ([], [], [])
+        worker._transfer_pool = ThreadPoolExecutor(max_workers=2)
+        self.addCleanup(worker._transfer_pool.shutdown)
+        return worker
+
+    def _load_meta(self,
+                   *,
+                   src_parallelism=4,
+                   src_page_tokens=128,
+                   num_tokens=256,
+                   dst_req_ids=("req-0#d0", "req-0#d1")):
+        src = _geometry(rank=0,
+                        parallelism=src_parallelism,
+                        page_tokens=src_page_tokens)
+        return trc.LoadMeta(
+            uuid=7,
+            local_block_ids=[100, 101, 102, 103, 104],
+            remote_block_ids=[10, 11],
+            remote_host="10.0.0.1",
+            remote_port=9100,
+            src_units=[
+                kvpl.unit_to_dict(kvpl.work_unit_id(trc._PREFILL_ROLE, rank))
+                for rank in range(src_parallelism)
+            ],
+            src_geometry=kvpl.geometry_to_dict(src),
+            src_controller=CONTROLLER,
+            num_tokens=num_tokens,
+            dst_req_ids=list(dst_req_ids),
+        )
+
+    def _run_load(self, worker, req_meta, req_id="req-0"):
+        log = []
+        with patch.object(trc, "RaidenControllerClientFacade",
+                          lambda address: _RecordingFacade(address, log)), \
+             patch.object(trc, "ReshardRequestBlockClient",
+                          lambda address: _RecordingBlockClient(address, log)):
+            worker._start_controller_load(req_id, req_meta)
+            wait(worker._loads_in_flight[req_id])
+        for future in worker._loads_in_flight[req_id]:
+            self.assertIsNone(future.exception())
+        return log
+
+    def test_one_transfer_per_destination_rank(self):
+        worker = self._worker()
+        log = self._run_load(worker, self._load_meta())
+
+        coordinations = [entry[1] for entry in log if entry[0] == "coordinate"]
+        self.assertEqual(len(coordinations), 2)
+        targeted = sorted(kwargs["dst_units"][0].data_replica_idx
+                          for kwargs in coordinations)
+        self.assertEqual(targeted, [0, 1])
+        for kwargs in coordinations:
+            # One destination unit per plan is a hard constraint of the
+            # byte-span planner, which is why a TP2 decode fans out to two
+            # calls rather than one call naming two shards.
+            self.assertEqual(len(kwargs["dst_units"]), 1)
+            self.assertEqual(kwargs["transfer_pool_tags"], [kvpl.KV_POOL_TAG])
+            # Distinct per destination: at TP4 -> TP2 each source feeds both
+            # of us, and a source rejects a second plan under a uuid it has
+            # already registered.
+            self.assertEqual(
+                kwargs["uuid"],
+                kvpl.dst_uuid(7, kwargs["dst_units"][0].data_replica_idx))
+            self.assertEqual(kwargs["src_controller_address"], CONTROLLER)
+            self.assertEqual(kwargs["num_tokens"], 256)
+            # 256 tokens at 64 tokens per destination page: the four pages
+            # those tokens actually fill, not every block vLLM allocated.
+            self.assertEqual(kwargs["dst_device_block_ids"],
+                             [100, 101, 102, 103])
+            self.assertEqual(
+                [unit.data_replica_idx for unit in kwargs["src_units"]],
+                [0, 1, 2, 3])
+
+    def test_each_destination_rank_gets_its_own_plan_uuid(self):
+        """Every source here feeds both destinations, so the uuids must differ.
+
+        A source keys its active plan by uuid and rejects a repeat with
+        ALREADY_EXISTS, which arms only the first destination and leaves the
+        second waiting on a push that never comes.
+        """
+        worker = self._worker()
+        log = self._run_load(worker, self._load_meta())
+
+        uuids = [
+            kwargs["uuid"] for entry in log if entry[0] == "coordinate"
+            for kwargs in [entry[1]]
+        ]
+        self.assertEqual(len(set(uuids)), 2)
+
+    def test_non_contributing_source_ranks_register_no_spans(self):
+        worker = self._worker()
+        log = self._run_load(worker, self._load_meta())
+
+        registrations = [entry for entry in log if entry[0] == "register"]
+        # Every source rank registers for every destination rank: a listed
+        # unit with no registration is "Missing producer block registration".
+        self.assertEqual(len(registrations), 8)
+        by_target = {}
+        for _, req_id, unit, block_ids, spans in registrations:
+            self.assertEqual(block_ids, (10, 11))
+            by_target.setdefault(req_id, {})[unit.data_replica_idx] = spans
+        # TP4 -> TP2 on the head axis: {0,1} feed d0 and {2,3} feed d1.
+        self.assertEqual(
+            {rank
+             for rank, spans in by_target["req-0#d0"].items() if spans},
+            {0, 1})
+        self.assertEqual(
+            {rank
+             for rank, spans in by_target["req-0#d1"].items() if spans},
+            {2, 3})
+
+    def test_request_is_finished_only_when_every_rank_lands(self):
+        worker = self._worker()
+        self._run_load(worker, self._load_meta())
+
+        # One rank's bytes have landed; the request is not loaded yet.
+        worker.shard_managers[0].poll_stats.return_value = ([], ["req-0#d0"],
+                                                            [])
+        self.assertEqual(worker.get_finished(), (set(), set()))
+
+        worker.shard_managers[0].poll_stats.return_value = ([], [], [])
+        worker.shard_managers[1].poll_stats.return_value = ([], ["req-0#d1"],
+                                                            [])
+        self.assertEqual(worker.get_finished(), (set(), {"req-0"}))
+        # Bookkeeping is released, not leaked.
+        self.assertEqual(worker._loads_in_flight, {})
+        self.assertEqual(worker._load_req_ids, {})
+        self.assertEqual(worker._recvd_ids, set())
+
+    def test_a_failed_reshard_is_never_reported_as_loaded(self):
+        worker = self._worker()
+
+        def _explode(address):
+            raise RuntimeError("controller unreachable")
+
+        with patch.object(trc, "RaidenControllerClientFacade", _explode):
+            worker._start_controller_load("req-0", self._load_meta())
+            wait(worker._loads_in_flight["req-0"])
+        # Decoding against KV that was never written asserts inside vLLM and
+        # takes the whole EngineCore down; the request must time out at the
+        # API layer instead.
+        self.assertEqual(worker.get_finished(), (set(), set()))
+        self.assertEqual(worker._loads_in_flight, {})
+        self.assertEqual(worker._load_req_ids, {})
+
+    def test_producer_holds_blocks_until_every_push_completes(self):
+        worker = self._worker(is_producer=True)
+        metadata = trc.TPUConnectorMetadata(
+            reqs_to_send={
+                "req-0":
+                trc.SendMeta(uuid=7,
+                             local_block_ids=[10, 11],
+                             expiration_time=1e18,
+                             dst_req_ids=["req-0#d0", "req-0#d1"])
+            })
+        worker.process_send_load(metadata)
+        # The controller fires the push over the listener socket; the producer
+        # arms nothing.
+        for manager in worker.shard_managers:
+            manager.register_read.assert_not_called()
+
+        worker.shard_managers[0].poll_stats.return_value = (["req-0#d0"], [],
+                                                            [])
+        self.assertEqual(worker.get_finished(), (set(), set()))
+        worker.shard_managers[0].poll_stats.return_value = ([], [], [])
+        worker.shard_managers[1].poll_stats.return_value = (["req-0#d1"], [],
+                                                            [])
+        self.assertEqual(worker.get_finished(), ({"req-0"}, set()))
+        self.assertEqual(worker._sends_outstanding, {})
+
+    def test_symmetric_load_still_takes_the_start_read_path(self):
+        worker = self._worker()
+        worker.kv_manager = MagicMock()
+        worker.kv_manager.get_local_endpoints.return_value = [{"shards": [0]}]
+        worker._parallelism = 1
+        metadata = trc.TPUConnectorMetadata(
+            reqs_to_load={
+                "req-1":
+                trc.LoadMeta(uuid=7,
+                             local_block_ids=[100],
+                             remote_block_ids=[10],
+                             remote_host="10.0.0.1",
+                             remote_port=9100)
+            })
+        worker.process_send_load(metadata)
+        worker.kv_manager.start_read.assert_called_once()
+        self.assertEqual(
+            worker.kv_manager.start_read.call_args.kwargs["remote_endpoint"],
+            "10.0.0.1:9100")
+        self.assertEqual(worker._loads_in_flight, {})
+
+    def test_post_load_notify_pass_does_not_touch_the_kv_manager(self):
+        # Once the load lands, the scheduler re-issues the request with
+        # remote_block_ids=None to release the producer -- and, because there
+        # is nothing left to load, without any of the controller fields. Under
+        # the controller there is no `kv_manager` at all (each device shard has
+        # its own), so that pass must resolve no endpoint and do nothing.
+        worker = self._worker()
+        self.assertIsNone(worker.kv_manager)
+        metadata = trc.TPUConnectorMetadata(
+            reqs_to_load={
+                "req-1":
+                trc.LoadMeta(uuid=7,
+                             local_block_ids=[100, 101],
+                             remote_block_ids=None,
+                             remote_host="10.0.0.1",
+                             remote_port=9100)
+            })
+        worker.process_send_load(metadata)
+        self.assertEqual(worker._loads_in_flight, {})
+        self.assertEqual(worker._submitted, set())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tpu_inference/distributed/kv_pool_layout.py
+++ b/tpu_inference/distributed/kv_pool_layout.py
@@ -1,0 +1,690 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Lowers this worker's KV cache geometry into Raiden's byte-span pool IR.
+
+Raiden's reshard pipeline is geometry-neutral: the controller validates and
+re-keys byte spans, but it never derives them. Every mapping from "my mesh,
+my page size, my head shard" to bytes is the caller's job -- see
+``tpu_raiden/api/torch/pool_layout.py``:
+
+    callers (e.g. the TPU vLLM connector) derive them from their own model
+    and kernel layouts.
+
+This module is that derivation. It produces two things:
+
+  * :func:`build_pool_manifest` -- the static, per-worker declaration of
+    where the live KV bytes sit inside each attention page. Registered once
+    at worker init via ``register_work_unit(pool_manifest=...)``.
+  * :func:`build_request_spans` -- the per-request, per-(src rank, dst rank)
+    byte spans that say which of *my* bytes land where in *your* pages.
+    Registered per request via ``register_request_blocks(pool_spans=...)``.
+
+Because the two sides may run different tensor-parallel degrees and
+different page sizes, neither side's page layout is assumed by the other.
+The only thing that must agree is :func:`layout_fingerprint`, which covers
+the model-invariant parts and deliberately excludes TP degree and page size
+-- those are precisely what differ.
+
+Scope:
+
+  * Attention (``fa``) pools only. MLA and Mamba/GDN state pools raise.
+  * No context parallelism (``KV_CONTEXT`` mesh product must be 1).
+  * ``BATCH`` unsharded, so a rank's local page is dense and contiguous.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import math
+from typing import Any, List, Optional, Sequence, Tuple
+
+from tpu_raiden.api.torch.pool_layout import PoolSpec, RegionSpec
+from tpu_sync.rpc.raiden_controller import RaidenId
+
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+# Raiden pool tag for flash-attention KV pages. Must match on both sides;
+# the controller filters plans by tag and treats it as an opaque string.
+KV_POOL_TAG = "fa"
+
+# `data_name` for every KV work unit. The controller keys pool identity on
+# (tag, dtype_tag), so this is only a human-readable discriminator.
+KV_DATA_NAME = "kv.fa"
+
+
+@dataclasses.dataclass(frozen=True)
+class PoolByteSpan:
+    """One (source -> destination) byte range of a rank's declaration.
+
+    Mirrors ``PoolByteSpan`` in Raiden's ``controller_service.proto``; field
+    names match so the encoder can copy them across without a mapping table.
+    A ``count`` above one repeats the range uniformly, advancing each side by
+    its own stride, which is how a head slice interleaved through a
+    token-major page is expressed without one entry per token.
+    """
+
+    src_block_ordinal: int
+    src_offset_bytes: int
+    dst_block_index: int
+    dst_offset_bytes: int
+    size_bytes: int
+    src_stride_bytes: int = 0
+    dst_stride_bytes: int = 0
+    count: int = 1
+
+
+@dataclasses.dataclass(frozen=True)
+class PoolSpanRegistration:
+    """One rank's byte declaration for one pool tag, for one request.
+
+    ``declared_bytes`` is cross-checked against the sum of the spans, and
+    over all contributing ranks against the destination's byte coverage, so
+    a rank that owns none of a destination's heads still registers with an
+    empty span list rather than staying silent.
+    """
+
+    tag: str
+    block_ids: Tuple[int, ...]
+    spans: Tuple[PoolByteSpan, ...]
+    declared_bytes: int
+    # 0: ``dst_block_index`` indexes the transfer's destination block list and
+    # ``dst_offset_bytes`` is page-local. 1 is destination-page-agnostic and
+    # cannot express a strided head slice, so this lowering always emits 0.
+    dst_space_version: int = 0
+
+
+@dataclasses.dataclass(frozen=True)
+class AttentionKVGeometry:
+    """One worker's byte-level view of its attention KV cache.
+
+    All ``*_bytes`` fields describe the worker's **local** shard, which is
+    what Raiden actually reads and writes. The logical (unsharded) array is
+    only used to derive them.
+
+    The kernel page layout is token-major, head-minor::
+
+        (num_blocks, page_tokens, head_groups, packing, padded_head_dim)
+           dim 0        dim 1        dim 2 (sharded)  dim 3      dim 4
+
+    so within one page the bytes run ``token 0 [all local head groups] |
+    token 1 [...] | ...``. That ordering is why a TP4 source contributes an
+    interleaved half of every destination token slot rather than one
+    contiguous run -- see :func:`build_request_spans`.
+    """
+
+    num_layers: int
+    num_blocks: int
+    page_tokens: int
+    # Global (unsharded) dim-2 extent, and this rank's slice of it.
+    head_groups: int
+    head_groups_local: int
+    packing: int
+    padded_head_dim: int
+    dtype_bits: int
+    # Position of this worker within the KV_HEAD mesh axis.
+    transfer_rank: int
+    transfer_parallelism: int
+    dtype_tag: str
+
+    def __post_init__(self):
+        if self.transfer_parallelism <= 0:
+            raise ValueError("transfer_parallelism must be positive")
+        if not 0 <= self.transfer_rank < self.transfer_parallelism:
+            raise ValueError(
+                f"transfer_rank {self.transfer_rank} is out of range for "
+                f"parallelism {self.transfer_parallelism}")
+        if self.head_groups != self.head_groups_local * self.transfer_parallelism:
+            raise ValueError(
+                f"head_groups {self.head_groups} is not "
+                f"{self.head_groups_local} x {self.transfer_parallelism}")
+
+    @property
+    def group_bytes(self) -> int:
+        """Bytes of one head group for one token."""
+        return self.packing * self.padded_head_dim * self.dtype_bits // 8
+
+    @property
+    def per_token_bytes(self) -> int:
+        """Local bytes occupied by one token slot in one page."""
+        return self.head_groups_local * self.group_bytes
+
+    @property
+    def block_live_bytes(self) -> int:
+        """Local live bytes in one page."""
+        return self.page_tokens * self.per_token_bytes
+
+    @property
+    def head_group_range(self) -> Tuple[int, int]:
+        """This rank's half-open slice of the global head-group axis."""
+        start = self.transfer_rank * self.head_groups_local
+        return (start, start + self.head_groups_local)
+
+
+def _require(condition: bool, message: str) -> None:
+    if not condition:
+        raise ValueError(message)
+
+
+def geometry_to_dict(geometry: AttentionKVGeometry) -> dict:
+    """JSON-safe form, for carrying a rank's geometry in ``kv_transfer_params``.
+
+    The destination is the side that builds the spans -- it is the only side
+    that knows both geometries -- so the producer publishes its own geometry
+    in the handshake and the consumer reconstitutes it here.
+    """
+    return dataclasses.asdict(geometry)
+
+
+def geometry_from_dict(payload: dict) -> AttentionKVGeometry:
+    """Inverse of :func:`geometry_to_dict`. Validates via ``__post_init__``."""
+    fields = {f.name for f in dataclasses.fields(AttentionKVGeometry)}
+    unknown = set(payload) - fields
+    _require(not unknown, f"Unknown geometry fields in handshake: {unknown}")
+    return AttentionKVGeometry(**payload)
+
+
+def work_unit_id(role: str, rank: int, instance: str = "") -> RaidenId:
+    """The Raiden work-unit identity of one KV shard.
+
+    One unit per **device shard**, not per process. A JAX vLLM worker is a
+    single process holding N chips, but Raiden's byte-span planner requires
+    one data-plane endpoint per work unit
+    (``raiden_controller.py``: "Pool reshard planning requires one data-plane
+    endpoint per work unit") and always emits ``dst_shard_idx = 0``. So each
+    local shard gets its own ``KVCacheManager``, its own endpoint, and its own
+    unit -- which is also exactly the shape
+    :func:`contributing_src_ranks` assumes.
+
+    ``job_replica_id`` must be the rank rendered as an int-parseable string:
+    when several single-shard sources feed one destination, the controller
+    facade keys the push schedules by ``int(src_unit.job_replica_id)``.
+
+    ``instance`` separates engines that share a role and a controller. The
+    controller's work-unit registry is keyed by the whole id, so two decode
+    engines of the same parallelism would otherwise register the same units
+    and the second would take over the first's endpoints -- every push then
+    lands on one engine and the other's loads never complete. Rank alone
+    cannot separate them: both engines hold ranks 0..TP-1. Pass a tag that is
+    stable across an engine's own processes and distinct between engines; see
+    :func:`engine_instance_tag`.
+    """
+    _require(rank >= 0, f"rank must be non-negative, got {rank}")
+    return RaidenId(
+        job_name=role if not instance else f"{role}@{instance}",
+        job_replica_id=str(int(rank)),
+        data_name=KV_DATA_NAME,
+        data_replica_idx=int(rank),
+    )
+
+
+def engine_instance_tag(host: str, transfer_port: int | str) -> str:
+    """A per-engine tag for :func:`work_unit_id`.
+
+    The data-plane host and base transfer port identify an engine uniquely --
+    two engines on one host must already differ in port to coexist -- and both
+    are read from the same configuration in the scheduler and the worker, so
+    the two processes derive the same tag without having to exchange one.
+    """
+    return f"{host}:{transfer_port}"
+
+
+def unit_to_dict(unit: RaidenId) -> dict:
+    """JSON-safe form of a work-unit id, for the handshake."""
+    return {
+        "job_name": unit.job_name,
+        "job_replica_id": unit.job_replica_id,
+        "data_name": unit.data_name,
+        "data_replica_idx": int(unit.data_replica_idx),
+    }
+
+
+def unit_from_dict(payload: dict) -> RaidenId:
+    """Inverse of :func:`unit_to_dict`."""
+    return RaidenId(
+        job_name=str(payload["job_name"]),
+        job_replica_id=str(payload["job_replica_id"]),
+        data_name=str(payload["data_name"]),
+        data_replica_idx=int(payload["data_replica_idx"]),
+    )
+
+
+def dst_req_id(req_id: str, dst_rank: int) -> str:
+    """Per-destination-rank request id.
+
+    The controller's registration store is keyed ``(req_id, unit)`` while a
+    span set addresses exactly one destination's byte space, so a request
+    fanning out to K decode ranks needs K distinct req_ids -- reusing one
+    would have each destination's spans overwrite the last.
+    """
+    return f"{req_id}#d{int(dst_rank)}"
+
+
+_DST_RANK_MASK = 0xFF
+
+
+def dst_uuid(uuid: int, dst_rank: int) -> int:
+    """Per-destination-rank plan uuid.
+
+    A source registers one active plan per transfer, keyed by uuid, and
+    rejects a repeat with ``ALREADY_EXISTS``. Whenever a source feeds more
+    than one destination -- any geometry with ``src_parallelism <
+    dst_parallelism``, and every source in a partial fan-in such as 4 -> 2 --
+    that same source registers K plans, so the uuid has to distinguish them
+    just as :func:`dst_req_id` distinguishes the registrations.
+
+    The rank goes in the low bits rather than being mixed in, so a uuid stays
+    recognisably one request's across its destinations. That spends 8 of the
+    uuid's 50 bits, which only has to keep *in-flight* requests apart.
+    """
+    _require(0 <= dst_rank <= _DST_RANK_MASK,
+             f"dst_rank {dst_rank} does not fit in {_DST_RANK_MASK:#x}")
+    return (int(uuid) & ~_DST_RANK_MASK) | int(dst_rank)
+
+
+def geometry_from_mesh(
+    mesh: Any,
+    *,
+    num_blocks: int,
+    block_size: int,
+    num_kv_heads: int,
+    head_dim: int,
+    kv_dtype: Any,
+    num_layers: int,
+    transfer_rank: int,
+    use_mla: bool = False,
+) -> AttentionKVGeometry:
+    """Derives the local byte geometry from a live mesh.
+
+    Reuses the runner's own shape helper rather than recomputing the kernel
+    layout, so a kernel change cannot silently desynchronise the manifest
+    from the actual allocation.
+    """
+    # Imported lazily: this pulls vLLM and the attention kernels, which the
+    # pure-arithmetic paths below do not need.
+    from jax._src import dtypes
+
+    from tpu_inference import utils
+    from tpu_inference.layers.common.sharding import ShardingAxisName
+    from tpu_inference.runner.kv_cache import get_kv_cache_shape_with_mesh
+    from tpu_inference.utils import to_jax_dtype
+
+    if use_mla:
+        raise NotImplementedError(
+            "MLA KV pools are out of scope: the latent cache has no KV_HEAD "
+            "axis, so head-slice resharding is not defined for it")
+
+    context_cnt = utils.get_mesh_shape_product(mesh,
+                                               ShardingAxisName.KV_CONTEXT)
+    _require(
+        context_cnt == 1,
+        f"Context parallelism (KV_CONTEXT={context_cnt}) is out of scope; a "
+        "page would then hold a strided token subset")
+    model_cnt = utils.get_mesh_shape_product(mesh, ShardingAxisName.KV_HEAD)
+
+    jax_dtype = to_jax_dtype(kv_dtype)
+    shape = get_kv_cache_shape_with_mesh(
+        mesh=mesh,
+        total_num_pages=num_blocks,
+        block_size=block_size,
+        actual_num_kv_heads=num_kv_heads,
+        actual_head_dim=head_dim,
+        kv_dtype=jax_dtype,
+        use_mla=False,
+    )
+    _, page_tokens, head_groups, packing, padded_head_dim = shape
+    _require(
+        head_groups % model_cnt == 0,
+        f"Head-group extent {head_groups} is not divisible by the KV_HEAD "
+        f"mesh product {model_cnt}")
+
+    return AttentionKVGeometry(
+        num_layers=num_layers,
+        num_blocks=num_blocks,
+        page_tokens=int(page_tokens),
+        head_groups=int(head_groups),
+        head_groups_local=int(head_groups) // model_cnt,
+        packing=int(packing),
+        padded_head_dim=int(padded_head_dim),
+        dtype_bits=int(dtypes.itemsize_bits(jax_dtype)),
+        transfer_rank=int(transfer_rank),
+        transfer_parallelism=int(model_cnt),
+        dtype_tag=str(jax_dtype.__name__ if hasattr(jax_dtype, "__name__"
+                                                    ) else jax_dtype),
+    )
+
+
+def layout_fingerprint(
+    *,
+    num_layers: int,
+    num_kv_heads: int,
+    head_dim: int,
+    dtype_tag: str,
+    use_mla: bool = False,
+) -> str:
+    """Stable identity of the parts of the layout that must agree.
+
+    The controller rejects a transfer whose source and destination
+    fingerprints differ (``raiden_controller.py``: "Layout fingerprint
+    mismatch between source and destination"), before any worker RPC.
+
+    Deliberately excluded: **tensor-parallel degree** and **page size**.
+    Those are exactly the axes this work makes heterogeneous, so folding
+    them in would reject every transfer we care about. Padding and packing
+    are excluded too because they are functions of ``head_dim`` and the
+    dtype, which are included.
+    """
+    payload = "|".join([
+        "tpu-inference.kv.v1",
+        f"layers={int(num_layers)}",
+        f"kv_heads={int(num_kv_heads)}",
+        f"head_dim={int(head_dim)}",
+        f"dtype={dtype_tag}",
+        f"mla={int(bool(use_mla))}",
+    ])
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()[:32]
+
+
+def build_pool_manifest(geometry: AttentionKVGeometry) -> List[PoolSpec]:
+    """One :class:`PoolSpec` per attention layer, in layer order.
+
+    The controller matches pools **positionally** by ``(tag, dtype_tag)``
+    against the destination manifest, so both sides must publish the same
+    number of pools in the same order. Layer count is model-invariant, so
+    that is compatible with differing TP and page size.
+
+    A rank's local shard is dense -- ``BATCH`` is unsharded and there is no
+    context parallelism -- so each block is one contiguous live region and
+    ``block_stride_bytes == live bytes``.
+    """
+    per_token = geometry.per_token_bytes
+    return [
+        PoolSpec(
+            tag=KV_POOL_TAG,
+            storage_index=layer_idx,
+            base_offset_bytes=0,
+            block_stride_bytes=geometry.block_live_bytes,
+            num_blocks=geometry.num_blocks,
+            dtype_tag=geometry.dtype_tag,
+            regions=(RegionSpec(
+                name=KV_POOL_TAG,
+                offset_bytes=0,
+                stride_bytes=per_token,
+                unit_bytes=per_token,
+                num_units=geometry.page_tokens,
+                units_per_stride=1,
+            ), ),
+        ) for layer_idx in range(geometry.num_layers)
+    ]
+
+
+def head_group_overlap(
+    src: AttentionKVGeometry,
+    dst: AttentionKVGeometry,
+) -> Optional[Tuple[int, int]]:
+    """Half-open global head-group range that ``src`` owes ``dst``.
+
+    Returns ``None`` when the two ranks share no heads, i.e. this source
+    contributes nothing to this destination and must be left out of the
+    transfer's ``src_units`` entirely.
+    """
+    _require(
+        src.head_groups == dst.head_groups,
+        "Source and destination disagree on the total head-group extent "
+        f"({src.head_groups} vs {dst.head_groups}). Alignment padding is "
+        "computed on the *local* head count, so it does not always scale "
+        "linearly with TP degree; this reshard is not well defined.")
+    _require(
+        src.group_bytes == dst.group_bytes,
+        f"Head-group byte size differs ({src.group_bytes} vs "
+        f"{dst.group_bytes}); dtype or head_dim padding disagree")
+
+    src_start, src_end = src.head_group_range
+    dst_start, dst_end = dst.head_group_range
+    start = max(src_start, dst_start)
+    end = min(src_end, dst_end)
+    return (start, end) if start < end else None
+
+
+def contributing_src_ranks(
+    src_geometries: Sequence[AttentionKVGeometry],
+    dst: AttentionKVGeometry,
+) -> List[int]:
+    """Indices of the source ranks that own any of ``dst``'s heads.
+
+    Every transfer targets exactly one destination rank (Raiden's byte-span
+    planner allows one shard per work unit and one destination unit per
+    plan, so ``dst_shard_idx`` is always 0 and a TP2 decode is two separate
+    work units). Passing a non-contributing source rank would leave a hole
+    in that rank's declared coverage and fail the controller's
+    exactly-once destination coverage check.
+    """
+    return [
+        index for index, src in enumerate(src_geometries)
+        if head_group_overlap(src, dst) is not None
+    ]
+
+
+def source_schedule_key(
+    transfer_rank: int,
+    transfer_parallelism: int,
+    dst_parallelism: int,
+) -> int:
+    """The Raiden ``node_id`` a source rank must carry to be routed correctly.
+
+    A pool-reshard push carries the sender's ``node_id`` in its wire header
+    (``block_transport.cc``: ``header.remote_id = block_delegate_->node_id()``)
+    and the receiver uses it, and only it, to pick which source's schedule to
+    scatter the payload with (``kv_cache_manager_base.cc``:
+    ``found_src_shard = sender_node_id``). The controller keys those schedules
+    by the source's **ordinal among the ranks that actually contribute to this
+    destination** (``raiden_controller.py``: ``src_schedule_keys = {unit:
+    ordinal for ordinal, unit in enumerate(active_src_units)}``), not by its
+    global ``transfer_rank``.
+
+    So ``node_id`` must be that ordinal. Leaving it at Raiden's default of 0 is
+    silently correct while exactly one source feeds each destination -- which
+    is every symmetric geometry -- and silently
+    *wrong* the moment two do: all the pushes resolve to the first source's
+    schedule, so every rank's bytes land in the first rank's head slots and the
+    rest of the destination keeps stale KV. Nothing errors; the plan validates,
+    the byte totals are exact, and the model emits garbage.
+
+    Under uniform tensor parallelism the ordinal is a property of the source
+    rank alone, so it can be fixed at worker init: destination ``d`` is fed by
+    the contiguous run of sources ``[d * P // D, (d+1) * P // D)`` when
+    ``P >= D``, and by the single source ``d * P // D`` when ``P < D``. The
+    ordering is derived here from :func:`contributing_src_ranks` rather than
+    open-coded, so it cannot drift from the spans it has to agree with.
+    """
+    _require(
+        0 <= transfer_rank < transfer_parallelism,
+        f"transfer_rank {transfer_rank} out of range for "
+        f"parallelism {transfer_parallelism}")
+    _require(dst_parallelism > 0, "dst_parallelism must be positive")
+
+    # Any extent both sides divide evenly routes identically to the real one,
+    # because ownership is the rank's equal share of it.
+    extent = transfer_parallelism * dst_parallelism // math.gcd(
+        transfer_parallelism, dst_parallelism)
+    src_geometries = [
+        _routing_geometry(rank, transfer_parallelism, extent)
+        for rank in range(transfer_parallelism)
+    ]
+    for dst_rank in range(dst_parallelism):
+        dst = _routing_geometry(dst_rank, dst_parallelism, extent)
+        contributors = contributing_src_ranks(src_geometries, dst)
+        if transfer_rank in contributors:
+            return contributors.index(transfer_rank)
+    raise ValueError(
+        f"Source rank {transfer_rank}/{transfer_parallelism} feeds no "
+        f"destination rank of a {dst_parallelism}-way decode; the head-group "
+        "extent is not divisible by both parallelisms")
+
+
+def _routing_geometry(rank: int, parallelism: int,
+                      extent: int) -> AttentionKVGeometry:
+    """A geometry that carries only what head-group routing depends on.
+
+    Head-group ownership is fixed by ``(transfer_rank, transfer_parallelism)``
+    and the global extent; page size, dtype and layer count do not enter it.
+    Using the smallest extent both parallelisms divide keeps this independent
+    of the model, so a producer can compute its schedule key before it has
+    ever seen the consumer's geometry.
+    """
+    return AttentionKVGeometry(
+        num_layers=1,
+        num_blocks=1,
+        page_tokens=1,
+        head_groups=extent,
+        head_groups_local=extent // parallelism,
+        packing=1,
+        padded_head_dim=1,
+        dtype_bits=16,
+        transfer_rank=rank,
+        transfer_parallelism=parallelism,
+        dtype_tag="bfloat16",
+    )
+
+
+def build_request_span_entries(
+    src: AttentionKVGeometry,
+    dst: AttentionKVGeometry,
+    *,
+    src_block_ids: Sequence[int],
+    num_tokens: int,
+) -> List[PoolSpanRegistration]:
+    """``register_request_blocks(pool_spans=...)`` payload for one rank pair.
+
+    Empty when this source owes this destination nothing. Register it anyway:
+    the transfer must list **every** source rank in ``src_units`` because the
+    controller requires ``transfer_rank`` values contiguous from zero
+    (``raiden_controller.py``: "Source transfer_rank values must be contiguous
+    from zero"), and it raises "Missing producer block registration" for any
+    listed unit without a registration under the transfer's uuid. Ranks that
+    contribute nothing therefore register an empty span list and are dropped
+    from ``active_src_units`` when the plan is built.
+
+    Because the registration store is keyed ``(req_id, unit)`` and a set of
+    spans addresses one destination's byte space, a request fanning out to
+    several decode ranks needs **a distinct req_id (and uuid) per destination
+    rank** -- otherwise the second registration overwrites the first.
+    """
+    if head_group_overlap(src, dst) is None:
+        return []
+    return [
+        build_request_spans(src,
+                            dst,
+                            src_block_ids=src_block_ids,
+                            num_tokens=num_tokens)
+    ]
+
+
+def build_request_spans(
+    src: AttentionKVGeometry,
+    dst: AttentionKVGeometry,
+    *,
+    src_block_ids: Sequence[int],
+    num_tokens: int,
+) -> PoolSpanRegistration:
+    """Byte spans carrying one source rank's share of one request to one
+    destination rank.
+
+    Under pure tensor parallelism every rank holds *all* tokens for its own
+    head slice, so source page ``o`` covers tokens
+    ``[o * src.page_tokens, (o+1) * src.page_tokens)`` and destination page
+    ``k`` covers ``[k * dst.page_tokens, (k+1) * dst.page_tokens)``. A run of
+    consecutive tokens that stays inside one page on both sides becomes a
+    single uniformly strided span.
+
+    The spans are emitted in the **v0** (page-indexed) form, not the
+    ``dst_space_version=1`` global-compact form. v1 requires every span to
+    be a plain contiguous range with no repeats, which cannot express a head
+    reshard: because pages are token-major, a TP4 source owns an interleaved
+    slice of every destination token slot, not one contiguous run. v1 stays
+    correct for the token-split (context-parallel) case, which this path is
+    not.
+    """
+    _require(num_tokens > 0, "num_tokens must be positive")
+    overlap = head_group_overlap(src, dst)
+    if overlap is None:
+        raise ValueError(
+            f"Source rank {src.transfer_rank}/{src.transfer_parallelism} owns "
+            f"no heads of destination rank "
+            f"{dst.transfer_rank}/{dst.transfer_parallelism}; it must be "
+            "excluded from src_units rather than declaring empty spans")
+    overlap_start, overlap_end = overlap
+
+    group_bytes = src.group_bytes
+    # Bytes this pair moves per token, and where they sit in each token slot.
+    width = (overlap_end - overlap_start) * group_bytes
+    src_in_token = (overlap_start - src.head_group_range[0]) * group_bytes
+    dst_in_token = (overlap_start - dst.head_group_range[0]) * group_bytes
+    src_token_bytes = src.per_token_bytes
+    dst_token_bytes = dst.per_token_bytes
+
+    expected_blocks = -(-num_tokens // src.page_tokens)  # ceil
+    _require(
+        len(src_block_ids) == expected_blocks,
+        f"Expected {expected_blocks} source block ids for {num_tokens} tokens "
+        f"at page_tokens={src.page_tokens}, got {len(src_block_ids)}")
+
+    spans: List[PoolByteSpan] = []
+    token = 0
+    while token < num_tokens:
+        src_block, src_token_off = divmod(token, src.page_tokens)
+        dst_block, dst_token_off = divmod(token, dst.page_tokens)
+        run = min(
+            num_tokens - token,
+            src.page_tokens - src_token_off,
+            dst.page_tokens - dst_token_off,
+        )
+        src_offset = src_token_off * src_token_bytes + src_in_token
+        dst_offset = dst_token_off * dst_token_bytes + dst_in_token
+
+        if width == src_token_bytes and width == dst_token_bytes:
+            # Same head slice on both sides: the strided form degenerates to
+            # one contiguous copy. Emitting it that way keeps the symmetric
+            # TP-N -> TP-N path cheap (one entry per run, not one per token).
+            spans.append(
+                PoolByteSpan(
+                    src_block_ordinal=src_block,
+                    src_offset_bytes=src_offset,
+                    dst_block_index=dst_block,
+                    dst_offset_bytes=dst_offset,
+                    size_bytes=width * run,
+                ))
+        else:
+            spans.append(
+                PoolByteSpan(
+                    src_block_ordinal=src_block,
+                    src_offset_bytes=src_offset,
+                    dst_block_index=dst_block,
+                    dst_offset_bytes=dst_offset,
+                    size_bytes=width,
+                    src_stride_bytes=src_token_bytes,
+                    dst_stride_bytes=dst_token_bytes,
+                    count=run,
+                ))
+        token += run
+
+    return PoolSpanRegistration(
+        tag=KV_POOL_TAG,
+        block_ids=tuple(int(block_id) for block_id in src_block_ids),
+        spans=tuple(spans),
+        declared_bytes=num_tokens * width,
+        dst_space_version=0,
+    )

--- a/tpu_inference/distributed/raiden_controller_sidecar.py
+++ b/tpu_inference/distributed/raiden_controller_sidecar.py
@@ -1,0 +1,247 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Raiden reshard controller sidecar for heterogeneous P/D KV transfer.
+
+The controller is the only component that sees both sides' geometry. It
+validates the layout fingerprints, plans the byte-span reshard, arms the
+destination workers (``PoolReshardRegisterRecv``) and fires the sources
+(``PoolReshardPush``) over their control-plane listener sockets. It moves no
+data itself, so one small process serves a whole P/D pair.
+
+It runs beside the prefill engine rather than inside it: the engine process
+owns TPU chips and is restarted far more often than the control plane, and
+prefill and decode may sit on different hosts, where an in-process controller
+would have no natural home.
+
+Raiden serves this plane from ``reshard_sidecar``, a standalone binary in the
+Raiden tree, so this module supervises that binary rather than hosting the
+plane itself: it resolves the binary, waits for the ready-file handshake, and
+republishes the bound port for the launcher. ``build.sh`` does not build
+``reshard_sidecar`` among its default targets and no wheel ships it, so a
+Raiden source checkout built with
+``//tpu_sync/kv_cache/reshard:reshard_sidecar`` is a prerequisite; point
+``TPU_KV_RESHARD_SIDECAR`` at the binary if it is not discoverable.
+
+Run it directly::
+
+    python -m tpu_inference.distributed.raiden_controller_sidecar --port 9700
+
+Both engines then point at it with ``TPU_KV_CONTROLLER_ADDRESS=<host>:9700``.
+"""
+
+import argparse
+import json
+import os
+import shutil
+import signal
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+from typing import Optional
+
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+_BINARY_NAME = "reshard_sidecar"
+_BINARY_ENV = "TPU_KV_RESHARD_SIDECAR"
+# Path of the binary inside a Bazel-built Raiden checkout, relative to the
+# repository root.
+_BAZEL_RELPATH = os.path.join("bazel-bin", "tpu_sync", "kv_cache", "reshard",
+                              _BINARY_NAME)
+
+
+def find_sidecar_binary(explicit: Optional[str] = None) -> str:
+    """Resolves the reshard sidecar binary.
+
+    Args:
+        explicit: A caller-supplied path, which wins if given.
+
+    Returns:
+        Path to an executable ``reshard_sidecar``.
+
+    Raises:
+        FileNotFoundError: If no candidate is executable, listing what was
+            tried so the fix is obvious.
+    """
+    candidates = []
+    if explicit:
+        candidates.append(explicit)
+    if os.environ.get(_BINARY_ENV):
+        candidates.append(os.environ[_BINARY_ENV])
+    on_path = shutil.which(_BINARY_NAME)
+    if on_path:
+        candidates.append(on_path)
+    try:
+        import tpu_sync
+
+        # Raiden ships as a namespace package, so __file__ is None and the
+        # search roots are the __path__ entries.
+        for entry in list(getattr(tpu_sync, "__path__", ())):
+            repo_root = os.path.dirname(entry)
+            candidates.append(os.path.join(repo_root, _BAZEL_RELPATH))
+    except Exception:  # pylint: disable=broad-except
+        pass
+
+    for candidate in candidates:
+        if candidate and os.access(candidate, os.X_OK):
+            return candidate
+    raise FileNotFoundError(
+        f"No executable {_BINARY_NAME} found. Build it with "
+        f"'bazel build //tpu_sync/kv_cache/reshard:{_BINARY_NAME}' in a "
+        f"Raiden checkout, or set {_BINARY_ENV}. Tried: "
+        f"{candidates or '(no candidates)'}")
+
+
+def primary_host_address() -> str:
+    """Returns the routable local address the peers should dial.
+
+    A connected UDP socket picks the interface the kernel would route out of
+    without sending anything, which beats ``gethostbyname(gethostname())`` on
+    hosts whose hostname resolves to loopback.
+    """
+    sock = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        sock.connect(("8.8.8.8", 53))
+        return sock.getsockname()[0]
+    except OSError:
+        return "127.0.0.1"
+    finally:
+        sock.close()
+
+
+def start_controller(port: int,
+                     advertise_host: Optional[str] = None,
+                     ready_file: Optional[str] = None,
+                     binary: Optional[str] = None,
+                     request_registry_ttl_s: float = 600.0,
+                     timeout_s: float = 60.0):
+    """Starts the reshard sidecar and waits for it to bind.
+
+    Args:
+        port: TCP port to bind. 0 selects an ephemeral port, which the
+            returned ready record reports under ``port``.
+        advertise_host: Host published to peers; defaults to the routable
+            local address.
+        ready_file: Path for the ready handshake; defaults to a temp file.
+        binary: Explicit path to ``reshard_sidecar``.
+        request_registry_ttl_s: Lifetime of an unclaimed request-block
+            registration.
+        timeout_s: How long to wait for the ready handshake.
+
+    Returns:
+        ``(process, ready)`` -- the running :class:`subprocess.Popen` and the
+        parsed ready record, whose ``port`` and ``address`` are authoritative.
+
+    Raises:
+        RuntimeError: If the binary exits or fails to publish in time.
+    """
+    binary_path = find_sidecar_binary(binary)
+    host = advertise_host or primary_host_address()
+    owns_ready_file = ready_file is None
+    if owns_ready_file:
+        handle, ready_file = tempfile.mkstemp(prefix="raiden_reshard_",
+                                              suffix=".ready")
+        os.close(handle)
+    # The launcher polls for non-empty content, so a stale file from a crashed
+    # run would be read as this run's handshake.
+    if os.path.exists(ready_file):
+        os.unlink(ready_file)
+
+    argv = [
+        binary_path,
+        f"--port={port}",
+        f"--advertise-host={host}",
+        f"--ready-file={ready_file}",
+        f"--request-registry-ttl-s={request_registry_ttl_s}",
+    ]
+    logger.info(f"Starting reshard sidecar: {' '.join(argv)}")
+    process = subprocess.Popen(argv)
+
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if process.poll() is not None:
+            raise RuntimeError(
+                f"Reshard sidecar exited with code {process.returncode} "
+                "before publishing its ready file")
+        try:
+            with open(ready_file, "r") as f:
+                line = f.read().strip()
+            if line:
+                ready = json.loads(line)
+                logger.info(
+                    f"Raiden reshard sidecar listening on {ready['address']}")
+                if owns_ready_file:
+                    os.unlink(ready_file)
+                return process, ready
+        except (FileNotFoundError, json.JSONDecodeError):
+            pass
+        time.sleep(0.1)
+
+    process.terminate()
+    raise RuntimeError(
+        f"Reshard sidecar did not publish {ready_file} within {timeout_s}s")
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--port",
+                        type=int,
+                        default=9700,
+                        help="TCP port to bind (0 for an ephemeral port).")
+    parser.add_argument("--advertise-host",
+                        default=None,
+                        help="Host published to peers (default: the routable "
+                        "local address).")
+    parser.add_argument("--ready-file",
+                        default=None,
+                        help="Path for the ready handshake (default: a temp "
+                        "file).")
+    parser.add_argument("--binary",
+                        default=None,
+                        help=f"Path to {_BINARY_NAME} (default: "
+                        f"${_BINARY_ENV}, $PATH, then the Bazel output of an "
+                        "importable Raiden checkout).")
+    parser.add_argument("--request-registry-ttl-s",
+                        type=float,
+                        default=600.0,
+                        help="Lifetime of an unclaimed request-block "
+                        "registration.")
+    args = parser.parse_args(argv)
+
+    process, ready = start_controller(
+        args.port,
+        advertise_host=args.advertise_host,
+        ready_file=args.ready_file,
+        binary=args.binary,
+        request_registry_ttl_s=args.request_registry_ttl_s)
+    # Emitted on stdout so a launcher script can capture the port when --port 0
+    # was used.
+    print(f"RAIDEN_CONTROLLER_PORT={ready['port']}", flush=True)
+
+    def forward(signum, _frame):
+        if process.poll() is None:
+            process.send_signal(signum)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(sig, forward)
+    returncode = process.wait()
+    logger.info("Raiden reshard sidecar stopped")
+    return returncode
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tpu_inference/distributed/raiden_reshard_client.py
+++ b/tpu_inference/distributed/raiden_reshard_client.py
@@ -1,0 +1,150 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Client for the reshard control plane's request-block registration.
+
+Raiden serves the reshard control plane -- the work-unit directory, the
+request-block registry, the plan builder and receiver arming -- from its C++
+reshard store. Two of the three commands this connector needs have Python
+clients in ``tpu_sync.rpc.raiden_controller``: ``register_work_unit`` and
+``coordinate_transfer``. Request-block registration does not, and its Python
+client is a torch extension binding, so the producer's byte-span declarations
+are encoded here instead.
+
+The encoding is not a reimplementation of anything: ``ControllerRequest`` with
+``COMMAND_REGISTER_REQUEST_BLOCKS`` over a 4-byte big-endian length frame is
+the same envelope the other two commands use, on the same port, so this shares
+``connect_socket`` with them and inherits its address parsing, IPv6 handling
+and connect retry.
+"""
+
+import typing
+from typing import Any
+
+_IMPORT_ERROR = None
+try:
+    from tpu_sync.rpc import controller_service_pb2, raiden_service_pb2
+    from tpu_sync.rpc.raiden_controller import connect_socket
+except Exception as _exc:  # pylint: disable=broad-except
+    controller_service_pb2 = None
+    raiden_service_pb2 = None
+    connect_socket = None
+    _IMPORT_ERROR = _exc
+
+# Matches the connect and read timeout the controller client uses for the
+# coordinate call, which blocks for the whole transfer.
+_DEFAULT_TIMEOUT_S = 300.0
+
+
+class ReshardRequestBlockClient:
+    """Registers a producer rank's byte-span declarations for one request.
+
+    One instance is cheap and holds no connection; each call opens and closes
+    its own socket, which is what the surrounding controller client does.
+    """
+
+    def __init__(self,
+                 controller_address: str,
+                 timeout_s: float = _DEFAULT_TIMEOUT_S):
+        if _IMPORT_ERROR is not None:
+            raise RuntimeError(
+                "tpu_sync.rpc is unavailable, so the reshard control plane "
+                f"cannot be reached: {_IMPORT_ERROR}")
+        self._address = controller_address
+        self._timeout_s = timeout_s
+
+    def register_request_blocks(
+        self,
+        req_id: str,
+        uuid: int,
+        unit: Any,
+        block_ids: typing.Sequence[int],
+        pool_spans: typing.Sequence[Any] = (),
+    ) -> None:
+        """Declares which of this rank's bytes land where, for one request.
+
+        Args:
+            req_id: Request identity the plan is keyed by, together with
+                ``uuid``. One destination rank per ``req_id``.
+            uuid: Plan identity. A source keys its active plan by uuid, so
+                each destination rank of a fan-out needs a distinct one.
+            unit: The registering producer rank's ``RaidenId``.
+            block_ids: The producer blocks holding this request's KV.
+            pool_spans: Per-tag span entries from
+                ``kv_pool_layout.build_request_span_entries``. Empty for a
+                rank that owns none of this destination's heads -- the
+                controller still requires it to register.
+        """
+        block_req = controller_service_pb2.RegisterRequestBlocksRequest(
+            req_id=req_id,
+            uuid=uuid,
+            unit=raiden_service_pb2.RaidenIdProto(
+                job_name=unit.job_name,
+                job_replica_id=unit.job_replica_id,
+                data_name=unit.data_name,
+                data_replica_idx=unit.data_replica_idx,
+            ),
+            block_ids=list(block_ids),
+        )
+        for entry in pool_spans:
+            entry_proto = block_req.pool_spans.add(
+                tag=str(entry.tag),
+                block_ids=[int(block_id) for block_id in entry.block_ids],
+                declared_bytes=int(entry.declared_bytes),
+                dst_space_version=int(getattr(entry, "dst_space_version", 0)),
+            )
+            for span in entry.spans:
+                entry_proto.spans.add(
+                    src_block_ordinal=int(span.src_block_ordinal),
+                    src_offset_bytes=int(span.src_offset_bytes),
+                    dst_block_index=int(span.dst_block_index),
+                    dst_offset_bytes=int(span.dst_offset_bytes),
+                    size_bytes=int(span.size_bytes),
+                    src_stride_bytes=int(span.src_stride_bytes),
+                    dst_stride_bytes=int(span.dst_stride_bytes),
+                    count=int(span.count),
+                )
+        req = controller_service_pb2.ControllerRequest(
+            command=controller_service_pb2.ControllerRequest.
+            COMMAND_REGISTER_REQUEST_BLOCKS,
+            register_request_blocks_request=block_req,
+        )
+        self._send(req)
+
+    def _send(self, req: Any) -> Any:
+        sock = connect_socket(self._address, timeout=self._timeout_s)
+        try:
+            payload = req.SerializeToString()
+            sock.sendall(len(payload).to_bytes(4, "big") + payload)
+            resp_len = int.from_bytes(_recv_exactly(sock, 4), "big")
+            resp = controller_service_pb2.ControllerResponse()
+            resp.ParseFromString(_recv_exactly(sock, resp_len))
+            if not resp.success:
+                raise RuntimeError(
+                    "Reshard control plane rejected register_request_blocks: "
+                    f"{resp.message}")
+            return resp
+        finally:
+            sock.close()
+
+
+def _recv_exactly(sock, count: int) -> bytes:
+    buf = b""
+    while len(buf) < count:
+        chunk = sock.recv(count - len(buf))
+        if not chunk:
+            raise RuntimeError(
+                "Reshard control plane closed the connection after "
+                f"{len(buf)} of {count} bytes")
+        buf += chunk
+    return buf

--- a/tpu_inference/distributed/tpu_raiden_connector.py
+++ b/tpu_inference/distributed/tpu_raiden_connector.py
@@ -60,7 +60,8 @@ D workflow:
 
 import os
 import time
-from dataclasses import dataclass, field
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field, replace
 from typing import TYPE_CHECKING, Any, Optional
 from uuid import uuid4
 
@@ -82,9 +83,19 @@ if TYPE_CHECKING:
 
 try:
     from tpu_raiden.api.jax.kv_cache_manager import KVCacheManager
+    from tpu_sync.rpc.raiden_controller import (RaidenControllerClientFacade,
+                                                RaidenMemoryType)
+
+    from tpu_inference.distributed import kv_pool_layout
+    from tpu_inference.distributed.raiden_reshard_client import (
+        ReshardRequestBlockClient)
     _RAIDEN_IMPORT_ERROR = None
 except Exception as _exc:  # pylint: disable=broad-except
     KVCacheManager = None
+    RaidenControllerClientFacade = None
+    RaidenMemoryType = None
+    kv_pool_layout = None
+    ReshardRequestBlockClient = None
     _RAIDEN_IMPORT_ERROR = _exc
 
 import tpu_inference.distributed.utils as dist_utils
@@ -95,6 +106,14 @@ from tpu_inference.logger import init_logger
 from tpu_inference.runner.tpu_runner import TPUModelRunner
 
 ReqId = str
+
+# `job_name` of the two sides' Raiden work units. Purely a label, but it must
+# agree between the producer (which names the source units in the handshake)
+# and the consumer (which names its own).
+_PREFILL_ROLE = "prefill"
+_DECODE_ROLE = "decode"
+# How often the worker reports its running reshard-latency split.
+_RESHARD_TIMING_EVERY = 50
 
 # Feature requests:
 # 1. support async pulling natively
@@ -111,6 +130,10 @@ class SendMeta:
     # `list[list[int]]` used for HMA connector (per-kv-cache-group)
     local_block_ids: list[int] | list[list[int]]
     expiration_time: float
+    # Controller path only: the per-destination-rank req_ids this request
+    # fans out to. The producer's blocks are done once every one of them has
+    # been pushed; see `TPUConnectorWorker.get_finished`.
+    dst_req_ids: list[str] | None = None
 
 
 @dataclass
@@ -122,6 +145,15 @@ class LoadMeta:
     remote_block_ids: list[int] | list[list[int]] | None
     remote_host: str | list[str]
     remote_port: int | list[int]
+    # Controller path only (all None on the symmetric fall-through). The
+    # destination is the only side that knows both geometries, so it builds
+    # the byte spans and drives the transfer; the producer publishes what it
+    # needs to do that.
+    src_units: list[dict] | None = None
+    src_geometry: dict | None = None
+    src_controller: str | None = None
+    num_tokens: int | None = None
+    dst_req_ids: list[str] | None = None
 
 
 # The metadata used for communicating between scheduler and worker connectors.
@@ -272,9 +304,46 @@ class TPUConnectorScheduler():
 
         self.kv_ip = dist_utils.get_kv_ips()
         self.kv_port = dist_utils.get_kv_ports()
+
+        # Controller path: when TPU_KV_CONTROLLER_ADDRESS is set the
+        # handshake carries geometry and the transfer is planned by Raiden's
+        # byte-span reshard planner, which tolerates a different TP degree and
+        # page size on the two sides. Unset, everything below is inert and the
+        # symmetric index-matched pull is unchanged.
+        self.controller_address = dist_utils.get_kv_controller_address()
+        self.use_controller = self.controller_address is not None
+        self.num_kv_ranks = vllm_config.parallel_config.tensor_parallel_size
+        self.num_decode_ranks = (dist_utils.get_kv_decode_tp_size(
+            vllm_config.kv_transfer_config) or self.num_kv_ranks)
+        # The handshake names this engine's own source units, which its workers
+        # register from a different process. Both sides derive the tag from the
+        # same configuration rather than exchanging it.
+        self.instance_tag = kv_pool_layout.engine_instance_tag(
+            dist_utils.get_host_ip(), dist_utils.get_kv_transfer_port())
+
         logger.info(
-            f"TPUConnectorScheduler --> kv_ip={self.kv_ip} | kv_port={self.kv_port}"
+            f"TPUConnectorScheduler --> kv_ip={self.kv_ip} | kv_port={self.kv_port} | "
+            f"controller={self.controller_address} | "
+            f"kv_ranks={self.num_kv_ranks} | decode_ranks={self.num_decode_ranks}"
         )
+
+    def _local_geometry(self) -> dict:
+        """This engine's KV byte geometry, published by its worker at init.
+
+        Derived from the live mesh and the runner's own page-shape helper, so
+        it cannot drift from the actual allocation; the worker stashes it
+        where the scheduler can reach it (see
+        `dist_utils.set_local_kv_geometry`).
+        """
+        geometry = dist_utils.get_local_kv_geometry()
+        if geometry is None:
+            raise RuntimeError(
+                "TPU_KV_CONTROLLER_ADDRESS is set but the worker never "
+                "published its KV geometry. The worker connector publishes it "
+                "in register_runner(); if the scheduler runs in a different "
+                "process (Ray multi-host), the executor must forward it the "
+                "same way it forwards get_node_kv_ip_port.")
+        return geometry
 
     def get_num_new_matched_tokens(
         self,
@@ -312,6 +381,21 @@ class TPUConnectorScheduler():
         # remote_block_ids in P's request_finished()
         rounded_num_prompt_tokens = round_down(len(request.prompt_token_ids),
                                                self.block_size)
+        # ... which stops being true once the two sides page differently. The
+        # producer drops its own trailing partial block, so it sends
+        # `round_down(len(prompt), P.block_size)`; deriving the same number
+        # from our block size gives a different answer for any prompt that is
+        # not a multiple of both. At P=128 / D=64 a 200-token prompt is 128
+        # tokens sent and 192 claimed, and tokens 128-191 would be decoded
+        # against KV nobody ever wrote. Take the producer's count when it
+        # tells us -- it is the one that bounds what actually arrives -- and
+        # round it to our own pages, because vLLM requires the externally
+        # computed prefix to be block-aligned here.
+        sent = request.kv_transfer_params.get("num_tokens")
+        if sent is not None:
+            rounded_num_prompt_tokens = min(
+                rounded_num_prompt_tokens,
+                round_down(int(sent), self.block_size))
         count = max(rounded_num_prompt_tokens - num_computed_tokens, 0)
         # NOTE(xiang): Although the JAX P2P pulling is a blocking op, we will run it in a
         # separte thread to make it async, so we are safe to return True here.
@@ -356,6 +440,7 @@ class TPUConnectorScheduler():
                 remote_block_ids=params["remote_block_ids"],
                 remote_host=params["remote_host"],
                 remote_port=params["remote_port"],
+                **self._controller_load_fields(params),
             )
         else:
             # This branch means two cases:
@@ -375,6 +460,32 @@ class TPUConnectorScheduler():
 
         logger.info(
             f"TPUConnector Scheduler update_state_after_alloc -->  reqs_to_load={self.reqs_to_load}"
+        )
+
+    def _controller_load_fields(self, params: dict) -> dict:
+        """The controller-path half of a `LoadMeta`, or empty for the
+        symmetric path.
+
+        A producer that predates this change (or runs with the controller
+        disabled) simply omits `src_units`, and the worker falls through to
+        `start_read`. That keeps the two sides independently deployable.
+        """
+        if not params.get("src_units"):
+            return {}
+        dst_req_ids = params["dst_req_ids"]
+        if len(dst_req_ids) != self.num_kv_ranks:
+            raise ValueError(
+                f"Producer expects {len(dst_req_ids)} decode ranks but this "
+                f"decoder has {self.num_kv_ranks}. Set "
+                f"--kv-transfer-config kv_connector_extra_config="
+                f'{{"decode_tp_size": {self.num_kv_ranks}}} on the prefill '
+                f"side.")
+        return dict(
+            src_units=params["src_units"],
+            src_geometry=params["src_geometry"],
+            src_controller=params["src_controller"],
+            num_tokens=params["num_tokens"],
+            dst_req_ids=dst_req_ids,
         )
 
     def build_connector_meta(self) -> TPUConnectorMetadata:
@@ -440,14 +551,38 @@ class TPUConnectorScheduler():
             uuid = get_uuid()
             expiration_time = time.perf_counter(
             ) + dist_utils.get_p2p_wait_pull_timeout()
-            self.reqs_to_send[request.request_id] = SendMeta(
-                uuid=uuid,
-                local_block_ids=computed_block_ids,
-                expiration_time=expiration_time)
+            dst_req_ids = None
             kv_transfer_params = dict(uuid=uuid,
                                       remote_block_ids=computed_block_ids,
                                       remote_host=self.kv_ip,
                                       remote_port=self.kv_port)
+            if self.use_controller:
+                dst_req_ids = [
+                    kv_pool_layout.dst_req_id(request.request_id, rank)
+                    for rank in range(self.num_decode_ranks)
+                ]
+                # The destination builds the byte spans -- it is the only side
+                # that sees both geometries -- so publish ours, every source
+                # unit (the controller requires transfer_rank contiguous from
+                # zero, so non-contributors are listed too and register empty
+                # spans), and the controller that owns the plan.
+                kv_transfer_params.update(
+                    src_units=[
+                        kv_pool_layout.unit_to_dict(
+                            kv_pool_layout.work_unit_id(
+                                _PREFILL_ROLE, rank, self.instance_tag))
+                        for rank in range(self.num_kv_ranks)
+                    ],
+                    src_geometry=self._local_geometry(),
+                    src_controller=self.controller_address,
+                    num_tokens=len(computed_block_ids) * self.block_size,
+                    dst_req_ids=dst_req_ids,
+                )
+            self.reqs_to_send[request.request_id] = SendMeta(
+                uuid=uuid,
+                local_block_ids=computed_block_ids,
+                expiration_time=expiration_time,
+                dst_req_ids=dst_req_ids)
             logger.info(
                 f"TPUConnector Scheduler ---->  generated reqs_to_send={self.reqs_to_send} | "
                 f"kv_transfer_params={kv_transfer_params}")
@@ -487,9 +622,50 @@ class TPUConnectorWorker:
 
         self.transfer_stats = TpuKVConnectorStats()
 
+        # --- Controller path ---------------------------------------------
+        # Raiden's byte-span planner is built around torch-vLLM's one process
+        # per rank: it requires one data-plane endpoint per work unit and
+        # always emits dst_shard_idx = 0. A JAX vLLM worker is instead one
+        # process holding N chips, so we give each *device shard* its own
+        # KVCacheManager over that shard's buffers -- one endpoint, one unit,
+        # one shard each. The per-shard views alias the same device memory the
+        # model computes into, so nothing is copied and nothing diverges.
+        self.controller_address = dist_utils.get_kv_controller_address()
+        self.use_controller = self.controller_address is not None
+        self.listener_port = dist_utils.get_raiden_listener_port()
+        self.role = _PREFILL_ROLE if self.is_producer else _DECODE_ROLE
+        self.instance_tag = kv_pool_layout.engine_instance_tag(
+            self.host_ip, self.kv_transfer_port)
+        # Per local device shard, index-aligned:
+        self.shard_managers: list = []
+        self.shard_geometries: list = []
+        self.shard_units: list = []
+        self._transfer_pool = None
+        # Consumer: req_id -> the per-destination-rank transfers still running,
+        # and the per-destination-rank req_ids they will complete under.
+        self._loads_in_flight: dict[ReqId, list] = {}
+        self._load_req_ids: dict[ReqId, set[str]] = {}
+        # Producer: req_id -> the per-destination-rank req_ids not yet pushed.
+        self._sends_outstanding: dict[ReqId, set[str]] = {}
+        # Completions drained from every shard manager. `poll_stats` consumes
+        # its queue, so exactly one place may call it: `get_finished`.
+        self._sent_ids: set[str] = set()
+        self._recvd_ids: set[str] = set()
+        self._failed_ids: set[str] = set()
+        # Reshard latency, split by phase; see _record_reshard_timing.
+        self._reshard_count = 0
+        self._reshard_register_s = 0.0
+        self._reshard_coordinate_s = 0.0
+        # ... and the latency vLLM actually waits on: submission of the first
+        # shard transfer to the step that reports the load finished.
+        self._load_started_at: dict[ReqId, float] = {}
+        self._load_count = 0
+        self._load_visible_s = 0.0
+
         logger.info(f"TPUConnector Worker --> init | "
                     f"is_producer={self.is_producer} | ip={self.host_ip} | "
-                    f"kv_transfer_port={self.kv_transfer_port}")
+                    f"kv_transfer_port={self.kv_transfer_port} | "
+                    f"controller={self.controller_address}")
 
     def register_runner(self, runner: TPUModelRunner):
         if KVCacheManager is None:
@@ -518,12 +694,7 @@ class TPUConnectorWorker:
         skip_lock = os.getenv("RAIDEN_UNSAFE_SKIP_BUFFER_LOCK",
                               "true").lower() in ("1", "true", "yes")
 
-        # The kv_cache_manager holds the physical KV buffers. The model forward updates
-        # them in place (donation), so the kv_cache_manager always serves/writes the live
-        # KV without re-registration (see plan, Blocker B).
-        self.kv_manager = KVCacheManager(
-            kv_caches=kv_caches,
-            local_control_port=self.kv_transfer_port,
+        manager_kwargs = dict(
             max_blocks=max_blocks,
             num_slots=num_slots,
             timeout_s=float(dist_utils.get_p2p_wait_pull_timeout()),
@@ -532,6 +703,19 @@ class TPUConnectorWorker:
             # `parallelism` (default 4!)
             parallelism=parallelism,
         )
+
+        if self.use_controller:
+            self._register_controller_shards(kv_caches, manager_kwargs)
+            return
+
+        # The kv_cache_manager holds the physical KV buffers. The model forward updates
+        # them in place (donation), so the kv_cache_manager always serves/writes the live
+        # KV without re-registration (see plan, Blocker B).
+        self.kv_manager = KVCacheManager(
+            kv_caches=kv_caches,
+            local_control_port=self.kv_transfer_port,
+            **manager_kwargs,
+        )
         logger.info(
             f"TPUConnector Worker {self.node_id} --> Raiden kv_cache_manager ready | "
             f"ip={self.host_ip} | "
@@ -539,6 +723,174 @@ class TPUConnectorWorker:
             f"data_port={getattr(self.kv_manager, 'local_data_port', None)} | "
             f"max_blocks={max_blocks} | num_slots={num_slots} | "
             f"parallelism={parallelism}")
+
+    def _shard_layout(self, kv_caches) -> tuple[int, int, list[int]]:
+        """(global head groups, local head groups, KV_HEAD rank per shard).
+
+        The KV page is ``(num_blocks, page_tokens, head_groups, packing,
+        padded_head_dim)`` with only dim 2 sharded, so a shard's position on
+        the KV_HEAD axis is read straight off its slice of that dim. Reading
+        the ranks from the arrays rather than from the mesh means a shard can
+        never be mislabelled: the byte spans are then addressed to the same
+        chip that holds those heads.
+        """
+        array = kv_caches[0]
+        shards = array.addressable_shards
+        global_groups = int(array.shape[2])
+        local_groups = int(shards[0].data.shape[2])
+
+        ranks: list[int] = []
+        for shard in shards:
+            index = shard.index
+            for dim in (0, 1):
+                span = index[dim]
+                if span.start not in (None, 0) or span.stop not in (
+                        None, array.shape[dim]):
+                    raise NotImplementedError(
+                        f"KV cache dim {dim} is sharded ({span}); the byte "
+                        "lowering assumes BATCH unsharded and no context "
+                        "parallelism, so a page is dense per rank")
+            if int(shard.data.shape[2]) != local_groups:
+                raise ValueError(
+                    "Uneven head-group sharding is not supported: "
+                    f"{shard.data.shape[2]} vs {local_groups}")
+            start = int(index[2].start or 0)
+            if start % local_groups:
+                raise ValueError(
+                    f"Head-group offset {start} is not a multiple of the "
+                    f"local extent {local_groups}")
+            ranks.append(start // local_groups)
+
+        for layer, array_l in enumerate(kv_caches):
+            if array_l.shape != array.shape:
+                raise ValueError(
+                    f"Layer {layer} KV shape {array_l.shape} differs from "
+                    f"layer 0 {array.shape}; the pool manifest is one dense "
+                    "pool per layer with a shared geometry")
+        return global_groups, local_groups, ranks
+
+    def _register_controller_shards(self, kv_caches, manager_kwargs) -> None:
+        """One Raiden work unit per local device shard.
+
+        Each unit gets its own `KVCacheManager` built over that shard's
+        buffers, its own data-plane endpoint and its own control-plane
+        listener, which is the only shape Raiden's byte-span planner accepts
+        (`raiden_controller.py`: "Pool reshard planning requires one
+        data-plane endpoint per work unit", and `dst_shard_idx` is always 0).
+        """
+        import jax.numpy as jnp
+
+        array = kv_caches[0]
+        num_blocks, page_tokens, _, packing, padded_head_dim = array.shape
+        global_groups, local_groups, ranks = self._shard_layout(kv_caches)
+        dtype_bits = jnp.dtype(array.dtype).itemsize * 8
+        dtype_tag = jnp.dtype(array.dtype).name
+
+        # A source's schedule key depends on the decode fan-out width, and it
+        # is fixed here, long before any handshake -- so the producer has to be
+        # told. `decode_tp_size` is the connector option the scheduler already
+        # uses to mint one request id per destination rank; 0 means symmetric.
+        # Only the producer pushes, so only the producer's key can matter.
+        parallelism = global_groups // local_groups
+        declared_peers = (dist_utils.get_kv_decode_tp_size(
+            self.vllm_config.kv_transfer_config) if self.is_producer else 0)
+        peer_ranks = declared_peers or parallelism
+
+        # Guessing symmetric is right whenever it is, and silently wrong
+        # otherwise: every rank would key to 0, every push would resolve to
+        # source 0's schedule, and the reshard would scatter one rank's bytes
+        # over all of them. That failure validates cleanly and is invisible
+        # until the output is garbage, so say so here rather than there.
+        if self.is_producer and not declared_peers and parallelism > 1:
+            logger.warning(
+                f"TPUConnector Worker {self.node_id} --> "
+                f"decode_tp_size is unset; assuming decode is "
+                f"TP{parallelism} like us. If decode runs a different TP "
+                f"degree, the per-shard schedule keys computed here are wrong "
+                f"and the reshard will silently corrupt KV.")
+
+        model_config = self.vllm_config.model_config
+        fingerprint = kv_pool_layout.layout_fingerprint(
+            num_layers=self.num_layers,
+            num_kv_heads=model_config.get_total_num_kv_heads(),
+            head_dim=model_config.get_head_size(),
+            dtype_tag=dtype_tag,
+        )
+
+        facade = RaidenControllerClientFacade(self.controller_address)
+        for position, rank in enumerate(ranks):
+            geometry = kv_pool_layout.AttentionKVGeometry(
+                num_layers=self.num_layers,
+                num_blocks=int(num_blocks),
+                page_tokens=int(page_tokens),
+                head_groups=global_groups,
+                head_groups_local=local_groups,
+                packing=int(packing),
+                padded_head_dim=int(padded_head_dim),
+                dtype_bits=int(dtype_bits),
+                transfer_rank=rank,
+                transfer_parallelism=global_groups // local_groups,
+                dtype_tag=dtype_tag,
+            )
+            # `addressable_shards[i].data` aliases the same device buffer the
+            # model writes -- verified pointer-identical against the global
+            # array's own buffer -- so Raiden reads and writes live KV.
+            shard_caches = [
+                layer.addressable_shards[position].data for layer in kv_caches
+            ]
+            # The receiver routes an incoming push to a source schedule purely
+            # by the sender's node_id, and the controller keys those schedules
+            # by the source's ordinal among the ranks feeding that destination
+            # -- see kv_pool_layout.source_schedule_key. Raiden defaults
+            # node_id to 0, which is only right while one source feeds each
+            # destination; with a head fan-in it silently misroutes every rank
+            # but the first.
+            schedule_key = kv_pool_layout.source_schedule_key(
+                rank, parallelism, peer_ranks)
+            manager = KVCacheManager(
+                kv_caches=shard_caches,
+                local_control_port=self.kv_transfer_port + position,
+                listener_port=self.listener_port + position,
+                node_id=schedule_key,
+                **manager_kwargs,
+            )
+            manifest = kv_pool_layout.build_pool_manifest(geometry)
+            summary = manager.register_pools(manifest)
+            unit = kv_pool_layout.work_unit_id(self.role, rank,
+                                               self.instance_tag)
+
+            facade.register_work_unit(
+                unit,
+                [manager.transfer_address],
+                control_plane_rpc_address=manager.listener_address,
+                pool_manifest=manifest,
+                layout_fingerprint=fingerprint,
+                page_tokens=geometry.page_tokens,
+                transfer_parallelism=geometry.transfer_parallelism,
+                transfer_rank=rank,
+            )
+
+            self.shard_managers.append(manager)
+            self.shard_geometries.append(geometry)
+            self.shard_units.append(unit)
+            logger.info(
+                f"TPUConnector Worker {self.node_id} --> registered {unit} | "
+                f"data={manager.transfer_address} | "
+                f"control={manager.listener_address} | "
+                f"heads={geometry.head_group_range} | "
+                f"schedule_key={schedule_key} | "
+                f"page_tokens={geometry.page_tokens} | "
+                f"bytes/token={geometry.per_token_bytes} | pools={summary}")
+
+        # The scheduler builds the handshake and has no mesh of its own.
+        # Every local shard has the same geometry bar its rank, so publishing
+        # shard 0's is enough for the peer to reconstruct all of them.
+        dist_utils.set_local_kv_geometry(
+            kv_pool_layout.geometry_to_dict(self.shard_geometries[0]))
+
+        self._transfer_pool = ThreadPoolExecutor(
+            max_workers=max(4, len(self.shard_managers)),
+            thread_name_prefix="raiden-reshard")
 
     def _remote_endpoint(self, req_meta: "LoadMeta"):
         """Resolve the producer endpoint(s) for start_read.
@@ -584,6 +936,14 @@ class TPUConnectorWorker:
             logger.info(
                 f"TPUConnector Worker {self.node_id} -->  reqs_to_send={reqs}")
         for req_id, req_meta in reqs.items():
+            if req_meta.dst_req_ids is not None:
+                # Controller path: the destination plans and drives the
+                # transfer, and the controller fires our push over the
+                # listener socket. Nothing to arm here -- just remember which
+                # pushes must land before these blocks may be freed.
+                self._sends_outstanding.setdefault(req_id, set()).update(
+                    req_meta.dst_req_ids)
+                continue
             self.kv_manager.register_read(req_id, req_meta.uuid,
                                           req_meta.local_block_ids)
 
@@ -593,7 +953,14 @@ class TPUConnectorWorker:
             logger.info(
                 f"TPUConnector Worker {self.node_id} -->  reqs_to_load={reqs}")
         for req_id, req_meta in reqs.items():
-            remote_endpoint = self._remote_endpoint(req_meta)
+            if req_meta.src_units is not None:
+                if req_meta.remote_block_ids is not None:
+                    self._start_controller_load(req_id, req_meta)
+                # remote_block_ids None means the transfer already finished
+                # (or never had to happen); the producer's blocks are freed by
+                # its own push completion, so there is nothing to notify.
+                continue
+
             if req_meta.remote_block_ids is not None:
                 # Consumer: pull remote_block_ids straight into the local KV
                 # cache at local_block_ids. The kv_manager does the H2H pull + H2D
@@ -603,6 +970,12 @@ class TPUConnectorWorker:
                     # Pre-allocated blocks may be re-issued; submit only once.
                     continue
                 self._submitted.add(req_id)
+                # Resolved here, not above: the post-load notify pass arrives
+                # with remote_block_ids=None and, because there is nothing left
+                # to load, none of the controller fields either. Under the
+                # controller there is no `kv_manager` to ask for endpoints, so
+                # resolving one unconditionally would crash that pass.
+                remote_endpoint = self._remote_endpoint(req_meta)
                 self.kv_manager.start_read(
                     req_id=req_id,
                     uuid=req_meta.uuid,
@@ -620,6 +993,216 @@ class TPUConnectorWorker:
                 # submit_load -- the producer rejects a 0-block pull stream.
                 self._submitted.discard(req_id)
 
+    def _start_controller_load(self, req_id: ReqId,
+                               req_meta: "LoadMeta") -> None:
+        """Drive one reshard per local decode shard, off the engine loop.
+
+        The destination is the side that owns the lowering: it is the only one
+        that sees both geometries. It declares each source rank's spans on its
+        behalf -- `register_request_blocks` is a controller-side declaration
+        and never touches the producer process -- and then asks the producer's
+        controller to plan, arm and fire.
+
+        `coordinate_transfer` blocks until the whole transfer completes, so it
+        runs on a thread pool; completion still surfaces through
+        `poll_stats()` in `get_finished()`, leaving the vLLM-facing contract
+        unchanged.
+        """
+        if req_id in self._loads_in_flight or req_id in self._load_req_ids:
+            # Pre-allocated blocks may be re-issued; submit only once.
+            return
+
+        src_base = kv_pool_layout.geometry_from_dict(req_meta.src_geometry)
+        src_units = [
+            kv_pool_layout.unit_from_dict(unit) for unit in req_meta.src_units
+        ]
+        if len(src_units) != src_base.transfer_parallelism:
+            raise ValueError(
+                f"Producer published {len(src_units)} source units but a "
+                f"transfer parallelism of {src_base.transfer_parallelism}; "
+                "the controller requires every source rank to be listed.")
+        # Tensor parallelism is uniform, so the peer's ranks differ from the
+        # published geometry only in their position on the head axis.
+        src_geometries = [
+            replace(src_base, transfer_rank=rank)
+            for rank in range(src_base.transfer_parallelism)
+        ]
+
+        futures = []
+        req_ids = set()
+        for position, geometry in enumerate(self.shard_geometries):
+            shard_req_id = req_meta.dst_req_ids[geometry.transfer_rank]
+            req_ids.add(shard_req_id)
+            futures.append(
+                self._transfer_pool.submit(self._reshard_one_shard,
+                                           shard_req_id, req_meta, position,
+                                           src_units, src_geometries))
+        self._loads_in_flight[req_id] = futures
+        self._load_req_ids[req_id] = req_ids
+        self._load_started_at[req_id] = time.perf_counter()
+
+    def _reshard_one_shard(self, shard_req_id: str, req_meta: "LoadMeta",
+                           position: int, src_units: list,
+                           src_geometries: list) -> None:
+        dst_geometry = self.shard_geometries[position]
+        # The scheduler admitted `round_down(sent, our page)` tokens as
+        # externally computed (get_num_new_matched_tokens), so move exactly
+        # that -- moving the producer's full count instead would write into a
+        # page the scheduler never reserved.
+        num_tokens = (int(req_meta.num_tokens) //
+                      dst_geometry.page_tokens) * dst_geometry.page_tokens
+        src_page = src_geometries[0].page_tokens
+        src_blocks = list(
+            req_meta.remote_block_ids)[:-(-num_tokens // src_page)]
+        # One uuid per destination rank, not one per request: a source keys
+        # its active plan by uuid and rejects a repeat with ALREADY_EXISTS, so
+        # any source feeding more than one of us would arm only the first and
+        # leave the rest waiting on a push that never comes.
+        uuid = kv_pool_layout.dst_uuid(req_meta.uuid,
+                                       dst_geometry.transfer_rank)
+        facade = RaidenControllerClientFacade(req_meta.src_controller)
+        blocks = ReshardRequestBlockClient(req_meta.src_controller)
+        started = time.perf_counter()
+
+        for src_unit, src_geometry in zip(src_units, src_geometries):
+            # Sources that own none of this destination's heads still have to
+            # be registered -- the controller wants transfer_rank contiguous
+            # from zero and raises "Missing producer block registration" for
+            # any listed unit without one -- but with no spans, which drops
+            # them from the plan.
+            entries = kv_pool_layout.build_request_span_entries(
+                src_geometry,
+                dst_geometry,
+                src_block_ids=src_blocks,
+                num_tokens=num_tokens)
+            blocks.register_request_blocks(shard_req_id,
+                                           uuid,
+                                           src_unit,
+                                           src_blocks,
+                                           pool_spans=entries)
+
+        registered = time.perf_counter()
+
+        # The producer only transferred whole source pages, so trim our own
+        # blocks to what those tokens actually fill at *our* page size.
+        dst_blocks = list(
+            req_meta.local_block_ids)[:-(-num_tokens //
+                                         dst_geometry.page_tokens)]
+        facade.coordinate_transfer(
+            src_units=src_units,
+            dst_units=[self.shard_units[position]],
+            req_id=shard_req_id,
+            use_block_chunks=True,
+            is_sender=True,
+            uuid=uuid,
+            src_controller_address=req_meta.src_controller,
+            dst_mem_type=RaidenMemoryType.HBM,
+            dst_device_block_ids=dst_blocks,
+            num_tokens=num_tokens,
+            transfer_pool_tags=[kv_pool_layout.KV_POOL_TAG],
+        )
+        self._record_reshard_timing(started, registered, time.perf_counter())
+
+    def _record_reshard_timing(self, started: float, registered: float,
+                               done: float) -> None:
+        """Split a reshard into declaration vs. plan-arm-push-wait.
+
+        `coordinate_transfer` blocks through the whole pipeline, so without
+        this split a TTFT regression is unattributable: it could be the span
+        declarations, the controller's planning, or the wire. Reported as a
+        running mean so the cost is one log line per `_RESHARD_TIMING_EVERY`
+        transfers rather than per request.
+        """
+        self._reshard_count += 1
+        self._reshard_register_s += registered - started
+        self._reshard_coordinate_s += done - registered
+        if self._reshard_count % _RESHARD_TIMING_EVERY:
+            return
+        count = self._reshard_count
+        logger.info(
+            f"TPUConnector Worker {self.node_id} --> reshard timing over "
+            f"{count} transfers | register_request_blocks="
+            f"{1e3 * self._reshard_register_s / count:.1f} ms | "
+            f"coordinate_transfer="
+            f"{1e3 * self._reshard_coordinate_s / count:.1f} ms (mean)")
+
+    def _record_load_latency(self, started: Optional[float]) -> None:
+        """The load latency vLLM is actually blocked on.
+
+        Everything past the reshard itself -- the completion ack reaching
+        `poll_stats`, and the engine step that next calls `get_finished` --
+        lands in the gap between this and the reshard timings above.
+        """
+        if started is None:
+            return
+        self._load_count += 1
+        self._load_visible_s += time.perf_counter() - started
+        if self._load_count % _RESHARD_TIMING_EVERY:
+            return
+        logger.info(
+            f"TPUConnector Worker {self.node_id} --> load latency over "
+            f"{self._load_count} requests | submit-to-done="
+            f"{1e3 * self._load_visible_s / self._load_count:.1f} ms (mean)")
+
+    def _get_finished_controller(self) -> tuple[set[str], set[str]]:
+        """Aggregate per-shard completions back to vLLM request ids.
+
+        A request fans out to one transfer per destination rank, each under
+        its own req_id, so a vLLM request is finished only when every one of
+        them is. On the producer side the mapping from source rank to
+        destination rank is the plan's business, not ours -- but every
+        destination has at least one contributing source, so waiting for the
+        union of the destination req_ids to be pushed is exact.
+        """
+        for manager in self.shard_managers:
+            done_sending, done_recving, failed_recving = manager.poll_stats()
+            self._sent_ids.update(done_sending)
+            self._recvd_ids.update(done_recving)
+            self._failed_ids.update(failed_recving)
+        if self._failed_ids:
+            logger.error(f"TPUConnector Worker {self.node_id} --> "
+                         f"failed_recving={sorted(self._failed_ids)}")
+
+        finished_sending: set[str] = set()
+        for req_id, outstanding in list(self._sends_outstanding.items()):
+            if outstanding <= self._sent_ids:
+                finished_sending.add(req_id)
+                del self._sends_outstanding[req_id]
+                self._sent_ids -= outstanding
+
+        finished_recving: set[str] = set()
+        for req_id, futures in list(self._loads_in_flight.items()):
+            if not all(future.done() for future in futures):
+                continue
+            errors = [f.exception() for f in futures if f.exception()]
+            if errors:
+                # Do NOT report a failed load as done: vLLM would decode
+                # against KV that was never written. Leave it pending and let
+                # the request time out at the API layer instead.
+                logger.error(
+                    f"TPUConnector Worker {self.node_id} --> reshard failed "
+                    f"for {req_id}: {errors[0]}")
+                del self._loads_in_flight[req_id]
+                del self._load_req_ids[req_id]
+                self._load_started_at.pop(req_id, None)
+                continue
+            shard_req_ids = self._load_req_ids[req_id]
+            if shard_req_ids <= self._recvd_ids:
+                finished_recving.add(req_id)
+                del self._loads_in_flight[req_id]
+                del self._load_req_ids[req_id]
+                self._recvd_ids -= shard_req_ids
+                self._record_load_latency(
+                    self._load_started_at.pop(req_id, None))
+
+        if finished_sending:
+            logger.info(f"TPUConnector Worker {self.node_id} -->  "
+                        f"done_sending={finished_sending}")
+        if finished_recving:
+            logger.info(f"TPUConnector Worker {self.node_id} -->  "
+                        f"done_recving={finished_recving}")
+        return finished_sending, finished_recving
+
     def get_kv_connector_stats(self) -> KVConnectorStats | None:
         """
         Get the KV transfer stats for the worker.
@@ -633,6 +1216,8 @@ class TPUConnectorWorker:
         # The kv_manager's control plane reports producer completion (done_sending,
         # after D acks) and consumer completion (done_recving, after H2H+H2D).
         # Replaces the reqs_wait_pull/reqs_pulling bookkeeping + ZMQ side channel.
+        if self.use_controller:
+            return self._get_finished_controller()
         if self.kv_manager is None:
             return set(), set()
         done_sending, done_recving, failed_recving = self.kv_manager.poll_stats(

--- a/tpu_inference/distributed/utils.py
+++ b/tpu_inference/distributed/utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from typing import Optional
 
 from vllm.utils.network_utils import get_ip
 
@@ -66,6 +67,75 @@ def get_kv_transfer_port() -> str:
 def get_side_channel_port() -> str:
     port = os.getenv("TPU_SIDE_CHANNEL_PORT", "9600")
     return port
+
+
+def get_kv_controller_address() -> Optional[str]:
+    """Address ('host:port') of the Raiden controller, or None.
+
+    When set, the connector registers each local KV shard as a Raiden work unit
+    and routes transfers through the controller's byte-span reshard planner,
+    which tolerates a different TP degree and page size on the two sides. When
+    unset, the connector keeps using the index-matched symmetric pull.
+    """
+    address = os.getenv("TPU_KV_CONTROLLER_ADDRESS", "").strip()
+    return address or None
+
+
+def get_kv_controller_port() -> int:
+    """Port the prefill host's controller sidecar binds. 0 selects an ephemeral port."""
+    return int(os.getenv("TPU_KV_CONTROLLER_PORT", "9700"))
+
+
+def get_raiden_listener_port() -> int:
+    """Base port for the per-shard Raiden KVCacheListener control-plane sockets.
+
+    Shard i binds `base + i`; the controller uses these to arm a receiver
+    (PoolReshardRegisterRecv) and to fire a sender (PoolReshardPush). Distinct
+    from `get_kv_transfer_port`, which is the data plane.
+    """
+    return int(os.getenv("TPU_KV_LISTENER_PORT", "9800"))
+
+
+def get_kv_decode_tp_size(kv_transfer_config=None) -> int:
+    """Number of KV shards on the decode side, or 0 to assume it matches ours.
+
+    The prefill scheduler needs the decode fan-out width to mint one request
+    id per destination rank, and each prefill worker needs it to compute its
+    shard's schedule key -- both before any handshake exists to carry it. It is
+    a deployment constant of a P/D pair, and the launcher already knows both TP
+    sizes. 0 (the default) means symmetric, which is the only case where
+    guessing is safe.
+
+    Read from ``kv_connector_extra_config["decode_tp_size"]`` so it rides in
+    ``--kv-transfer-config`` alongside every other connector option, the way
+    connectors on other backends take their settings. ``TPU_KV_DECODE_TP_SIZE``
+    remains as a fallback for launchers that set it in the environment.
+    """
+    if kv_transfer_config is not None:
+        declared = kv_transfer_config.get_from_extra_config(
+            "decode_tp_size", None)
+        if declared is not None:
+            return int(declared)
+    # An empty value is what a launcher produces from an unset shell variable;
+    # treat it as "not declared" rather than crashing the engine at init.
+    return int(os.getenv("TPU_KV_DECODE_TP_SIZE", "").strip() or 0)
+
+
+# Byte geometry of this process's local KV shards, published by the worker
+# connector at init and read by the scheduler connector when it builds the
+# handshake. Same bridging pattern as _NODES_KV_IP_PORT above: identical
+# process for single-host, collected over collective_rpc by the Ray executor
+# for multi-host.
+_LOCAL_KV_GEOMETRY: Optional[dict] = None
+
+
+def set_local_kv_geometry(geometry: dict) -> None:
+    global _LOCAL_KV_GEOMETRY
+    _LOCAL_KV_GEOMETRY = geometry
+
+
+def get_local_kv_geometry() -> Optional[dict]:
+    return _LOCAL_KV_GEOMETRY
 
 
 def get_transfer_channel_number() -> str:


### PR DESCRIPTION
# Description

> **Stacked on #3378.** That PR adds `tpu_inference/distributed/kv_pool_layout.py`, the byte-span lowering this connector consumes; nothing else imports it. Until it merges, GitHub shows both commits here — **only the second, `8161d1e`, is new in this PR.**

## Problem

TPU prefill/decode disaggregation only works when both sides run identical hardware and parallelism. The connector's own comment says so — "both prefill and decode run identical hardware, so producer sub-manager i (port base+i) serves the same shards as our local sub-manager i" — the handshake carries no geometry, and the worker path is an index-matched block pull. `examples/disagg/run_disagg_single_host.sh` encodes the restriction by requiring `PREFILLER_TP_SIZE == DECODER_TP_SIZE`.

## Approach

Route the transfer through Raiden's byte-span reshard pipeline instead, so a prefill node at one TP degree and page size can hand KV to a decode node at another, in either direction. Set `TPU_KV_CONTROLLER_ADDRESS` and the new path is taken; leave it unset and the index-matched pull runs exactly as before — the change is revertible by environment variable and adds nothing to the symmetric deployment.

No transport is reimplemented. `RegisterWorkUnit` → `RegisterRequestBlocks` → `CoordinateTransfer` → `PoolReshardRegisterRecv` / `PoolReshardPush` already exists in tpu-raiden and is geometry-neutral; what was missing was a production caller that lowers a vLLM TPU KV cache into it (`kv_pool_layout.py`, #3378) and a connector that drives it. Reaching that pipeline from a JAX worker also needs tpu-raiden's JAX framework surface to expose pool admission and a control-plane listener, which is a separate change to that repo; until it lands, the controller path here stays inert because it's gated on `TPU_KV_CONTROLLER_ADDRESS`.

Five design constraints fell out of Raiden's process-per-rank planner meeting a JAX worker that holds several chips in one process:

| constraint | resolution |
|---|---|
| Raiden allows one data-plane endpoint per work unit and hardcodes `dst_shard_idx = 0` | one `KVCacheManager` per device shard, each aliasing `arr.addressable_shards[i].data` and registered as its own work unit — no copy, no tpu-raiden change |
| a push is resolved by the sender's `node_id` alone, but schedules are keyed by the source's *ordinal among ranks feeding that destination* | each worker derives its own key via `source_schedule_key()`, from the same contributor set the spans are built from; at equal parallelism the ordinal is always 0, which is why the symmetric path never needed this |
| a source rejects a repeat plan uuid with `ALREADY_EXISTS`, and one source can feed several destinations | one uuid per destination rank (`dst_uuid()`) |
| the work-unit registry is keyed by the whole `RaidenId`, so two engines of the same role and parallelism collide | `engine_instance_tag()`, derived from the data-plane host and base transfer port — a pair that must already differ between coexisting engines, so both sides agree without exchanging one |
| the consumer used to re-derive the transferred prefix from *its own* block size, which only matches the producer's at equal page sizes | the producer's token count is now authoritative, rounded down to the consumer's own pages |

The remaining piece — the decode side's TP degree — has to be known at producer engine init, earlier than any handshake, so it can't be negotiated. It rides in `--kv-transfer-config` as `kv_connector_extra_config.decode_tp_size`, the way connector options work on other backends (`TPU_KV_DECODE_TP_SIZE` is an environment fallback). Left unset, the producer assumes decode is as wide as itself — correct for every symmetric deployment — and warns, because a wrong guess produces a well-formed plan with exact byte totals and stays invisible until the output is garbage; the decoder cross-checks the assumption against its own rank count and refuses a mismatch.

Completion still surfaces through `poll_stats()` in `get_finished()`, so the vLLM-facing contract is unchanged.

## What changed

- `tpu_inference/distributed/tpu_raiden_connector.py` — per-shard managers and work units, schedule keys, per-destination uuids, engine tags, producer-authoritative prefix length, `decode_tp_size` handling.
- `tpu_inference/distributed/raiden_controller_sidecar.py` (new) — runs the controller as its own process, since the control plane outlives the engines and may not share a host with either.
- `tpu_inference/distributed/utils.py` — `TPU_KV_CONTROLLER_ADDRESS`, `TPU_KV_LISTENER_PORT`, the `decode_tp_size` connector option, and a hook for the worker to publish its local KV geometry.
- `examples/disagg/run_disagg_single_host.sh` — takes a TP degree, a chip set, and a page size per side; starts the controller sidecar; refuses a heterogeneous configuration on the symmetric connector instead of transferring the wrong bytes. Everything here is opt-in: with no variables set, the script launches the same two stock-connector engines it always did, on the same chips, with the same process grid and the same `--kv-transfer-config`.

### Running it

```bash
# prefill host
python -m tpu_inference.distributed.raiden_controller_sidecar --port 9700 &

TPU_KV_CONTROLLER_ADDRESS=<controller-host>:9700 TPU_KV_LISTENER_PORT=9800 \
  vllm serve $MODEL --tensor-parallel-size 8 --block-size 128 \
    --kv-transfer-config '{"kv_connector":"TPUConnector",
      "kv_connector_module_path":"tpu_inference.distributed.tpu_raiden_connector",
      "kv_role":"kv_producer",
      "kv_connector_extra_config":{"decode_tp_size":4}}'

# decode host
TPU_KV_CONTROLLER_ADDRESS=<controller-host>:9700 TPU_KV_LISTENER_PORT=9900 \
  vllm serve $MODEL --tensor-parallel-size 4 --block-size 64 \
    --kv-transfer-config '{"kv_connector":"TPUConnector",
      "kv_connector_module_path":"tpu_inference.distributed.tpu_raiden_connector",
      "kv_role":"kv_consumer"}'
```

# Tests

## Offline

`tests/distributed/test_tpu_raiden_connector_controller.py` — 22 test functions against a mocked controller:

```bash
pytest tests/distributed/test_tpu_raiden_connector_controller.py
```

Covers: the symmetric handshake is unchanged without a controller; the controller handshake lists every source rank and the units it names match what workers register; two engines of one role register distinct units; `decode_tp_size` is read from the connector config, wins over the environment fallback, and defaults to symmetric when neither is set, while a rank-count mismatch is refused; matched tokens follow the producer's count rather than the consumer's page size; there is one transfer per destination rank with its own plan uuid, and non-contributing source ranks register empty spans; a request finishes only when every rank lands, a failed reshard is never reported as loaded, and the producer holds its blocks until every push completes.

Both new test files start with `pytest.importorskip("tpu_sync.rpc.raiden_controller")`, which isn't in any dependency manifest or in the Buildkite image, so they collect and skip cleanly in upstream CI rather than error — verified locally without tpu-raiden: `2 skipped`. Everything below ran on TPU hardware with tpu-raiden built from source. The rest of `tests/distributed/` under `JAX_PLATFORMS=cpu` is 39 passed / 5 failed, and the same suite run on `main` in the same session is also 39 passed / 5 failed with the same five names — all in `test_kv_transfer.py`, all needing a TPU backend. `pre-commit run --all-files` passes with a clean tree afterwards.

## Correctness on hardware

`Qwen/Qwen3-0.6B` and `HuggingFaceTB/SmolLM2-1.7B-Instruct` on v6e, 200 benchmark prompts at 4 req/s, correctness over 150 requests of real prose at `temperature=0` against a non-disaggregated baseline. Each geometry is paired with a symmetric control measured on the same model, same hosts, same session — that comparison, not the absolute count, is what carries the signal, because greedy decoding has a nonzero mismatch floor even with zero transfer (see #3369).

| prefill → decode | model | hosts | mismatches | failed | median TTFT |
|---|---|---|---|---|---|
| TP8 page 128 → TP4 page 64 | Qwen3-0.6B | 2 | 3/150 | 0/200 | 195.9 ms |
| TP8 page 128 → TP4 page 64, two decode replicas | Qwen3-0.6B | 3 | 3/150 | 0/200 | 199.7 ms |
| *control:* TP4 page 128 → TP4 page 128 | Qwen3-0.6B | 2 | 3/150 | 0/200 | 105.4 ms |
| TP4 page 128 → TP8 page 64 | SmolLM2-1.7B | 2 | 7/150 | 0/200 | 423.7 ms |
| *control:* TP4 page 128 → TP4 page 128 | SmolLM2-1.7B | 2 | 10/150 | 0/200 | 110.0 ms |
| TP4 page 128 → TP1 page 64 | Qwen3-0.6B | 1 | 3/150 | 0/200 | 77.2 ms |
| TP1 page 128 → TP4 page 64 | Qwen3-0.6B | 1 | 3/150 | 0/200 | 124.3 ms |
| TP1 page 128 → TP1 page 64 | Qwen3-0.6B | 1 | 1/50 | 0/200 | 70.9 ms |
| *reference:* TP1 → TP1, existing connector, no controller | Qwen3-0.6B | 1 | 2/150 | 0/200 | 35.3 ms |

**The geometry adds no mismatches.** In the Qwen3 group, all runs diverge on the same three prompts at the same three character offsets regardless of fan-in, page split, or host boundary. In the SmolLM2 group, the expansion scores *below* its own symmetric control — five of its seven mismatching prompts are among the control's ten, at identical offsets. The residual diverges 12–159 characters into the completion, never at character 0.

Both decode replicas in the two-replica row genuinely served: 700 shard transfers each against 1400 through the single replica, matching per-shard timings. The second replica costs ~4 ms of median TTFT and nothing measurable in quality or throughput.

## What a genuine transfer fault looks like

For contrast: three runs with the source shards' schedule keys left at the transport's default `node_id` (the pre-fix behavior), differing only in one variable:

| prefill → decode | mismatches |
|---|---|
| TP4 page 128 → TP4 page 128 | 1/50 |
| TP8 page 128 → TP4 page 128 | **50/50, from character 0** |
| TP8 page 128 → TP4 page 64 | **150/150, from character 0** |

Nothing errors — the plan validates, byte totals are exact, every worker reports success — the pushes simply scatter with the wrong source's schedule, so whole head groups keep stale KV. This is the failure mode `source_schedule_key()` exists to prevent, and it's what a real fault looks like against which the correctness table above should be read.

## Byte-exact at a geometry no v6e engine can be started in

libtpu's per-process v6e slice table admits 1, 4, or 8 chips, not 2 — every two-chip partition of a v6e-8 fails, so vLLM can't run at TP2 on v6e at all. But the reshard addresses shards, not engines, and a TP2 worker is one process holding one `KVCacheManager` per shard. Six single-chip JAX processes (4 source at page 128, 2 destination at page 64) present the controller with the same work units, manifests, spans, and schedule keys as a real TP4 → TP2 pair, over 8 head groups, 2 layers, 256 tokens. The oracle is built by indexing the source patterns independently, not by re-deriving spans:

| | result |
|---|---|
| TP4 page 128 → TP2 page 64, 524288 elements over 2 destinations | exact |
| destination blocks outside the plan | still hold the sentinel |
| source arrays after their own push | unchanged |
| same run, sender's `node_id` left at the transport default | 131072/262144 and 262144/262144 elements wrong, by whole head groups |

The last row is the negative control: identical plan, exact byte totals, every worker reports success, and the receiver-side coverage check passes — because it validates the plan, not the wire. Only a byte comparison catches it.

## Latency

Measured at TP1 → TP1 on one host, isolating the reshard from prefill compute: 35.4 ms median TTFT for the existing default connector, 60.0 ms for the existing Raiden connector's symmetric pull, 70.0 ms through the controller. `register_request_blocks` + `coordinate_transfer` together cost ~6 ms symmetric and ~23 ms with a reshard; the remainder is completion detection (push ack reaching `poll_stats()`, plus the once-per-engine-step `get_finished()` cadence) — a mechanism the symmetric path already shares.

Destination fan-out is the larger cost: one destination shard to four moves TTFT 70.9 → 124.3 ms; the SmolLM2 expansion from four to eight moves it 110.0 → 423.7 ms against its symmetric control. The per-shard calls already dispatch concurrently at ~20 ms each, so this isn't serialized RPC — the cause isn't isolated further here.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
