### PR TITLE
Fused MoE Kernel integration and optimization

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -66,6 +66,7 @@ if TYPE_CHECKING:
     MOE_APPROX_TOPK_RECALL_TARGET: float | None = None
     VLLM_TPU_PATCH_MM_EMBEDDINGS: bool = False
     ENABLE_RS_KERNEL: bool = False
+    USE_GMM_FUSED_RS_KERNEL: bool = False
     NUM_PRECOMPILE_WORKERS: int = 1
     DP_SCHED_BATCH_PREFILL: bool = False
     DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS: int = 10000
@@ -412,6 +413,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable hierarchical reduce-scatter kernel for MoE
     "ENABLE_RS_KERNEL":
     env_bool("ENABLE_RS_KERNEL", default=False),
+    # Enable fused GMM reduce-scatter kernel for MoE
+    "USE_GMM_FUSED_RS_KERNEL":
+    env_bool("USE_GMM_FUSED_RS_KERNEL", default=False),
     # Number of worker threads for parallel XLA precompilation.
     "NUM_PRECOMPILE_WORKERS":
     lambda: int(os.getenv("NUM_PRECOMPILE_WORKERS") or "1"),

--- a/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
+++ b/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
@@ -38,10 +38,12 @@ from jax.experimental.pallas import tpu as pltpu
 # isort: off
 # yapf: disable
 from .gmm_v2_gather_scatter import (
-    Dimensions, FusedDims, FusedWeightsRef, GmmConfigs, InputConfigs,
-    MetadataRef, TileSizes, WeightsRef, _recover_quant_block_size, align_to,
-    calculate_tiling, dma_gather_gm_start, dma_gather_gm_wait, fill_metadata,
-    get_maybe_quantize_lhs, inner_kernel, zero_out_end_3d, zero_out_start_3d)
+    Dimensions, FusedDims, FusedWeightsRef, GatherMetadata, GmmConfigs,
+    InputConfigs, MetadataRef, ScatterMetadata, TileSizes, WeightsRef,
+    _recover_quant_block_size, align_to, calculate_tiling, dma_gather_gm_start,
+    dma_gather_gm_wait, fill_metadata, get_maybe_quantize_lhs, inner_kernel,
+    prepare_gather_tile_metadata, prepare_scatter_tile_metadata, zero_out_end_3d,
+    zero_out_start_3d)
 # yapf: enable
 # isort: on
 
