### PR TITLE
[DSv4] add safe guard to avoid cache being mistakenly copied

### DIFF
--- a/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/compressor_v1.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/compress_and_store/compressor_v1.py
@@ -303,4 +303,17 @@ def compressor_forward(
         rms_eps=rms_eps,
     )
 
-    return cache, rope_cache, (cache if shares_buffer else state_cache)
+    if shares_buffer:
+        return cache, rope_cache, cache
+
+    # `compress_norm_rope_store` READS `state_cache` (its read-only state
+    # operand) but emits no new version of it, so the value published here is
+    # the pre-read one straight off `proj_and_save_state`. The DSv4 KV-cache
+    # overlay hosts another layer's SWA cache on this same physical array, and
+    # that kernel takes whole-buffer ownership via `input_output_aliases`.
+    # Nothing orders the read against that write, so XLA's copy-insertion
+    # AddCopiesToResolveInterference cannot prove the read completes first and
+    # insert the cache copy. Publishing a version that is downstream of
+    # the read supplies the missing ordering edge.
+    state_cache, cache = jax.lax.optimization_barrier((state_cache, cache))
+    return cache, rope_cache, state_cache


### PR DESCRIPTION
[DSv4] Add safe guard to avoid cache being mistakenly copied due to XLA compiler HLO transformation (more details in the comments)

Observed cache being copied in 8 layers microbenchmark:
before this fix:
http://xprof.corp.google.com/trace_viewer/gxd-9010194911334918722
https://screenshot-v2.corp.google.com/66aittuuf2bhg

After the fix:
http://xprof/trace_viewer.html?session_id=gxd-900400297238143778 

This issue seem not triggered in real e2e run; didn't see perf diff e2e, 
but still add a safeguard to avoid such issue.