### PR TITLE
Fix model registry in experimental

### DIFF
--- a/tpu_inference/models/vllm/experimental/__init__.py
+++ b/tpu_inference/models/vllm/experimental/__init__.py
@@ -28,7 +28,7 @@ def register_models():
     Called from the ``vllm.general_plugins`` entrypoint so it runs at vLLM
     startup, before any model is resolved from its architecture name.
     """
-    from vllm import ModelRegistry
+    from vllm.model_executor.models import ModelRegistry
 
     for arch, model_cls in _TPU_VLLM_MODELS.items():
         ModelRegistry.register_model(arch, model_cls)


### PR DESCRIPTION

ModelRegistry has been moved to vllm.model_executor.models 