@@ -838,43 +840,66 @@ def kernel_main_fused_rs(
                 for _i in range(min(num_w2_bufs, total_w2_steps)):
                     start_w2_dma(_i, expert_id, _i // num_k2, _i % num_k2)
 
+            # --- Prepare Scatter Metadata (for current gm_id direct-write) ---
+            scatter_meta = prepare_scatter_tile_metadata(
+                gm_id,
+                metadata_ref,
+                tile_m=tile_m,
+                size_m=fused_dims.size_m,
+                lhs_indices_ref=lhs_indices_ref,
+                topk_indices_ref=topk_indices_ref,
+                my_id=my_id,
+                chunk_size=chunk_size,
+                top_k=top_k,
+                pack_indices=pack_indices,
+            )
+
             # --- DMA gather (issued after weight DMAs are in flight) ---
-            # When indices are packed, set divisor=top_k so the
-            # gather extracts the actual lhs_idx via integer division.
             _gather_divisor = top_k if pack_indices else 1
 
             @jax.named_scope("dma_gather_start")
             @pl.when(gm_id == 0)
             def _():
+                gather_meta_0 = prepare_gather_tile_metadata(
+                    0,
+                    metadata_ref,
+                    tile_m=tile_m,
+                    size_m=fused_dims.size_m,
+                    lhs_indices_ref=lhs_indices_ref,
+                    pack_indices=pack_indices,
+                    gather_divisor=_gather_divisor,
+                )
                 dma_gather_gm_start(
                     hidden_states_ref,
                     gathered_lhs_2x_ref.at[sem_id],
-                    lhs_indices_ref,
                     gather_sem_ref.at[sem_id],
-                    0,
-                    metadata_ref,
-                    divisor=_gather_divisor,
+                    gather_meta_0,
                 )
 
             @jax.named_scope("dma_gather_prefetch")
             @pl.when(gm_id + 1 < local_num_gm)
             def _():
+                next_gather_meta = prepare_gather_tile_metadata(
+                    gm_id + 1,
+                    metadata_ref,
+                    tile_m=tile_m,
+                    size_m=fused_dims.size_m,
+                    lhs_indices_ref=lhs_indices_ref,
+                    pack_indices=pack_indices,
+                    gather_divisor=_gather_divisor,
+                )
                 dma_gather_gm_start(
                     hidden_states_ref,
                     gathered_lhs_2x_ref.at[1 - sem_id],
-                    lhs_indices_ref,
                     gather_sem_ref.at[1 - sem_id],
-                    gm_id + 1,
-                    metadata_ref,
-                    divisor=_gather_divisor,
+                    next_gather_meta,
                 )
 
             # Wait for gather (weight DMAs running in parallel).
             dma_gather_gm_wait(
                 gathered_lhs_2x_ref.at[sem_id],
                 gather_sem_ref.at[sem_id],
-                gm_id,
-                metadata_ref,
+                scatter_meta,
             )
 
             # GMM1 loop.
@@ -959,8 +984,7 @@ def kernel_main_fused_rs(
             def _():
                 zero_out_end_3d(out_buf_ref, zero_sem_ref, zero_size)
 
-            m_st = metadata_ref.gm_id_to_m_offset[gm_id]
-            m_en = metadata_ref.gm_id_to_m_offset[gm_id + 1]
+            m_st = scatter_meta.m_start
             _sls = pltpu.get_tpu_info().get_sublane_tiling(out_dtype)
             _ml = m_st % _sls
 
@@ -972,71 +996,46 @@ def kernel_main_fused_rs(
                         scatter_staging_3x_ref.shape[3],
                     )
 
-            # Step 10: Direct-write — single pass over valid rows only.
-            # Each row either ICI-sends (remote) or DMA-copies (local) to
-            # direct_write_buf[local_row * top_k + topk_idx].
-            # Loop bound is m_en - m_st (valid rows), not tile_m, eliminating
-            # wasted iterations on padding rows.
-            m_valid = m_en - m_st
-
+            # Step 10: Direct-write — branchless static loop over tile_m rows.
+            # Uses pre-computed should_send / should_local from ScatterMetadata to avoid
+            # dynamic loops and dynamic branching on @pl.when.
             @jax.named_scope("direct_write_rows")
             def _do_direct_write():
+                with jax.named_scope("direct_write_do_dma"):
+                    for i in range(tile_m):
+                        row_idx = _ml + i
+                        write_pos = scatter_meta.write_positions[i]
+                        dest_chip = scatter_meta.dest_chips[i]
+                        should_send = scatter_meta.should_sends[i]
+                        should_local = scatter_meta.should_locals[i]
 
-                def _write_row(i, carry):
-                    send_sz, local_sz = carry
-                    row_idx = _ml + i
-                    # Read indices. Either packed (one ref) or separate.
-                    if pack_indices:
-                        # combined = lhs_idx * top_k + topk_slot
-                        #          = (dest_chip * chunk_size + local_row) * top_k + topk_slot
-                        # So:
-                        #   write_pos = local_row * top_k + topk_slot
-                        #             = combined % (chunk_size * top_k)
-                        #   dest_chip = combined // (chunk_size * top_k)
-                        # When chunk_size * top_k is a power of 2 (typical),
-                        # XLA lowers these to a shift + mask — essentially free.
-                        # No need to compute oi/topk_idx/local_row separately.
-                        combined = lhs_indices_ref[m_st + i]
-                        cs_tk = chunk_size * top_k
-                        write_pos = combined % cs_tk
-                        dest_chip = combined // cs_tk
-                    else:
-                        oi = lhs_indices_ref[m_st + i]
-                        topk_idx = topk_indices_ref[m_st + i]
-                        dest_chip = oi // chunk_size
-                        local_row = oi % chunk_size
-                        write_pos = local_row * top_k + topk_idx
-                    is_local = dest_chip == my_id
+                        if fp8_direct_write:
+                            # Quantize each completed expert row before the direct
+                            # write. Remote ICI then moves FP8 payload plus one
+                            # fp32 row scale instead of the full bf16 activation row.
+                            row_f32 = scatter_staging_3x_ref[stg_id,
+                                                             row_idx, :, :].astype(
+                                                                 jnp.float32)
+                            fp8_max = jnp.array(jnp.finfo(jnp.float8_e4m3fn).max,
+                                                dtype=jnp.float32)
+                            row_scale = (jnp.maximum(
+                                jnp.max(jnp.abs(row_f32)),
+                                jnp.array(1e-6, dtype=jnp.float32),
+                            ) / fp8_max)
+                            scatter_scale_3x_ref[stg_id, row_idx, :] = (
+                                row_scale + jnp.zeros((128, ), dtype=jnp.float32))
+                            scatter_fp8_staging_3x_ref[stg_id,
+                                                      row_idx, :, :] = jnp.clip(
+                                                          row_f32 / row_scale,
+                                                          -fp8_max,
+                                                          fp8_max).astype(
+                                                              jnp.float8_e4m3fn)
 
-                    if fp8_direct_write:
-                        # Quantize each completed expert row before the direct
-                        # write. Remote ICI then moves FP8 payload plus one
-                        # fp32 row scale instead of the full bf16 activation row.
-                        row_f32 = scatter_staging_3x_ref[stg_id,
-                                                         row_idx, :, :].astype(
-                                                             jnp.float32)
-                        fp8_max = jnp.array(jnp.finfo(jnp.float8_e4m3fn).max,
-                                            dtype=jnp.float32)
-                        row_scale = (jnp.maximum(
-                            jnp.max(jnp.abs(row_f32)),
-                            jnp.array(1e-6, dtype=jnp.float32),
-                        ) / fp8_max)
-                        scatter_scale_3x_ref[stg_id, row_idx, :] = (
-                            row_scale + jnp.zeros((128, ), dtype=jnp.float32))
-                        scatter_fp8_staging_3x_ref[stg_id,
-                                                   row_idx, :, :] = jnp.clip(
-                                                       row_f32 / row_scale,
-                                                       -fp8_max,
-                                                       fp8_max).astype(
-                                                           jnp.float8_e4m3fn)
-
-                        @pl.when(~is_local)
-                        def _():
                             pltpu.make_async_remote_copy(
                                 src_ref=scatter_fp8_staging_3x_ref.at[
-                                    stg_id, pl.ds(row_idx, 1), :, :],
+                                    stg_id, pl.ds(row_idx, should_send), :, :],
                                 dst_ref=out_buf_ref.at[
-                                    pl.ds(write_pos, 1), :, :],
+                                    pl.ds(write_pos, should_send), :, :],
                                 send_sem=send_sems_ref.at[stg_id],
                                 recv_sem=recv_sem_ref.at[0],
                                 device_id={
@@ -1046,9 +1045,9 @@ def kernel_main_fused_rs(
                             ).start()
                             pltpu.make_async_remote_copy(
                                 src_ref=scatter_scale_3x_ref.at[
-                                    stg_id, pl.ds(row_idx, 1), :],
+                                    stg_id, pl.ds(row_idx, should_send), :],
                                 dst_ref=out_scale_ref.at[
-                                    pl.ds(write_pos, 1), :],
+                                    pl.ds(write_pos, should_send), :],
                                 send_sem=scale_send_sems_ref.at[stg_id],
                                 recv_sem=scale_recv_sem_ref.at[0],
                                 device_id={
@@ -1057,32 +1056,27 @@ def kernel_main_fused_rs(
                                 device_id_type=pltpu.DeviceIdType.MESH,
                             ).start()
 
-                        @pl.when(is_local)
-                        def _():
                             pltpu.make_async_copy(
                                 src_ref=scatter_fp8_staging_3x_ref.at[
-                                    stg_id, pl.ds(row_idx, 1), :, :],
+                                    stg_id, pl.ds(row_idx, should_local), :, :],
                                 dst_ref=out_buf_ref.at[
-                                    pl.ds(write_pos, 1), :, :],
+                                    pl.ds(write_pos, should_local), :, :],
                                 sem=local_write_sems_ref.at[stg_id],
                             ).start()
                             pltpu.make_async_copy(
                                 src_ref=scatter_scale_3x_ref.at[
-                                    stg_id, pl.ds(row_idx, 1), :],
+                                    stg_id, pl.ds(row_idx, should_local), :],
                                 dst_ref=out_scale_ref.at[
-                                    pl.ds(write_pos, 1), :],
+                                    pl.ds(write_pos, should_local), :],
                                 sem=scale_local_write_sems_ref.at[stg_id],
                             ).start()
 
