### PR TITLE
[DSv4] Port mhc kernels from g3 to tpu-inference 

### DIFF
--- a/tests/kernels/deepseek_v4/mhc_test.py
+++ b/tests/kernels/deepseek_v4/mhc_test.py
@@ -1,0 +1,556 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import torch
+import vllm.model_executor.kernels.mhc as mhc_kernels
+from absl.testing import absltest, parameterized
+
+from tpu_inference.kernels.experimental.deepseek_v4.mhc import utils
+
+HC_MULT = 4
+# Values from the official DeepSeek-V4 config.json: rms_norm_eps=1e-6,
+# hc_eps=1e-6 (feeds BOTH pre_eps and sinkhorn_eps), hc_sinkhorn_iters=20;
+# hc_post_alpha=2.0 is hardcoded in the model (deepseek_v4.py).
+RMS_EPS = 1e-6
+HC_PRE_EPS = 1e-6
+HC_SINKHORN_EPS = 1e-6
+HC_POST_MULT_VALUE = 2.0
+
+# f32 outputs: absorb summation-order differences of the (D=hc_mult*H)-long
+# f32 accumulations between torch and XLA.
+F32_RTOL, F32_ATOL = 1e-4, 1e-5
+# bf16 outputs: ~1-2 ulp at magnitude O(1).
+BF16_RTOL, BF16_ATOL = 2e-2, 2e-2
+# Fused-path f32 gate outputs: the seam kernel's recombine and the
+# reference's einsum can round near-boundary stream values to different
+# adjacent bf16 values before the mix GEMM, so gates carry ~1 bf16-ulp of
+# extra input noise (worst at small H, where each element weighs more).
+FUSED_F32_RTOL, FUSED_F32_ATOL = 1e-3, 1e-5
+# At the tiny test H=256 each flipped element weighs 28x more than at the
+# real H=7168, and the flip pattern is backend-dependent (measured up to
+# 2.4e-3 on the TPU backend); the small-shape fused tests use this
+# looser bound, the real-shape tests keep FUSED_F32_RTOL.
+FUSED_SMALL_H_RTOL = 5e-3
+
+
+def _ref_mhc_pre_mixes(x2d: jax.Array,
+                       fn: jax.Array) -> tuple[jax.Array, jax.Array]:
+    x = x2d.astype(jnp.float32)
+    mixes = jax.lax.dot_general(
+        x,
+        fn,
+        dimension_numbers=(((1, ), (1, )), ((), ())),
+        precision=jax.lax.Precision.HIGHEST,
+    )
+    sqrsum = jnp.sum(x * x, axis=-1, keepdims=True)
+    return mixes, sqrsum
+
+
+def _ref_mhc_pre_collapse(
+    pre_mix: jax.Array,
+    x2d: jax.Array,
+    hc_mult: int,
+    hidden_size: int,
+) -> jax.Array:
+    out = pre_mix[:, 0:1] * x2d[:, :hidden_size].astype(jnp.float32)
+    for i in range(1, hc_mult):
+        out = out + (pre_mix[:, i:i + 1] *
+                     x2d[:, i * hidden_size:
+                         (i + 1) * hidden_size].astype(jnp.float32))
+    return out.astype(jnp.bfloat16)
+
+
+def _ref_mhc_pre(
+    residual: jax.Array,
+    fn: jax.Array,
+    hc_scale: jax.Array,
+    hc_base: jax.Array,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    assert residual.dtype == jnp.bfloat16
+    assert fn.dtype == jnp.float32
+
+    outer_shape = residual.shape[:-2]
+    hc_mult, hidden_size = residual.shape[-2:]
+    x2d = residual.reshape(-1, hc_mult * hidden_size)
+
+    mixes, sqrsum = _ref_mhc_pre_mixes(x2d, fn)
+    pre_mix, post_mix, comb_mix = utils.mhc_pre_gates(
+        mixes, sqrsum, hc_mult, hidden_size, hc_scale, hc_base, rms_eps,
+        hc_pre_eps, hc_sinkhorn_eps, hc_post_mult_value, sinkhorn_repeat)
+    layer_input = _ref_mhc_pre_collapse(pre_mix, x2d, hc_mult, hidden_size)
+
+    return (post_mix.reshape(*outer_shape, hc_mult, 1),
+            comb_mix.reshape(*outer_shape, hc_mult, hc_mult),
+            layer_input.reshape(*outer_shape, hidden_size))
+
+
+def _ref_mhc_post(
+    x: jax.Array,
+    residual: jax.Array,
+    post_layer_mix: jax.Array,
+    comb_res_mix: jax.Array,
+    *,
+    precision: jax.lax.Precision | None = None,
+) -> jax.Array:
+    mixed_residual = jnp.einsum(
+        "...ij,...ih->...jh",
+        comb_res_mix.astype(jnp.float32),
+        residual.astype(jnp.float32),
+        precision=precision,
+    )
+    post_term = (post_layer_mix.astype(jnp.float32) *
+                 x[..., None, :].astype(jnp.float32))
+    return (mixed_residual + post_term).astype(residual.dtype)
+
+
+def _ref_mhc_fused_post_pre(
+    x: jax.Array,
+    residual: jax.Array,
+    post_layer_mix: jax.Array,
+    comb_res_mix: jax.Array,
+    fn: jax.Array,
+    hc_scale: jax.Array,
+    hc_base: jax.Array,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    residual_cur = _ref_mhc_post(x,
+                                 residual,
+                                 post_layer_mix,
+                                 comb_res_mix,
+                                 precision=jax.lax.Precision.HIGHEST)
+    post_mix_cur, comb_mix_cur, layer_input_cur = _ref_mhc_pre(
+        residual_cur, fn, hc_scale, hc_base, rms_eps, hc_pre_eps,
+        hc_sinkhorn_eps, hc_post_mult_value, sinkhorn_repeat)
+    return residual_cur, post_mix_cur, comb_mix_cur, layer_input_cur
+
+
+def _to_np(x) -> np.ndarray:
+    """jax array (any dtype incl. bf16) -> float32 numpy."""
+    return np.asarray(jnp.asarray(x).astype(jnp.float32))
+
+
+def _make_pre_inputs(rng, num_tokens, hidden_size):
+    hc_mult3 = 2 * HC_MULT + HC_MULT * HC_MULT
+    residual = rng.standard_normal((num_tokens, HC_MULT, hidden_size),
+                                   dtype=np.float32)
+    fn = (rng.standard_normal(
+        (hc_mult3, HC_MULT * hidden_size), dtype=np.float32) * 0.02)
+    hc_scale = (1.0 + 0.1 * rng.standard_normal(3)).astype(np.float32)
+    hc_base = (0.5 * rng.standard_normal(hc_mult3)).astype(np.float32)
+    return residual, fn, hc_scale, hc_base
+
+
+class MhcPreParityTest(parameterized.TestCase):
+
+    @parameterized.product(
+        num_tokens=[1, 8, 17, 128],
+        hidden_size=[256, 7168],
+        sinkhorn_repeat=[1, 2, 20],
+    )
+    def test_matches_torch_reference(self, num_tokens, hidden_size,
+                                     sinkhorn_repeat):
+
+        rng = np.random.default_rng(0)
+        residual, fn, hc_scale, hc_base = _make_pre_inputs(
+            rng, num_tokens, hidden_size)
+
+        want_post, want_comb, want_layer = mhc_kernels.mhc_pre_torch(
+            torch.from_numpy(residual).to(torch.bfloat16),
+            torch.from_numpy(fn),
+            torch.from_numpy(hc_scale),
+            torch.from_numpy(hc_base),
+            RMS_EPS,
+            HC_PRE_EPS,
+            HC_SINKHORN_EPS,
+            HC_POST_MULT_VALUE,
+            sinkhorn_repeat,
+        )
+
+        got_post, got_comb, got_layer = _ref_mhc_pre(
+            jnp.asarray(residual).astype(jnp.bfloat16),
+            jnp.asarray(fn),
+            jnp.asarray(hc_scale),
+            jnp.asarray(hc_base),
+            RMS_EPS,
+            HC_PRE_EPS,
+            HC_SINKHORN_EPS,
+            HC_POST_MULT_VALUE,
+            sinkhorn_repeat,
+        )
+
+        self.assertEqual(got_post.shape, (num_tokens, HC_MULT, 1))
+        self.assertEqual(got_comb.shape, (num_tokens, HC_MULT, HC_MULT))
+        self.assertEqual(got_layer.shape, (num_tokens, hidden_size))
+        self.assertEqual(got_layer.dtype, jnp.bfloat16)
+
+        np.testing.assert_allclose(_to_np(got_post),
+                                   want_post.float().numpy(),
+                                   rtol=F32_RTOL,
+                                   atol=F32_ATOL)
+        np.testing.assert_allclose(_to_np(got_comb),
+                                   want_comb.float().numpy(),
+                                   rtol=F32_RTOL,
+                                   atol=F32_ATOL)
+        np.testing.assert_allclose(_to_np(got_layer),
+                                   want_layer.float().numpy(),
+                                   rtol=BF16_RTOL,
+                                   atol=BF16_ATOL)
+
+    def test_padded_zero_rows_are_finite(self):
+        """vLLM pads token buckets with all-zero rows; they must not NaN."""
+
+        rng = np.random.default_rng(1)
+        residual, fn, hc_scale, hc_base = _make_pre_inputs(rng, 8, 256)
+        residual[4:] = 0.0  # padded tail
+
+        got_post, got_comb, got_layer = _ref_mhc_pre(
+            jnp.asarray(residual).astype(jnp.bfloat16),
+            jnp.asarray(fn),
+            jnp.asarray(hc_scale),
+            jnp.asarray(hc_base),
+            RMS_EPS,
+            HC_PRE_EPS,
+            HC_SINKHORN_EPS,
+            HC_POST_MULT_VALUE,
+            2,
+        )
+        for out in (got_post, got_comb, got_layer):
+            self.assertTrue(bool(jnp.isfinite(out.astype(jnp.float32)).all()))
+
+
+class MhcPostParityTest(parameterized.TestCase):
+
+    @parameterized.product(num_tokens=[1, 17, 128], hidden_size=[256, 7168])
+    def test_matches_torch_reference(self, num_tokens, hidden_size):
+
+        rng = np.random.default_rng(2)
+        x = rng.standard_normal((num_tokens, hidden_size), dtype=np.float32)
+        residual = rng.standard_normal((num_tokens, HC_MULT, hidden_size),
+                                       dtype=np.float32)
+        # Mimic mhc_pre outputs: positive doubly-normalized-ish comb mix and
+        # sigmoid-scaled post mix, both f32.
+        post_mix = (2.0 / (1.0 + np.exp(-rng.standard_normal(
+            (num_tokens, HC_MULT, 1))))).astype(np.float32)
+        comb_raw = np.abs(rng.standard_normal(
+            (num_tokens, HC_MULT, HC_MULT))).astype(np.float32) + 0.01
+        comb_mix = comb_raw / comb_raw.sum(axis=-1, keepdims=True)
+
+        want = mhc_kernels.mhc_post_torch(
+            torch.from_numpy(x).to(torch.bfloat16),
+            torch.from_numpy(residual).to(torch.bfloat16),
+            torch.from_numpy(post_mix),
+            torch.from_numpy(comb_mix),
+        )
+
+        got = _ref_mhc_post(
+            jnp.asarray(x).astype(jnp.bfloat16),
+            jnp.asarray(residual).astype(jnp.bfloat16),
+            jnp.asarray(post_mix),
+            jnp.asarray(comb_mix),
+        )
+
+        self.assertEqual(got.shape, (num_tokens, HC_MULT, hidden_size))
+        self.assertEqual(got.dtype, jnp.bfloat16)
+        np.testing.assert_allclose(_to_np(got),
+                                   want.float().numpy(),
+                                   rtol=BF16_RTOL,
+                                   atol=BF16_ATOL)
+
+
+def _make_post_inputs(rng, num_tokens, hidden_size):
+    x = rng.standard_normal((num_tokens, hidden_size), dtype=np.float32)
+    residual = rng.standard_normal((num_tokens, HC_MULT, hidden_size),
+                                   dtype=np.float32)
+    post_mix = (
+        2.0 /
+        (1.0 + np.exp(-rng.standard_normal((num_tokens, HC_MULT, 1))))).astype(
+            np.float32)
+    comb_raw = np.abs(rng.standard_normal(
+        (num_tokens, HC_MULT, HC_MULT))).astype(np.float32) + 0.01
+    comb_mix = comb_raw / comb_raw.sum(axis=-1, keepdims=True)
+    return (jnp.asarray(x).astype(jnp.bfloat16),
+            jnp.asarray(residual).astype(jnp.bfloat16), jnp.asarray(post_mix),
+            jnp.asarray(comb_mix))
+
+
+class MhcPostPallasSmallShapeTest(parameterized.TestCase):
+    """Post kernel vs the jnp oracle at small shapes and ragged token
+    counts (block indexing and padding); needs TPU hardware."""
+
+    def setUp(self):
+        super().setUp()
+        if jax.default_backend() != "tpu":
+            self.skipTest("Pallas TPU kernel needs TPU hardware")
+
+    @parameterized.product(num_tokens=[1, 17, 64, 200], hidden_size=[256])
+    def test_matches_reference(self, num_tokens, hidden_size):
+        from tpu_inference.kernels.experimental.deepseek_v4.mhc import \
+            post_kernel
+
+        rng = np.random.default_rng(7)
+        args = _make_post_inputs(rng, num_tokens, hidden_size)
+
+        want = _ref_mhc_post(*args)
+        got = post_kernel.mhc_post(*args, token_block_size=64)
+
+        self.assertEqual(got.shape, want.shape)
+        self.assertEqual(got.dtype, jnp.bfloat16)
+        np.testing.assert_allclose(_to_np(got),
+                                   _to_np(want),
+                                   rtol=BF16_RTOL,
+                                   atol=BF16_ATOL)
+
+
+class MhcPostPallasTpuTest(parameterized.TestCase):
+    """Compiled (Mosaic) post kernel vs the jnp reference. Needs TPU."""
+
+    def setUp(self):
+        super().setUp()
+        if jax.default_backend() != "tpu":
+            self.skipTest("Pallas TPU kernel needs TPU hardware")
+
+    @parameterized.product(
+        num_tokens=[16, 17, 128, 2048],
+        token_block_size=[32, 64],
+    )
+    def test_matches_reference(self, num_tokens, token_block_size):
+        from tpu_inference.kernels.experimental.deepseek_v4.mhc import \
+            post_kernel
+
+        rng = np.random.default_rng(8)
+        args = _make_post_inputs(rng, num_tokens, 7168)
+
+        want = _ref_mhc_post(*args)
+        got = post_kernel.mhc_post(*args, token_block_size=token_block_size)
+
+        self.assertEqual(got.shape, want.shape)
+        np.testing.assert_allclose(_to_np(got),
+                                   _to_np(want),
+                                   rtol=BF16_RTOL,
+                                   atol=BF16_ATOL)
+
+
+def _make_fused_inputs(rng, num_tokens, hidden_size):
+    """x/residual/gates (post-style) plus fn/scale/base (pre-style)."""
+    x, residual, post_mix, comb_mix = _make_post_inputs(
+        rng, num_tokens, hidden_size)
+    _, fn, hc_scale, hc_base = _make_pre_inputs(rng, num_tokens, hidden_size)
+    return (x, residual, post_mix, comb_mix, jnp.asarray(fn),
+            jnp.asarray(hc_scale), jnp.asarray(hc_base))
+
+
+def _fused_args(rng, num_tokens, hidden_size, sinkhorn_repeat=20):
+    x, res, plm, crm, fn, sc, hb = _make_fused_inputs(rng, num_tokens,
+                                                      hidden_size)
+    return (x, res, plm, crm, fn, sc, hb, RMS_EPS, HC_PRE_EPS, HC_SINKHORN_EPS,
+            HC_POST_MULT_VALUE, sinkhorn_repeat)
+
+
+class MhcFusedPostPrePallasSmallShapeTest(parameterized.TestCase):
+    """Fused seam kernel vs the sequential oracle at small shapes and
+    ragged token counts; needs TPU hardware."""
+
+    def setUp(self):
+        super().setUp()
+        if jax.default_backend() != "tpu":
+            self.skipTest("Pallas TPU kernel needs TPU hardware")
+
+    @parameterized.product(num_tokens=[1, 17, 64, 200], hidden_size=[256])
+    def test_matches_sequential_reference(self, num_tokens, hidden_size):
+        from tpu_inference.kernels.experimental.deepseek_v4.mhc import \
+            fused_post_pre_kernel
+
+        args = _fused_args(np.random.default_rng(9), num_tokens, hidden_size)
+        fused_fn = fused_post_pre_kernel.mhc_fused_post_pre
+
+        want_res, want_post, want_comb, want_layer = (_ref_mhc_fused_post_pre(
+            *args))
+        got_res, got_post, got_comb, got_layer = (fused_fn(
+            *args, token_block_size=64))
+
+        self.assertEqual(got_res.shape, want_res.shape)
+        self.assertEqual(got_res.dtype, jnp.bfloat16)
+        self.assertEqual(got_layer.dtype, jnp.bfloat16)
+        np.testing.assert_allclose(_to_np(got_res),
+                                   _to_np(want_res),
+                                   rtol=BF16_RTOL,
+                                   atol=BF16_ATOL)
+        np.testing.assert_allclose(_to_np(got_post),
+                                   _to_np(want_post),
+                                   rtol=FUSED_SMALL_H_RTOL,
+                                   atol=FUSED_F32_ATOL)
+        np.testing.assert_allclose(_to_np(got_comb),
+                                   _to_np(want_comb),
+                                   rtol=FUSED_SMALL_H_RTOL,
+                                   atol=FUSED_F32_ATOL)
+        np.testing.assert_allclose(_to_np(got_layer),
+                                   _to_np(want_layer),
+                                   rtol=BF16_RTOL,
+                                   atol=BF16_ATOL)
+
+
+class MhcFusedPostPrePallasTpuTest(parameterized.TestCase):
+    """Compiled (Mosaic) fused seam kernel vs the sequential reference.
+    Needs TPU hardware."""
+
+    def setUp(self):
+        super().setUp()
+        if jax.default_backend() != "tpu":
+            self.skipTest("Pallas TPU kernel needs TPU hardware")
+
+    @parameterized.product(
+        num_tokens=[16, 17, 128, 2048],
+        token_block_size=[32, 64],
+    )
+    def test_matches_sequential_reference(self, num_tokens, token_block_size):
+        from tpu_inference.kernels.experimental.deepseek_v4.mhc import \
+            fused_post_pre_kernel
+
+        args = _fused_args(np.random.default_rng(10), num_tokens, 7168)
+        fused_fn = fused_post_pre_kernel.mhc_fused_post_pre
+
+        want = _ref_mhc_fused_post_pre(*args)
+        got = fused_fn(*args, token_block_size=token_block_size)
+
+        for g, w, tol in zip(got, want, ("bf16", "f32", "f32", "bf16")):
+            rtol, atol = ((BF16_RTOL, BF16_ATOL) if tol == "bf16" else
+                          (FUSED_F32_RTOL, FUSED_F32_ATOL))
+            np.testing.assert_allclose(_to_np(g),
+                                       _to_np(w),
+                                       rtol=rtol,
+                                       atol=atol)
+
+
+class MhcPreMixesPallasSmallShapeTest(parameterized.TestCase):
+    """Mix-GEMM kernel vs the jnp oracle at small shapes and ragged
+    token counts, validating block indexing and padding; needs TPU
+    hardware."""
+
+    def setUp(self):
+        super().setUp()
+        if jax.default_backend() != "tpu":
+            self.skipTest("Pallas TPU kernel needs TPU hardware")
+
+    @parameterized.product(num_tokens=[1, 17, 64, 200], hidden_size=[256])
+    def test_matches_reference(self, num_tokens, hidden_size):
+        from tpu_inference.kernels.experimental.deepseek_v4.mhc import \
+            pre_kernel
+
+        rng = np.random.default_rng(4)
+        residual, fn, _, _ = _make_pre_inputs(rng, num_tokens, hidden_size)
+        x2d = (jnp.asarray(residual).astype(jnp.bfloat16).reshape(
+            num_tokens, HC_MULT * hidden_size))
+        fn_j = jnp.asarray(fn)
+
+        want_mixes, want_sqrsum = _ref_mhc_pre_mixes(x2d, fn_j)
+        got_mixes, got_sqrsum = pre_kernel.mhc_pre_mixes(
+            x2d,
+            fn_j,
+            token_block_size=64,
+        )
+
+        self.assertEqual(got_mixes.shape, want_mixes.shape)
+        self.assertEqual(got_sqrsum.shape, want_sqrsum.shape)
+        np.testing.assert_allclose(_to_np(got_mixes),
+                                   _to_np(want_mixes),
+                                   rtol=F32_RTOL,
+                                   atol=F32_ATOL)
+        np.testing.assert_allclose(_to_np(got_sqrsum),
+                                   _to_np(want_sqrsum),
+                                   rtol=F32_RTOL,
+                                   atol=F32_ATOL)
+
+
+class MhcPrePallasTpuTest(parameterized.TestCase):
+    """Compiled (Mosaic) kernel vs the jnp reference. Needs TPU hardware."""
+
+    def setUp(self):
+        super().setUp()
+        if jax.default_backend() != "tpu":
+            self.skipTest("Pallas TPU kernel needs TPU hardware")
+
+    @parameterized.product(
+        num_tokens=[16, 17, 128, 2048],
+        token_block_size=[64, 128],
+    )
+    def test_mixes_matches_reference(self, num_tokens, token_block_size):
+        from tpu_inference.kernels.experimental.deepseek_v4.mhc import \
+            pre_kernel
+
+        hidden_size = 7168  # DeepSeek-V4 shape; D = 28672
+        rng = np.random.default_rng(5)
+        residual, fn, _, _ = _make_pre_inputs(rng, num_tokens, hidden_size)
+        x2d = (jnp.asarray(residual).astype(jnp.bfloat16).reshape(
+            num_tokens, HC_MULT * hidden_size))
+        fn_j = jnp.asarray(fn)
+
+        want_mixes, want_sqrsum = _ref_mhc_pre_mixes(x2d, fn_j)
+        got_mixes, got_sqrsum = pre_kernel.mhc_pre_mixes(
+            x2d, fn_j, token_block_size=token_block_size)
+
+        np.testing.assert_allclose(_to_np(got_mixes),
+                                   _to_np(want_mixes),
+                                   rtol=F32_RTOL,
+                                   atol=F32_ATOL)
+        np.testing.assert_allclose(_to_np(got_sqrsum),
+                                   _to_np(want_sqrsum),
+                                   rtol=F32_RTOL,
+                                   atol=F32_ATOL)
+
+    @parameterized.product(num_tokens=[16, 128], sinkhorn_repeat=[1, 20])
+    def test_full_op_matches_reference(self, num_tokens, sinkhorn_repeat):
+        from tpu_inference.kernels.experimental.deepseek_v4.mhc import \
+            pre_kernel
+
+        hidden_size = 7168
+        rng = np.random.default_rng(6)
+        residual, fn, hc_scale, hc_base = _make_pre_inputs(
+            rng, num_tokens, hidden_size)
+        args = (jnp.asarray(residual).astype(jnp.bfloat16), jnp.asarray(fn),
+                jnp.asarray(hc_scale), jnp.asarray(hc_base), RMS_EPS,
+                HC_PRE_EPS, HC_SINKHORN_EPS, HC_POST_MULT_VALUE,
+                sinkhorn_repeat)
+
+        want_post, want_comb, want_layer = _ref_mhc_pre(*args)
+        got_post, got_comb, got_layer = pre_kernel.mhc_pre(*args)
+
+        self.assertEqual(got_layer.dtype, jnp.bfloat16)
+        np.testing.assert_allclose(_to_np(got_post),
+                                   _to_np(want_post),
+                                   rtol=F32_RTOL,
+                                   atol=F32_ATOL)
+        np.testing.assert_allclose(_to_np(got_comb),
+                                   _to_np(want_comb),
+                                   rtol=F32_RTOL,
+                                   atol=F32_ATOL)
+        np.testing.assert_allclose(_to_np(got_layer),
+                                   _to_np(want_layer),
+                                   rtol=BF16_RTOL,
+                                   atol=BF16_ATOL)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tpu_inference/kernels/experimental/deepseek_v4/mhc/__init__.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/mhc/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tpu_inference/kernels/experimental/deepseek_v4/mhc/fused_post_pre_kernel.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/mhc/fused_post_pre_kernel.py
@@ -1,0 +1,279 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+from tpu_inference.kernels.experimental.deepseek_v4.mhc import utils
+
+# bf16 tiles are (16, 128); keep token blocks sublane-aligned.
+_SUBLANE = 16
+
+# Explicit scoped-VMEM budget, repo convention (mla/v1, deepseek_v4 and
+# fused_moe use the same constant). Never rely on the backend default —
+# it varies by Mosaic version.
+DEFAULT_VMEM_LIMIT_BYTES = 100 * 1024 * 1024
+
+
+def _round_up(x: int, multiple: int) -> int:
+    return (x + multiple - 1) // multiple * multiple
+
+
+def _fused_kernel(x_ref, res_ref, post_ref, comb_ref, fn_hi_ref, fn_mid_ref,
+                  fn_lo_ref, sc_ref, hb_ref, newres_ref, mixes_ref, sqrsum_ref,
+                  layer_ref, *, hc_mult, hidden_size, gemm_precision, rms_eps,
+                  hc_pre_eps):
+    """One token block: recombine, store once, 3-pass GEMM, collapse."""
+    post = post_ref[...]  # (tb, hc_mult) f32
+    comb = comb_ref[...]  # (tb, hc_mult * hc_mult) f32, row-major (i, j)
+
+    # Keep the streams (and x) in bf16 and upcast per use: transient f32
+    # values instead of 4 held f32 copies halves the resident working set,
+    # leaving VMEM headroom for the pipeline to prefetch the next block.
+    # bf16 -> f32 casts are exact, so results are unchanged.
+    x_bf = x_ref[...]  # (tb, hidden) bf16
+    old_bf = [
+        res_ref[:, i * hidden_size:(i + 1) * hidden_size]
+        for i in range(hc_mult)
+    ]
+
+    streams_bf = []
+    for j in range(hc_mult):
+        acc = post[:, j:j + 1] * x_bf.astype(jnp.float32)
+        for i in range(hc_mult):
+            k = i * hc_mult + j
+            acc = acc + comb[:, k:k + 1] * old_bf[i].astype(jnp.float32)
+        # Round to bf16 BEFORE the GEMM: the unfused path's pre reads the
+        # bf16 residual that post stored, and parity requires matching it.
+        new_bf = acc.astype(jnp.bfloat16)
+        newres_ref[:, j * hidden_size:(j + 1) * hidden_size] = new_bf
+        streams_bf.append(new_bf)
+
+    g_bf = jnp.concatenate(streams_bf, axis=1)  # (tb, hc_mult * hidden_size)
+    dn = (((1, ), (1, )), ((), ()))
+    acc = jax.lax.dot_general(g_bf,
+                              fn_hi_ref[...],
+                              dn,
+                              preferred_element_type=jnp.float32)
+    if gemm_precision == "highest":
+        acc = acc + jax.lax.dot_general(
+            g_bf, fn_mid_ref[...], dn, preferred_element_type=jnp.float32)
+        acc = acc + jax.lax.dot_general(
+            g_bf, fn_lo_ref[...], dn, preferred_element_type=jnp.float32)
+    mixes_ref[...] = acc
+    gf = g_bf.astype(jnp.float32)  # f32 for the squared sum + collapse
+    sqr = jnp.sum(gf * gf, axis=-1, keepdims=True)
+    sqrsum_ref[...] = sqr
+
+    m, h = hc_mult, hidden_size
+    scaled = acc[:, :m] * jax.lax.rsqrt(sqr / (m * h) + rms_eps)
+    pre_mix = jax.nn.sigmoid(scaled * sc_ref[0, 0] + hb_ref[:, :m]) + \
+        hc_pre_eps
+    lay = pre_mix[:, 0:1] * gf[:, :h]
+    for i in range(1, m):
+        lay = lay + pre_mix[:, i:i + 1] * gf[:, i * h:(i + 1) * h]
+    layer_ref[...] = lay.astype(jnp.bfloat16)
+
+
+@functools.partial(jax.jit,
+                   static_argnames=("rms_eps", "hc_pre_eps",
+                                    "token_block_size", "gemm_precision",
+                                    "vmem_limit_bytes"))
+def fused_post_pre_mixes(
+    x2d: jax.Array,
+    res2d: jax.Array,
+    post2d: jax.Array,
+    comb2d: jax.Array,
+    fn: jax.Array,
+    hc_scale: jax.Array,
+    hc_base: jax.Array,
+    rms_eps: float,
+    hc_pre_eps: float,
+    *,
+    token_block_size: int = 32,
+    gemm_precision: str = "highest",
+    vmem_limit_bytes: int = DEFAULT_VMEM_LIMIT_BYTES,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    """The Pallas seam kernel: post recombine fused with pre's mix GEMM
+    and in-block collapse.
+
+    Args:
+        x2d: (num_tokens, hidden_size), bfloat16 — sublayer output.
+        res2d: (num_tokens, hc_mult * hidden_size), bfloat16 — old streams.
+        post2d: (num_tokens, hc_mult), float32.
+        comb2d: (num_tokens, hc_mult * hc_mult), float32, row-major (i, j).
+        fn: (hc_mult3, hc_mult * hidden_size), float32 — next sublayer's
+            gate projection.
+        hc_scale: (3,), float32 — pre/post/comb logit scales (the kernel
+            uses only the pre entry; the rest feed the XLA gates).
+        hc_base: (hc_mult3,), float32 — logit biases, pre entries first.
+        rms_eps: static; RMS-norm epsilon for the in-block pre gates.
+        hc_pre_eps: static; additive floor on the sigmoid pre gates.
+        token_block_size: tokens per grid step. Default 32 keeps the
+            worst-case VMEM footprint (f32 old streams + bf16 blocks +
+            the three resident bf16 fn chunks) near 12 MB at DeepSeek-V4
+            shapes; 64 also fits.
+        gemm_precision: "highest" (3-pass exact decomposition, the
+            default) or "default" (hi-chunk pass only; pre_mix and the
+            collapse then also see the hi-only mixes).
+
+    Returns:
+        new_res2d: (num_tokens, hc_mult * hidden_size), bfloat16.
+        mixes: (num_tokens, hc_mult3), float32 — raw, unscaled, for the
+            XLA gates.
+        sqrsum: (num_tokens, 1), float32.
+        layer2d: (num_tokens, hidden_size), bfloat16.
+    """
+    assert x2d.dtype == jnp.bfloat16, x2d.dtype
+    assert res2d.dtype == jnp.bfloat16, res2d.dtype
+    assert post2d.dtype == jnp.float32, post2d.dtype
+    assert comb2d.dtype == jnp.float32, comb2d.dtype
+    assert fn.dtype == jnp.float32, fn.dtype
+
+    num_tokens, hidden_size = x2d.shape
+    hc_hidden = res2d.shape[1]
+    hc_mult = hc_hidden // hidden_size
+    hc_mult3 = fn.shape[0]
+    assert res2d.shape == (num_tokens, hc_mult * hidden_size)
+    assert fn.shape == (hc_mult3, hc_hidden), (fn.shape, res2d.shape)
+    assert gemm_precision in ("highest", "default"), gemm_precision
+
+    tb = min(token_block_size, _round_up(num_tokens, _SUBLANE))
+    padded_tokens = _round_up(num_tokens, tb)
+    if padded_tokens != num_tokens:
+        pad = padded_tokens - num_tokens
+        x2d = jnp.pad(x2d, ((0, pad), (0, 0)))
+        res2d = jnp.pad(res2d, ((0, pad), (0, 0)))
+        post2d = jnp.pad(post2d, ((0, pad), (0, 0)))
+        comb2d = jnp.pad(comb2d, ((0, pad), (0, 0)))
+
+    # 3-chunk bf16 split of fn (8 mantissa bits each = f32's 24). Computed
+    # in XLA outside the kernel; the chunks are what stays VMEM-resident.
+    # Chunks MUST be built with reduce_precision, not dtype round-trips:
+    # XLA's excess-precision simplification folds f32->bf16->f32 into the
+    # identity, which silently zeroes the mid/lo chunks.
+    fn_hi = jax.lax.reduce_precision(fn, 8, 7)
+    rem = fn - fn_hi
+    fn_mid = jax.lax.reduce_precision(rem, 8, 7)
+    fn_lo = jax.lax.reduce_precision(rem - fn_mid, 8, 7)
+    fn_hi, fn_mid, fn_lo = (t.astype(jnp.bfloat16)
+                            for t in (fn_hi, fn_mid, fn_lo))
+    sc2d = hc_scale.reshape(1, 3).astype(jnp.float32)
+    hb2d = hc_base.reshape(1, hc_mult3).astype(jnp.float32)
+
+    compiler_params = pltpu.CompilerParams(
+        dimension_semantics=("parallel", ),
+        vmem_limit_bytes=vmem_limit_bytes,
+    )
+
+    resident = pl.BlockSpec((hc_mult3, hc_hidden), lambda i: (0, 0))
+    new_res, mixes, sqrsum, layer2d = pl.pallas_call(
+        functools.partial(_fused_kernel,
+                          hc_mult=hc_mult,
+                          hidden_size=hidden_size,
+                          gemm_precision=gemm_precision,
+                          rms_eps=rms_eps,
+                          hc_pre_eps=hc_pre_eps),
+        grid=(padded_tokens // tb, ),
+        in_specs=[
+            pl.BlockSpec((tb, hidden_size), lambda i: (i, 0)),
+            pl.BlockSpec((tb, hc_hidden), lambda i: (i, 0)),
+            pl.BlockSpec((tb, hc_mult), lambda i: (i, 0)),
+            pl.BlockSpec((tb, hc_mult * hc_mult), lambda i: (i, 0)),
+            resident,
+            resident,
+            resident,
+            pl.BlockSpec((1, 3), lambda i: (0, 0)),
+            pl.BlockSpec((1, hc_mult3), lambda i: (0, 0)),
+        ],
+        out_specs=[
+            pl.BlockSpec((tb, hc_hidden), lambda i: (i, 0)),
+            pl.BlockSpec((tb, hc_mult3), lambda i: (i, 0)),
+            pl.BlockSpec((tb, 1), lambda i: (i, 0)),
+            pl.BlockSpec((tb, hidden_size), lambda i: (i, 0)),
+        ],
+        out_shape=[
+            jax.ShapeDtypeStruct((padded_tokens, hc_hidden), jnp.bfloat16),
+            jax.ShapeDtypeStruct((padded_tokens, hc_mult3), jnp.float32),
+            jax.ShapeDtypeStruct((padded_tokens, 1), jnp.float32),
+            jax.ShapeDtypeStruct((padded_tokens, hidden_size), jnp.bfloat16),
+        ],
+        compiler_params=compiler_params,
+    )(x2d, res2d, post2d, comb2d, fn_hi, fn_mid, fn_lo, sc2d, hb2d)
+
+    if padded_tokens != num_tokens:
+        new_res = new_res[:num_tokens]
+        mixes = mixes[:num_tokens]
+        sqrsum = sqrsum[:num_tokens]
+        layer2d = layer2d[:num_tokens]
+    return new_res, mixes, sqrsum, layer2d
+
+
+def mhc_fused_post_pre(
+    x: jax.Array,
+    residual: jax.Array,
+    post_layer_mix: jax.Array,
+    comb_res_mix: jax.Array,
+    fn: jax.Array,
+    hc_scale: jax.Array,
+    hc_base: jax.Array,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    *,
+    token_block_size: int = 32,
+    gemm_precision: str = "highest",
+    vmem_limit_bytes: int = DEFAULT_VMEM_LIMIT_BYTES,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    """Fused seam op: Pallas post+GEMM+collapse kernel, XLA gates epilogue.
+    Returns (residual_cur, post_mix_cur, comb_mix_cur, layer_input_cur).
+    """
+    assert residual.dtype == jnp.bfloat16
+
+    outer_shape = residual.shape[:-2]
+    hc_mult, hidden_size = residual.shape[-2:]
+
+    x2d = x.reshape(-1, hidden_size).astype(jnp.bfloat16)
+    res2d = residual.reshape(-1, hc_mult * hidden_size)
+    post2d = post_layer_mix.reshape(-1, hc_mult)
+    comb2d = comb_res_mix.reshape(-1, hc_mult * hc_mult)
+
+    new_res2d, mixes, sqrsum, layer_input_cur = fused_post_pre_mixes(
+        x2d,
+        res2d,
+        post2d,
+        comb2d,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        token_block_size=token_block_size,
+        gemm_precision=gemm_precision,
+        vmem_limit_bytes=vmem_limit_bytes,
+    )
+    _, post_mix_cur, comb_mix_cur = utils.mhc_pre_gates(
+        mixes, sqrsum, hc_mult, hidden_size, hc_scale, hc_base, rms_eps,
+        hc_pre_eps, hc_sinkhorn_eps, hc_post_mult_value, sinkhorn_repeat)
+
+    return (new_res2d.reshape(*outer_shape, hc_mult, hidden_size),
+            post_mix_cur.reshape(*outer_shape, hc_mult, 1),
+            comb_mix_cur.reshape(*outer_shape, hc_mult, hc_mult),
+            layer_input_cur.reshape(*outer_shape, hidden_size))

--- a/tpu_inference/kernels/experimental/deepseek_v4/mhc/post_kernel.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/mhc/post_kernel.py
@@ -1,0 +1,172 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+# bf16 tiles are (16, 128); keep token blocks sublane-aligned.
+_SUBLANE = 16
+
+# Explicit scoped-VMEM budget, repo convention (mla/v1, deepseek_v4 and
+# fused_moe use the same constant).
+DEFAULT_VMEM_LIMIT_BYTES = 100 * 1024 * 1024
+
+
+def _round_up(x: int, multiple: int) -> int:
+    return (x + multiple - 1) // multiple * multiple
+
+
+def _post_kernel(x_ref, res_ref, post_ref, comb_ref, out_ref, *, hc_mult,
+                 hidden_size):
+    """One token block of the unrolled stream recombine."""
+    x = x_ref[...].astype(jnp.float32)  # (tb, hidden)
+    post = post_ref[...]  # (tb, hc_mult) f32
+    comb = comb_ref[...]  # (tb, hc_mult * hc_mult) f32, row-major (i, j)
+
+    streams = [
+        res_ref[:, i * hidden_size:(i + 1) * hidden_size].astype(jnp.float32)
+        for i in range(hc_mult)
+    ]
+    for j in range(hc_mult):
+        acc = post[:, j:j + 1] * x
+        for i in range(hc_mult):
+            k = i * hc_mult + j
+            acc = acc + comb[:, k:k + 1] * streams[i]
+        out_ref[:, j * hidden_size:(j + 1) * hidden_size] = acc.astype(
+            out_ref.dtype)
+
+
+@functools.partial(jax.jit,
+                   static_argnames=("token_block_size", "vmem_limit_bytes"))
+def mhc_post_2d(
+    x: jax.Array,
+    res2d: jax.Array,
+    post_layer_mix: jax.Array,
+    comb_res_mix: jax.Array,
+    *,
+    token_block_size: int = 64,
+    vmem_limit_bytes: int = DEFAULT_VMEM_LIMIT_BYTES,
+) -> jax.Array:
+    """2D-native entry: the kernel's own layout as public API.
+
+    The kernel consumes and produces flat ``(num_tokens, hc_mult *
+    hidden_size)`` streams. Callers that can keep the residual flat (a
+    composed seam, 2D model plumbing) should call this directly.
+
+    Args:
+        x: (num_tokens, hidden_size), bfloat16 — the sublayer output.
+        res2d: (num_tokens, hc_mult * hidden_size), bfloat16.
+        post_layer_mix: (num_tokens, hc_mult, 1) or (num_tokens, hc_mult),
+            float32.
+        comb_res_mix: (num_tokens, hc_mult, hc_mult), float32.
+
+    Returns:
+        (num_tokens, hc_mult * hidden_size) in ``res2d.dtype``.
+    """
+    assert res2d.dtype == jnp.bfloat16, res2d.dtype
+    assert post_layer_mix.dtype == jnp.float32, post_layer_mix.dtype
+    assert comb_res_mix.dtype == jnp.float32, comb_res_mix.dtype
+
+    hc_mult = comb_res_mix.shape[-1]
+    hidden_size = res2d.shape[-1] // hc_mult
+
+    x2d = x.reshape(-1, hidden_size).astype(jnp.bfloat16)
+    post2d = post_layer_mix.reshape(-1, hc_mult)
+    comb2d = comb_res_mix.reshape(-1, hc_mult * hc_mult)
+    num_tokens = res2d.shape[0]
+
+    def _vmem_need(tb: int) -> int:
+        # Double-buffered bf16 in/out blocks (x + old streams + new
+        # streams) plus f32 accumulator transients; x2 spill headroom.
+        return 2 * (tb * hidden_size *
+                    (2 + 2 * hc_mult * 2) * 2 + tb * hidden_size * 4 * 2)
+
+    tb = min(token_block_size, _round_up(num_tokens, _SUBLANE))
+    while tb > _SUBLANE and _vmem_need(tb) > vmem_limit_bytes:
+        # Degrade to a smaller block instead of a compile-time VMEM OOM.
+        tb //= 2
+    padded_tokens = _round_up(num_tokens, tb)
+    if padded_tokens != num_tokens:
+        pad = padded_tokens - num_tokens
+        x2d = jnp.pad(x2d, ((0, pad), (0, 0)))
+        res2d = jnp.pad(res2d, ((0, pad), (0, 0)))
+        post2d = jnp.pad(post2d, ((0, pad), (0, 0)))
+        comb2d = jnp.pad(comb2d, ((0, pad), (0, 0)))
+
+    compiler_params = pltpu.CompilerParams(dimension_semantics=("parallel", ),
+                                           vmem_limit_bytes=vmem_limit_bytes)
+
+    out = pl.pallas_call(
+        functools.partial(_post_kernel,
+                          hc_mult=hc_mult,
+                          hidden_size=hidden_size),
+        grid=(padded_tokens // tb, ),
+        in_specs=[
+            pl.BlockSpec((tb, hidden_size), lambda i: (i, 0)),
+            pl.BlockSpec((tb, hc_mult * hidden_size), lambda i: (i, 0)),
+            pl.BlockSpec((tb, hc_mult), lambda i: (i, 0)),
+            pl.BlockSpec((tb, hc_mult * hc_mult), lambda i: (i, 0)),
+        ],
+        out_specs=pl.BlockSpec((tb, hc_mult * hidden_size), lambda i: (i, 0)),
+        out_shape=jax.ShapeDtypeStruct((padded_tokens, hc_mult * hidden_size),
+                                       res2d.dtype),
+        compiler_params=compiler_params,
+    )(x2d, res2d, post2d, comb2d)
+
+    if padded_tokens != num_tokens:
+        out = out[:num_tokens]
+    return out
+
+
+def mhc_post(
+    x: jax.Array,
+    residual: jax.Array,
+    post_layer_mix: jax.Array,
+    comb_res_mix: jax.Array,
+    *,
+    token_block_size: int = 64,
+    vmem_limit_bytes: int = DEFAULT_VMEM_LIMIT_BYTES,
+) -> jax.Array:
+    """Pallas replacement for vLLM's ``mhc_post_torch``.
+
+    Thin adapter over ``mhc_post_2d`` matching vLLM's op signature.
+
+    Args:
+        x: (..., hidden_size), bfloat16 — the sublayer output.
+        residual: (..., hc_mult, hidden_size), bfloat16.
+        post_layer_mix: (..., hc_mult, 1), float32.
+        comb_res_mix: (..., hc_mult, hc_mult), float32.
+        token_block_size: tokens per grid step.
+
+    Returns:
+        (..., hc_mult, hidden_size) in ``residual.dtype``.
+    """
+    assert residual.dtype == jnp.bfloat16, residual.dtype
+
+    outer_shape = residual.shape[:-2]
+    hc_mult, hidden_size = residual.shape[-2:]
+
+    out2d = mhc_post_2d(
+        x.reshape(-1, hidden_size),
+        residual.reshape(-1, hc_mult * hidden_size),
+        post_layer_mix.reshape(-1, hc_mult, 1),
+        comb_res_mix.reshape(-1, hc_mult, hc_mult),
+        token_block_size=token_block_size,
+        vmem_limit_bytes=vmem_limit_bytes,
+    )
+    return out2d.reshape(*outer_shape, hc_mult, hidden_size)

--- a/tpu_inference/kernels/experimental/deepseek_v4/mhc/pre_kernel.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/mhc/pre_kernel.py
@@ -1,0 +1,315 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+from tpu_inference.kernels.experimental.deepseek_v4.mhc import utils
+
+# bf16 tiles are (16, 128); keep token blocks sublane-aligned.
+_SUBLANE = 16
+
+# Explicit scoped-VMEM budget, repo convention (mla/v1, deepseek_v4 and
+# fused_moe use the same constant).
+DEFAULT_VMEM_LIMIT_BYTES = 100 * 1024 * 1024
+
+
+def _round_up(x: int, multiple: int) -> int:
+    return (x + multiple - 1) // multiple * multiple
+
+
+def _split_fn3(fn: jax.Array) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """3-chunk bf16 split of fn (8 mantissa bits each = f32's 24).
+
+    Chunks MUST be built with reduce_precision, not dtype round-trips:
+    XLA's excess-precision simplification folds f32->bf16->f32 into the
+    identity, which silently zeroes the mid/lo chunks.
+    """
+    fn_hi = jax.lax.reduce_precision(fn, 8, 7)
+    rem = fn - fn_hi
+    fn_mid = jax.lax.reduce_precision(rem, 8, 7)
+    fn_lo = jax.lax.reduce_precision(rem - fn_mid, 8, 7)
+    return tuple(t.astype(jnp.bfloat16) for t in (fn_hi, fn_mid, fn_lo))
+
+
+def _dot3(x, fn_hi_ref, fn_mid_ref, fn_lo_ref):
+    """3-pass exact GEMM: x is bf16 (its low chunks are zero), so three
+    bf16 passes against the resident fn chunks reproduce HIGHEST. The
+    dimension numbers contract x dim 1 with fn dim 1 (i.e. x @ fn.T) so
+    fn needs no transpose on the host side."""
+    dn = (((1, ), (1, )), ((), ()))
+    acc = jax.lax.dot_general(x,
+                              fn_hi_ref[...],
+                              dn,
+                              preferred_element_type=jnp.float32)
+    acc = acc + jax.lax.dot_general(
+        x, fn_mid_ref[...], dn, preferred_element_type=jnp.float32)
+    acc = acc + jax.lax.dot_general(
+        x, fn_lo_ref[...], dn, preferred_element_type=jnp.float32)
+    return acc
+
+
+def _mixes_kernel(x_ref, fn_hi_ref, fn_mid_ref, fn_lo_ref, mixes_ref,
+                  sqrsum_ref):
+    """One token block: 3-pass exact GEMM against resident fn chunks."""
+    x = x_ref[...]
+    mixes_ref[...] = _dot3(x, fn_hi_ref, fn_mid_ref, fn_lo_ref)
+    xf = x.astype(jnp.float32)  # f32 needed only for the squared sum
+    sqrsum_ref[...] = jnp.sum(xf * xf, axis=-1, keepdims=True)
+
+
+def _mixes_collapse_kernel(x_ref, fn_hi_ref, fn_mid_ref, fn_lo_ref, sc_ref,
+                           hb_ref, mixes_ref, sqrsum_ref, layer_ref, *,
+                           hc_mult, hidden_size, rms_eps, hc_pre_eps):
+    """Mixes kernel plus the in-block collapse.
+
+    The collapse's weights are ``pre_mix`` — the sigmoid read gates,
+    which need no Sinkhorn and are per-token, so they are computable
+    entirely in-block. The Sinkhorn/post/comb gates stay in
+    XLA on the raw ``mixes`` output.
+    """
+    m, h = hc_mult, hidden_size
+    x = x_ref[...]
+    acc = _dot3(x, fn_hi_ref, fn_mid_ref, fn_lo_ref)
+    mixes_ref[...] = acc
+    xf = x.astype(jnp.float32)
+    sqr = jnp.sum(xf * xf, axis=-1, keepdims=True)
+    sqrsum_ref[...] = sqr
+    # Same op order as utils.mhc_pre_gates for bit-level agreement.
+    scaled = acc[:, :m] * jax.lax.rsqrt(sqr / (m * h) + rms_eps)
+    pre_mix = jax.nn.sigmoid(scaled * sc_ref[0, 0] + hb_ref[:, :m]) + \
+        hc_pre_eps
+    lay = pre_mix[:, 0:1] * xf[:, :h]
+    for i in range(1, m):
+        lay = lay + pre_mix[:, i:i + 1] * xf[:, i * h:(i + 1) * h]
+    layer_ref[...] = lay.astype(jnp.bfloat16)
+
+
+@functools.partial(jax.jit,
+                   static_argnames=("token_block_size", "vmem_limit_bytes"))
+def mhc_pre_mixes(
+    x2d: jax.Array,
+    fn: jax.Array,
+    *,
+    token_block_size: int = 64,
+    vmem_limit_bytes: int = DEFAULT_VMEM_LIMIT_BYTES,
+) -> tuple[jax.Array, jax.Array]:
+    """Pallas replacement for the mix GEMM + squared sum of mhc_pre.
+
+    Args:
+        x2d: (num_tokens, hc_mult * hidden_size), bfloat16.
+        fn: (hc_mult3, hc_mult * hidden_size), float32.
+        token_block_size: tokens per grid step. The default (64) keeps the
+            worst-case VMEM footprint (bf16 block + f32 cast + resident fn)
+            around 14 MB at DeepSeek-V4 shapes.
+
+    Returns:
+        mixes: (num_tokens, hc_mult3), float32.
+        sqrsum: (num_tokens, 1), float32.
+    """
+    assert x2d.dtype == jnp.bfloat16, x2d.dtype
+    assert fn.dtype == jnp.float32, fn.dtype
+    num_tokens, hc_hidden = x2d.shape
+    hc_mult3 = fn.shape[0]
+    assert fn.shape == (hc_mult3, hc_hidden), (fn.shape, x2d.shape)
+
+    def _vmem_need(tb: int) -> int:
+        # Double-buffered bf16 x block, transient f32 copy for the squared
+        # sum, resident bf16 fn chunks; x2 headroom for spills/scratch
+        # (quantized_matmul-style safety factor).
+        return 2 * (tb * hc_hidden *
+                    (2 * 2 + 4) + 3 * hc_mult3 * hc_hidden * 2)
+
+    tb = min(token_block_size, _round_up(num_tokens, _SUBLANE))
+    while tb > _SUBLANE and _vmem_need(tb) > vmem_limit_bytes:
+        # Degrade to a smaller block instead of a compile-time VMEM OOM.
+        tb //= 2
+    padded_tokens = _round_up(num_tokens, tb)
+    if padded_tokens != num_tokens:
+        # Zero rows are safe: they produce zero mixes/sqrsum and are
+        # sliced off below.
+        x2d = jnp.pad(x2d, ((0, padded_tokens - num_tokens), (0, 0)))
+
+    # Split in XLA outside the kernel; the chunks stay VMEM-resident.
+    fn_hi, fn_mid, fn_lo = _split_fn3(fn)
+
+    compiler_params = pltpu.CompilerParams(dimension_semantics=("parallel", ),
+                                           vmem_limit_bytes=vmem_limit_bytes)
+
+    resident = pl.BlockSpec((hc_mult3, hc_hidden), lambda i: (0, 0))
+    mixes, sqrsum = pl.pallas_call(
+        _mixes_kernel,
+        grid=(padded_tokens // tb, ),
+        in_specs=[
+            pl.BlockSpec((tb, hc_hidden), lambda i: (i, 0)),
+            resident,
+            resident,
+            resident,
+        ],
+        out_specs=[
+            pl.BlockSpec((tb, hc_mult3), lambda i: (i, 0)),
+            pl.BlockSpec((tb, 1), lambda i: (i, 0)),
+        ],
+        out_shape=[
+            jax.ShapeDtypeStruct((padded_tokens, hc_mult3), jnp.float32),
+            jax.ShapeDtypeStruct((padded_tokens, 1), jnp.float32),
+        ],
+        compiler_params=compiler_params,
+    )(x2d, fn_hi, fn_mid, fn_lo)
+
+    if padded_tokens != num_tokens:
+        mixes = mixes[:num_tokens]
+        sqrsum = sqrsum[:num_tokens]
+    return mixes, sqrsum
+
+
+@functools.partial(jax.jit,
+                   static_argnames=("rms_eps", "hc_pre_eps",
+                                    "token_block_size", "vmem_limit_bytes"))
+def mhc_pre_mixes_collapse(
+    x2d: jax.Array,
+    fn: jax.Array,
+    hc_scale: jax.Array,
+    hc_base: jax.Array,
+    rms_eps: float,
+    hc_pre_eps: float,
+    *,
+    token_block_size: int = 64,
+    vmem_limit_bytes: int = DEFAULT_VMEM_LIMIT_BYTES,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Mixes + in-block collapse: the full memory-bound half of ``mhc_pre``.
+
+    Returns (mixes (T, hc_mult3) f32 — raw, unscaled, for the XLA gates;
+    sqrsum (T, 1) f32; layer_input2d (T, hidden_size) bf16).
+    """
+    assert x2d.dtype == jnp.bfloat16, x2d.dtype
+    assert fn.dtype == jnp.float32, fn.dtype
+    num_tokens, hc_hidden = x2d.shape
+    hc_mult3 = fn.shape[0]
+    assert fn.shape == (hc_mult3, hc_hidden), (fn.shape, x2d.shape)
+    # hc_mult3 = hc_mult * (hc_mult + 2) -> unique positive hc_mult.
+    hc_mult = next(m for m in range(1, 64) if m * (m + 2) == hc_mult3)
+    hidden_size = hc_hidden // hc_mult
+
+    fn_hi, fn_mid, fn_lo = _split_fn3(fn)
+    sc2d = hc_scale.reshape(1, 3).astype(jnp.float32)
+    hb2d = hc_base.reshape(1, hc_mult3).astype(jnp.float32)
+
+    def _vmem_need(tb: int) -> int:
+        # Double-buffered bf16 x block + layer output, transient f32
+        # copy, resident bf16 fn chunks; x2 spill/scratch headroom.
+        return 2 * (tb * hc_hidden * (2 * 2 + 4) + tb * hidden_size * 2 * 2 +
+                    3 * hc_mult3 * hc_hidden * 2)
+
+    tb = min(token_block_size, _round_up(num_tokens, _SUBLANE))
+    while tb > _SUBLANE and _vmem_need(tb) > vmem_limit_bytes:
+        # Degrade to a smaller block instead of a compile-time VMEM OOM.
+        tb //= 2
+    padded_tokens = _round_up(num_tokens, tb)
+    if padded_tokens != num_tokens:
+        # Zero rows are safe: they produce zero mixes/sqrsum/layer rows
+        # and are sliced off below.
+        x2d = jnp.pad(x2d, ((0, padded_tokens - num_tokens), (0, 0)))
+
+    compiler_params = pltpu.CompilerParams(dimension_semantics=("parallel", ),
+                                           vmem_limit_bytes=vmem_limit_bytes)
+
+    resident = pl.BlockSpec((hc_mult3, hc_hidden), lambda i: (0, 0))
+    mixes, sqrsum, layer2d = pl.pallas_call(
+        functools.partial(_mixes_collapse_kernel,
+                          hc_mult=hc_mult,
+                          hidden_size=hidden_size,
+                          rms_eps=rms_eps,
+                          hc_pre_eps=hc_pre_eps),
+        grid=(padded_tokens // tb, ),
+        in_specs=[
+            pl.BlockSpec((tb, hc_hidden), lambda i: (i, 0)),
+            resident,
+            resident,
+            resident,
+            pl.BlockSpec((1, 3), lambda i: (0, 0)),
+            pl.BlockSpec((1, hc_mult3), lambda i: (0, 0)),
+        ],
+        out_specs=[
+            pl.BlockSpec((tb, hc_mult3), lambda i: (i, 0)),
+            pl.BlockSpec((tb, 1), lambda i: (i, 0)),
+            pl.BlockSpec((tb, hidden_size), lambda i: (i, 0)),
+        ],
+        out_shape=[
+            jax.ShapeDtypeStruct((padded_tokens, hc_mult3), jnp.float32),
+            jax.ShapeDtypeStruct((padded_tokens, 1), jnp.float32),
+            jax.ShapeDtypeStruct((padded_tokens, hidden_size), jnp.bfloat16),
+        ],
+        compiler_params=compiler_params,
+    )(x2d, fn_hi, fn_mid, fn_lo, sc2d, hb2d)
+
+    if padded_tokens != num_tokens:
+        mixes = mixes[:num_tokens]
+        sqrsum = sqrsum[:num_tokens]
+        layer2d = layer2d[:num_tokens]
+    return mixes, sqrsum, layer2d
+
+
+def mhc_pre(
+    residual: jax.Array,
+    fn: jax.Array,
+    hc_scale: jax.Array,
+    hc_base: jax.Array,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+    *,
+    token_block_size: int = 64,
+    vmem_limit_bytes: int = DEFAULT_VMEM_LIMIT_BYTES,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """``mhc_pre`` with the mix GEMM AND the collapse in Pallas; only the
+    tiny gates/Sinkhorn stay in XLA.
+
+    Same contract as vLLM's ``mhc_pre_torch``:
+    residual (..., hc_mult, hidden_size) bf16 in; post_mix (..., hc_mult, 1)
+    f32, comb_mix (..., hc_mult, hc_mult) f32, layer_input (..., hidden_size)
+    bf16 out. The gates recompute ``pre_mix`` on the raw mixes; its cost is
+    a few tiny VPU ops and keeping ``utils.mhc_pre_gates`` shared and
+    unsliced is worth more than removing them.
+    """
+    assert residual.dtype == jnp.bfloat16
+    assert fn.dtype == jnp.float32
+
+    outer_shape = residual.shape[:-2]
+    hc_mult, hidden_size = residual.shape[-2:]
+    x2d = residual.reshape(-1, hc_mult * hidden_size)
+
+    mixes, sqrsum, layer2d = mhc_pre_mixes_collapse(
+        x2d,
+        fn,
+        hc_scale,
+        hc_base,
+        rms_eps,
+        hc_pre_eps,
+        token_block_size=token_block_size,
+        vmem_limit_bytes=vmem_limit_bytes,
+    )
+    _, post_mix, comb_mix = utils.mhc_pre_gates(
+        mixes, sqrsum, hc_mult, hidden_size, hc_scale, hc_base, rms_eps,
+        hc_pre_eps, hc_sinkhorn_eps, hc_post_mult_value, sinkhorn_repeat)
+
+    return (post_mix.reshape(*outer_shape, hc_mult, 1),
+            comb_mix.reshape(*outer_shape, hc_mult, hc_mult),
+            layer2d.reshape(*outer_shape, hidden_size))

--- a/tpu_inference/kernels/experimental/deepseek_v4/mhc/utils.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/mhc/utils.py
@@ -1,0 +1,59 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+import jax.numpy as jnp
+
+
+def mhc_pre_gates(
+    mixes: jax.Array,
+    sqrsum: jax.Array,
+    hc_mult: int,
+    hidden_size: int,
+    hc_scale: jax.Array,
+    hc_base: jax.Array,
+    rms_eps: float,
+    hc_pre_eps: float,
+    hc_sinkhorn_eps: float,
+    hc_post_mult_value: float,
+    sinkhorn_repeat: int,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Gating / softmax / Sinkhorn on the tiny (T, hc_mult3) mix logits.
+
+    Shared by the Pallas ``pre_kernel`` and the fused seam op.
+    Returns (pre_mix (T, M), post_mix (T, M), comb_mix (T, M, M)).
+    """
+    num_tokens = mixes.shape[0]
+
+    mixes = mixes * jax.lax.rsqrt(sqrsum / (hc_mult * hidden_size) + rms_eps)
+
+    pre_logits = mixes[:, :hc_mult] * hc_scale[0] + hc_base[:hc_mult]
+    pre_mix = jax.nn.sigmoid(pre_logits) + hc_pre_eps
+
+    post_logits = (mixes[:, hc_mult:2 * hc_mult] * hc_scale[1] +
+                   hc_base[hc_mult:2 * hc_mult])
+    post_mix = jax.nn.sigmoid(post_logits) * hc_post_mult_value
+
+    comb_logits = (
+        mixes[:, 2 * hc_mult:].reshape(num_tokens, hc_mult, hc_mult) *
+        hc_scale[2] + hc_base[2 * hc_mult:].reshape(1, hc_mult, hc_mult))
+    comb_mix = jax.nn.softmax(comb_logits, axis=-1) + hc_sinkhorn_eps
+    comb_mix = comb_mix / (jnp.sum(comb_mix, axis=-2, keepdims=True) +
+                           hc_sinkhorn_eps)
+    for _ in range(sinkhorn_repeat - 1):
+        comb_mix = comb_mix / (jnp.sum(comb_mix, axis=-1, keepdims=True) +
+                               hc_sinkhorn_eps)
+        comb_mix = comb_mix / (jnp.sum(comb_mix, axis=-2, keepdims=True) +
+                               hc_sinkhorn_eps)
+    return pre_mix, post_mix, comb_mix

--- a/tpu_inference/layers/vllm/custom_ops/mhc.py
+++ b/tpu_inference/layers/vllm/custom_ops/mhc.py
@@ -12,15 +12,55 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import jax
 import torch
 import torch.nn.functional as F
-import vllm.model_executor.kernels.mhc as mhc_kernels
+from jax.sharding import PartitionSpec as P
+from torchax.interop import jax_view, torch_view
 from vllm.model_executor.layers.mhc import (HCHeadOp, MHCFusedPostPreOp,
                                             MHCPostOp, MHCPreOp)
 
+from tpu_inference.kernels.experimental.deepseek_v4.mhc import (
+    fused_post_pre_kernel, post_kernel, pre_kernel)
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
+from tpu_inference.models.vllm.vllm_model_wrapper_context import \
+    get_vllm_model_wrapper_context
 
 logger = init_logger(__name__)
+
+
+def _sharded_kernel(fn, n_token_args, n_token_outs):
+    """Wrap a Pallas mHC kernel call for SPMD execution.
+
+    Mosaic custom calls cannot be auto-partitioned by GSPMD; in the
+    sharded model graph they must run per-device on local shards via
+    shard_map. Every mHC tensor is token-major, so the first
+    ``n_token_args`` inputs and all outputs shard on the attention-DP
+    token axis; trailing inputs (fn / hc_scale / hc_base) replicate.
+    Falls back to a direct call outside the model wrapper context
+    (single-device tests, standalone use).
+    """
+    try:
+        ctx = get_vllm_model_wrapper_context()
+    except AssertionError:
+        # Outside the model wrapper (single-device tests, standalone use).
+        return fn
+    if ctx is None or getattr(ctx, "mesh", None) is None:
+        return fn
+    data = P(ShardingAxisName.ATTN_DATA)
+
+    def wrapped(*args):
+        in_specs = tuple(data for _ in range(n_token_args)) + tuple(
+            P() for _ in range(len(args) - n_token_args))
+        out_specs = tuple(data for _ in range(n_token_outs))
+        return jax.shard_map(fn,
+                             mesh=ctx.mesh,
+                             in_specs=in_specs,
+                             out_specs=out_specs if n_token_outs > 1 else data,
+                             check_vma=False)(*args)
+
+    return wrapped
 
 
 @MHCPreOp.register_oot
@@ -45,17 +85,22 @@ class VllmMHCPreOp(MHCPreOp):
         norm_weight: torch.Tensor | None = None,
         norm_eps: float = 0.0,
     ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
-        return mhc_kernels.mhc_pre_torch(
-            residual,
-            fn,
-            hc_scale,
-            hc_base,
-            rms_eps,
-            hc_pre_eps,
-            hc_sinkhorn_eps,
-            hc_post_mult_value,
-            sinkhorn_repeat,
-        )
+        assert norm_weight is None, (
+            "the TPU Pallas mHC path does not support fused RMSNorm")
+
+        # Only the chain endpoint reaches this op: the layer-0 pre, which
+        # has no preceding post to fuse with.
+        def _pre(residual_jax, fn_jax, hc_scale_jax, hc_base_jax):
+            return pre_kernel.mhc_pre(residual_jax, fn_jax, hc_scale_jax,
+                                      hc_base_jax, rms_eps, hc_pre_eps,
+                                      hc_sinkhorn_eps, hc_post_mult_value,
+                                      sinkhorn_repeat)
+
+        post_mix, comb_mix, layer_input = _sharded_kernel(_pre, 1, 3)(
+            jax_view(residual), jax_view(fn), jax_view(hc_scale),
+            jax_view(hc_base))
+        return (torch_view(post_mix), torch_view(comb_mix),
+                torch_view(layer_input))
 
 
 @MHCPostOp.register_oot
@@ -72,12 +117,11 @@ class VllmMHCPostOp(MHCPostOp):
         post_layer_mix: torch.Tensor,
         comb_res_mix: torch.Tensor,
     ) -> torch.Tensor:
-        return mhc_kernels.mhc_post_torch(
-            x,
-            residual,
-            post_layer_mix,
-            comb_res_mix,
-        )
+        # Only the chain endpoint reaches this op.
+        post_fn = _sharded_kernel(post_kernel.mhc_post, 4, 1)
+        return torch_view(
+            post_fn(jax_view(x), jax_view(residual), jax_view(post_layer_mix),
+                    jax_view(comb_res_mix)))
 
 
 @HCHeadOp.register_oot
@@ -126,6 +170,47 @@ class VllmMHCFusedPostPreOp(MHCFusedPostPreOp):
     def enabled(cls) -> bool:
         return True
 
-    def forward_tpu(self, *args, **kwargs):
-        raise NotImplementedError(
-            "Native implementation of mhc_fused_post_pre is not available")
+    def forward_tpu(
+        self,
+        x: torch.Tensor,
+        residual: torch.Tensor,
+        post_layer_mix: torch.Tensor,
+        comb_res_mix: torch.Tensor,
+        fn: torch.Tensor,
+        hc_scale: torch.Tensor,
+        hc_base: torch.Tensor,
+        rms_eps: float,
+        hc_pre_eps: float,
+        hc_sinkhorn_eps: float,
+        hc_post_mult_value: float,
+        sinkhorn_repeat: int,
+        n_splits: int = 1,
+        tile_n: int = 1,
+        norm_weight: torch.Tensor | None = None,
+        norm_eps: float = 0.0,
+    ) -> tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+        assert norm_weight is None, (
+            "the TPU fused mHC path does not support fused RMSNorm")
+
+        # Takes the jax_view'd arrays (what shard_map maps over) and
+        # captures the eps scalars, which are static kernel parameters
+        # rather than traced arrays.
+        def _fused(x_jax, residual_jax, post_layer_mix_jax, comb_res_mix_jax,
+                   fn_jax, hc_scale_jax, hc_base_jax):
+            return fused_post_pre_kernel.mhc_fused_post_pre(
+                x_jax, residual_jax, post_layer_mix_jax, comb_res_mix_jax,
+                fn_jax, hc_scale_jax, hc_base_jax, rms_eps, hc_pre_eps,
+                hc_sinkhorn_eps, hc_post_mult_value, sinkhorn_repeat)
+
+        residual_cur, post_mix_cur, comb_mix_cur, layer_input_cur = (
+            _sharded_kernel(_fused, 4, 4)(
+                jax_view(x),
+                jax_view(residual),
+                jax_view(post_layer_mix),
+                jax_view(comb_res_mix),
+                jax_view(fn),
+                jax_view(hc_scale),
+                jax_view(hc_base),
+            ))
+        return (torch_view(residual_cur), torch_view(post_mix_cur),
+                torch_view(comb_mix_cur), torch_view(layer_input_cur))

--- a/tpu_inference/models/vllm/experimental/deepseek_v4.py
+++ b/tpu_inference/models/vllm/experimental/deepseek_v4.py
@@ -203,7 +203,10 @@ class DeepseekV4MoE(nn.Module):
                 "DeepSeek V4 hash MoE routing requires input_ids.")
 
         org_shape = hidden_states.shape
-        if self.experts.is_internal_router:
+        # getattr guard: not every runner FusedMoEFactory can produce
+        # declares is_internal_router (VllmMoERunner lacks it, and the
+        # pinned vLLM LKG does not define it either).
+        if getattr(self.experts, "is_internal_router", False):
             # In this case, the gate/router runs inside the MoE runner.
             final_hidden_states = self.experts(
                 hidden_states=hidden_states,
@@ -418,8 +421,12 @@ class DeepseekV4DecoderLayer(nn.Module):
         residual: torch.Tensor | None = None,
     ) -> tuple[torch.Tensor, torch.Tensor | None, torch.Tensor | None,
                torch.Tensor | None]:
-        return self._forward_unfused_post_pre(x, positions, input_ids,
-                                              post_mix, res_mix, residual)
+        # The fused seam path: each layer defers its post into the next
+        # layer's pre, so the pair runs as one Pallas kernel
+        # (MHCFusedPostPreOp). ``_forward_unfused_post_pre`` above is the
+        # sequential semantics this must match.
+        return self._forward_fused_post_pre(x, positions, input_ids, post_mix,
+                                            res_mix, residual)
 
 
 class DeepseekV4Model(nn.Module):
@@ -446,6 +453,7 @@ class DeepseekV4Model(nn.Module):
         self.hc_mult = config.hc_mult
         self.hc_dim = self.hc_mult * config.hidden_size
         self.rms_norm_eps = config.rms_norm_eps
+        self.mhc_post = MHCPostOp()
 
         aux_stream_list = (None)
 
@@ -566,6 +574,11 @@ class DeepseekV4Model(nn.Module):
                 res_mix,
                 residual,
             )
+
+        if post_mix is not None:
+            # Fused path: complete the deferred final post.
+            hidden_states = self.mhc_post(hidden_states, residual, post_mix,
+                                          res_mix)
 
         if not get_pp_group().is_last_rank:
             return IntermediateTensors({"hidden_states": hidden_states})


### PR DESCRIPTION
# Description

Introduces TPU-optimized Pallas kernel implementations for the DeepSeek V4 Manifold-Constrained Hyper-Connections (MHC) operator. It includes standalone kernels for post-recombine and pre-mixes, as well as a fused post-pre kernel. 

# Tests

After the change 
```
============ Serving Benchmark Result ============
Successful requests:                     2048      
Failed requests:                         0         
Benchmark duration (s):                  383.19    
Total input tokens:                      16777216  
Total generated tokens:                  2097152   
Request throughput (req/s):              5.34      
Output token throughput (tok/s):         5472.84   
Peak output token throughput (tok/s):    29328.00  
Peak concurrent requests:                2048.00   
Total token throughput (tok/s):          49255.56  
---------------Time to First Token----------------
Mean TTFT (ms):                          159758.89 
Median TTFT (ms):                        157411.38 
P99 TTFT (ms):                           319707.23 
-----Time per Output Token (excl. 1st token)------
Mean TPOT (ms):                          187.70    
Median TPOT (ms):                        192.92    
P99 TPOT (ms):                           291.89    
---------------Inter-token Latency----------------
Mean ITL (ms):                           187.70    
Median ITL (ms):                         278.14    
P99 ITL (ms):                            510.95    
==================================================

mmlu
{'accuracy': 0.8703, 'gen_num': 14042}
```

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
