### PR TITLE
Revert "Bit-pack GDN v3 per-p_id metadata to reduce SMEM (#3349)"

### DIFF
--- a/tpu_inference/kernels/gdn/v3/memory_ref.py
+++ b/tpu_inference/kernels/gdn/v3/memory_ref.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 import dataclasses
 import functools
 from typing import Any
@@ -21,17 +22,6 @@ from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
 from tpu_inference.kernels.gdn.v3 import config
-
-
-def _flat_pos(shape: tuple[int, ...], indices: tuple[Any, ...]) -> Any:
-    """Row-major flat offset of `indices` into a logical array of `shape`."""
-    strides = pl.strides_from_shape(shape)
-    assert len(strides) == len(indices)
-
-    pos = 0
-    for stride, idx in zip(strides, indices):
-        pos += stride * idx
-    return pos
 
 
 @jax.tree_util.register_dataclass
@@ -55,94 +45,36 @@ class WeightRefs:
     gdn: GDNWeightsRef
 
 
-class FieldOffset:
-    """Descriptor returning the record field at ``data[pos + offset]``.
-
-  Reads a single dynamically-indexed element rather than a slice, since JAX
-  can't slice a range with traced indices. Read-only: metadata is never
-  written.
-  """
-
-    def __init__(self, offset: int):
-        self.offset = offset
-
-    def __get__(self, obj, objtype=None):
-        if obj is None:
-            return self
-        return obj.data[obj.pos + self.offset]
-
-
-# Per-p_id metadata is an array of structs: each p_id's fields sit contiguously
-# and FieldOffset(k) reads the k-th word of its struct.
-#
-# Packed struct: [r_base, packed_word].
-# Fields share packed_word to save SMEM: is_first_tile(0), is_last_tile(1), r_size(2..15), s_idx(16..31).
+@jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
-class PackedPIdRecord:
-    """Packed struct [r_base, packed_word]; the four small fields bit-slice word.
-
-  Each bit field masks after shifting, which also clears the sign bits that
-  ``>>`` extends on the signed int32 word.
-  """
-
-    STRUCT_SIZE = 2
-    FIRST_TILE_SHIFT = 0
-    LAST_TILE_SHIFT = 1
-    R_SIZE_SHIFT = 2
-    S_IDX_SHIFT = 16
-    FLAG_MASK = 1
-    R_SIZE_MASK = (1 << (S_IDX_SHIFT - R_SIZE_SHIFT)) - 1
-    S_IDX_MASK = (1 << (32 - S_IDX_SHIFT)) - 1
-    MAX_SEQS = S_IDX_MASK + 1
+class SmemWrapper:
+    """Maps physical 1-D data into logical N-D representation."""
 
     data: Any
-    pos: Any
-    r_base = FieldOffset(0)
-    word = FieldOffset(1)
+    shape: tuple[int, ...] = dataclasses.field(metadata=dict(static=True))
 
-    @property
-    def s_idx(self):
-        return (self.word >> self.S_IDX_SHIFT) & self.S_IDX_MASK
+    def _get_pos(self, indices):
+        strides = pl.strides_from_shape(self.shape)
+        assert len(strides) == len(indices)
 
-    @property
-    def r_size(self):
-        return (self.word >> self.R_SIZE_SHIFT) & self.R_SIZE_MASK
+        pos = 0
+        for stride, idx in zip(strides, indices):
+            pos += stride * idx
+        return pos
 
-    @property
-    def is_first_tile(self):
-        return (self.word & self.FLAG_MASK) != 0
-
-    @property
-    def is_last_tile(self):
-        return ((self.word >> self.LAST_TILE_SHIFT) & self.FLAG_MASK) != 0
-
-    @classmethod
-    def pack(
-        cls,
-        s_idx: jax.Array,
-        r_size: jax.Array,
-        is_first_tile: jax.Array,
-        is_last_tile: jax.Array,
-    ) -> jax.Array:
-        """Packs s_idx, row size and two tile-state flags into one int32 word."""
-
-        s_idx = s_idx.reshape(-1).astype(jnp.int32)
-        r_size = r_size.reshape(-1).astype(jnp.int32)
-        is_first_tile = is_first_tile.reshape(-1).astype(jnp.int32)
-        is_last_tile = is_last_tile.reshape(-1).astype(jnp.int32)
-        word = s_idx << cls.S_IDX_SHIFT
-        word |= r_size << cls.R_SIZE_SHIFT
-        word |= is_last_tile << cls.LAST_TILE_SHIFT
-        word |= is_first_tile << cls.FIRST_TILE_SHIFT
-        return word
+    def __getitem__(self, indices):
+        return self.data[self._get_pos(indices)]
 
 
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
 class MetadataRef:
     num_tiles: Any
