### PR TITLE
[multimodal] Raise ViT flash-attention scoped-vmem limit to 64MiB

### DIFF
--- a/tests/layers/vllm/ops/test_scaled_dot_product_attention.py
+++ b/tests/layers/vllm/ops/test_scaled_dot_product_attention.py
@@ -80,7 +80,7 @@ class TestAttnDpBatchAxisFix:
 class TestVitVmemLimit:
     """The ViT flash attention must raise the scoped-vmem limit above the
     32MiB pallas default: large flattened image sequences exceed it
-    (CompileTimeScopedVmemOom at bf16[1,16,25344,80], nightly 24382)."""
+    (CompileTimeScopedVmemOom at bf16[1,16,25344,80])."""
 
     def test_vit_vmem_limit_covers_failing_shape(self):
         # 37.22M was the observed scoped allocation that OOMed at 32M.

--- a/tests/layers/vllm/ops/test_scaled_dot_product_attention.py
+++ b/tests/layers/vllm/ops/test_scaled_dot_product_attention.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from unittest import mock
+
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -19,6 +21,7 @@ import pytest
 from jax.sharding import Mesh
 
 import tpu_inference.layers.common.attention_interface as attention_interface
+import tpu_inference.layers.vllm.ops.scaled_dot_product_attention as sdpa_ops
 from tpu_inference.layers.vllm.ops.scaled_dot_product_attention import (
     scaled_dot_product_attention, vllm_vit_sdpa)
 
@@ -72,3 +75,35 @@ class TestAttnDpBatchAxisFix:
             out = vllm_vit_sdpa(q, k, v, cu_seqlens=[0, 64, 128])
 
         assert out.shape == (1, 128, 2, 64)
+
+
+class TestVitVmemLimit:
+    """The ViT flash attention must raise the scoped-vmem limit above the
+    32MiB pallas default: large flattened image sequences exceed it
+    (CompileTimeScopedVmemOom at bf16[1,16,25344,80], nightly 24382)."""
+
+    def test_vit_vmem_limit_covers_failing_shape(self):
+        # 37.22M was the observed scoped allocation that OOMed at 32M.
+        assert sdpa_ops._VIT_FLASH_ATTENTION_VMEM_LIMIT_BYTES >= int(
+            38 * 1024 * 1024)
+
+    @pytest.mark.parametrize('op,extra_kwargs', [
+        (scaled_dot_product_attention, {}),
+        (vllm_vit_sdpa, {
+            'cu_seqlens': [0, 128]
+        }),
+    ])
+    def test_ops_pass_vmem_limit_to_flash_attention(self, op, extra_kwargs):
+        q = k = v = jnp.ones((1, 2, 128, 64), dtype=jnp.float32)
+        if op is vllm_vit_sdpa:
+            q = k = v = jnp.ones((1, 128, 2, 64), dtype=jnp.float32)
+
+        with mock.patch.object(sdpa_ops,
+                               'sharded_flash_attention') as mock_sfa:
+            mock_sfa.return_value = mock.MagicMock(
+                return_value=jnp.ones((1, 2, 128, 64), dtype=jnp.float32))
+            op(q, k, v, **extra_kwargs)
+
+        assert mock_sfa.call_count == 1
+        assert mock_sfa.call_args.kwargs['vmem_limit_bytes'] == \
+            sdpa_ops._VIT_FLASH_ATTENTION_VMEM_LIMIT_BYTES

--- a/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
+++ b/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
@@ -21,12 +21,10 @@ from torchax.ops.jtorch import register_function
 from tpu_inference.layers.common.attention_interface import \
     sharded_flash_attention
 
-# The pallas default scoped-vmem limit is 32MiB, which the ViT flash-attention
-# exceeds on large flattened image sequences: nightly 24382
-# (MODEL_IMPL_TYPE=vllm, Qwen2.5-VL-3B MM perf) failed with
-# CompileTimeScopedVmemOom "size 37.22M and limit 32.00M" at
-# bf16[1,16,25344,80]. 64MiB covers those shapes with headroom; the RPA
-# kernels already run with up to 100MiB on both v6e and v7x.
+# ViT flash-attention on large flattened image sequences needs more scoped
+# vmem than the 32MiB pallas default (~37MiB at bf16[1,16,25344,80]); 64MiB
+# covers such shapes with headroom. The RPA kernels already run with up to
+# 100MiB on both v6e and v7x.
 _VIT_FLASH_ATTENTION_VMEM_LIMIT_BYTES = 64 * 1024 * 1024
 
 

--- a/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
+++ b/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
@@ -21,6 +21,14 @@ from torchax.ops.jtorch import register_function
 from tpu_inference.layers.common.attention_interface import \
     sharded_flash_attention
 
+# The pallas default scoped-vmem limit is 32MiB, which the ViT flash-attention
+# exceeds on large flattened image sequences: nightly 24382
+# (MODEL_IMPL_TYPE=vllm, Qwen2.5-VL-3B MM perf) failed with
+# CompileTimeScopedVmemOom "size 37.22M and limit 32.00M" at
+# bf16[1,16,25344,80]. 64MiB covers those shapes with headroom; the RPA
+# kernels already run with up to 100MiB on both v6e and v7x.
+_VIT_FLASH_ATTENTION_VMEM_LIMIT_BYTES = 64 * 1024 * 1024
+
 
 @register_function(torch.nn.functional.scaled_dot_product_attention)
 def scaled_dot_product_attention(
@@ -83,11 +91,13 @@ def scaled_dot_product_attention(
     # into one sequence via cu_seqlens/segment_ids, no real batch axis), so
     # it must stay replicated rather than sharded by the DP ('data') axis --
     # sharding a size-1 axis by DP>1 fails divisibility under enable_dp_attention.
-    attn_fn = sharded_flash_attention(mesh,
-                                      causal=is_causal,
-                                      sm_scale=scale,
-                                      use_attention_bias=True,
-                                      batch_axis=None)
+    attn_fn = sharded_flash_attention(
+        mesh,
+        causal=is_causal,
+        sm_scale=scale,
+        vmem_limit_bytes=_VIT_FLASH_ATTENTION_VMEM_LIMIT_BYTES,
+        use_attention_bias=True,
+        batch_axis=None)
     out = attn_fn(query, key, value, attention_bias, None)
 
     if q_pad > 0:
@@ -175,11 +185,13 @@ def vllm_vit_sdpa(
     #    flattened into one sequence via cu_seqlens/segment_ids), so it must
     #    stay replicated -- sharding a size-1 axis by DP>1 fails divisibility
     #    under enable_dp_attention.
-    attn_fn = sharded_flash_attention(mesh,
-                                      causal=False,
-                                      sm_scale=scale,
-                                      use_attention_bias=False,
-                                      batch_axis=None)
+    attn_fn = sharded_flash_attention(
+        mesh,
+        causal=False,
+        sm_scale=scale,
+        vmem_limit_bytes=_VIT_FLASH_ATTENTION_VMEM_LIMIT_BYTES,
+        use_attention_bias=False,
+        batch_axis=None)
 
     out = attn_fn(query, key, value, seg_ids)
 


### PR DESCRIPTION
## Problem

The `MODEL_IMPL_TYPE=vllm` nightly's "Performance tests for Multimodal Inputs" fails on both tpu6e and tpu7x (e.g. [build 24382](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24382)): under the MM perf request mix, large flattened image sequences push the ViT flash-attention pallas kernel past the default 32MiB scoped-vmem limit and the engine dies mid-benchmark:

```
CompileTimeScopedVmemOom: Ran out of memory in memory space vmem ... for
%flash_attention.1 = bf16[1,16,25344,80] ... Scoped allocation with size
37.22M and limit 32.00M exceeded scoped vmem limit by 5.22M.
```

## Change

Pass `vmem_limit_bytes=64MiB` to `sharded_flash_attention` at the two vision SDPA entry points (`scaled_dot_product_attention`, `vllm_vit_sdpa`). The plumbing already existed down to the kernel; only these call sites never set it. 64MiB covers the observed 37–38M shapes with headroom, and the RPA kernels already run with up to 100MiB on both v6e and v7x.

## Verification

- New unit tests assert both ops pass the limit through and that it covers the failing shape.
- [Dev 897](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/897) (`MODEL_IMPL_TYPE=vllm`): MM perf passes on BOTH tpu7x and tpu6e (previously failed every nightly), and MM correctness passes (no regression).
