### PR TITLE
Forward RPA v3 block-size overrides on the MaxText serving path

### DIFF
--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -551,3 +551,106 @@ class TestSegmentIdsFromCuSeqlens:
         eager = segment_ids_from_cu_seqlens(cu, 16)
         jitted = jax.jit(segment_ids_from_cu_seqlens, static_argnums=1)(cu, 16)
         np.testing.assert_array_equal(np.asarray(jitted), np.asarray(eager))
+
+
+# ---- Tests for the RPA v3 block-size env overrides ----
+
+
+def _capture_rpa_kwargs(monkeypatch, mesh, head_dim=128):
+    """Call `attention` with a stubbed RPA kernel and return its kwargs.
+
+    Deliberately does not reuse `_test_attention`: that helper installs its own
+    kernel mock, which would replace the stub whose call we need to inspect.
+
+    The env vars are set with monkeypatch.setenv rather than patched onto the
+    `envs` module: `envs` resolves these lazily through a module-level
+    __getattr__, so setattr would install a real attribute that shadows the
+    lazy lookup for the rest of the session. setenv also exercises the real
+    env -> env_int_list parsing.
+    """
+    q_dtype = kv_dtype = jnp.float32
+    q = jnp.ones((TOTAL_TOKENS, NUM_HEADS, head_dim), dtype=q_dtype)
+    k = jnp.ones((TOTAL_TOKENS, NUM_KV_HEADS, head_dim), dtype=kv_dtype)
+    v = jnp.ones((TOTAL_TOKENS, NUM_KV_HEADS, head_dim), dtype=kv_dtype)
+    kv_cache_shape = get_kv_cache_shape_with_mesh(mesh, NUM_BLOCKS, BLOCK_SIZE,
+                                                  NUM_KV_HEADS, head_dim,
+                                                  kv_dtype)
+    kv_cache = jnp.zeros(kv_cache_shape, dtype=kv_dtype)
+
+    mock_kernel = MagicMock(return_value=(jnp.ones((TOTAL_TOKENS, NUM_HEADS,
+                                                    head_dim)), kv_cache))
+    monkeypatch.setattr(
+        "tpu_inference.layers.common.attention_interface.ragged_paged_attention",
+        mock_kernel,
+    )
+
+    attention_metadata = AttentionMetadata(
+        input_positions=jnp.arange(TOTAL_TOKENS, dtype=jnp.int32),
+        block_tables=jnp.zeros((MAX_NUM_SEQS * MAX_BLOCKS_PER_SEQ, ),
+                               dtype=jnp.int32),
+        seq_lens=jnp.array([5, 5, 0, 0], dtype=jnp.int32),
+        query_start_loc=jnp.array([0, 5, 10, 10, 10], dtype=jnp.int32),
+        request_distribution=jnp.array([0, 0, NUM_SEQS], dtype=jnp.int32),
+    )
+    shared_attention_metadata = SharedAttentionMetadata(
+        input_positions=jnp.arange(TOTAL_TOKENS, dtype=jnp.int32),
+        seq_lens=jnp.array([5, 5, 0, 0], dtype=jnp.int32),
+        query_start_loc=jnp.array([0, 5, 10, 10, 10], dtype=jnp.int32),
+        request_distribution=jnp.array([0, 0, NUM_SEQS], dtype=jnp.int32),
+    )
+
+    attention(
+        kv_cache=kv_cache,
+        q=q,
+        k=k,
+        v=v,
+        attention_metadata=attention_metadata,
+        mesh=mesh,
+        head_dim_original=head_dim,
+        sinks=None,
+        shared_attention_metadata=shared_attention_metadata,
+    )
+    mock_kernel.assert_called_once()
+    return mock_kernel.call_args.kwargs
+
+
+def test_rpa_block_sizes_absent_when_env_unset(monkeypatch, mesh):
+    """Unset env leaves the stock call untouched -- no v3-only kwargs."""
+    monkeypatch.delenv("RPA_V3_DECODE_BLOCK_SIZES", raising=False)
+    monkeypatch.delenv("RPA_V3_PREFILL_BLOCK_SIZES", raising=False)
+    monkeypatch.delenv("RPA_V3_MIXED_BLOCK_SIZES", raising=False)
+    kwargs = _capture_rpa_kwargs(monkeypatch, mesh)
+    assert "d_block_sizes" not in kwargs
+    assert "p_block_sizes" not in kwargs
+    assert "m_block_sizes" not in kwargs
+
+
+def test_rpa_block_sizes_forwarded_from_env(monkeypatch, mesh):
+    """RPA_V3_*_BLOCK_SIZES reach the kernel through this entry point too.
+
+    Regression test: the override was wired into
+    layers/jax/attention/attention.py only, so callers arriving through
+    sharded_ragged_paged_attention silently got get_default_block_sizes().
+    Only non-empty vars are forwarded.
+    """
+    monkeypatch.setenv("RPA_V3_DECODE_BLOCK_SIZES", "1,16384,1,4096")
+    monkeypatch.delenv("RPA_V3_PREFILL_BLOCK_SIZES", raising=False)
+    monkeypatch.setenv("RPA_V3_MIXED_BLOCK_SIZES", "8,512,4,256")
+    kwargs = _capture_rpa_kwargs(monkeypatch, mesh)
+    assert kwargs["d_block_sizes"] == (1, 16384, 1, 4096)
+    assert kwargs["m_block_sizes"] == (8, 512, 4, 256)
+    assert "p_block_sizes" not in kwargs
+
+
+def test_rpa_block_sizes_not_forwarded_to_batched_kernel(monkeypatch, mesh):
+    """The v3 block-size env must not reach the experimental batched kernel.
+
+    Its `ragged_paged_attention` takes `decode_block_sizes` /
+    `prefill_block_sizes` configs, not the v3 4-tuples, so forwarding them
+    would raise TypeError whenever USE_BATCHED_RPA_KERNEL=1 and the env is set.
+    """
+    monkeypatch.setenv("USE_BATCHED_RPA_KERNEL", "1")
+    monkeypatch.setenv("RPA_V3_DECODE_BLOCK_SIZES", "1,16384,1,4096")
+    kwargs = _capture_rpa_kwargs(monkeypatch, mesh)
+    assert "d_block_sizes" not in kwargs
+    assert "decode_query_size" in kwargs

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -403,6 +403,25 @@ def sharded_splash_attention(
         ))
 
 
