### PR TITLE
[continue_decode] Make EOS_CHECK_INTERVAL<=0 a correct continuous-batching window

### DIFF
--- a/tests/runner/test_decode_loop.py
+++ b/tests/runner/test_decode_loop.py
@@ -217,9 +217,13 @@ def test_continue_decode_early_exit():
     )
     assert np.array_equal(token_buffer, expected_tokens)
 
-    # Verify final state (state at the start of step 2, which did not run)
+    # Verify final state (state at the start of step 2, which did not run).
+    # A finished slot keeps its last input token (43) rather than padding:
+    # masked slots re-feed that token at their frozen position so any masked
+    # iteration rewrites the same KV it already holds. With the every-step EOS
+    # check no masked iteration runs, so this only shows up in the carry.
     assert np.array_equal(final_state.active_mask, [True, False])
-    assert np.array_equal(final_state.current_tokens, [44, -1])
+    assert np.array_equal(final_state.current_tokens, [44, 43])
     assert np.array_equal(final_state.attn_metadata.input_positions, [2, 1])
     assert np.array_equal(final_state.attn_metadata.seq_lens, [3, 2])
     assert all_expert_indices is None
@@ -385,15 +389,17 @@ def test_continue_decode_no_exit_on_eos():
         continue_decode_eos_check_interval=-1,
     )
 
-    # Verify loop ran all 5 steps despite EOS hit
-    assert int(final_state.step_counter) == 5
+    # With interval <= 0 an EOS never breaks the window: req 1 finishing at
+    # step 1 does not stop the loop. The loop only exits once every sequence
+    # has finished (after step 2) or at the static depth, whichever is first.
+    assert int(final_state.step_counter) == 3
 
     # Expected tokens:
     # Step 0: [42, 43]
     # Step 1: [44, 99] (req 1 hits EOS)
     # Step 2: [99, -1] (req 0 hits EOS; req 1 inactive -> -1)
