### PR TITLE
[gemma4] Fix torchax-path E2B/E4B accuracy: inline PLE + skip KV-cache writes for KV-shared layers

### DIFF
--- a/.buildkite/models/google_gemma-4-E2B-it.yml
+++ b/.buildkite/models/google_gemma-4-E2B-it.yml
@@ -67,16 +67,7 @@ steps:
       MINIMUM_ACCURACY_THRESHOLD: 0.35
     commands:
       - |
-        if [ "${MODEL_IMPL_TYPE:-auto}" = "vllm" ]; then
-          echo "gemma-4 E2B on the vllm (torchax) path has never passed" \
-               "accuracy: the model's per_layer_embeddings CUDA-graph buffer" \
-               "is incompatible with torchax and its KV-shared layers corrupt" \
-               "the target layer's cache. Recording as unverified until the" \
-               "torchax path is fixed."
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-E2B-it_Accuracy" "unverified"
-        else
-          .buildkite/scripts/run_in_docker.sh bash -c 'bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
-        fi
+        .buildkite/scripts/run_in_docker.sh bash -c 'bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
 
   - label: "${TPU_VERSION:-tpu6e} Record integration test result for google/gemma-4-E2B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E2B-it_Accuracy"

--- a/.buildkite/models/google_gemma-4-E4B-it.yml
+++ b/.buildkite/models/google_gemma-4-E4B-it.yml
@@ -65,16 +65,7 @@ steps:
       MINIMUM_ACCURACY_THRESHOLD: 0.65
     commands:
       - |
-        if [ "${MODEL_IMPL_TYPE:-auto}" = "vllm" ]; then
-          echo "gemma-4 E4B on the vllm (torchax) path has never passed" \
-               "accuracy: the model's per_layer_embeddings CUDA-graph buffer" \
-               "is incompatible with torchax and its KV-shared layers corrupt" \
-               "the target layer's cache. Recording as unverified until the" \
-               "torchax path is fixed."
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Accuracy" "unverified"
-        else
-          .buildkite/scripts/run_in_docker.sh bash -c 'bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
-        fi
+        .buildkite/scripts/run_in_docker.sh bash -c 'bash /workspace/tpu_inference/tests/e2e/benchmarking/test_accuracy.sh'
 
   - label: "${TPU_VERSION:-tpu6e} Record integration test result for google/gemma-4-E4B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_Accuracy"

--- a/tests/layers/vllm/backends/test_flash_attn.py
+++ b/tests/layers/vllm/backends/test_flash_attn.py
@@ -216,6 +216,54 @@ class TestPallasAttentionBackendImpl:
                 shared_attn_metadata=shared_metadata):
             impl.forward(layer, query, key, value, torch.tensor([]), metadata)
 