+def _rpa_block_size_kwargs() -> dict[str, tuple[int, int, int, int]]:
+    """Optional RPA v3 block-size overrides from env, for the call site to
+    forward with ``**``.
+
+    The kernel is self-contained and never reads env, so the caller must supply
+    these; layers/jax/attention/attention.py does the same. Without it the
+    RPA_V3_*_BLOCK_SIZES vars are silently ignored on this path and the kernel
+    falls back to get_default_block_sizes(). Each var is a comma-separated
+    4-tuple ``(bq_sz, bkv_sz, bq_csz, bkv_csz)``; a key is included only when
+    its var is non-empty, so the default call is unchanged.
+    """
+    env_to_kwarg = {
+        "d_block_sizes": envs.RPA_V3_DECODE_BLOCK_SIZES,
+        "p_block_sizes": envs.RPA_V3_PREFILL_BLOCK_SIZES,
+        "m_block_sizes": envs.RPA_V3_MIXED_BLOCK_SIZES,
+    }
+    return {k: tuple(v) for k, v in env_to_kwarg.items() if v}
+
+
 def sharded_ragged_paged_attention(
     mesh: Mesh,
     q: jax.Array,
@@ -493,6 +512,10 @@ def sharded_ragged_paged_attention(
             kwargs["use_causal_mask"] = use_causal_mask
             if envs.USE_BATCHED_RPA_KERNEL:
                 kwargs["decode_query_size"] = decode_query_size
+            else:
+                # RPA_V3_*_BLOCK_SIZES are v3-kernel knobs; the experimental
+                # batched kernel takes its own BlockSizes configs instead.
+                kwargs.update(_rpa_block_size_kwargs())
         return func(*args, **kwargs)
 
     return jax.shard_map(

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -403,16 +403,17 @@ def sharded_splash_attention(
         ))
 
 
-def _rpa_block_size_kwargs() -> dict[str, tuple[int, int, int, int]]:
+def rpa_block_size_kwargs() -> dict[str, tuple[int, int, int, int]]:
     """Optional RPA v3 block-size overrides from env, for the call site to
     forward with ``**``.
 
-    The kernel is self-contained and never reads env, so the caller must supply
-    these; layers/jax/attention/attention.py does the same. Without it the
-    RPA_V3_*_BLOCK_SIZES vars are silently ignored on this path and the kernel
-    falls back to get_default_block_sizes(). Each var is a comma-separated
-    4-tuple ``(bq_sz, bkv_sz, bq_csz, bkv_csz)``; a key is included only when
-    its var is non-empty, so the default call is unchanged.
+    The kernel is self-contained and never reads env, so every call site must
+    supply these (the vLLM-model path in layers/jax/attention/attention.py and
+    the MaxText path below). Without it the RPA_V3_*_BLOCK_SIZES vars are
+    silently ignored and the kernel falls back to get_default_block_sizes().
+    Each var is a comma-separated 4-tuple ``(bq_sz, bkv_sz, bq_csz, bkv_csz)``;
+    a key is included only when its var is non-empty, so the default call is
+    unchanged.
     """
     env_to_kwarg = {
         "d_block_sizes": envs.RPA_V3_DECODE_BLOCK_SIZES,
@@ -515,7 +516,7 @@ def sharded_ragged_paged_attention(
             else:
                 # RPA_V3_*_BLOCK_SIZES are v3-kernel knobs; the experimental
                 # batched kernel takes its own BlockSizes configs instead.
-                kwargs.update(_rpa_block_size_kwargs())
+                kwargs.update(rpa_block_size_kwargs())
         return func(*args, **kwargs)
 
     return jax.shard_map(

--- a/tpu_inference/layers/jax/attention/attention.py
+++ b/tpu_inference/layers/jax/attention/attention.py
@@ -23,9 +23,11 @@ from jax import lax
 from jax.sharding import Mesh
 from jax.sharding import PartitionSpec as P
 
-from tpu_inference import envs, utils
+from tpu_inference import utils
 from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
     ragged_paged_attention
+from tpu_inference.layers.common.attention_interface import \
+    rpa_block_size_kwargs
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.common.sharding import ShardingAxisName
@@ -33,24 +35,6 @@ from tpu_inference.layers.jax.base import create_param
 from tpu_inference.layers.jax.rope_interface import apply_rope
 
 KVCache = Tuple[jax.Array, jax.Array]
-
-
-def _rpa_block_size_kwargs() -> dict[str, tuple[int, int, int, int]]:
-    """Optional RPA v3 block-size overrides from env, for the call site to
-    forward with ``**``.
-
-    Each ``RPA_V3_*_BLOCK_SIZES`` env var is a comma-separated 4-tuple
-    ``(bq_sz, bkv_sz, bq_csz, bkv_csz)``. A key is included only when its env
-    var is non-empty, so the default call forwards nothing and stays identical
-    to the stock invocation (and never passes a v3-only kwarg to a kernel whose
-    signature doesn't accept it).
-    """
-    env_to_kwarg = {
-        "d_block_sizes": envs.RPA_V3_DECODE_BLOCK_SIZES,
-        "p_block_sizes": envs.RPA_V3_PREFILL_BLOCK_SIZES,
-        "m_block_sizes": envs.RPA_V3_MIXED_BLOCK_SIZES,
-    }
-    return {k: tuple(v) for k, v in env_to_kwarg.items() if v}
 
 
 @dataclass(kw_only=True)
@@ -265,7 +249,7 @@ class Attention(nnx.Module):
             # (bq_sz, bkv_sz, bq_csz, bkv_csz); an empty list (the default) is
             # omitted entirely, so the stock call is unchanged and no v3-only
             # kwarg is passed to a kernel that doesn't accept it.
-            block_size_kwargs = _rpa_block_size_kwargs()
+            block_size_kwargs = rpa_block_size_kwargs()
             return ragged_paged_attention(
                 *args,
                 sm_scale=q_TNH.shape[-1]**-0.5,


### PR DESCRIPTION
## Summary

`RPA_V3_{DECODE,PREFILL,MIXED}_BLOCK_SIZES` (added in #3102) were wired into only one of the two entry points to the RPA v3 kernel:

| entry point | forwards the override? | used by |
|---|---|---|
| `layers/jax/attention/attention.py` — `_rpa_block_size_kwargs()` | yes | tpu-inference's own JAX models |
| `layers/common/attention_interface.py` — `sharded_ragged_paged_attention` | **no** | **MaxText**, via `Attention.forward_serve_vllm` |

On the MaxText path `d_block_sizes` therefore reached the kernel as `None`, `_prepare_block_sizes` fell back to `get_default_block_sizes()`, and for tpu7 `DECODE` that sets **both** `bkv_sz` and `bkv_csz` to `min(min_bkv_sz_to_peak, max_kv)` — so setting the env var had no effect whatsoever.

This is consistent with the kernel test's own note, which says the caller-side plumbing "is covered in the attention-layer tests" — true for `attention.py`, but there was no equivalent for `attention_interface.py`.

## Change

Forward the three tuples as kwargs when non-empty, mirroring `attention.py`. Guarded by the existing `not use_hd64` check, because the hd64 kernel derives its own sizes via `get_tuned_block_sizes` and does not accept these arguments. An unset var is an empty list and is omitted, so the default call is unchanged.

## Evidence

TPU v7x 4x4x4 (64 chips), qwen3-0.6b GRPO rollout, `RPA_V3_DECODE_BLOCK_SIZES=1,16384,1,4096`. Kernel actually executed, read from the decode-phase xplane:

```
before   RPAd-p_64-bq_1_1-bkv_16384_16384    138.4 ms   77.0% of XLA-Ops time
after    RPAd-p_64-bq_1_1-bkv_16384_4096     117.5 ms   56.6%
```

The compute block is 4096 only after this change; before it was silently 16384.

End to end over 19 warm steps:

| | rollout | global step | train (control) |
|---|---|---|---|
| before | 184.3 s | 267.9 s | 48.3 s |
| after | 134.7 s | 218.6 s | 48.4 s |
| delta | −49.6 s | **−49.3 s (−18.4%)** | 0.0 |

The entire saving lands in the rollout phase and the training phase is unchanged to 0.1 s, which is what a decode-kernel change should look like.

Net effect: this makes #3102's measured +49% decode throughput actually reachable for MaxText serving, which currently gets none of it.

## Testing

Two device-free regression tests in `tests/layers/common/test_attention_interface.py`, both stubbing the kernel and asserting on the kwargs it receives:

- `test_rpa_block_sizes_absent_when_env_unset` — unset env leaves the stock call untouched
- `test_rpa_block_sizes_forwarded_from_env` — decode/mixed forwarded, empty prefill omitted

They use `monkeypatch.setenv` rather than patching the `envs` module, since `envs` resolves these lazily via a module-level `__getattr__`; this also exercises the real `env_int_list` parsing.

Opened as a draft: I do not have a TPU/vLLM environment to execute the tests locally, so CI is their first run.



**Rebase note (2026-09-04):** rebased onto main after the batched-RPA-kernel change landed. The override is forwarded only on the default v3 kernel path; with `USE_BATCHED_RPA_KERNEL=1` the batched kernel takes its own `BlockSizes` configs and the v3 4-tuples are not passed to it (covered by `test_rpa_block_sizes_not_forwarded_to_batched_kernel`).
