### PR TITLE
[CI] Mark DFlash as unverified on the vllm (torchax) nightly variant

### DIFF
--- a/.buildkite/features/Speculative_Decoding-_DFlash.yml
+++ b/.buildkite/features/Speculative_Decoding-_DFlash.yml
@@ -22,8 +22,16 @@ steps:
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
     commands:
       - |
-        .buildkite/scripts/run_in_docker.sh \
-          python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_correctness
+        if [ "${MODEL_IMPL_TYPE:-auto}" = "vllm" ]; then
+          echo "DFlash on the vllm (torchax) path is not integrated yet:" \
+               "DFlashTorchaxProposer is not wired into the runner and the" \
+               "generic torchax draft step does not match the vLLM DFlash" \
+               "model contract. Recording as unverified."
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_CorrectnessTest" "unverified"
+        else
+          .buildkite/scripts/run_in_docker.sh \
+            python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_correctness
+        fi
   - label: "${TPU_VERSION:-tpu6e} Record correctness test result for Speculative Decoding: DFlash"
     key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_DFlash_CorrectnessTest"
     depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_CorrectnessTest"
@@ -48,8 +56,14 @@ steps:
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
     commands:
       - |
-        .buildkite/scripts/run_in_docker.sh \
-          python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_performance
+        if [ "${MODEL_IMPL_TYPE:-auto}" = "vllm" ]; then
+          echo "DFlash on the vllm (torchax) path is not integrated yet." \
+               "Recording as unverified."
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_PerformanceTest" "unverified"
+        else
+          .buildkite/scripts/run_in_docker.sh \
+            python3 -m pytest -s -v /workspace/tpu_inference/tests/e2e/test_speculative_decoding.py::test_dflash_performance
+        fi
   - label: "${TPU_VERSION:-tpu6e} Record performance test result for Speculative Decoding: DFlash"
     key: "${TPU_VERSION:-tpu6e}_record_Speculative_Decoding-_DFlash_PerformanceTest"
     depends_on: "${TPU_VERSION:-tpu6e}_Speculative_Decoding-_DFlash_PerformanceTest"


### PR DESCRIPTION
## Problem

The `MODEL_IMPL_TYPE=vllm` nightly's DFlash correctness/performance jobs have never been green (checked back to Jul 30; e.g. build 24352). The failure is architectural, not a flake: the runner always instantiates the JAX `DFlashProposer`, whose draft step goes through the generic torchax wrapper draft fn, and that contract does not match the vLLM DFlash model — DFlash pre-populates context KV from target hidden states (`precompute_and_store_context_kv`) and its forward takes only `input_ids`/`positions`. The staged `DFlashTorchaxProposer` exists for this contract but is not wired into the runner, and its `prepare_inputs` predates the current 8-arg drafter interface.

## Change

Record the DFlash nightly steps as `unverified` on the vllm variant (support matrix shows "Untested" via the existing `record_step_result.sh` mechanism) instead of a permanent red. The flax_nnx variant is unchanged and keeps running the tests.

DFlash on the vllm/torchax path is unsupported until `DFlashTorchaxProposer` is properly integrated; that is left to the feature owner to triage.

## Verification

Buildkite-yml-only change; no product code touched. The `unverified` meta-data value flows through the existing record/support-matrix mechanism used by other untested steps.