+    def test_forward_kv_shared_layer_does_not_write_cache(self, mesh):
+        """KV-shared layers (kv_sharing_target_layer_name set, e.g. gemma-4
+        E2B/E4B cross-decoder) map to their target layer's cache index, so
+        writing would overwrite the target's entries with this layer's
+        discarded K/V. The write must only happen for non-shared layers."""
+        from tpu_inference.models.vllm.vllm_model_wrapper_context import \
+            get_vllm_model_wrapper_context
+
+        cache_after = {}
+        for shared in (False, True):
+            impl = PallasAttentionBackendImpl(
+                num_heads=NUM_HEADS,
+                head_size=HEAD_DIM,
+                scale=0.088,
+                num_kv_heads=NUM_KV_HEADS,
+                alibi_slopes=None,
+                sliding_window=None,
+                kv_cache_dtype="auto",
+                attn_type=AttentionType.DECODER,
+                kv_sharing_target_layer_name=("model.layers.0.self_attn.attn"
+                                              if shared else None),
+            )
+
+            layer = MagicMock()
+            layer.layer_name = "0"
+
+            query, key, value, kv_cache, metadata, shared_metadata = \
+                create_inputs(mesh)
+            cache_before = np.asarray(jax.device_get(kv_cache))
+
+            with torchax.default_env(), set_vllm_model_wrapper_context(
+                    kv_caches=[kv_cache],
+                    mesh=mesh,
+                    layer_name_to_kvcache_index={'0': 0},
+                    shared_attn_metadata=shared_metadata):
+                impl.forward(layer, query, key, value, torch.tensor([]),
+                             metadata)
+                ctx = get_vllm_model_wrapper_context()
+                cache_after[shared] = np.asarray(
+                    jax.device_get(ctx.kv_caches[0]))
+
+            if shared:
+                np.testing.assert_array_equal(cache_after[shared],
+                                              cache_before)
+
+        # Sanity: the non-shared layer with identical inputs DID write.
+        assert not np.array_equal(cache_after[True], cache_after[False])
+
     def test_forward_with_3d_qkv(self, mesh):
         impl = PallasAttentionBackendImpl(
             num_heads=NUM_HEADS,

--- a/tests/models/vllm/experimental/test_gemma4_mm_patcher.py
+++ b/tests/models/vllm/experimental/test_gemma4_mm_patcher.py
@@ -1,0 +1,118 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest import mock
+
+import torch
+from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration
+
+from tpu_inference.models.vllm.experimental.gemma4_mm_patcher import (
+    apply_gemma4_mm_patches, maybe_apply_gemma4_mm_patches)
+
+IMAGE_TOKEN_ID = 7
+AUDIO_TOKEN_ID = 8
+NUM_LAYERS = 3
+PLE_DIM = 4
+
+
+def _make_mock_gemma4(ple_dim=PLE_DIM):
+    # spec= makes isinstance(model, Gemma4ForConditionalGeneration) true but
+    # blocks reads of instance-only attributes, so attach them explicitly.
+    model = mock.MagicMock(spec=Gemma4ForConditionalGeneration)
+    model.config = mock.MagicMock()
+    model.config.image_token_id = IMAGE_TOKEN_ID
+    model.config.audio_token_id = AUDIO_TOKEN_ID
+    model.config.text_config.num_hidden_layers = NUM_LAYERS
+    model.config.text_config.hidden_size_per_layer_input = ple_dim
+    model.language_model = mock.MagicMock()
+    model._clear_mm_prefix_for_full_attn_layers = mock.MagicMock()
+    model.per_layer_embeddings = None if ple_dim is None else torch.zeros(
+        16, NUM_LAYERS, ple_dim)
+    return model
+
+
+def test_maybe_apply_skips_non_gemma4():
+    model = mock.MagicMock()
+    orig_forward = model.forward
+    maybe_apply_gemma4_mm_patches(model)
+    assert model.forward is orig_forward
+
+
+def test_maybe_apply_skips_variant_without_ple():
+    model = _make_mock_gemma4(ple_dim=None)
+    orig_forward = model.forward
+    maybe_apply_gemma4_mm_patches(model)
+    assert model.forward is orig_forward
+
+
+def test_apply_drops_buffer_and_replaces_forward():
+    model = _make_mock_gemma4()
+    orig_forward = model.forward
+    maybe_apply_gemma4_mm_patches(model)
+
+    # The plain-tensor CUDA-graph buffer must be gone: it is invisible to
+    # shard_model_to_tpu and crashes _aten_copy under torchax.
+    assert model.per_layer_embeddings is None
+    assert model.forward is not orig_forward
+    assert model._tpu_ple_mask_token_ids == (IMAGE_TOKEN_ID, AUDIO_TOKEN_ID)
+
+
+def test_patched_forward_computes_masked_ple_inline():
+    model = _make_mock_gemma4()
+    apply_gemma4_mm_patches(model)
+
+    num_tokens = 6
+    input_ids = torch.tensor(
+        [1, IMAGE_TOKEN_ID, 2, AUDIO_TOKEN_ID, 3, IMAGE_TOKEN_ID])
+    positions = torch.arange(num_tokens)
+    inputs_embeds = torch.ones(num_tokens, 5)
+
+    seen_ple_ids = []
+
+    def fake_get_per_layer_inputs(ids):
+        seen_ple_ids.append(ids)
+        return torch.ones(num_tokens, NUM_LAYERS * PLE_DIM)
+
+    model.language_model.model.get_per_layer_inputs.side_effect = \
+        fake_get_per_layer_inputs
+
+    model.forward(input_ids, positions, inputs_embeds=inputs_embeds)
+
+    # Reference semantics: embed_input_ids masks multimodal placeholder
+    # positions to token 0 before the PLE lookup.
+    assert len(seen_ple_ids) == 1
+    assert seen_ple_ids[0].tolist() == [1, 0, 2, 0, 3, 0]
+
+    # The language model receives the reshaped PLE tensor, not a buffer read.
+    lm_call = model.language_model.model.call_args
+    ple = lm_call.kwargs['per_layer_inputs']
+    assert ple.shape == (num_tokens, NUM_LAYERS, PLE_DIM)
+    assert lm_call.kwargs['inputs_embeds'] is inputs_embeds
+
+    # mm_prefix_range clearing must still run outside the compiled region.
+    model._clear_mm_prefix_for_full_attn_layers.assert_called_once()
+
+
+def test_patched_forward_skips_ple_without_inputs_embeds():
+    model = _make_mock_gemma4()
+    apply_gemma4_mm_patches(model)
+
+    input_ids = torch.tensor([1, 2, 3])
+    positions = torch.arange(3)
+
+    model.forward(input_ids, positions, inputs_embeds=None)
+
+    model.language_model.model.get_per_layer_inputs.assert_not_called()
+    assert model.language_model.model.call_args.kwargs[
+        'per_layer_inputs'] is None

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -690,3 +690,59 @@ class TestTpuPlatform:
         with pytest.raises(ValueError, match=expected_error):
             TpuPlatform.check_and_update_config(vllm_config)
         mock_patch.assert_not_called()
+
+
+class TestTorchAcceleratorGetMemoryInfoShim:
+    """tpu_platform patches torch.accelerator.get_memory_info at import time so
+    the torchax path (PrivateUse1 "jax" device) answers from the JAX device
+    instead of raising "PyTorch is not linked with support for jax devices"."""
+
+    @staticmethod
+    def _jax_device(stats):
+        device = MagicMock()
+        device.memory_stats.return_value = stats
+        return device
+
+    def test_shim_is_installed(self):
+        import tpu_inference.platforms.tpu_platform as tpu_platform
+        assert torch.accelerator.get_memory_info is (
+            tpu_platform._patched_get_memory_info)
+
+    def test_jax_device_error_falls_back_to_jax_memory_stats(self):
+        import tpu_inference.platforms.tpu_platform as tpu_platform
+        stats = {"bytes_limit": 1000, "bytes_in_use": 250}
+        with patch.object(
+                tpu_platform,
+                "_orig_get_memory_info",
+                side_effect=RuntimeError(
+                    "PyTorch is not linked with support for jax devices")), \
+             patch.object(tpu_platform.jax, "local_devices",
+                          return_value=[self._jax_device(stats)]):
+            assert torch.accelerator.get_memory_info() == (750, 1000)
+
+    def test_missing_memory_stats_yields_zero_budget(self):
+        import tpu_inference.platforms.tpu_platform as tpu_platform
+        with patch.object(
+                tpu_platform,
+                "_orig_get_memory_info",
+                side_effect=RuntimeError(
+                    "PyTorch is not linked with support for jax devices")), \
+             patch.object(tpu_platform.jax, "local_devices",
+                          return_value=[self._jax_device(None)]):
+            assert torch.accelerator.get_memory_info() == (0, 0)
+
+    def test_unrelated_runtime_error_is_reraised(self):
+        import tpu_inference.platforms.tpu_platform as tpu_platform
+        with patch.object(tpu_platform,
+                          "_orig_get_memory_info",
+                          side_effect=RuntimeError("CUDA out of memory")), \
+             pytest.raises(RuntimeError, match="CUDA out of memory"):
+            torch.accelerator.get_memory_info()
+
+    def test_success_path_passes_through(self):
+        import tpu_inference.platforms.tpu_platform as tpu_platform
+        with patch.object(tpu_platform,
+                          "_orig_get_memory_info",
+                          return_value=(1, 2)) as orig:
+            assert torch.accelerator.get_memory_info(0) == (1, 2)
+            orig.assert_called_once_with(0)

--- a/tpu_inference/layers/vllm/backends/flash_attn.py
+++ b/tpu_inference/layers/vllm/backends/flash_attn.py
@@ -261,6 +261,14 @@ class PallasAttentionBackendImpl(AttentionImpl):
 
                 sinks = jax_view(self.sinks)
 
+                # KV-shared layers (kv_sharing_target_layer_name set, e.g.
+                # gemma-4 E2B/E4B cross-decoder) read the target layer's
+                # cache and must NOT write to it: layer_name_to_kvcache_index
+                # maps them to the target's cache index, so an unconditional
+                # write would overwrite the target's entries with this
+                # layer's discarded K/V and corrupt every subsequent step.
+                update_kv_cache = self.kv_sharing_target_layer_name is None
+
                 new_kv_cache, outputs = _jax_attn_func(
                     kv_cache,
                     q_jax,
@@ -278,7 +286,11 @@ class PallasAttentionBackendImpl(AttentionImpl):
                     k_scale,
                     v_scale,
                     self.sliding_window,
+                    update_kv_cache=update_kv_cache,
                 )
+                # With update_kv_cache=False the kernel returns the cache
+                # unchanged; still store the returned array (kv_cache is a
+                # donated argument, so the old reference must not be reused).
                 vllm_model_wrapper_context.kv_caches[
                     kv_cache_index] = new_kv_cache
             case _:
@@ -334,6 +346,7 @@ def _format_attention_output(
         "v_scale",
         "sliding_window",
         "soft_cap",
+        "update_kv_cache",
     ),
     donate_argnames=("kv_cache"),
 )