-                    else:
-
-                        @pl.when(~is_local)
-                        def _():
+                        else:
                             pltpu.make_async_remote_copy(
                                 src_ref=scatter_staging_3x_ref.at[
-                                    stg_id, pl.ds(row_idx, 1), :, :],
+                                    stg_id, pl.ds(row_idx, should_send), :, :],
                                 dst_ref=out_buf_ref.at[
-                                    pl.ds(write_pos, 1), :, :],
+                                    pl.ds(write_pos, should_send), :, :],
                                 send_sem=send_sems_ref.at[stg_id],
                                 recv_sem=recv_sem_ref.at[0],
                                 device_id={
@@ -1091,34 +1085,15 @@ def kernel_main_fused_rs(
                                 device_id_type=pltpu.DeviceIdType.MESH,
                             ).start()
 
-                        @pl.when(is_local)
-                        def _():
                             pltpu.make_async_copy(
                                 src_ref=scatter_staging_3x_ref.at[
-                                    stg_id, pl.ds(row_idx, 1), :, :],
+                                    stg_id, pl.ds(row_idx, should_local), :, :],
                                 dst_ref=out_buf_ref.at[
-                                    pl.ds(write_pos, 1), :, :],
+                                    pl.ds(write_pos, should_local), :, :],
                                 sem=local_write_sems_ref.at[stg_id],
                             ).start()
 
-                    return (
-                        send_sz +
-                        lax.select(~is_local, jnp.int32(1), jnp.int32(0)),
-                        local_sz +
-                        lax.select(is_local, jnp.int32(1), jnp.int32(0)),
-                    )
-
-                def _full_tile():
-                    carry = (jnp.int32(0), jnp.int32(0))
-                    for i in range(tile_m):
-                        carry = _write_row(i, carry)
-                    return carry
-
-                def _partial_tile():
-                    return lax.fori_loop(0, m_valid, _write_row,
-                                         (jnp.int32(0), jnp.int32(0)))
-
-                return lax.cond(m_valid == tile_m, _full_tile, _partial_tile)
+                return scatter_meta.total_send_sz, scatter_meta.total_local_sz
 
             send_sz, local_sz = _do_direct_write()
             gm_id_ref[1 + stg_id] = gm_id_ref[1 + stg_id] + send_sz

