### PR TITLE
Load the Raiden engine extension before env_override

### DIFF
--- a/tpu_inference/__init__.py
+++ b/tpu_inference/__init__.py
@@ -12,17 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# The environment variables override should be imported before any other
-# modules to ensure that the environment variables are set before any
-# other modules are imported.
-import tpu_inference.env_override  # noqa: F401
-from tpu_inference import envs
-
-# Engine-first XLA load: import Raiden's engine extension here -- the earliest
-# tpu_inference entry point, before any submodule (e.g. platforms/tpu_platform.py)
-# runs `import jax` and loads jaxlib's libjax_common.so. This ensures Raiden's
-# embedded XLA runtime comes up before jaxlib's so the two XLA copies don't collide
-# in static initializers.
+# Engine-first XLA load: import Raiden's engine extension before anything else,
+# so Raiden's embedded XLA runtime comes up before jaxlib's and the two copies
+# don't collide in static initializers.
+#
+# This must precede `env_override` as well as any submodule: env_override imports
+# `vllm.sampling_params`, which reaches `vllm.config` -> `torch` and loads jaxlib's
+# XLA. Loading Raiden's extension after that segfaults the process outright, and
+# the `except` clauses below cannot catch a SIGSEGV. Hoisting it is safe for the
+# environment overrides below: the extension does not map libtpu at import time,
+# so LIBTPU_INIT_ARGS and XLA_FLAGS are still set long before TPU initialization.
 try:
     import tpu_raiden.frameworks.jax._tpu_raiden_jax  # noqa: F401
 except ModuleNotFoundError:
@@ -34,7 +33,12 @@ except Exception as _raiden_exc:  # pragma: no cover - best-effort preload
     print(f"[tpu_raiden] engine preload failed: {_raiden_exc}",
           file=_sys.stderr)
 
-from tpu_inference import tpu_info as ti
+# The environment variables override should be imported before any other
+# modules to ensure that the environment variables are set before any
+# other modules are imported.
+import tpu_inference.env_override  # noqa: F401, E402
+from tpu_inference import envs  # noqa: E402
+from tpu_inference import tpu_info as ti  # noqa: E402
 from tpu_inference.logger import init_logger
 
 logger = init_logger(__name__)


### PR DESCRIPTION
# Description

## Problem

`tpu_inference/__init__.py` preloads Raiden's engine extension so its XLA registers before jaxlib's. It doesn't: the preload sits below `import tpu_inference.env_override`, and that import reaches `vllm.sampling_params` → `vllm.config` → `torch`, which loads jaxlib's XLA first. With tpu-raiden on `PYTHONPATH`, a bare `import tpu_inference` segfaults in a static initializer — no traceback, no log line, just a core dump. The `try/except` around the preload catches `ModuleNotFoundError`, not `SIGSEGV`, so nothing here explains the crash. Without tpu-raiden installed the preload is already a no-op, which is why this has gone unnoticed.

## Approach

Hoist the preload above `env_override` and mark the demoted imports `# noqa: E402`. This is safe for the environment overrides themselves: the extension doesn't map libtpu at import time, so `LIBTPU_INIT_ARGS` and `XLA_FLAGS` are still set long before TPU initialization. Only the module-registration order changes.

## What changed

`tpu_inference/__init__.py` — one file, moved one import block above another and updated the comment explaining why the order matters.

# Tests

Reproduced and cleared on a v6e-8 running `Qwen/Qwen3-0.6B`. With tpu-raiden importable:

```bash
python -c "import tpu_inference"
```

Before: `Segmentation fault (core dumped)`, exit 139, no output. After: exits 0.

With tpu-raiden absent, the import is unchanged before and after — the preload's `try/except` swallows `ModuleNotFoundError` exactly as it did.

`pre-commit run --all-files` passes. This changes import order in one file and adds no behavior, so the rest of the suite is untouched.

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
