### PR TITLE
[Fix Test Failure] Make the TP performance threshold platform-aware.

### DIFF
--- a/.buildkite/parallelism/TP.yml
+++ b/.buildkite/parallelism/TP.yml
@@ -40,6 +40,8 @@ steps:
     key: "${TPU_VERSION:-tpu6e}_TP_PerformanceTest_Single_Host"
     depends_on: "${TPU_VERSION:-tpu6e}_record_TP_CorrectnessTest_Single_Host"
     soft_fail: true
+    env:
+      TPU_VERSION: "${TPU_VERSION:-tpu6e}"
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     commands:

--- a/tests/e2e/test_tensor_parallel.py
+++ b/tests/e2e/test_tensor_parallel.py
@@ -178,12 +178,10 @@ def test_tp_performance(sampling_params: SamplingParams):
     os.environ['SKIP_JAX_PRECOMPILE'] = '0'
     os.environ['VLLM_XLA_CHECK_RECOMPILATION'] = '1'
 
-    # The historical short-prompt workload was host-overhead-bound: TP=8
-    # measured the same as TP=1 on both v6e-8 and tpu7x-8, so the old
-    # TP=2 >= 1.05x assert only amplified engine CPU noise (and tracked
-    # vLLM host-path changes like logprobs detokenization, not TPU perf).
-    # Long dense prompts + 128-token decode make TPU compute dominate each
-    # step. No logprobs: they add per-token host work that masks TP scaling.
+    # Long dense prompts and a 128-token decode keep TPU compute dominant
+    # over per-step engine host overhead, so the assert tracks TPU TP
+    # scaling. No logprobs: they add per-token host work that masks TP
+    # scaling.
     #
     # Per-platform config: on tpu7x the long-context attention kernel
     # exceeds the 64M vmem budget at max_model_len >= 2048 on the

--- a/tests/e2e/test_tensor_parallel.py
+++ b/tests/e2e/test_tensor_parallel.py
@@ -174,10 +174,16 @@ def test_tp_performance(sampling_params: SamplingParams):
     os.environ['SKIP_JAX_PRECOMPILE'] = '0'
     os.environ['VLLM_XLA_CHECK_RECOMPILATION'] = '1'
 
+    # On v6e this workload gets no real TP=2 speedup: nightly runs measure
+    # 1.00x-1.05x, straddling a 1.05 threshold, while tpu7x measures
+    # 1.05x-1.16x. Keep 1.05 as a genuine speedup check on tpu7x; on v6e
+    # only guard against TP being materially slower than a single chip.
+    min_speedup = 1.05 if os.environ.get('TPU_VERSION') == 'tpu7x' else 0.9
+
     _test_tensor_parallelism_performance(
         sampling_params=sampling_params,
         model_name="meta-llama/Llama-3.1-8B-Instruct",
         tensor_parallel_size=2,
         pipeline_parallel_size=1,
-        min_speedup=1.05,
+        min_speedup=min_speedup,
     )

--- a/tests/e2e/test_tensor_parallel.py
+++ b/tests/e2e/test_tensor_parallel.py
@@ -42,7 +42,8 @@ class InferenceConfig:
     enable_prefix_caching: bool = False
 
 
-def generate_test_prompts(num_prompts: int = 256) -> list[str]:
+def generate_test_prompts(num_prompts: int = 256,
+                          repeat: int = 1) -> list[str]:
     base_text = (
         "The rapid advancement of artificial intelligence has transformed "
         "numerous industries and continues to reshape our understanding of "
@@ -52,8 +53,9 @@ def generate_test_prompts(num_prompts: int = 256) -> list[str]:
         "language processing to computer vision, AI systems are now capable "
         "of understanding context, recognizing patterns, and making decisions "
         "with remarkable accuracy. ")
+    body = base_text * repeat
     return [
-        f"Prompt {i}: {base_text} What are your thoughts on this topic?"
+        f"Prompt {i}: {body} What are your thoughts on this topic?"
         for i in range(num_prompts)
     ]
 
@@ -132,10 +134,12 @@ def _test_tensor_parallelism_performance(
     pipeline_parallel_size: int = 1,
     additional_config: dict | None = None,
     min_speedup: float = 1.05,
+    cfg: TestConfig | None = None,
+    prompt_repeat: int = 1,
 ):
     """Performance test for tensor parallelism."""