-    # Array of structs holding every p_id's metadata
-    records: Any
+    p_id_to_s_idx: SmemWrapper
+    p_id_to_r_base: SmemWrapper
+    p_id_to_r_size: SmemWrapper
+    p_id_is_first_tile: SmemWrapper
+    p_id_is_last_tile: SmemWrapper
     s_idx_has_initial_state: Any
     s_idx_to_state_indices: Any
     # Per-sequence state read offset for speculative decoding: the initial
@@ -150,13 +82,6 @@ class MetadataRef:
     # (the checkpoint of the last accepted token). Zero everywhere without
     # speculative decoding.
     s_idx_to_read_offset: Any
-    shape: tuple[int, ...] = dataclasses.field(metadata=dict(static=True))
-
-    def get_record(self, p_id, idx) -> PackedPIdRecord:
-        """View of one p_id's metadata: .r_base / .s_idx / .r_size / .is_*_tile."""
-        record_idx = _flat_pos(self.shape, (p_id, idx))
-        return PackedPIdRecord(self.records,
-                               record_idx * PackedPIdRecord.STRUCT_SIZE)
 
     @classmethod
     def create(
@@ -174,27 +99,16 @@ class MetadataRef:
     ):
         # NOTE: First dim does not matter when it comes to calculating stride.
         shape = (1, cfgs.seq_tile_size)
-        assert s_idx_has_initial_state.shape[0] <= PackedPIdRecord.MAX_SEQS, (
-            f"Number of sequences ({s_idx_has_initial_state.shape[0]}) exceeds"
-            f" PackedPIdRecord limit ({PackedPIdRecord.MAX_SEQS}).")
-        assert cfgs.tile_size <= PackedPIdRecord.R_SIZE_MASK, (
-            f"Tile size ({cfgs.tile_size}) exceeds PackedPIdRecord limit"
-            f" ({PackedPIdRecord.R_SIZE_MASK}).")
-
-        r_base = p_id_to_r_base.reshape(-1).astype(jnp.int32)
-        word = PackedPIdRecord.pack(p_id_to_s_idx, p_id_to_r_size,
-                                    p_id_is_first_tile, p_id_is_last_tile)
-        fields = [r_base, word]
-        # Interleave fields into one array of structs: [rec0_f0, rec0_f1, ...].
-        records = jnp.stack(fields, axis=-1).reshape(-1)
-
         return cls(
             num_tiles=num_tiles,
-            records=records,
+            p_id_to_s_idx=SmemWrapper(p_id_to_s_idx, shape),
+            p_id_to_r_base=SmemWrapper(p_id_to_r_base, shape),
+            p_id_to_r_size=SmemWrapper(p_id_to_r_size, shape),
+            p_id_is_first_tile=SmemWrapper(p_id_is_first_tile, shape),
+            p_id_is_last_tile=SmemWrapper(p_id_is_last_tile, shape),
             s_idx_has_initial_state=s_idx_has_initial_state,
             s_idx_to_state_indices=s_idx_to_state_indices,
             s_idx_to_read_offset=s_idx_to_read_offset,
-            shape=shape,
         )
 
     def __len__(self) -> int:
@@ -252,9 +166,8 @@ class InBufferedRef(BaseBufferedRef):
         p_id = grid_indices[0]
 
         for idx in range(self.cfg.seq_tile_size):
