### PR TITLE
[SpecDecode] Remove _disable_shardy_for_qwen35_4b workaround in speculative decoding tests

### DIFF
--- a/tests/e2e/test_speculative_decoding.py
+++ b/tests/e2e/test_speculative_decoding.py
@@ -23,22 +23,6 @@ from vllm import LLM, SamplingParams
 from vllm.v1.metrics.reader import Counter
 
 
-def _disable_shardy_for_qwen35_4b(mp: pytest.MonkeyPatch) -> None:
-    """Disables Shardy to avoid a libtpu 0.0.41 segfault in `embed_multimodal`.
-
-    TODO: Remove once libtpu >= 0.0.42.dev20260527.
-    """
-    import jax
-
-    mp.setenv("JAX_USE_SHARDY_PARTITIONER", "false")
-    libtpu_init_args = os.environ.get("LIBTPU_INIT_ARGS", "")
-    mp.setenv(
-        "LIBTPU_INIT_ARGS",
-        "--xla_use_shardy=false --xla_tpu_scoped_vmem_limit_kib=131072 " +
-        libtpu_init_args)
-    jax.config.update("jax_use_shardy_partitioner", False)
-
-
 # TODO (Qiliang Cui): remove this when XLA fixes the recursive jit call issue.
 def _is_v7x():
     # jax.devices() will hang so use TPU_VERSION to indicate the version.
@@ -646,7 +630,6 @@ def mtp_baseline():
     }
     test_prompts = get_eagle3_test_prompts()
     with pytest.MonkeyPatch.context() as mp:
-        _disable_shardy_for_qwen35_4b(mp)
         ref_outputs = _get_baseline_results(
             mp,
             sampling_config,
@@ -680,7 +663,6 @@ def test_mtp_correctness(
     model_name = "Qwen/Qwen3.5-4B"
     monkeypatch.setenv("MODEL_IMPL_TYPE", "vllm")
     monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", "vllm")
-    _disable_shardy_for_qwen35_4b(monkeypatch)
 
     speculative_config = {
         "method": "mtp",
@@ -720,7 +702,6 @@ def test_mtp_performance(
     model_name = "Qwen/Qwen3.5-4B"
     monkeypatch.setenv("MODEL_IMPL_TYPE", "vllm")
     monkeypatch.setenv("DRAFT_MODEL_IMPL_TYPE", "vllm")
-    _disable_shardy_for_qwen35_4b(monkeypatch)
 
     extra_kwargs = {
         "seed": 42,


### PR DESCRIPTION
# Description

Remove the obsolete `_disable_shardy_for_qwen35_4b` workaround in `tests/e2e/test_speculative_decoding.py`.

`_disable_shardy_for_qwen35_4b` was originally added to work around a `libtpu 0.0.41` segfault in `embed_multimodal` with the following TODO:
```python
# TODO: Remove once libtpu >= 0.0.42.dev20260527.
```

# Tests

TPU_VERSION=tpu7x python3 -m pytest -s -v tests/e2e/test_speculative_decoding.py -k "test_mtp_correctness"

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