@@ -355,6 +368,7 @@ def _jax_attn_func(
     v_scale: float | None = None,
     sliding_window: int | None = None,
     soft_cap: float | None = None,
+    update_kv_cache: bool = True,
 ) -> Tuple[jax.Array, jax.Array]:
     q_len = q.shape[0]
     q, k, v = _prepare_qkv_layout(q, k, v, num_heads, num_kv_heads, head_size)
@@ -373,6 +387,7 @@ def _jax_attn_func(
         sinks=sinks,
         attention_chunk_size=sliding_window,
         attn_logits_soft_cap=soft_cap,
+        update_kv_cache=update_kv_cache,
         shared_attention_metadata=shared_attention_metadata,
     )
 

--- a/tpu_inference/models/vllm/experimental/gemma4_mm_patcher.py
+++ b/tpu_inference/models/vllm/experimental/gemma4_mm_patcher.py
@@ -1,0 +1,137 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Gemma4 multimodal patches for running the vLLM model via torchax.
+
+Why this exists:
+vLLM's Gemma4ForConditionalGeneration caches per-layer embeddings (PLE) in a
+pre-allocated instance attribute for CUDA-graph compatibility:
+
+1. ``__init__`` creates ``self.per_layer_embeddings`` with a bare
+   ``torch.zeros(...)`` — a plain attribute, NOT a registered buffer. Our
+   ``shard_model_to_tpu`` only converts ``named_parameters()`` and
+   ``named_buffers()`` to torchax tensors, so this attribute stays a plain
+   CPU ``torch.Tensor``, and ``embed_input_ids``'s
+   ``self.per_layer_embeddings[:n].copy_(...)`` crashes inside torchax's
+   ``_aten_copy`` with ``AttributeError: 'Tensor' object has no attribute
+   '_elem'`` (destination has no jax array behind it).
+2. Even with the buffer converted, the write cannot work here: writes into
+   a slice-view mutate a temporary torchax tensor, and the jitted forward
+   receives ``params_and_buffers`` materialized once at load time — the
+   stateful write never crosses the jit boundary.
+
+Fix: drop the buffer and compute PLE *inside* the jitted forward from
+``input_ids`` (which the forward already receives as a jit argument). This
+is a pure embedding lookup and reproduces the reference computation exactly:
+``embed_input_ids`` masks multimodal placeholder positions to token 0 before
+calling ``get_per_layer_inputs``; those positions are exactly the ones whose
+``input_ids`` equal the image/audio placeholder token ids, so masking by
+token id is equivalent.
+"""
+
+from types import MethodType
+
+import torch
+import torch.nn as nn
+from vllm.model_executor.models.gemma4_mm import Gemma4ForConditionalGeneration
+from vllm.sequence import IntermediateTensors
+
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+
+def _ple_forward(
+    self,
+    input_ids: torch.Tensor,
+    positions: torch.Tensor,
+    intermediate_tensors: IntermediateTensors | None = None,
+    inputs_embeds: torch.Tensor | None = None,
+    **kwargs: object,
+) -> IntermediateTensors:
+    """Replaces Gemma4ForConditionalGeneration.forward on the TPU path.
+
+    Identical to the vLLM forward except PLE is computed inline from
+    input_ids instead of being read from the pre-allocated
+    ``per_layer_embeddings`` CUDA-graph buffer (see module docstring).
+    """
+    if intermediate_tensors is not None:
+        inputs_embeds = None
+
+    per_layer_inputs = None
+    if inputs_embeds is not None and input_ids is not None:
+        # Reference semantics: embed_input_ids computes PLE with multimodal
+        # placeholder positions masked to token 0. Those positions hold the
+        # image/audio placeholder token ids, so mask by token id.
+        ple_input_ids = input_ids
+        for token_id in self._tpu_ple_mask_token_ids:
+            ple_input_ids = torch.where(
+                ple_input_ids == token_id,
+                torch.zeros_like(ple_input_ids),
+                ple_input_ids,
+            )
+        per_layer_inputs = self.language_model.model.get_per_layer_inputs(
+            ple_input_ids)
+        if per_layer_inputs is not None:
+            per_layer_inputs = per_layer_inputs.reshape(
+                -1,
+                self.config.text_config.num_hidden_layers,
+                self.config.text_config.hidden_size_per_layer_input,
+            )
+
+    self._clear_mm_prefix_for_full_attn_layers()
+
+    hidden_states = self.language_model.model(
+        input_ids,
+        positions,
+        per_layer_inputs=per_layer_inputs,
+        intermediate_tensors=intermediate_tensors,
+        inputs_embeds=inputs_embeds,
+        **kwargs,
+    )
+
+    return hidden_states
+
+
+def apply_gemma4_mm_patches(vllm_model: nn.Module) -> None:
+    # Dropping the buffer makes embed_input_ids skip its
+    # per_layer_embeddings[:n].copy_(...) block (guarded by
+    # ``if self.per_layer_embeddings is not None``), which would crash on
+    # the plain CPU tensor under torchax.
+    vllm_model.per_layer_embeddings = None
+
+    mask_token_ids = []
+    for attr in ("image_token_id", "audio_token_id"):
+        token_id = getattr(vllm_model.config, attr, None)
+        if token_id is not None:
+            mask_token_ids.append(token_id)
+    vllm_model._tpu_ple_mask_token_ids = tuple(mask_token_ids)
+
+    vllm_model.forward = MethodType(_ple_forward, vllm_model)
+    logger.info(
+        "[gemma4-patch] Replaced per_layer_embeddings CUDA-graph buffer with "
+        "inline PLE computation in forward (mask_token_ids=%s).",
+        mask_token_ids,
+    )
+
+
+def maybe_apply_gemma4_mm_patches(vllm_model: nn.Module) -> None:
+    if not isinstance(vllm_model, Gemma4ForConditionalGeneration):
+        return
+    ple_dim = getattr(vllm_model.config.text_config,
+                      "hidden_size_per_layer_input", None)
+    if ple_dim is None or ple_dim <= 0:
+        # Variant without PLE (e.g. 26B/31B): per_layer_embeddings is None
+        # and the forward's buffer read is already skipped. Nothing to patch.
+        return
+    apply_gemma4_mm_patches(vllm_model)

--- a/tpu_inference/models/vllm/experimental/gemma4_mm_patcher.py
+++ b/tpu_inference/models/vllm/experimental/gemma4_mm_patcher.py
@@ -64,15 +64,30 @@ def _ple_forward(
     Identical to the vLLM forward except PLE is computed inline from
     input_ids instead of being read from the pre-allocated
     ``per_layer_embeddings`` CUDA-graph buffer (see module docstring).
+
+    Provenance, for review against the upstream source
+    (vllm/model_executor/models/gemma4_mm.py): everything here is copied
+    verbatim from ``Gemma4ForConditionalGeneration.forward`` except the
+    ``per_layer_inputs`` block, which replaces upstream's buffer read
+    (``self.per_layer_embeddings[:n]``) with the producer computation
+    copied from ``embed_input_ids``. Each section is marked below.
     """