-    # Step 3: [-1, -1] (both inactive)
-    # Step 4: [-1, -1] (both inactive)
+    # Step 3: [-1, -1] (not executed: all sequences finished)
+    # Step 4: [-1, -1] (not executed)
     expected_tokens = np.array(
         [
             [42, 43],
@@ -406,6 +412,118 @@ def test_continue_decode_no_exit_on_eos():
     )
     assert np.array_equal(token_buffer, expected_tokens)
     assert np.array_equal(final_state.active_mask, [False, False])
+
+
+def test_continue_decode_no_exit_on_eos_while_any_active():
+    """interval <= 0: the window runs to its static depth while any sequence
+    is still active; finished slots stay masked (padding in the buffer, frozen
+    position / seq_len, last input token re-fed)."""
+    batch_size = 2
+    max_decode_steps = 5
+    static_max_decode_steps = 5
+
+    init_tokens = jnp.array([10, 20], dtype=jnp.int32)
+    active_mask = jnp.array([True, True], dtype=jnp.bool_)
+
+    attn_metadata = AttentionMetadata(
+        input_positions=jnp.array([0, 0], dtype=jnp.int32),
+        block_tables=jnp.zeros((2, 16), dtype=jnp.int32),
+        seq_lens=jnp.array([1, 1], dtype=jnp.int32),
+        query_start_loc=jnp.array([0, 1, 2], dtype=jnp.int32),
+        request_distribution=jnp.array([0, 0], dtype=jnp.int32),
+        mamba_state_indices=None,
+    )
+
+    init_state = TpuSamplingState(
+        current_tokens=init_tokens,
+        active_mask=active_mask,
+        attn_metadata=attn_metadata,
+        step_counter=jnp.array(0, dtype=jnp.int32),
+    )
+
+    kv_caches = [jnp.zeros((2, 10))]
+
+    def mock_model_fn(state, kv_caches, current_tokens, attn_metadata, *args,
+                      **kwargs):
+        hidden_states = attn_metadata.input_positions.astype(jnp.float32)[:,
+                                                                          None,
+                                                                          None]
+        return kv_caches, hidden_states, None, None
+
+    def mock_compute_logits_fn(state, hidden_states, _):
+        pos = hidden_states[:, 0, 0]
+        logits = jnp.zeros((batch_size, 100))
+        logits = logits.at[:, 0].set(pos)
+        return logits
+
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+        pos = logits[:, 0].astype(jnp.int32)
+        token_table = jnp.array(
+            [
+                [42, 43],  # pos 0
+                [44, 99],  # pos 1 (req 1 hits EOS)
+                [50, 50],  # pos 2
+                [60, 61],  # pos 3
+                [70, 71],  # pos 4
+            ],
+            dtype=jnp.int32,
+        )
+        batch_idx = jnp.arange(batch_size)
+        next_tokens = token_table[pos, batch_idx]
+        return next_tokens, None
+
+    rng = jax.random.PRNGKey(0)
+
+    (
+        token_buffer,
+        final_kv_caches,
+        final_state,
+        current_rng,
+        all_expert_indices,
+        logprobs_tensors,
+    ) = continue_decode(
+        state={},
+        model_fn=mock_model_fn,
+        compute_logits_fn=mock_compute_logits_fn,
+        sample_fn=mock_sample_fn,
+        init_state=init_state,
+        kv_caches=kv_caches,
+        max_decode_steps=max_decode_steps,
+        static_max_decode_steps=static_max_decode_steps,
+        eos_token_id=(99, ),
+        padding_token_id=-1,
+        rng=rng,
+        mesh=None,
+        sampling_metadata=None,
+        continue_decode_eos_check_interval=-1,
+    )
+
+    # req 0 never hits EOS, so the window runs the full static depth.
+    assert int(final_state.step_counter) == 5
+
+    # Step 0: [42, 43]
+    # Step 1: [44, 99] (req 1 hits EOS)
+    # Step 2: [50, -1] (req 1 masked from here on)
+    # Step 3: [60, -1]
+    # Step 4: [70, -1]
+    expected_tokens = np.array(
+        [
+            [42, 43],
+            [44, 99],
+            [50, -1],
+            [60, -1],
+            [70, -1],
+        ],
+        dtype=np.int32,
+    )
+    assert np.array_equal(token_buffer, expected_tokens)
+    assert np.array_equal(final_state.active_mask, [True, False])
+    # req 0 advanced through all 5 steps; req 1 is frozen at the state it had
+    # when it finished (position 1, seq_len 2) and keeps re-feeding its last
+    # input token (43) instead of padding.
+    assert np.array_equal(final_state.current_tokens, [70, 43])
+    assert np.array_equal(final_state.attn_metadata.input_positions, [5, 1])
+    assert np.array_equal(final_state.attn_metadata.seq_lens, [6, 2])
 
 
 def test_continue_decode_exit_on_eos_interval():

--- a/tpu_inference/runner/decode_loop.py
+++ b/tpu_inference/runner/decode_loop.py
@@ -180,6 +180,17 @@ def _decode_core_impl(
              pad_len,
          )
 
+        # A finished (masked) slot keeps executing until the window exits.
+        # Re-feed its current input token rather than the padding token:
+        # same token, same frozen position, same context, so the K/V it
+        # rewrites each iteration is identical to what is already stored and
+        # the slot is inert. Feeding padding here overwrites the slot's last
+        # real token's KV with padding-derived KV on every masked iteration.
+        # (With the default every-step EOS check the window exits before any
+        # masked iteration runs, so this line only matters for
+        # CONTINUE_DECODE_EOS_CHECK_INTERVAL != 1.)
+        next_input_ids = jnp.where(new_active_mask, next_input_ids, ct)
+
         lp_ids_step = None
         lp_val_step = None
         lp_ranks_step = None
@@ -254,7 +265,13 @@ def _decode_core_impl(
         eos_flag = carry[-1]
         not_done = i < max_decode_steps
         if continue_decode_eos_check_interval <= 0:
-            return not_done
+            # Continuous-batching window: EOS never breaks the fused loop.
+            # Run to the static depth, or until every sequence has finished.
+            # Finished slots are masked by _update_loop_state and re-fed
+            # their current input token, which keeps their KV writes
+            # idempotent (see _run_one_step).
+            active_mask = carry[2]
+            return jnp.logical_and(not_done, jnp.any(active_mask))
         should_check_eos = (i % continue_decode_eos_check_interval == 0)
         return jnp.logical_and(
             not_done,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -861,6 +861,15 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # every-step check.
         self.continue_decode_eos_check_interval = (
             envs.CONTINUE_DECODE_EOS_CHECK_INTERVAL)
+        if (self.continue_decode_eos_check_interval <= 0
+                and self.scheduler_config.async_scheduling):
+            logger.warning(
+                "CONTINUE_DECODE_EOS_CHECK_INTERVAL <= 0 (continuous-batching "
+                "decode window) combined with async_scheduling has been "
+                "observed to degrade generation quality: sequences fail to "
+                "terminate and run to their token limit. Until that "
+                "interaction is resolved, run this mode with "
+                "async_scheduling disabled.")
         self.static_max_decode_steps = self.vllm_config.additional_config.get(
             "max_decode_steps", DEFAULT_MAX_DECODE_STEPS)
         self.eos_token_id = runner_utils.get_eos_token_id(self.model_config)
@@ -1846,10 +1855,23 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             self.rng_params_for_sampling = final_rng
             self.kv_caches = final_kv_caches
 
-            last_step_idx = jnp.clip(final_state.step_counter - 1, 0,
-                                     self.static_max_decode_steps - 1)
+            # Reseed each sequence from its own newest token. Reading the
+            # window's final row is only correct when the window stops right
+            # after an EOS; in a continuous-batching window
+            # (CONTINUE_DECODE_EOS_CHECK_INTERVAL <= 0) a sequence that
+            # finishes mid-window has padding in that row, and reseeding from
+            # padding makes the model continue from garbage and never
+            # terminate. Take the last non-padding row within the executed
+            # steps instead; whenever the window early-exits this reduces to
+            # the final row, so the default path is unchanged.
+            num_steps = jnp.clip(final_state.step_counter, 1,
+                                 self.static_max_decode_steps)
+            row_idx = jnp.arange(generated_tokens.shape[0])[:, None]
+            is_real_row = jnp.logical_and(
+                generated_tokens != self.pad_token_id, row_idx < num_steps)
+            last_real_row = jnp.max(jnp.where(is_real_row, row_idx, 0), axis=0)
             next_tokens_in_tpu = generated_tokens[
-                last_step_idx,
+                last_real_row,
                 jnp.arange(generated_tokens.shape[1])]
 
             generated_tokens_async = jax.copy_to_host_async(generated_tokens)


### PR DESCRIPTION
## Summary

`CONTINUE_DECODE_EOS_CHECK_INTERVAL <= 0` currently just disables the EOS early-exit inside the fused decode loop. That configuration is broken today: sequences stop terminating and run to their token limit. This PR turns `interval <= 0` into a correct **continuous-batching decode window** — the fused loop runs to its static depth regardless of EOS, finished slots stay masked and inert, and the host reseeds every sequence from its own newest token.

On a decode-heavy RL post-training workload this removes the dominant host-side overhead of continue-decode (the window currently early-exits after only a handful of iterations once EOS events become frequent, paying the host gap on almost every decode step): **rollout 130 s → 98 s per training step (−25%)** with output quality identical to the default path.

## Why `interval <= 0` is broken today

Three independent issues, each invisible until the window runs past an EOS:

1. **Reseed reads the window's final row.** `tpu_runner._execute_continue_decode` derives every sequence's newest token from `generated_tokens[step_counter - 1]`. That is only correct because the default window stops immediately after any EOS. Once the window keeps running, a sequence that finished mid-window has **padding** in that row, so it is reseeded from a padding token, continues generating from garbage, and never terminates.
2. **Masked slots overwrite their own KV with padding-KV.** `_update_loop_state` re-feeds finished slots `padding_token_id` at a frozen position, so every masked iteration recomputes and rewrites that slot's KV from a padding embedding. With the default every-step check no masked iteration ever executes, so this path has never run in production.
3. **The window never exits when all sequences are done** (`return not_done` ignores `active_mask`).

## Changes

- `decode_loop.cond_fn` (`interval <= 0` branch): `return i < max_decode_steps AND any(active_mask)`.
- `decode_loop._run_one_step`: masked slots re-feed their **current input token** instead of the padding token — same token, same frozen position, same context, so the KV rewrite is byte-identical to what is stored and the slot is provably inert.
- `tpu_runner`: reseed from each sequence's **last non-padding row** within the executed steps. Whenever the window early-exits this reduces exactly to the final row, so the default path is unchanged.
- Warn if this mode is enabled together with `async_scheduling` (see limitation below).

**Default behavior (`interval >= 1`) is byte-identical**: with the every-step check the window exits before any masked iteration executes, and the last-non-padding-row reseed reduces to the final row.

## Known limitation: requires `async_scheduling=False` for now

With async scheduling enabled, deep mixed (active+masked) windows degrade generation quality: the EOS-termination rate roughly halves and 30%+ of sequences run to their token limit (measured at 54% truncated-at-cap vs 24% baseline on the workload below, reproducible at inference step 0 with byte-identical prompts). Extensive instrumentation shows every host-visible mechanism is correct in that regime — per-request retirement, extraction, `num_computed_tokens`, per-DP-rank layout, and page bookkeeping all audit clean, and there are no vLLM preemptions — so the failure is an interaction between the async machinery and deep windows that has not been pinpointed yet. The same window under `async_scheduling=False` produces generation statistically identical to the default path.

Since a deep window cuts the number of scheduler/runner round-trips per decode chain by ~20x (e.g. 64 windows instead of ~1400 for an 8192-token chain at depth 128), sync scheduling costs very little in this mode: on the workload below, everything except ~15 s of prefill serialization per step is recovered. The warning added in this PR points users at the constraint. I'm happy to file the async interaction as a separate issue with the full bisection data.

## Measurements

Qwen3-0.6B GRPO post-training (MaxText/Tunix), 2048 sequences/step, generation cap 8192, `max_decode_steps=128`, TPU v7x 4x4x4, DP16×TP8 rollout sharding, `async_scheduling=False`, 11 training steps:

| | default early-exit | this PR (`interval=0`) |
|---|---|---|
| rollout time / step | 130 s | **98 s** |
| training-step time | 190 s | **157 s** |
| reward mean | ~0.146 | 0.137–0.155 |
| truncated-at-cap | 22–26% | 22–27% |
| mean completion length | ~3750 | 3600–4020 |

Termination-health check at inference step 0 (identical prompts, identical base checkpoint, so directly comparable across configs): 22.7% truncated-at-cap vs 24.0% baseline; per-sequence EOS-termination counts match the baseline across the full decode chain.

## Test notes

- Unit tests (`tests/runner/test_decode_loop.py`): `test_continue_decode_no_exit_on_eos` now expects the window to exit once every sequence has finished (`step_counter == 3`, not 5); new `test_continue_decode_no_exit_on_eos_while_any_active` covers run-to-depth with a masked slot (padding in the buffer, frozen position/seq_len, last input token re-fed); `test_continue_decode_early_exit` expects a finished slot to carry its last input token instead of padding (the carry is the only observable difference on the default path — the window exits before any masked iteration runs, so KV and outputs are unchanged). All 8 decode-loop tests pass on CPU.
- Verified the default path is unchanged by construction (masked iterations cannot execute at `interval=1`; reseed reduction argument above) and by an 11-step baseline run.
- Correctness of the continuous window validated end-to-end on the RL workload above: reward, reward-component, and output-length distributions match the default path step-for-step.
- Edge case: a legitimately sampled token equal to `pad_token_id` in the window's final row would make the reseed pick an earlier row for that sequence. For models where `pad_token_id` is a plausible generation (id 0 here), this is rare; models where pad is also an EOS are unaffected (the sequence is finished either way). Flagging for reviewer judgment — an explicit per-row step counter carried through the loop would eliminate it at the cost of one more carried array.

