### PR TITLE
[DSv4] Pass attention metadata to jit once per KV-cache group

### DIFF
--- a/tests/layers/common/test_grouped_attention_metadata.py
+++ b/tests/layers/common/test_grouped_attention_metadata.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""GroupedAttentionMetadata: dict semantics, and one jit parameter per group."""
+
+import jax
+import jax.numpy as jnp
+from absl.testing import absltest
+
+from tpu_inference.layers.common.attention_metadata import (
+    AttentionMetadata, GroupedAttentionMetadata)
+
+GROUP_0 = ("layers.0.attn", "layers.1.attn", "layers.2.attn")
+GROUP_1 = ("layers.0.attn.compressor", )
+
+
+def _metadata(seed: int) -> AttentionMetadata:
+    return AttentionMetadata(
+        input_positions=jnp.arange(8, dtype=jnp.int32),
+        block_tables=jnp.arange(16, dtype=jnp.int32) + seed,
+        seq_lens=jnp.ones(4, jnp.int32),
+        query_start_loc=jnp.arange(5, dtype=jnp.int32),
+        request_distribution=jnp.array([1, 1, 4], jnp.int32),
+    )
+
+
+def _build() -> GroupedAttentionMetadata:
+    return GroupedAttentionMetadata(
+        groups=(_metadata(0), _metadata(100)),
+        layer_names_per_group=(GROUP_0, GROUP_1),
+    )
+
+
+class GroupedAttentionMetadataTest(absltest.TestCase):
+
+    def test_behaves_like_the_per_layer_dict_it_replaces(self):
+        md = _build()
+        # Consumers do `isinstance(attn_metadata, dict)` and index by layer.
+        self.assertIsInstance(md, dict)
+        self.assertEqual(set(md), set(GROUP_0) | set(GROUP_1))
+        self.assertLen(md, len(GROUP_0) + len(GROUP_1))
+        self.assertIsNotNone(md[GROUP_0[0]].block_tables)
+        self.assertIsNotNone(next(iter(md.values())).block_tables)
+
+    def test_layers_of_a_group_share_one_object(self):
+        md = _build()
+        for name in GROUP_0[1:]:
+            self.assertIs(md[name], md[GROUP_0[0]])
+        self.assertIsNot(md[GROUP_1[0]], md[GROUP_0[0]])
+
+    def test_flattens_once_per_group_not_once_per_layer(self):
+        md = _build()
+        per_group = len(jax.tree_util.tree_leaves(_metadata(0)))
+        self.assertLen(jax.tree_util.tree_leaves(md), 2 * per_group)
+
+    def test_work_derived_per_layer_is_emitted_once_per_group(self):
+        """The point of the class: one HLO parameter per group, so XLA shares."""
+
+        def work(md):
+            acc = jnp.zeros((), jnp.int32)
+            for i, name in enumerate(GROUP_0):
+                bt = md[name].block_tables
+                # A gather off the block table, as the attention/compressor
+                # paths do, with a different consumer per layer.
+                acc += jnp.sum(bt[md[name].input_positions] * (i + 1))
+            return acc
+
+        grouped = _build()
+        plain = {name: value for name, value in grouped.items()}
+
+        def gathers(arg):
+            text = jax.jit(work).lower(arg).compile().as_text()
+            return sum(1 for line in text.splitlines() if " gather(" in line)
+
+        self.assertEqual(jax.jit(work)(grouped), jax.jit(work)(plain))
+        # The plain dict re-gathers per layer; the grouped one gathers once.
+        self.assertLess(gathers(grouped), gathers(plain))
+        self.assertEqual(gathers(grouped), 1)
+
+
+if __name__ == "__main__":
+    absltest.main()

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -133,6 +133,39 @@ class SharedAttentionMetadata(object):
     padded_num_reqs: int = -1
 
 
+class GroupedAttentionMetadata(dict):
+    """``{layer_name: AttentionMetadata}`` that flattens once per KV-cache group.
+
+    Every layer in a KV-cache group shares one ``block_tables`` array,  it
+    flattens to the unique per-group entries. After unflattening inside the
+    trace, every layer of a group holds the *same* ``AttentionMetadata`` object,
+    so anything derived from the block tables gets computed once per group instead
+    of once per layer.
+    """
+
+    def __init__(
+        self,
+        groups: "tuple[AttentionMetadata, ...]",
+        layer_names_per_group: "tuple[tuple[str, ...], ...]",
+    ):
+        self.groups = tuple(groups)
+        self.layer_names_per_group = tuple(
+            tuple(names) for names in layer_names_per_group)
+        assert len(self.groups) == len(self.layer_names_per_group)
+        super().__init__({
+            name: self.groups[gid]
+            for gid, names in enumerate(self.layer_names_per_group)
+            for name in names
+        })
+
+
+jax.tree_util.register_pytree_node(
+    GroupedAttentionMetadata,
+    lambda m: (m.groups, m.layer_names_per_group),
+    lambda layer_names_per_group, groups: GroupedAttentionMetadata(
+        groups, layer_names_per_group),
+)
+
 PCP_CACHE_PAGE_BUCKET_COUNT = 5
 
 

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -28,8 +28,8 @@ import tpu_inference.envs as envs
 from tpu_inference.core.disagg_utils import is_disagg_enabled
 from tpu_inference.core.sched.utils import DEFAULT_MAX_DECODE_STEPS
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, PCPMetadata, SharedAttentionMetadata,
-    pcp_cache_page_buckets)
+    AttentionMetadata, GroupedAttentionMetadata, PCPMetadata,
+    SharedAttentionMetadata, pcp_cache_page_buckets)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling import (
     compute_and_gather_logprobs, compute_and_gather_prompt_logprobs, sample)
@@ -487,12 +487,16 @@ class CompilationManager:
             attention_metadata = build_attn(block_tables)
             shared_attention_metadata = build_shared_attn()
         else:
-            attention_metadata = {
-                name: build_attn(build_block_table(gid))
-                for gid, kv_cache_group in enumerate(
-                    self.runner.kv_cache_config.kv_cache_groups)
-                for name in kv_cache_group.layer_names
-            }
+            # Must mirror the runtime structure built in `_prepare_inputs`, or
+            # the precompiled executable does not match and we recompile.
+            attention_metadata = GroupedAttentionMetadata(
+                groups=tuple(
+                    build_attn(build_block_table(gid)) for gid in range(
+                        len(self.runner.kv_cache_config.kv_cache_groups))),
+                layer_names_per_group=tuple(
+                    tuple(group.layer_names)
+                    for group in self.runner.kv_cache_config.kv_cache_groups),
+            )
             shared_attention_metadata = build_shared_attn()
 
         def model_fn_warmup(_fn, _args, _call_kwargs):
@@ -1990,21 +1994,22 @@ class CompilationManager:
                     padded_num_reqs=num_reqs,
                 )
             else:
-                attn_metadata = {
-                    name:
-                    AttentionMetadata(
-                        input_positions=init_tokens,
-                        block_tables=build_block_table(gid),
-                        seq_lens=seq_lens,
-                        query_start_loc=query_start_loc,
-                        request_distribution=request_distribution,
-                        mamba_state_indices=mamba_state_indices,
-                        padded_num_reqs=num_reqs,
-                    )
-                    for gid, kv_cache_group in enumerate(
-                        self.runner.kv_cache_config.kv_cache_groups)
-                    for name in kv_cache_group.layer_names
-                }
+                attn_metadata = GroupedAttentionMetadata(
+                    groups=tuple(
+                        AttentionMetadata(
+                            input_positions=init_tokens,
+                            block_tables=build_block_table(gid),
+                            seq_lens=seq_lens,
+                            query_start_loc=query_start_loc,
+                            request_distribution=request_distribution,
+                            mamba_state_indices=mamba_state_indices,
+                            padded_num_reqs=num_reqs,
+                        ) for gid in range(
+                            len(self.runner.kv_cache_config.kv_cache_groups))),
+                    layer_names_per_group=tuple(
+                        tuple(group.layer_names) for group in
+                        self.runner.kv_cache_config.kv_cache_groups),
+                )
 
             init_state = TpuSamplingState(
                 current_tokens=init_tokens,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -53,8 +53,8 @@ import tpu_inference.envs as envs
 from tpu_inference import utils as common_utils
 from tpu_inference.core.sched.utils import DEFAULT_MAX_DECODE_STEPS
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, PCPMetadata, SharedAttentionMetadata,
-    round_up_pcp_cache_pages)
+    AttentionMetadata, GroupedAttentionMetadata, PCPMetadata,
+    SharedAttentionMetadata, round_up_pcp_cache_pages)
 from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
                                                   MESH_AXIS_NAMES_2D,
                                                   ShardingAxisName,
@@ -3087,12 +3087,17 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             attention_metadata = build_attn(block_tables)
             shared_attention_metadata = build_shared_attn()
         else:
-            attention_metadata = {
-                name: build_attn(metadata[f"block_tables_gid_{gid}"])
-                for gid, kv_cache_group in enumerate(
-                    self.kv_cache_config.kv_cache_groups)
-                for name in kv_cache_group.layer_names
-            }
+            # One AttentionMetadata per group, layers of a group
+            # share the block tables, and GroupedAttentionMetadata keeps that
+            # sharing across the jit boundary. See its docstring.
+            attention_metadata = GroupedAttentionMetadata(
+                groups=tuple(
+                    build_attn(metadata[f"block_tables_gid_{gid}"]) for gid in
+                    range(len(self.kv_cache_config.kv_cache_groups))),
+                layer_names_per_group=tuple(
+                    tuple(group.layer_names)
+                    for group in self.kv_cache_config.kv_cache_groups),
+            )
             shared_attention_metadata = build_shared_attn()
 
         # Async scheduling: substitute placeholder tokens for DP


### PR DESCRIPTION
[DSv4] Pass attention metadata to jit once per KV-cache group

Layers of a KV-cache group share a single `block_tables` array, but
`_prepare_inputs` handed the model a `{layer_name: AttentionMetadata}` dict
with one entry per layer. `jax.jit` does not dedupe duplicate pytree leaves,
so each layer's copy became its own HLO entry parameter, and HloCSE never
merges distinct parameters. Everything derived from the block tables was
therefore recomputed once per layer.

`GroupedAttentionMetadata` is a `dict` subclass registered as a pytree node
that flattens to one `AttentionMetadata` per group, carrying the layer names
in the treedef. Unflattening inside the trace re-creates the layer -> group
aliasing, so every layer of a group reads the same HLO values and the
duplicate subgraphs collapse under plain CSE.

Measured on DeepSeek-V4-Flash (tpu7x, 8 devices): the compressor's
`derive_metadata` and `prepare_boundary_batch` now run 3x per forward pass
(CSA main, CSA index, HCA main) instead of once per compressor instances.

Before this PR, 8 layers DSv4 xprof::
http://xprof/trace_viewer.html?session_id=gxd-3658044117050797865 

After this PR, the `derive_metadata` and `prepare_boundary_batch` has been dedup:
Xprof: http://xprof/trace_viewer.html?session_id=gxd-11312421285432293780 


MMLU: https://paste.googleplex.com/4800140811567104 verified

Before this PR perf: https://screenshot-v2.corp.google.com/71o1tanf48oc8
After this PR: https://paste.googleplex.com/5608948718764032 
~5% improvement.