--- a/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
+++ b/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
@@ -63,8 +63,8 @@ def get_fused_rs_tuned_block_sizes(
     # Device-specific tuned tables were removed; return the default (with the
     # fp8 direct-write tile_m clamp for VMEM safety).
     result = default_block_sizes
-    if fp8_direct_write and result[0] > 64:
-        result = (64, ) + tuple(result[1:])
+    if fp8_direct_write and result[0] > 128:
+        result = (128, ) + tuple(result[1:])
     return result
 
 
@@ -309,9 +309,11 @@ def _select_fused_rs_block_sizes(
     # NOTE: fp8 direct-write tile_m sizing is now handled in Step 4
     # (get_fused_rs_tuned_block_sizes, called with fp8_direct_write): dedicated
     # fp8-comm entries carry VMEM-safe tiles (e.g. tile_m=96 full-N), and shapes
-    # without one fall back to the bf16 tile clamped to tile_m<=64. Both the host
+    # without one fall back to the bf16 tile clamped to tile_m<=128. Both the host
     # max-gm calc and the kernel call this helper, so their loop bounds stay
     # aligned. (Replaces the former unconditional ``tile_m = min(tile_m, 64)``.)
+    if size_m > 128 and tile_m < 128:
+        tile_m = 128
 
     # --- Step 6: Assertions ---
     assert size_k1 % tile_k1 == 0, f"tile_k1={tile_k1} must divide size_k1={size_k1}"

--- a/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
+++ b/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
@@ -977,7 +977,7 @@ def kernel_main_fused_rs(
             # direct_write_buf[local_row * top_k + topk_idx].
             # Loop bound is m_en - m_st (valid rows), not tile_m, eliminating
             # wasted iterations on padding rows.
-            num_valid = m_en - m_st
+            m_valid = m_en - m_st
 
             @jax.named_scope("direct_write_rows")
             def _do_direct_write():
@@ -1108,8 +1108,17 @@ def kernel_main_fused_rs(
                         lax.select(is_local, jnp.int32(1), jnp.int32(0)),
                     )
 
-                return lax.fori_loop(0, num_valid, _write_row,
-                                     (jnp.int32(0), jnp.int32(0)))
+                def _full_tile():
+                    carry = (jnp.int32(0), jnp.int32(0))
+                    for i in range(tile_m):
+                        carry = _write_row(i, carry)
+                    return carry
+
+                def _partial_tile():
+                    return lax.fori_loop(0, m_valid, _write_row,
+                                         (jnp.int32(0), jnp.int32(0)))
+
+                return lax.cond(m_valid == tile_m, _full_tile, _partial_tile)
 
             send_sz, local_sz = _do_direct_write()
             gm_id_ref[1 + stg_id] = gm_id_ref[1 + stg_id] + send_sz

--- a/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
+++ b/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
@@ -1774,7 +1774,8 @@ def gmm_v2_fused_rs(
     )
     pallas_name = (f"gmm_v2_fused_rs-E_{size_group}-M_{size_m}"
                    f"-K1_{size_k1}-N1_{size_n1}-K2_{size_k2}-N2_{size_n2}"
-                   f"-EP_{ep_size}-TK_{top_k}"
+                   f"-TM_{tile_m}-TPK1_{tile_k1}-TN1_{tile_n1}"
+                   f"-TK2_{tile_k2}-TN2_{tile_n2}-EP_{ep_size}-TK_{top_k}"
                    f"{'-packed' if pack_indices else ''}")
     kernel_kwargs = dict(
         fused_dims=fused_dims,

--- a/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
+++ b/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
@@ -38,8 +38,8 @@ from jax.experimental.pallas import tpu as pltpu
 # isort: off
 # yapf: disable
 from .gmm_v2_gather_scatter import (
-    Dimensions, FusedDims, FusedWeightsRef, GatherMetadata, GmmConfigs,
-    InputConfigs, MetadataRef, ScatterMetadata, TileSizes, WeightsRef,
+    Dimensions, FusedDims, FusedWeightsRef, GmmConfigs,
+    InputConfigs, MetadataRef, TileSizes, WeightsRef,
     _recover_quant_block_size, align_to, calculate_tiling, dma_gather_gm_start,
     dma_gather_gm_wait, fill_metadata, get_maybe_quantize_lhs, inner_kernel,
     prepare_gather_tile_metadata, prepare_scatter_tile_metadata, zero_out_end_3d,
@@ -1013,27 +1013,27 @@ def kernel_main_fused_rs(
                             # Quantize each completed expert row before the direct
                             # write. Remote ICI then moves FP8 payload plus one
                             # fp32 row scale instead of the full bf16 activation row.
-                            row_f32 = scatter_staging_3x_ref[stg_id,
-                                                             row_idx, :, :].astype(
-                                                                 jnp.float32)
-                            fp8_max = jnp.array(jnp.finfo(jnp.float8_e4m3fn).max,
+                            row_f32 = scatter_staging_3x_ref[
+                                stg_id, row_idx, :, :].astype(jnp.float32)
+                            fp8_max = jnp.array(jnp.finfo(
+                                jnp.float8_e4m3fn).max,
                                                 dtype=jnp.float32)
                             row_scale = (jnp.maximum(
                                 jnp.max(jnp.abs(row_f32)),
                                 jnp.array(1e-6, dtype=jnp.float32),
                             ) / fp8_max)
                             scatter_scale_3x_ref[stg_id, row_idx, :] = (
-                                row_scale + jnp.zeros((128, ), dtype=jnp.float32))
-                            scatter_fp8_staging_3x_ref[stg_id,
-                                                      row_idx, :, :] = jnp.clip(
-                                                          row_f32 / row_scale,
-                                                          -fp8_max,
-                                                          fp8_max).astype(
-                                                              jnp.float8_e4m3fn)
+                                row_scale + jnp.zeros(
+                                    (128, ), dtype=jnp.float32))
+                            scatter_fp8_staging_3x_ref[
+                                stg_id, row_idx, :, :] = jnp.clip(
+                                    row_f32 / row_scale, -fp8_max,
+                                    fp8_max).astype(jnp.float8_e4m3fn)
 
                             pltpu.make_async_remote_copy(
                                 src_ref=scatter_fp8_staging_3x_ref.at[
-                                    stg_id, pl.ds(row_idx, should_send), :, :],
+                                    stg_id,
+                                    pl.ds(row_idx, should_send), :, :],
                                 dst_ref=out_buf_ref.at[
                                     pl.ds(write_pos, should_send), :, :],
                                 send_sem=send_sems_ref.at[stg_id],
@@ -1045,7 +1045,8 @@ def kernel_main_fused_rs(
                             ).start()
                             pltpu.make_async_remote_copy(
                                 src_ref=scatter_scale_3x_ref.at[
-                                    stg_id, pl.ds(row_idx, should_send), :],
+                                    stg_id,
+                                    pl.ds(row_idx, should_send), :],
                                 dst_ref=out_scale_ref.at[
                                     pl.ds(write_pos, should_send), :],
                                 send_sem=scale_send_sems_ref.at[stg_id],
@@ -1058,14 +1059,16 @@ def kernel_main_fused_rs(
 
                             pltpu.make_async_copy(
                                 src_ref=scatter_fp8_staging_3x_ref.at[
-                                    stg_id, pl.ds(row_idx, should_local), :, :],
+                                    stg_id,
+                                    pl.ds(row_idx, should_local), :, :],
                                 dst_ref=out_buf_ref.at[
                                     pl.ds(write_pos, should_local), :, :],
                                 sem=local_write_sems_ref.at[stg_id],
                             ).start()
                             pltpu.make_async_copy(
                                 src_ref=scatter_scale_3x_ref.at[
-                                    stg_id, pl.ds(row_idx, should_local), :],
+                                    stg_id,
+                                    pl.ds(row_idx, should_local), :],
                                 dst_ref=out_scale_ref.at[
                                     pl.ds(write_pos, should_local), :],
                                 sem=scale_local_write_sems_ref.at[stg_id],
@@ -1074,7 +1077,8 @@ def kernel_main_fused_rs(
                         else:
                             pltpu.make_async_remote_copy(
                                 src_ref=scatter_staging_3x_ref.at[
-                                    stg_id, pl.ds(row_idx, should_send), :, :],
+                                    stg_id,
+                                    pl.ds(row_idx, should_send), :, :],
                                 dst_ref=out_buf_ref.at[
                                     pl.ds(write_pos, should_send), :, :],
                                 send_sem=send_sems_ref.at[stg_id],
@@ -1087,7 +1091,8 @@ def kernel_main_fused_rs(
 
                             pltpu.make_async_copy(
                                 src_ref=scatter_staging_3x_ref.at[
-                                    stg_id, pl.ds(row_idx, should_local), :, :],
+                                    stg_id,
+                                    pl.ds(row_idx, should_local), :, :],
                                 dst_ref=out_buf_ref.at[
                                     pl.ds(write_pos, should_local), :, :],
                                 sem=local_write_sems_ref.at[stg_id],

--- a/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
+++ b/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
@@ -792,37 +792,7 @@ def kernel_main_fused_rs(
                 1] = metadata_ref.gm_id_to_m_offset[gm_id + 1]
             expert_id = fused_metadata_ref.gm_id_to_group_id[0]
 
-            # DMA gather. When indices are packed, set divisor=top_k so the
-            # gather extracts the actual lhs_idx via integer division.
-            _gather_divisor = top_k if pack_indices else 1
-
-            @jax.named_scope("dma_gather_start")
-            @pl.when(gm_id == 0)
-            def _():
-                dma_gather_gm_start(
-                    hidden_states_ref,
-                    gathered_lhs_2x_ref.at[sem_id],
-                    lhs_indices_ref,
-                    gather_sem_ref.at[sem_id],
-                    0,
-                    metadata_ref,
-                    divisor=_gather_divisor,
-                )
-
-            @jax.named_scope("dma_gather_prefetch")
-            @pl.when(gm_id + 1 < local_num_gm)
-            def _():
-                dma_gather_gm_start(
-                    hidden_states_ref,
-                    gathered_lhs_2x_ref.at[1 - sem_id],
-                    lhs_indices_ref,
-                    gather_sem_ref.at[1 - sem_id],
-                    gm_id + 1,
-                    metadata_ref,
-                    divisor=_gather_divisor,
-                )
-
-            # --- Weight DMA (overlapped with gather) ---
+            # --- Weight DMA (issued first to overlap with gather issuance) ---
             # w1 prologue: load first num_w1_bufs tiles (gm==0 only;
             # for gm>0, tiles were prefetched during previous gm's GMM2).
             total_w1_steps = num_n1 * num_k1
@@ -865,6 +835,37 @@ def kernel_main_fused_rs(
             def _():
                 for _i in range(min(num_w2_bufs, total_w2_steps)):
                     start_w2_dma(_i, expert_id, _i // num_k2, _i % num_k2)
+
+            # --- DMA gather (issued after weight DMAs are in flight) ---
+            # When indices are packed, set divisor=top_k so the
+            # gather extracts the actual lhs_idx via integer division.
+            _gather_divisor = top_k if pack_indices else 1
+
+            @jax.named_scope("dma_gather_start")
+            @pl.when(gm_id == 0)
+            def _():
+                dma_gather_gm_start(
+                    hidden_states_ref,
+                    gathered_lhs_2x_ref.at[sem_id],
+                    lhs_indices_ref,
+                    gather_sem_ref.at[sem_id],
+                    0,
+                    metadata_ref,
+                    divisor=_gather_divisor,
+                )
+
+            @jax.named_scope("dma_gather_prefetch")
+            @pl.when(gm_id + 1 < local_num_gm)
+            def _():
+                dma_gather_gm_start(
+                    hidden_states_ref,
+                    gathered_lhs_2x_ref.at[1 - sem_id],
+                    lhs_indices_ref,
+                    gather_sem_ref.at[1 - sem_id],
+                    gm_id + 1,
+                    metadata_ref,
+                    divisor=_gather_divisor,
+                )
 
             # Wait for gather (weight DMAs running in parallel).
             dma_gather_gm_wait(

--- a/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
+++ b/tpu_inference/kernels/experimental/fused_moe/gmm_fused_rs_nodedup.py
@@ -449,12 +449,12 @@ def kernel_main_fused_rs(
     def sync_barrier():
         barrier_sem = pltpu.get_barrier_semaphore()
         for i in range(ep_size):
-            pltpu.semaphore_signal(
+            pl.semaphore_signal(
                 barrier_sem,
                 device_id={ep_axis_name: jnp.int32(i)},
-                device_id_type=pltpu.DeviceIdType.MESH,
+                device_id_type=pl.DeviceIdType.MESH,
             )
-        pltpu.semaphore_wait(barrier_sem, ep_size)
+        pl.semaphore_wait(barrier_sem, ep_size)
 
     sync_barrier()
 
@@ -1041,7 +1041,7 @@ def kernel_main_fused_rs(
                                 device_id={
                                     ep_axis_name: dest_chip
                                 },
-                                device_id_type=pltpu.DeviceIdType.MESH,
+                                device_id_type=pl.DeviceIdType.MESH,
                             ).start()
                             pltpu.make_async_remote_copy(
                                 src_ref=scatter_scale_3x_ref.at[
@@ -1053,7 +1053,7 @@ def kernel_main_fused_rs(
                                 device_id={
                                     ep_axis_name: dest_chip
                                 },
-                                device_id_type=pltpu.DeviceIdType.MESH,
+                                device_id_type=pl.DeviceIdType.MESH,
                             ).start()
 
                             pltpu.make_async_copy(
@@ -1082,7 +1082,7 @@ def kernel_main_fused_rs(
                                 device_id={
                                     ep_axis_name: dest_chip
                                 },
-                                device_id_type=pltpu.DeviceIdType.MESH,
+                                device_id_type=pl.DeviceIdType.MESH,
                             ).start()
 
                             pltpu.make_async_copy(

--- a/tpu_inference/kernels/experimental/fused_moe/gmm_v2_gather_scatter.py
+++ b/tpu_inference/kernels/experimental/fused_moe/gmm_v2_gather_scatter.py
@@ -1006,6 +1006,8 @@ def calculate_tiling(
     lhs_mod = min(pl.cdiv(16, lhs_bits), 2)
     rhs_mod = min(pl.cdiv(16, rhs_bits), 2)
     tile_m = bf16_bf16_tile_m * lhs_mod // rhs_mod
+    if dims.size_m > 128:
+        tile_m = max(tile_m, 128)
     tile_m = min(tile_m, dims.size_m)
 
     # Subtract non-rhs VMEM overhead before computing per-buffer budget.

--- a/tpu_inference/kernels/experimental/fused_moe/gmm_v2_gather_scatter.py
+++ b/tpu_inference/kernels/experimental/fused_moe/gmm_v2_gather_scatter.py
@@ -922,9 +922,7 @@ def prepare_gather_tile_metadata(
             src_rows[i] = combined // gather_divisor
         else:
             oi = lhs_indices_ref[m_idx]
-            src_rows[i] = (
-                oi // gather_divisor if gather_divisor != 1 else oi
-            )
+            src_rows[i] = (oi // gather_divisor if gather_divisor != 1 else oi)
 
     return GatherMetadata(
         m_start=m_start,
@@ -971,11 +969,8 @@ def prepare_scatter_tile_metadata(
             dest_chips[i] = combined // cs_tk
         else:
             oi = lhs_indices_ref[m_idx]
-            topk_idx = (
-                topk_indices_ref[m_idx]
-                if topk_indices_ref is not None
-                else jnp.int32(0)
-            )
+            topk_idx = (topk_indices_ref[m_idx]
+                        if topk_indices_ref is not None else jnp.int32(0))
             dest_chips[i] = oi // chunk_size
             local_row = oi % chunk_size
             write_positions[i] = local_row * top_k + topk_idx
@@ -1026,7 +1021,8 @@ def dma_gather_gm_start(
             should_gather = gather_metadata.is_valid[i]
             pltpu.make_async_copy(
                 src_ref=src_ref.at[pl.ds(src_row, should_gather), :, :],
-                dst_ref=dst_ref.at[pl.ds(m_start_local + i, should_gather), :, :],
+                dst_ref=dst_ref.at[pl.ds(m_start_local +
+                                         i, should_gather), :, :],
                 sem=sem_ref,
             ).start()
 
@@ -1050,7 +1046,6 @@ def dma_gather_gm_wait(
         dst_ref=dst_ref.at[pl.ds(m_start_local, num_rows), :, :],
         sem=sem_ref,
     ).wait()
-
 
 
 @jax.named_scope("dma_scatter_gm_start")

--- a/tpu_inference/kernels/experimental/fused_moe/gmm_v2_gather_scatter.py
+++ b/tpu_inference/kernels/experimental/fused_moe/gmm_v2_gather_scatter.py
@@ -95,6 +95,35 @@ class MetadataRef:
 
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
+class GatherMetadata:
+    """Per-tile metadata container for GMM gather DMA."""
+
+    m_start: jax.Array
+    m_end: jax.Array
+    num_rows: jax.Array
+    is_valid: jax.Array
+    src_rows: list[jax.Array]
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class ScatterMetadata:
+    """Per-tile metadata container for GMM direct-write (scatter) DMA."""
+
+    m_start: jax.Array
+    m_end: jax.Array
+    num_rows: jax.Array
+    is_valid: jax.Array
+    dest_chips: list[jax.Array]
+    write_positions: list[jax.Array]
+    should_sends: list[jax.Array]
+    should_locals: list[jax.Array]
+    total_send_sz: jax.Array
+    total_local_sz: jax.Array
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
 class WeightsRef:
     weight: Any
     scale: Any | None
@@ -867,70 +896,153 @@ def zero_out_end_3d(
     ).wait()
 
 
+@jax.named_scope("prepare_gather_tile_metadata")
+def prepare_gather_tile_metadata(
+    gm_id,
+    metadata_ref: MetadataRef,
+    tile_m: int,
+    size_m: int,
+    lhs_indices_ref: jax.Array,
+    *,
+    pack_indices: bool = True,
+    gather_divisor: int = 1,
+) -> GatherMetadata:
+    """Prepares gather metadata for a single tile (gm_id)."""
+    m_start = metadata_ref.gm_id_to_m_offset[gm_id]
+    m_end = metadata_ref.gm_id_to_m_offset[gm_id + 1]
+    num_rows = m_end - m_start
+    tile_arange = jnp.arange(tile_m)
+    is_valid = (tile_arange < num_rows).astype(jnp.int32)
+
+    src_rows = [None] * tile_m
+    for i in range(tile_m):
+        m_idx = jnp.minimum(m_start + i, size_m - 1)
+        if pack_indices:
+            combined = lhs_indices_ref[m_idx]
+            src_rows[i] = combined // gather_divisor
+        else:
+            oi = lhs_indices_ref[m_idx]
+            src_rows[i] = (
+                oi // gather_divisor if gather_divisor != 1 else oi
+            )
+
+    return GatherMetadata(
+        m_start=m_start,
+        m_end=m_end,
+        num_rows=num_rows,
+        is_valid=is_valid,
+        src_rows=src_rows,
+    )
+
+
+@jax.named_scope("prepare_scatter_tile_metadata")
+def prepare_scatter_tile_metadata(
+    gm_id,
+    metadata_ref: MetadataRef,
+    tile_m: int,
+    size_m: int,
+    lhs_indices_ref: jax.Array,
+    topk_indices_ref: jax.Array | None = None,
+    *,
+    my_id: int | jax.Array,
+    chunk_size: int,
+    top_k: int,
+    pack_indices: bool = True,
+) -> ScatterMetadata:
+    """Prepares direct-write (scatter) routing metadata for a single tile (gm_id)."""
+    m_start = metadata_ref.gm_id_to_m_offset[gm_id]
+    m_end = metadata_ref.gm_id_to_m_offset[gm_id + 1]
+    num_rows = m_end - m_start
+    tile_arange = jnp.arange(tile_m)
+    is_valid = (tile_arange < num_rows).astype(jnp.int32)
+
+    dest_chips = [None] * tile_m
+    write_positions = [None] * tile_m
+    should_sends = [None] * tile_m
+    should_locals = [None] * tile_m
+
+    cs_tk = chunk_size * top_k
+    for i in range(tile_m):
+        m_idx = jnp.minimum(m_start + i, size_m - 1)
+        v = is_valid[i]
+        if pack_indices:
+            combined = lhs_indices_ref[m_idx]
+            write_positions[i] = combined % cs_tk
+            dest_chips[i] = combined // cs_tk
+        else:
+            oi = lhs_indices_ref[m_idx]
+            topk_idx = (
+                topk_indices_ref[m_idx]
+                if topk_indices_ref is not None
+                else jnp.int32(0)
+            )
+            dest_chips[i] = oi // chunk_size
+            local_row = oi % chunk_size
+            write_positions[i] = local_row * top_k + topk_idx
+
+        is_local = dest_chips[i] == my_id
+        should_sends[i] = jnp.where(is_local, 0, v)
+        should_locals[i] = jnp.where(is_local, v, 0)
+
+    should_sends_arr = jnp.stack(should_sends)
+    should_locals_arr = jnp.stack(should_locals)
+    total_send_sz = jnp.sum(should_sends_arr)
+    total_local_sz = jnp.sum(should_locals_arr)
+
+    return ScatterMetadata(
+        m_start=m_start,
+        m_end=m_end,
+        num_rows=num_rows,
+        is_valid=is_valid,
+        dest_chips=dest_chips,
+        write_positions=write_positions,
+        should_sends=should_sends,
+        should_locals=should_locals,
+        total_send_sz=total_send_sz,
+        total_local_sz=total_local_sz,
+    )
+
+
 @jax.named_scope("dma_gather_gm_start")
-def dma_gather_gm_start(src_ref,
-                        dst_ref,
-                        indices_ref,
-                        sem_ref,
-                        gm_id,
-                        metadata_ref,
-                        divisor: int = 1):
+def dma_gather_gm_start(
+    src_ref,
+    dst_ref,
+    sem_ref,
+    gather_metadata: GatherMetadata,
+):
     """Start gathering rows for a specific gm tile via DMA.
 
     src_ref and dst_ref must be 3D: (rows, k // num_lanes, num_lanes).
     No reshape — reshape on refs breaks dynamic pl.ds offsets.
-
-    `divisor`: optional integer divisor applied to indices_ref values before
-    use. Set > 1 when indices_ref contains packed values (e.g.,
-    `combined = lhs_idx * divisor + extra_field`) and we need to recover the
-    actual src_row via integer division. Default 1 = no unpacking.
     """
-    m_start = metadata_ref.gm_id_to_m_offset[gm_id]
-    m_end = metadata_ref.gm_id_to_m_offset[gm_id + 1]
-    num_rows = m_end - m_start
+    m_start = gather_metadata.m_start
     sls = pltpu.get_tpu_info().get_sublane_tiling(src_ref.dtype)
     m_start_local = m_start % sls
     tile_m = dst_ref.shape[0]
 
-    def _full_tile():
+    with jax.named_scope("dma_gather_gm_start_dma"):
         for i in range(tile_m):
-            row = m_start + i
-            src_row = indices_ref[row]
-            if divisor != 1:
-                src_row = src_row // divisor
+            src_row = gather_metadata.src_rows[i]
+            should_gather = gather_metadata.is_valid[i]
             pltpu.make_async_copy(
-                src_ref=src_ref.at[pl.ds(src_row, 1), :, :],
-                dst_ref=dst_ref.at[pl.ds(m_start_local + i, 1), :, :],
+                src_ref=src_ref.at[pl.ds(src_row, should_gather), :, :],
+                dst_ref=dst_ref.at[pl.ds(m_start_local + i, should_gather), :, :],
                 sem=sem_ref,
             ).start()
-
-    def _partial_tile():
-        def _gather_body(i, _):
-            row = m_start + i
-            src_row = indices_ref[row]
-            if divisor != 1:
-                src_row = src_row // divisor
-            pltpu.make_async_copy(
-                src_ref=src_ref.at[pl.ds(src_row, 1), :, :],
-                dst_ref=dst_ref.at[pl.ds(m_start_local + i, 1), :, :],
-                sem=sem_ref,
-            ).start()
-            return _
-
-        lax.fori_loop(0, num_rows, _gather_body, 0)
-
-    lax.cond(num_rows == tile_m, _full_tile, _partial_tile)
 
 
 @jax.named_scope("dma_gather_gm_wait")
-def dma_gather_gm_wait(dst_ref, sem_ref, gm_id, metadata_ref):
+def dma_gather_gm_wait(
+    dst_ref,
+    sem_ref,
+    metadata: GatherMetadata | ScatterMetadata,
+):
     """Wait for all gather DMAs for a specific gm tile to complete.
 
     dst_ref must be 3D: (rows, k // num_lanes, num_lanes).
     """
-    m_start = metadata_ref.gm_id_to_m_offset[gm_id]
-    m_end = metadata_ref.gm_id_to_m_offset[gm_id + 1]
-    num_rows = m_end - m_start
+    m_start = metadata.m_start
+    num_rows = metadata.num_rows
     sls = pltpu.get_tpu_info().get_sublane_tiling(dst_ref.dtype)
     m_start_local = m_start % sls
     pltpu.make_async_copy(
@@ -938,6 +1050,7 @@ def dma_gather_gm_wait(dst_ref, sem_ref, gm_id, metadata_ref):
         dst_ref=dst_ref.at[pl.ds(m_start_local, num_rows), :, :],
         sem=sem_ref,
     ).wait()
+
 
 
 @jax.named_scope("dma_scatter_gm_start")

--- a/tpu_inference/kernels/experimental/fused_moe/gmm_v2_gather_scatter.py
+++ b/tpu_inference/kernels/experimental/fused_moe/gmm_v2_gather_scatter.py
@@ -887,22 +887,39 @@ def dma_gather_gm_start(src_ref,
     """
     m_start = metadata_ref.gm_id_to_m_offset[gm_id]
     m_end = metadata_ref.gm_id_to_m_offset[gm_id + 1]
+    num_rows = m_end - m_start
     sls = pltpu.get_tpu_info().get_sublane_tiling(src_ref.dtype)
     m_start_local = m_start % sls
+    tile_m = dst_ref.shape[0]
 
-    def _gather_body(i, _):
-        row = m_start + i
-        src_row = indices_ref[row]
-        if divisor != 1:
-            src_row = src_row // divisor
-        pltpu.make_async_copy(
-            src_ref=src_ref.at[pl.ds(src_row, 1), :, :],
-            dst_ref=dst_ref.at[pl.ds(m_start_local + i, 1), :, :],
-            sem=sem_ref,
-        ).start()
-        return _
+    def _full_tile():
+        for i in range(tile_m):
+            row = m_start + i
+            src_row = indices_ref[row]
+            if divisor != 1:
+                src_row = src_row // divisor
+            pltpu.make_async_copy(
+                src_ref=src_ref.at[pl.ds(src_row, 1), :, :],
+                dst_ref=dst_ref.at[pl.ds(m_start_local + i, 1), :, :],
+                sem=sem_ref,
+            ).start()
 
-    lax.fori_loop(0, m_end - m_start, _gather_body, 0)
+    def _partial_tile():
+        def _gather_body(i, _):
+            row = m_start + i
+            src_row = indices_ref[row]
+            if divisor != 1:
+                src_row = src_row // divisor
+            pltpu.make_async_copy(
+                src_ref=src_ref.at[pl.ds(src_row, 1), :, :],
+                dst_ref=dst_ref.at[pl.ds(m_start_local + i, 1), :, :],
+                sem=sem_ref,
+            ).start()
+            return _
+
+        lax.fori_loop(0, num_rows, _gather_body, 0)
+
+    lax.cond(num_rows == tile_m, _full_tile, _partial_tile)
 
 
 @jax.named_scope("dma_gather_gm_wait")

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -22,9 +22,8 @@ from jax.sharding import PartitionSpec as P
 
 import tpu_inference.envs as envs
 from tpu_inference.kernels.collectives.hierrs_sc import wrapper as hier_rs_sc
-from tpu_inference.kernels.experimental.fused_moe.fused_moe_rs import (
-    fused_moe_func_rs,
-)
+from tpu_inference.kernels.experimental.fused_moe.fused_moe_rs import \
+    fused_moe_func_rs
 from tpu_inference.kernels.megablox.gmm_v2 import gmm_v2
 from tpu_inference.kernels.sparse_core.dense_gather_reduce import \
     dense_gather_reduce
@@ -595,21 +594,20 @@ def fused_moe_func(
     """
 
     if use_gmm_fused_rs_kernel:
-        return fused_moe_func_rs(
-            hidden_states=hidden_states,
-            w1=w1,
-            w2=w2,
-            w1_scale=w1_scale,
-            w2_scale=w2_scale,
-            w1_bias=w1_bias,
-            w2_bias=w2_bias,
-            gating_output=gating_output,
-            topk=topk,
-            renormalize=renormalize,
-            mesh=mesh,
-            activation=activation,
-            scoring_fn=scoring_fn,
-            fp8_post_gather=all_gather_fp8)
+        return fused_moe_func_rs(hidden_states=hidden_states,
+                                 w1=w1,
+                                 w2=w2,
+                                 w1_scale=w1_scale,
+                                 w2_scale=w2_scale,
+                                 w1_bias=w1_bias,
+                                 w2_bias=w2_bias,
+                                 gating_output=gating_output,
+                                 topk=topk,
+                                 renormalize=renormalize,
+                                 mesh=mesh,
+                                 activation=activation,
+                                 scoring_fn=scoring_fn,
+                                 fp8_post_gather=all_gather_fp8)
 
     num_tokens, hidden_size = hidden_states.shape
     global_num_experts, padded_hidden_size, _ = w1.shape

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -593,7 +593,8 @@ def fused_moe_func(
         Output of moe operation [num_tokens, hidden_size]
     """
 
-    if use_gmm_fused_rs_kernel:
+    if use_ep and use_gmm_fused_rs_kernel:
+        logger.info("fused_moe_rs kernel in use")
         return fused_moe_func_rs(hidden_states=hidden_states,
                                  w1=w1,
                                  w2=w2,

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -22,8 +22,6 @@ from jax.sharding import PartitionSpec as P
 
 import tpu_inference.envs as envs
 from tpu_inference.kernels.collectives.hierrs_sc import wrapper as hier_rs_sc
-from tpu_inference.kernels.experimental.fused_moe.fused_moe_rs import \
-    fused_moe_func_rs
 from tpu_inference.kernels.megablox.gmm_v2 import gmm_v2
 from tpu_inference.kernels.sparse_core.dense_gather_reduce import \
     dense_gather_reduce
@@ -594,6 +592,8 @@ def fused_moe_func(
     """
 
     if use_ep and use_gmm_fused_rs_kernel:
+        from tpu_inference.kernels.experimental.fused_moe.fused_moe_rs import \
+            fused_moe_func_rs
         logger.info("fused_moe_rs kernel in use")
         return fused_moe_func_rs(hidden_states=hidden_states,
                                  w1=w1,

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -22,6 +22,9 @@ from jax.sharding import PartitionSpec as P
 
 import tpu_inference.envs as envs
 from tpu_inference.kernels.collectives.hierrs_sc import wrapper as hier_rs_sc
+from tpu_inference.kernels.experimental.fused_moe.fused_moe_rs import (
+    fused_moe_func_rs,
+)
 from tpu_inference.kernels.megablox.gmm_v2 import gmm_v2
 from tpu_inference.kernels.sparse_core.dense_gather_reduce import \
     dense_gather_reduce
@@ -535,6 +538,7 @@ def _apply_all_gather_fp8(hidden_states: jax.Array, mesh: Mesh,
     "scoring_fn",
     "all_gather_fp8",
     "enable_rs_kernel",
+    "use_gmm_fused_rs_kernel",
     "onehot_moe_permute_threshold",
     "scatter_results",
     "moe_chunk_size",
@@ -557,6 +561,7 @@ def fused_moe_func(
     scoring_fn: str,
     all_gather_fp8: bool = False,
     enable_rs_kernel: bool = False,
+    use_gmm_fused_rs_kernel: bool = False,
     onehot_moe_permute_threshold: int = 0,
     scatter_results: bool = False,
     defer_all_reduce: bool = False,
@@ -583,10 +588,29 @@ def fused_moe_func(
         activation: activation function to perform on the output of w1.
         scoring_fn: scoring function to apply on gating_output.
         enable_rs_kernel: enable custom Hierarchical Reduce-Scatter kernel.
+        use_gmm_fused_rs_kernel: enable fused GMM reduce-scatter kernel.
 
     Returns:
         Output of moe operation [num_tokens, hidden_size]
     """
+
+    if use_gmm_fused_rs_kernel:
+        return fused_moe_func_rs(
+            hidden_states=hidden_states,
+            w1=w1,
+            w2=w2,
+            w1_scale=w1_scale,
+            w2_scale=w2_scale,
+            w1_bias=w1_bias,
+            w2_bias=w2_bias,
+            gating_output=gating_output,
+            topk=topk,
+            renormalize=renormalize,
+            mesh=mesh,
+            activation=activation,
+            scoring_fn=scoring_fn,
+            fp8_post_gather=all_gather_fp8)
+
     num_tokens, hidden_size = hidden_states.shape
     global_num_experts, padded_hidden_size, _ = w1.shape
     dtype = hidden_states.dtype

--- a/tpu_inference/layers/common/moe.py
+++ b/tpu_inference/layers/common/moe.py
@@ -166,6 +166,7 @@ def moe_apply(
                     scoring_fn=layer.scoring_func,
                     all_gather_fp8=all_gather_fp8,
                     enable_rs_kernel=envs.ENABLE_RS_KERNEL,
+                    use_gmm_fused_rs_kernel=envs.USE_GMM_FUSED_RS_KERNEL,
                     onehot_moe_permute_threshold=envs.
                     ONEHOT_MOE_PERMUTE_THRESHOLD,
                     scatter_results=scatter_results,

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -133,6 +133,7 @@ class TpuPlatform(Platform):
         "USE_JAX_PROFILER_SERVER",
         "JAX_PROFILER_SERVER_PORT",
         "ENABLE_RS_KERNEL",
+        "USE_GMM_FUSED_RS_KERNEL",
         "MOE_ALL_GATHER_ACTIVATION_DTYPE",
     ]
 


### PR DESCRIPTION
# Description

Add integration, optimization to the fused MoE kernel based on https://github.com/vllm-project/tpu-inference/pull/3040

Performance is optimized for large m (> 1024). Tested on 10 run median of qwen coder 480b moe layer setup.

qwen_coder_1024
fused_moe_gmm 854 us
Original kernel 560.93 us
Optimized kernel 456.98 us
-18.53%

qwen_coder_2048
fused_moe_gmm: 1959 us
Original kernel 916.30 us
Optimized kernel 581.96 us
-36.49%

qwen_coder_4096
fused_moe_gmm:  6264 us
Original kernel  1694.44 us
Optimized kernel  1024.17 us
-39.56%

qwen_coder_8192
fused_moe_gmm 3513 us
Original kernel  3140.65 us
Optimized kernel  2001.39 us
-36.28%


*Ablation of changes*:
qwen_coder_2048

Original kernel 916.30 us
Gather optimization: 902 us
Scatter optimization: 878 us
Tile m size min 64 -> 128: 582 us

If the change fixes a Github issue, please include a link, e.g.,:
FIXES: #123456

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