+    # [upstream forward, verbatim]
     if intermediate_tensors is not None:
         inputs_embeds = None
 
+    # [replaces upstream forward's buffer read] Upstream forward does
+    #   per_layer_inputs = self.per_layer_embeddings[:inputs_embeds.shape[0]]
+    #   (guarded on per_layer_embeddings/inputs_embeds not None).
+    # Here PLE is computed inline instead, under the equivalent guard
+    # (input_ids replaces the buffer as the data source).
     per_layer_inputs = None
     if inputs_embeds is not None and input_ids is not None:
-        # Reference semantics: embed_input_ids computes PLE with multimodal
-        # placeholder positions masked to token 0. Those positions hold the
-        # image/audio placeholder token ids, so mask by token id.
+        # [new — replaces upstream embed_input_ids' is_multimodal mask]
+        # Upstream masks multimodal placeholder positions to token 0 via the
+        # is_multimodal tensor, which forward does not receive. Those
+        # positions hold the image/audio placeholder token ids, so masking
+        # by token id selects the same positions.
         ple_input_ids = input_ids
         for token_id in self._tpu_ple_mask_token_ids:
             ple_input_ids = torch.where(
@@ -80,6 +95,8 @@ def _ple_forward(
                 torch.zeros_like(ple_input_ids),
                 ple_input_ids,
             )
+        # [upstream embed_input_ids, verbatim] The PLE producer computation
+        # (lookup + reshape), minus the final buffer copy_.
         per_layer_inputs = self.language_model.model.get_per_layer_inputs(
             ple_input_ids)
         if per_layer_inputs is not None:
@@ -89,6 +106,7 @@ def _ple_forward(
                 self.config.text_config.hidden_size_per_layer_input,
             )
 
+    # [upstream forward, verbatim]
     self._clear_mm_prefix_for_full_attn_layers()
 
     hidden_states = self.language_model.model(

--- a/tpu_inference/models/vllm/experimental/model_patcher.py
+++ b/tpu_inference/models/vllm/experimental/model_patcher.py
@@ -30,6 +30,8 @@ from torchax.interop import JittableModule, torch_view
 
 from tpu_inference import envs
 from tpu_inference.logger import init_logger
+from tpu_inference.models.vllm.experimental.gemma4_mm_patcher import \
+    maybe_apply_gemma4_mm_patches
 from tpu_inference.models.vllm.experimental.qwen3_omni_patcher import \
     maybe_apply_qwen3_omni_patches
 from tpu_inference.models.vllm.experimental.qwen3_vl_patcher import \
@@ -212,3 +214,4 @@ def apply_model_specific_patches(vllm_model) -> None:
     """
     maybe_apply_qwen3_vl_patches(vllm_model)
     maybe_apply_qwen3_omni_patches(vllm_model)
+    maybe_apply_gemma4_mm_patches(vllm_model)

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -24,6 +24,39 @@ if hasattr(torch, "accelerator") and hasattr(torch.accelerator, "empty_cache"):
                 raise e
 
     torch.accelerator.empty_cache = _patched_empty_cache
+
+# Monkeypatch torch.accelerator.get_memory_info to answer from the JAX device.
+# torchax registers "jax" as a PrivateUse1 device, and torch.accelerator's memory
+# APIs resolve the device via torch._C._accelerator_getDeviceIndex(), which
+# raises "PyTorch is not linked with support for jax devices". vLLM model code
+# on the torchax path calls get_memory_info() to size work by free HBM (e.g.
+# Gemma4ForConditionalGeneration._process_image_input chunks the vision
+# encoder by it), and an unhandled raise there kills the EngineCore mid-request.
+if hasattr(torch, "accelerator") and hasattr(torch.accelerator,
+                                             "get_memory_info"):
+    _orig_get_memory_info = torch.accelerator.get_memory_info
+
+    def _jax_device_memory_info() -> Tuple[int, int]:
+        """(free_bytes, total_bytes) of the first local JAX device.
+
+        Falls back to (0, 0) when the backend exposes no memory stats; callers
+        that derive a budget from it then take their minimum-work path instead
+        of crashing.
+        """
+        stats = jax.local_devices()[0].memory_stats() or {}
+        total = int(stats.get("bytes_limit", 0))
+        in_use = int(stats.get("bytes_in_use", 0))
+        return max(total - in_use, 0), total
+
+    def _patched_get_memory_info(*args, **kwargs) -> Tuple[int, int]:
+        try:
+            return _orig_get_memory_info(*args, **kwargs)
+        except RuntimeError as e:
+            if "jax" not in str(e):
+                raise
+            return _jax_device_memory_info()
+
+    torch.accelerator.get_memory_info = _patched_get_memory_info
 from vllm.platforms.interface import Platform, PlatformEnum
 
 from tpu_inference import envs


### PR DESCRIPTION
## Problem

gemma-4 E2B/E4B Accuracy has failed on every `MODEL_IMPL_TYPE=vllm` nightly since June (e.g. [build 24382](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24382), both tpu6e and tpu7x). Two independent bugs:

**1. Engine-init crash (the visible failure).** vLLM's `Gemma4ForConditionalGeneration` caches per-layer embeddings (PLE) in a pre-allocated plain-attribute buffer (`self.per_layer_embeddings = torch.zeros(...)`, a CUDA-graph pattern). It is not a parameter or registered buffer, so `shard_model_to_tpu` never converts it to a torchax tensor and `embed_input_ids`'s `per_layer_embeddings[:n].copy_(...)` crashes in torchax's `_aten_copy`:

```
AttributeError: 'Tensor' object has no attribute '_elem'
```

Only the Accuracy job hits it because it runs the engine-init precompile (the UnitTest job's `offline_inference.py` sets `SKIP_JAX_PRECOMPILE=1`). Even if converted, the write cannot work here: the runner materializes `jax_view(params_and_buffers)` once at load, so a stateful slice-`copy_` never crosses the jit boundary.

**2. KV-share cache corruption (masked by the crash).** With (1) fixed, text generation is garbage. E2B/E4B mark their last 20/18 layers KV-shared: `kv_sharing_target_layer_name` is set and `layer_name_to_kvcache_index` maps them to the target layer's cache index. `PallasAttentionBackendImpl.forward` wrote `new_kv_cache` back unconditionally, so every shared layer overwrote its target's cache with its own (supposed-to-be-discarded) K/V. Consistent with the nightly matrix: 26B/31B (`num_kv_shared_layers=0`) Accuracy passes on the vllm variant; E2B/E4B (20/18 shared layers) never has.

## Changes

- `gemma4_mm_patcher.py`: drop the PLE buffer and compute PLE inline in the jitted forward from `input_ids` (a pure embedding lookup), masking multimodal placeholder token ids to 0 — exactly the reference `is_multimodal` masking (placeholder positions hold those ids; gemma-4 `image_token_id=258880 < vocab_size_per_layer_input=262144`, so `get_per_layer_inputs`'s internal mask does not cover them).
- `flash_attn.py`: pass `update_kv_cache=(kv_sharing_target_layer_name is None)` through to `attention()`, mirroring the JAX-native model (`models/jax/gemma4.py`: `update_kv_cache=not self.is_kv_shared_layer`). The returned (unchanged) cache is still stored: the argument is donated, and always threading the returned value keeps the cache use-chain linear so XLA input-output aliasing holds without copy insertion (a conditional skip produced a 170G HLO-temporaries OOM).

## Verification

- Unit tests: `test_gemma4_mm_patcher.py` (masking, buffer drop, forward wiring) and `test_flash_attn.py::test_forward_kv_shared_layer_does_not_write_cache` (real kernel: shared layer leaves the cache bit-identical, non-shared layer writes). All pass on tpu7x.
- A/B on tpu7x, `MODEL_IMPL_TYPE=vllm`, gemma-4-E2B offline_inference with precompile enabled: unpatched crashes with the `_aten_copy` AttributeError; with only the PLE fix it runs but generates token soup and scores gsm8k 0.0 ([dev 896](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/896)); with both fixes the output matches the JAX-native path ("The capital of France is **Paris**.") and gsm8k strict-match is **0.494** (threshold 0.35).
- [Dev 897](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/897): E2B Accuracy (tpu6e TP=1) and E4B Accuracy (tpu7x TP=2) both pass; MM correctness (Qwen2.5-VL) passes, i.e. no regression on non-gemma multimodal.


## Update (2026-08-21): rebased on main, reverts #3414, and a third torchax bug

- Rebased onto current `main`.
- Added a revert of #3414 (`9fd55bc67f`), which had marked the gemma-4 E2B/E4B **Accuracy** steps as `unverified` on the `MODEL_IMPL_TYPE=vllm` nightly variant while the torchax path was broken. With this PR the vllm variant runs those accuracy tests for real again, so merging this PR and lifting the gate are one atomic change. This also makes #3436 (which would copy the same gate onto the Benchmark step) unnecessary.
- **Third bug, found by the verification below:** with the PLE + KV-share fixes in place, text inference is correct, but any request carrying an *image* still killed the EngineCore: since vLLM #42662 (Aug 13) `Gemma4ForConditionalGeneration._process_image_input` sizes vision-encoder chunks with `torch.accelerator.get_memory_info()`, and on the torchax path (PrivateUse1 `jax` device) every `torch.accelerator` memory API raises `RuntimeError: PyTorch is not linked with support for jax devices`. The 26B/31B nightly perf steps don't hit it only because they set `cudagraph_mm_encoder`, which routes the encoder through `MMEncoderJitManager` and never enters `_process_image_input`. Fix: `tpu_platform.py` now shims `torch.accelerator.get_memory_info` to answer from `jax.local_devices()[0].memory_stats()`, mirroring the existing `empty_cache` shim; unit-tested in `tests/platforms/test_tpu_platform.py`.

### Verification on the dev pipeline

The complete per-model yml step set (Unit tests → Accuracy → Performance benchmarks), for **both** `MODEL_IMPL_TYPE=flax_nnx` and `MODEL_IMPL_TYPE=vllm`, on **both** tpu6e and tpu7x, with `soft_fail` removed so every step is hard-gated:

- [build 918](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/918) — `google_gemma-4-E2B-it.yml` (TP=1 on both chips): **12/12 passed**. gsm8k strict-match on the vllm path: tpu6e 0.485, tpu7x 0.492 (flax_nnx: 0.493 / 0.494; floor 0.35).
- [build 919](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/919) — `google_gemma-4-E4B-it.yml` (tpu6e TP=1, tpu7x TP=2): **12/12 passed**. gsm8k strict-match on the vllm path: tpu6e 0.715, tpu7x 0.717 (flax_nnx: 0.716 / 0.718; floor 0.65). flax_nnx perf: 5.1 req/s tpu6e, 6.9 req/s tpu7x.
- Caveat that led to the third fix: in 918/919 the *vllm* Performance steps reported PASSED but with `Total generated tokens: 0` — the EngineCore had died on the first image request (the `get_memory_info` crash above) and the recipe's 0.0 throughput floor let it through. The flax_nnx perf runs were real (E2B: 8.5 req/s tpu7x, 6.3 req/s tpu6e).
- [build 927](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/927) — the four vllm Performance steps (E2B/E4B × tpu6e/tpu7x) re-run with the shim: **4/4 real passes** — 128/128 requests, 16384 generated tokens each, no EngineCore errors. Request throughput: E2B 1.09 req/s tpu7x / 1.05 tpu6e, E4B 0.72 tpu7x / 0.91 tpu6e (floor 0.0). Slower than the JAX path (5–8.5 req/s) because these steps run the eager vision encoder without `cudagraph_mm_encoder`; perf tuning is a follow-up, correctness is what this PR restores.


