### PR TITLE
[Spec Decode] Guard draft tokens and slice assignments against shape broadcast mismatch

### DIFF
--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -55,13 +55,15 @@ class SpeculativeDecodingManager:
             return DraftTokenIds(req_ids, draft_token_ids)
 
         # reorders per-rank outputs back to the original batch ordering
+        num_spec = self.runner.speculative_config.num_speculative_tokens
         reorded_draft_token_ids = [[] for _ in range(len(draft_token_ids))]
         max_num_reqs_per_dp_rank = self.runner.max_num_reqs // self.runner.dp_size
         for rank in range(self.runner.dp_size):
             req_indices = self._req_indices_dp[rank]
             for j, req_idx in enumerate(req_indices):
-                reorded_draft_token_ids[req_idx] = draft_token_ids[
+                tokens = draft_token_ids[
                     j + rank * max_num_reqs_per_dp_rank]
+                reorded_draft_token_ids[req_idx] = tokens[:num_spec]
         self._draft_token_ids = None
         self._req_indices_dp = None
         return DraftTokenIds(req_ids, reorded_draft_token_ids)
@@ -93,11 +95,13 @@ class SpeculativeDecodingManager:
                 self.runner, spec_decode_metadata, sampled_output,
                 logits_indices_selector, discard_sampled_tokens_req_indices,
                 self.runner.input_batch.num_reqs)
-            self._draft_token_ids = self.runner.drafter.propose(
-                self.runner.speculative_config.num_speculative_tokens,
+            num_spec = self.runner.speculative_config.num_speculative_tokens
+            proposed = self.runner.drafter.propose(
+                num_spec,
                 valid_sampled_token_ids[:self.runner.input_batch.num_reqs],
                 self.runner.input_batch.num_tokens_no_spec,
                 self.runner.input_batch.token_ids_cpu)
+            self._draft_token_ids = [tokens[:num_spec] for tokens in proposed]
         elif self.runner.speculative_config.use_eagle(
         ) or self.runner.speculative_config.method == "dflash":
             assert input_ids is not None
@@ -209,15 +213,16 @@ class SpeculativeDecodingManager:
             target_hidden_states=target_hidden_states,
         )
 
+        num_spec = self.runner.speculative_config.num_speculative_tokens
         if async_scheduling:
             if jnp.ndim(draft_token_ids) == 1:
                 draft_token_ids = jnp.expand_dims(draft_token_ids, 1)
-            return draft_token_ids
+            return draft_token_ids[:, :num_spec]
         else:
             draft_token_ids = np.array(draft_token_ids)
             if draft_token_ids.ndim == 1:
                 draft_token_ids = np.expand_dims(draft_token_ids, axis=-1)
-            return draft_token_ids.tolist()
+            return draft_token_ids[:, :num_spec].tolist()
 
     def propose_eagle3_draft_token_ids(
         self,
@@ -304,15 +309,16 @@ class SpeculativeDecodingManager:
             target_hidden_states=target_hidden_states,
         )
 
+        num_spec = self.runner.speculative_config.num_speculative_tokens
         if async_scheduling:
             if jnp.ndim(draft_token_ids) == 1:
                 draft_token_ids = jnp.expand_dims(draft_token_ids, 1)
-            return draft_token_ids
+            return draft_token_ids[:, :num_spec]
         else:
             draft_token_ids = np.array(draft_token_ids)
             if draft_token_ids.ndim == 1:
                 draft_token_ids = np.expand_dims(draft_token_ids, axis=-1)
-            return draft_token_ids.tolist()
+            return draft_token_ids[:, :num_spec].tolist()
 
     def get_spec_decode_metadata(
         self,

--- a/tpu_inference/runner/speculative_decoding_manager.py
+++ b/tpu_inference/runner/speculative_decoding_manager.py
@@ -61,8 +61,7 @@ class SpeculativeDecodingManager:
         for rank in range(self.runner.dp_size):
             req_indices = self._req_indices_dp[rank]
             for j, req_idx in enumerate(req_indices):
-                tokens = draft_token_ids[
-                    j + rank * max_num_reqs_per_dp_rank]
+                tokens = draft_token_ids[j + rank * max_num_reqs_per_dp_rank]
                 reorded_draft_token_ids[req_idx] = tokens[:num_spec]
         self._draft_token_ids = None
         self._req_indices_dp = None

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1481,7 +1481,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     req_id, []))
 
             end_idx = self.input_batch.num_tokens_no_spec[req_idx]