-    cfg = TestConfig.for_performance()
-    test_prompts = generate_test_prompts(cfg.num_prompts)
+    cfg = cfg or TestConfig.for_performance()
+    test_prompts = generate_test_prompts(cfg.num_prompts, prompt_repeat)
 
     tp_config = InferenceConfig(
         model_name=model_name,
@@ -174,16 +178,50 @@ def test_tp_performance(sampling_params: SamplingParams):
     os.environ['SKIP_JAX_PRECOMPILE'] = '0'
     os.environ['VLLM_XLA_CHECK_RECOMPILATION'] = '1'
 
-    # On v6e this workload gets no real TP=2 speedup: nightly runs measure
-    # 1.00x-1.05x, straddling a 1.05 threshold, while tpu7x measures
-    # 1.05x-1.16x. Keep 1.05 as a genuine speedup check on tpu7x; on v6e
-    # only guard against TP being materially slower than a single chip.
-    min_speedup = 1.05 if os.environ.get('TPU_VERSION') == 'tpu7x' else 0.9
+    # The historical short-prompt workload was host-overhead-bound: TP=8
+    # measured the same as TP=1 on both v6e-8 and tpu7x-8, so the old
+    # TP=2 >= 1.05x assert only amplified engine CPU noise (and tracked
+    # vLLM host-path changes like logprobs detokenization, not TPU perf).
+    # Long dense prompts + 128-token decode make TPU compute dominate each
+    # step. No logprobs: they add per-token host work that masks TP scaling.
+    #
+    # Per-platform config: on tpu7x the long-context attention kernel
+    # exceeds the 64M vmem budget at max_model_len >= 2048 on the
+    # unsharded leg, so tpu7x runs max_model_len=1024 with shorter
+    # prompts and TP=2. Thresholds sit well below measured floors
+    # (v6e TP=8: 4.16x-4.20x over 6 runs; tpu7x TP=2: 1.41x-1.56x).
+    if os.environ.get('TPU_VERSION') == 'tpu7x':
+        cfg = TestConfig(
+            max_model_len=1024,
+            max_num_batched_tokens=2048,
+            max_num_seqs=256,
+            num_prompts=256,
+        )
+        prompt_repeat = 9
+        tensor_parallel_size = 2
+        min_speedup = 1.25
+    else:
+        cfg = TestConfig(
+            max_model_len=2048,
+            max_num_batched_tokens=2048,
+            max_num_seqs=256,
+            num_prompts=256,
+        )
+        prompt_repeat = 18
+        tensor_parallel_size = 8
+        min_speedup = 3.5
 
+    heavy_sampling = SamplingParams(
+        temperature=0.0,
+        max_tokens=128,
+        ignore_eos=True,
+    )
     _test_tensor_parallelism_performance(
-        sampling_params=sampling_params,
+        sampling_params=heavy_sampling,
         model_name="meta-llama/Llama-3.1-8B-Instruct",
-        tensor_parallel_size=2,
+        tensor_parallel_size=tensor_parallel_size,
         pipeline_parallel_size=1,
         min_speedup=min_speedup,
+        cfg=cfg,
+        prompt_repeat=prompt_repeat,
     )


### PR DESCRIPTION
## Summary

Fix `test_tp_performance` by testing what the hardware is actually for: **on v6e-8 the test now runs TP=8 instead of TP=2** (full-slice tensor parallelism, threshold 3.5x); **tpu7x keeps TP=2** (its long-context attention kernel exceeds the 64M vmem budget above `max_model_len=1024`, threshold 1.25x). The workload is also made TPU-bound (long dense prompts, longer decode, no logprobs) so the assert measures TPU TP scaling instead of engine CPU noise — details in the table below.

## Why the old test could not work

The short-prompt workload was host-overhead-bound: **TP=8 measured the same as TP=1 on both v6e-8 and tpu7x-8** (24 runs: v6e 0.95–1.10x, tpu7x 1.00–1.08x — [870](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/870)/[871](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/871)/[872](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/872)/[873](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/873)). Total time was per-step engine CPU overhead; the TPU sat idle most of each step. Consequently the old `TP=2 >= 1.05x` assert:

- flaked on noise (a month of v6e nightlies measured 1.00–1.05x against the 1.05 threshold: 19 fail / 5 pass, every pass exactly at 1.05);
- "detected" vLLM host-path changes instead of TPU regressions — the Jul 21 tp_time step was vLLM `dcfebf93f4` (vllm-project/vllm#48674) doubling per-logprob-token host detokenization (this test sampled `logprobs=1`), proven parent-vs-child with only `vllm_lkg.version` varied ([891](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/891) 11.75s vs [892](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/892) 11.98s); the August drift was transformers 5.15.0 adding ~0.3s shared CPU cost (5-version sweep in comments below).

## Root causes of the historical failures

The nightly red decomposed into three independent effects — all host-side, none a TPU regression:

1. **TP=2 slowdown (from Jul 21, the harmful one): vLLM `dcfebf93f4` ("[Bugfix] Fix logprobs token-string collision from SentencePiece space…", vllm-project/vllm#48674)**, which reached this repo via the Jul 20 LKG advance. It doubles per-logprob-token host detokenization for SentencePiece models (Llama included), and this test sampled with `logprobs=1` — the added host time hides under TP=1's longer TPU steps but becomes the critical path at TP=2. Proven parent-vs-child with tpu-inference held fixed and only `vllm_lkg.version` varied: parent `752bd10647` tp_time 11.75s vs child 11.98s, 8 runs each ([891](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/891)/[892](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/892)); slow persists through the range end. No tpu-inference commit was at fault (#3223 explicitly exonerated, [874](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/874)-[876](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/876)).
2. **August worsening (nightly readings 1.02/1.00): transformers 5.15.0** (released Aug 10, required since #3372) adds ~0.3s shared CPU cost per run — compresses the speedup ratio equally on both platforms. Pinned by a 5-version sweep: 5.13.0/5.13.1/5.14.0/5.14.1 all fast, 5.15.0 slow ([856](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/856)/[866](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/866)-[869](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/869)).
3. **Jul 9-era ratio dip: the TP=1 baseline got faster** (not TP getting worse). A full sweep of every commit that day came back flat ([856](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/856)-[863](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/863)); the speedup is environmental / pre-window and, being a benign improvement near the old test's noise floor, was not chased further.

All three could only move this test because the old workload measured host time; the reworked test is structurally immune to this class (no logprobs, TPU-dominant steps).

## What changed

| knob | old | new | why |
|---|---|---|---|
| prompts | 2048 × ~110 tokens | 256 × long dense prompts (~1.6k tok v6e / ~850 tok 7x) | each step dominated by TPU prefill compute, not host work |
| decode | 32 tokens | 128 tokens | heavier, steadier decode phase |
| `logprobs` | 1 | none | logprobs add per-token host work that masks TP scaling |
| `max_num_batched_tokens` | 2048 | 2048 (unchanged) | no platform-specific compile risk |
| TP degree | TP=2 both platforms | v6e-8: **TP=8**; tpu7x: **TP=2** | v6e tests the full slice; tpu7x's long-context attention kernel exceeds its 64M vmem budget at `max_model_len >= 2048` on the unsharded leg, so it runs `max_model_len=1024` + TP=2 |
| threshold | 1.05x (atop the noise band) | v6e **>= 3.5x**, 7x **>= 1.25x** | measured floors 4.16x / 1.41x over 6 runs each; thresholds sit 11–16% below the worst observed run |
| `TPU.yml` env | — | `TPU_VERSION` passed into the perf step | lets the test select its platform config (same pattern as the multimodal steps) |

Within-build spread is ±0.01x on both platforms (vs ±0.05 on a 1.05x signal before) — a real TP regression now has to erase most of a 4x speedup on v6e to go unnoticed, while host/library drift cannot move the ratio out of band.

## Verification

- Measurement: dev builds [894](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/894) and [895](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/895) (3+3 runs per platform): v6e TP=8 = 4.16–4.20x; tpu7x TP=2 = 1.41–1.56x.
- Real-pipeline check: both reworked TP jobs passed first-try in CI ([24396](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24396); that build's only red was the pre-existing GDN core-halt flake since fixed by #3405).

Known limitation: the tpu7x leg guards TP=2 on a vmem-capped config — weaker than v6e's full-slice check. If the vmem constraint is lifted (kernel budget flag or smaller-footprint attention), promoting 7x to TP=8 with a ~3.5x threshold is the natural follow-up.