-            record = self.metadata_ref.get_record(p_id, idx)
-            r_base = record.r_base
-            dma_size = record.r_size
+            r_base = self.metadata_ref.p_id_to_r_base[p_id, idx]
+            dma_size = self.metadata_ref.p_id_to_r_size[p_id, idx]
             pltpu.make_async_copy(
                 src_ref.at[pl.ds(r_base, dma_size)],
                 vmem_ref.at[idx, pl.ds(0, dma_size)],
@@ -271,7 +184,7 @@ class InBufferedRef(BaseBufferedRef):
 
         dma_size = 0
         for idx in range(self.cfg.seq_tile_size):
-            dma_size += self.metadata_ref.get_record(p_id, idx).r_size
+            dma_size += self.metadata_ref.p_id_to_r_size[p_id, idx]
 
         pltpu.make_async_copy(
             vmem_ref.at[0, pl.ds(0, dma_size)],
@@ -293,9 +206,8 @@ class OutBufferedRef(BaseBufferedRef):
         p_id = grid_indices[0]
 
         for idx in range(self.cfg.seq_tile_size):
-            record = self.metadata_ref.get_record(p_id, idx)
-            r_base = record.r_base
-            dma_size = record.r_size
+            r_base = self.metadata_ref.p_id_to_r_base[p_id, idx]
+            dma_size = self.metadata_ref.p_id_to_r_size[p_id, idx]
             pltpu.make_async_copy(
                 vmem_ref.at[idx, pl.ds(0, dma_size)],
                 dst_ref.at[pl.ds(r_base, dma_size)],
@@ -312,7 +224,7 @@ class OutBufferedRef(BaseBufferedRef):
 
         dma_size = 0
         for idx in range(self.cfg.seq_tile_size):
-            dma_size += self.metadata_ref.get_record(p_id, idx).r_size
+            dma_size += self.metadata_ref.p_id_to_r_size[p_id, idx]
 
         pltpu.make_async_copy(
             vmem_ref.at[0, pl.ds(0, dma_size)],
@@ -347,9 +259,9 @@ class StateBufferedRef(BaseBufferedRef):
         p_id = grid_indices[0]
 
         for idx in range(self.cfg.seq_tile_size):
-            record = self.metadata_ref.get_record(p_id, idx)
-            is_first_tile = record.is_first_tile
-            s_idx = record.s_idx
+
+            is_first_tile = self.metadata_ref.p_id_is_first_tile[p_id, idx]
+            s_idx = self.metadata_ref.p_id_to_s_idx[p_id, idx]
             state_idx = self.metadata_ref.s_idx_to_state_indices[s_idx]
             has_initial_state = self.metadata_ref.s_idx_has_initial_state[
                 s_idx]
@@ -375,9 +287,8 @@ class StateBufferedRef(BaseBufferedRef):
 
         dma_size = 0
         for idx in range(self.cfg.seq_tile_size):
-            record = self.metadata_ref.get_record(p_id, idx)
-            is_first_tile = record.is_first_tile
-            s_idx = record.s_idx
+            is_first_tile = self.metadata_ref.p_id_is_first_tile[p_id, idx]
+            s_idx = self.metadata_ref.p_id_to_s_idx[p_id, idx]
             has_initial_state = self.metadata_ref.s_idx_has_initial_state[
                 s_idx]
             should_read = jnp.logical_and(is_first_tile, has_initial_state)
@@ -398,15 +309,14 @@ class StateBufferedRef(BaseBufferedRef):
         p_id = grid_indices[0]
 
         for idx in range(self.cfg.seq_tile_size):
-            record = self.metadata_ref.get_record(p_id, idx)
-            is_last_tile = record.is_last_tile
-            s_idx = record.s_idx
-            r_size = record.r_size
+            is_last_tile = self.metadata_ref.p_id_is_last_tile[p_id, idx]
+            s_idx = self.metadata_ref.p_id_to_s_idx[p_id, idx]
             state_idx = self.metadata_ref.s_idx_to_state_indices[s_idx]
             # Write one checkpoint per valid window position, starting at the
             # group's base slot. `r_size` never exceeds `window_size` for
             # windowed sequences; the clamp is for PER_SEQ tiles, which hold
             # many tokens but keep only the final state.
+            r_size = self.metadata_ref.p_id_to_r_size[p_id, idx]
             num_ckpts = jnp.minimum(r_size, self.cfg.window_size)
             dma_size = jnp.where(is_last_tile, num_ckpts, 0)
 
@@ -426,9 +336,8 @@ class StateBufferedRef(BaseBufferedRef):
 
         dma_size = 0
         for idx in range(self.cfg.seq_tile_size):
-            record = self.metadata_ref.get_record(p_id, idx)
-            is_last_tile = record.is_last_tile
-            r_size = record.r_size
+            is_last_tile = self.metadata_ref.p_id_is_last_tile[p_id, idx]
+            r_size = self.metadata_ref.p_id_to_r_size[p_id, idx]
             num_ckpts = jnp.minimum(r_size, self.cfg.window_size)
             dma_size += jnp.where(is_last_tile, num_ckpts, 0)
 

--- a/tpu_inference/kernels/gdn/v3/vmem_ldst.py
+++ b/tpu_inference/kernels/gdn/v3/vmem_ldst.py
@@ -176,10 +176,9 @@ def load_and_select_states(
     prev_recurrent_state_list = []
 
     for idx in range(cfg.seq_tile_size):
-        record = metadata_ref.get_record(p_id, idx)
-        s_idx = record.s_idx
-        real_sizes = record.r_size
-        is_first_tile = record.is_first_tile
+        s_idx = metadata_ref.p_id_to_s_idx[p_id, idx]
+        real_sizes = metadata_ref.p_id_to_r_size[p_id, idx]
+        is_first_tile = metadata_ref.p_id_is_first_tile[p_id, idx]
         has_initial_state = metadata_ref.s_idx_has_initial_state[s_idx]
 
         # NOTE: The VMEM window holds one state per window position and the


### PR DESCRIPTION
Reverts #3349 (`02841b1d9`).

## Problem

Since #3349 landed (Aug 11), the tpu7x E2E speculative decoding job core-halts intermittently — `RuntimeUnexpectedCoreHalt` in HLO `fused_conv1d_gdn_batched` during the Qwen3.5-4B MTP baseline (plain, non-speculative) decode — and has been the dominant nightly/PR-CI red since Aug 12 (~60% of runs; e.g. nightly 24290, main builds 24248–24307). v6e is unaffected; failures spread across many tpu7x agents.

## Evidence (8 runs each of the CI job command, dev pipeline, tpu_v7x_2_queue)

Introduction A/B:
| commit | build | core halts |
|---|---|---|
| `65eedbd46` (parent of #3349) | [850](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/850) | **0/8** |
| `02841b1d9` (#3349) | [849](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/849) | 1/8 |
| `43e18e8fe` (+#3376) | [851](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/851) | 5/8 |
| `7dddc17a9` (+#3351) | [852](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/852) | 5/8 |

#3376 only amplifies the trigger rate (same halt, same HLO); #3351 has no effect (that code isn't reachable here).

Removal proof on current main:
| config | build | core halts |
|---|---|---|
| main | [854](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/854) | **5/8** |
| main + this revert | [855](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/855) | **0/8** |

Every failure across all builds is the identical signature: `ERROR at setup of test_mtp_correctness[False-False]` → `RuntimeUnexpectedCoreHalt` at `TensorCoreSequencer` (e.g. pc `0xe27`) in `fused_conv1d_gdn_batched.72`, module `jit_step_fun_impl`.

## Notes for re-landing

Masking the packed fields to their bit widths and clamping the negative pad-slot `r_size` (the obvious packing hazards) was tried and does **not** cure the halt ([verification build 853](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/853), 5/8 halts), so the defect is elsewhere in the packed-record restructuring — possibly the per-field dynamically-indexed single-word SMEM reads feeding DMA descriptors. The kernel-level unit tests and a direct `fused_conv1d_gdn` stress (4700+ invocations, real Qwen3.5-4B dims, serving-like metadata churn) do not reproduce; the halt needs the full engine program context, so the 8x dev-pipeline rig above is the practical repro harness.

GDN v3 kernel unit tests (`fused_gdn_kernel_test`, `gdn_attention_v3_test`, 31 tests) pass on the reverted tree on tpu7x.