-            num_sampled_tokens = len(sampled_ids)
+            num_sampled_tokens = min(len(sampled_ids), pre_num_placeholder_tokens)
             assert num_sampled_tokens <= pre_num_placeholder_tokens
             start_idx = end_idx - pre_num_placeholder_tokens
             assert end_idx <= self.max_model_len, (
@@ -1490,7 +1490,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 f"{self.max_model_len}")
 
             self.input_batch.token_ids_cpu[req_idx, start_idx:start_idx +
-                                           num_sampled_tokens] = sampled_ids
+                                           num_sampled_tokens] = sampled_ids[:num_sampled_tokens]
             self.input_batch.num_tokens_no_spec[
                 req_idx] = start_idx + num_sampled_tokens
             self.input_batch.num_tokens[
@@ -2222,15 +2222,16 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             if not sampled_ids:
                 continue
 
+            num_sampled = len(sampled_ids)
             start_idx = self.input_batch.num_tokens_no_spec[req_idx]
-            end_idx = start_idx + len(sampled_ids)
+            end_idx = start_idx + num_sampled
             assert end_idx <= self.max_model_len, (
                 "Sampled token IDs exceed the max model length. "
                 f"Total number of tokens: {end_idx} > max_model_len: "
                 f"{self.max_model_len}")
 
             self.input_batch.token_ids_cpu[req_idx,
-                                           start_idx:end_idx] = sampled_ids
+                                           start_idx:end_idx] = sampled_ids[:num_sampled]
             self.input_batch.num_tokens_no_spec[req_idx] = end_idx
             self.input_batch.num_tokens[req_idx] = end_idx
             req_state.output_token_ids.extend(sampled_ids)

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1481,7 +1481,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     req_id, []))
 
             end_idx = self.input_batch.num_tokens_no_spec[req_idx]
-            num_sampled_tokens = min(len(sampled_ids), pre_num_placeholder_tokens)
+            num_sampled_tokens = min(len(sampled_ids),
+                                     pre_num_placeholder_tokens)
             assert num_sampled_tokens <= pre_num_placeholder_tokens
             start_idx = end_idx - pre_num_placeholder_tokens
             assert end_idx <= self.max_model_len, (
@@ -1489,8 +1490,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 f"Total number of tokens: {end_idx} > max_model_len: "
                 f"{self.max_model_len}")
 
-            self.input_batch.token_ids_cpu[req_idx, start_idx:start_idx +
-                                           num_sampled_tokens] = sampled_ids[:num_sampled_tokens]
+            self.input_batch.token_ids_cpu[
+                req_idx, start_idx:start_idx +
+                num_sampled_tokens] = sampled_ids[:num_sampled_tokens]
             self.input_batch.num_tokens_no_spec[
                 req_idx] = start_idx + num_sampled_tokens
             self.input_batch.num_tokens[
@@ -2230,8 +2232,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 f"Total number of tokens: {end_idx} > max_model_len: "
                 f"{self.max_model_len}")
 
-            self.input_batch.token_ids_cpu[req_idx,
-                                           start_idx:end_idx] = sampled_ids[:num_sampled]
+            self.input_batch.token_ids_cpu[
+                req_idx, start_idx:end_idx] = sampled_ids[:num_sampled]
             self.input_batch.num_tokens_no_spec[req_idx] = end_idx
             self.input_batch.num_tokens[req_idx] = end_idx
             req_state.output_token_ids.extend(sampled_ids)

--- a/tpu_inference/spec_decode/vllm/dflash.py
+++ b/tpu_inference/spec_decode/vllm/dflash.py
@@ -203,7 +203,8 @@ class DFlashTorchaxProposer:
         hidden_states: jax.Array,
         embed_weight: jax.Array,
     ) -> jax.Array:
-        draft_hidden = hidden_states[1:1 + self.num_speculative_tokens]
+        num_spec = min(self.num_speculative_tokens, hidden_states.shape[0] - 1)
+        draft_hidden = hidden_states[1:1 + num_spec]
         logits = self._compute_logits_fn(params, draft_hidden, embed_weight)
         return jnp.argmax(logits, axis=-1)
 


### PR DESCRIPTION
# Description

Fix potential shape and broadcast mismatches in speculative decoding during draft token proposal and post-processing slice assignments.

FIXES: #546029519

# Tests

- Unit tests: `pytest tests/runner/test_speculative_decoding_manager.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
