### PR TITLE
Re-land: bit-pack GDN v3 per-p_id metadata

### DIFF
--- a/tpu_inference/kernels/gdn/v3/memory_ref.py
+++ b/tpu_inference/kernels/gdn/v3/memory_ref.py
@@ -127,7 +127,9 @@ class PackedPIdRecord:
         """Packs s_idx, row size and two tile-state flags into one int32 word."""
 
         s_idx = s_idx.reshape(-1).astype(jnp.int32)
-        r_size = r_size.reshape(-1).astype(jnp.int32)
+        # PER_SEQ pads unused slots with large negative sizes; shifting one of
+        # those left would set the high bits and overwrite s_idx.
+        r_size = jnp.maximum(r_size.reshape(-1).astype(jnp.int32), 0)
         is_first_tile = is_first_tile.reshape(-1).astype(jnp.int32)
         is_last_tile = is_last_tile.reshape(-1).astype(jnp.int32)
         word = s_idx << cls.S_IDX_SHIFT
@@ -184,6 +186,16 @@ class MetadataRef:
         r_base = p_id_to_r_base.reshape(-1).astype(jnp.int32)
         word = PackedPIdRecord.pack(p_id_to_s_idx, p_id_to_r_size,
                                     p_id_is_first_tile, p_id_is_last_tile)
+        # Every tile reads all `seq_tile_size` of its records, so the last tile
+        # reads up to `seq_tile_size - 1` records past the valid ones. Round the
+        # record count up so those reads hit zeroed records instead of whatever
+        # SMEM follows: a zero word is s_idx 0, r_size 0 and both tile flags
+        # false, which issues no DMA.
+        pad = -r_base.shape[0] % cfgs.seq_tile_size
+        if pad:
+            r_base = jnp.pad(r_base, (0, pad))
+            word = jnp.pad(word, (0, pad))
+
         fields = [r_base, word]
         # Interleave fields into one array of structs: [rec0_f0, rec0_f1, ...].
         records = jnp.stack(fields, axis=-1).reshape(-1)

--- a/tpu_inference/kernels/gdn/v3/memory_ref.py
+++ b/tpu_inference/kernels/gdn/v3/memory_ref.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import dataclasses
 import functools
 from typing import Any
@@ -22,6 +21,17 @@ from jax.experimental import pallas as pl
 from jax.experimental.pallas import tpu as pltpu
 
 from tpu_inference.kernels.gdn.v3 import config
+
+
+def _flat_pos(shape: tuple[int, ...], indices: tuple[Any, ...]) -> Any:
+    """Row-major flat offset of `indices` into a logical array of `shape`."""
+    strides = pl.strides_from_shape(shape)
+    assert len(strides) == len(indices)
+
+    pos = 0
+    for stride, idx in zip(strides, indices):
+        pos += stride * idx
+    return pos
 
 
 @jax.tree_util.register_dataclass
@@ -45,36 +55,94 @@ class WeightRefs:
     gdn: GDNWeightsRef
 
 
-@jax.tree_util.register_dataclass
+class FieldOffset:
+    """Descriptor returning the record field at ``data[pos + offset]``.
+
+  Reads a single dynamically-indexed element rather than a slice, since JAX
+  can't slice a range with traced indices. Read-only: metadata is never
+  written.
+  """
+
+    def __init__(self, offset: int):
+        self.offset = offset
+
+    def __get__(self, obj, objtype=None):
+        if obj is None:
+            return self
+        return obj.data[obj.pos + self.offset]
+
+
+# Per-p_id metadata is an array of structs: each p_id's fields sit contiguously
+# and FieldOffset(k) reads the k-th word of its struct.
+#
+# Packed struct: [r_base, packed_word].
+# Fields share packed_word to save SMEM: is_first_tile(0), is_last_tile(1), r_size(2..15), s_idx(16..31).
 @dataclasses.dataclass(frozen=True)
-class SmemWrapper:
-    """Maps physical 1-D data into logical N-D representation."""
+class PackedPIdRecord:
+    """Packed struct [r_base, packed_word]; the four small fields bit-slice word.
+
+  Each bit field masks after shifting, which also clears the sign bits that
+  ``>>`` extends on the signed int32 word.
+  """
+
+    STRUCT_SIZE = 2
+    FIRST_TILE_SHIFT = 0
+    LAST_TILE_SHIFT = 1
+    R_SIZE_SHIFT = 2
+    S_IDX_SHIFT = 16
+    FLAG_MASK = 1
+    R_SIZE_MASK = (1 << (S_IDX_SHIFT - R_SIZE_SHIFT)) - 1
+    S_IDX_MASK = (1 << (32 - S_IDX_SHIFT)) - 1
+    MAX_SEQS = S_IDX_MASK + 1
 
     data: Any
-    shape: tuple[int, ...] = dataclasses.field(metadata=dict(static=True))
+    pos: Any
+    r_base = FieldOffset(0)
+    word = FieldOffset(1)
 
-    def _get_pos(self, indices):
-        strides = pl.strides_from_shape(self.shape)
-        assert len(strides) == len(indices)
+    @property
+    def s_idx(self):
+        return (self.word >> self.S_IDX_SHIFT) & self.S_IDX_MASK
 
-        pos = 0
-        for stride, idx in zip(strides, indices):
-            pos += stride * idx
-        return pos
+    @property
+    def r_size(self):
+        return (self.word >> self.R_SIZE_SHIFT) & self.R_SIZE_MASK
 
-    def __getitem__(self, indices):
-        return self.data[self._get_pos(indices)]
+    @property
+    def is_first_tile(self):
+        return (self.word & self.FLAG_MASK) != 0
+
+    @property
+    def is_last_tile(self):
+        return ((self.word >> self.LAST_TILE_SHIFT) & self.FLAG_MASK) != 0
+
+    @classmethod
+    def pack(
+        cls,
+        s_idx: jax.Array,
+        r_size: jax.Array,
+        is_first_tile: jax.Array,
+        is_last_tile: jax.Array,
+    ) -> jax.Array:
+        """Packs s_idx, row size and two tile-state flags into one int32 word."""
+
+        s_idx = s_idx.reshape(-1).astype(jnp.int32)
+        r_size = r_size.reshape(-1).astype(jnp.int32)
+        is_first_tile = is_first_tile.reshape(-1).astype(jnp.int32)
+        is_last_tile = is_last_tile.reshape(-1).astype(jnp.int32)
+        word = s_idx << cls.S_IDX_SHIFT
+        word |= r_size << cls.R_SIZE_SHIFT
+        word |= is_last_tile << cls.LAST_TILE_SHIFT
+        word |= is_first_tile << cls.FIRST_TILE_SHIFT
+        return word
 
 
 @jax.tree_util.register_dataclass
 @dataclasses.dataclass(frozen=True)
 class MetadataRef:
     num_tiles: Any
-    p_id_to_s_idx: SmemWrapper
-    p_id_to_r_base: SmemWrapper
-    p_id_to_r_size: SmemWrapper
-    p_id_is_first_tile: SmemWrapper
-    p_id_is_last_tile: SmemWrapper
+    # Array of structs holding every p_id's metadata
+    records: Any
     s_idx_has_initial_state: Any
     s_idx_to_state_indices: Any
     # Per-sequence state read offset for speculative decoding: the initial
@@ -82,6 +150,13 @@ class MetadataRef:
     # (the checkpoint of the last accepted token). Zero everywhere without
     # speculative decoding.
     s_idx_to_read_offset: Any
+    shape: tuple[int, ...] = dataclasses.field(metadata=dict(static=True))
+
+    def get_record(self, p_id, idx) -> PackedPIdRecord:
+        """View of one p_id's metadata: .r_base / .s_idx / .r_size / .is_*_tile."""
+        record_idx = _flat_pos(self.shape, (p_id, idx))
+        return PackedPIdRecord(self.records,
+                               record_idx * PackedPIdRecord.STRUCT_SIZE)
 
     @classmethod
     def create(
@@ -99,16 +174,27 @@ class MetadataRef:
     ):
         # NOTE: First dim does not matter when it comes to calculating stride.
         shape = (1, cfgs.seq_tile_size)
+        assert s_idx_has_initial_state.shape[0] <= PackedPIdRecord.MAX_SEQS, (
+            f"Number of sequences ({s_idx_has_initial_state.shape[0]}) exceeds"
+            f" PackedPIdRecord limit ({PackedPIdRecord.MAX_SEQS}).")
+        assert cfgs.tile_size <= PackedPIdRecord.R_SIZE_MASK, (
+            f"Tile size ({cfgs.tile_size}) exceeds PackedPIdRecord limit"
+            f" ({PackedPIdRecord.R_SIZE_MASK}).")
+
+        r_base = p_id_to_r_base.reshape(-1).astype(jnp.int32)
+        word = PackedPIdRecord.pack(p_id_to_s_idx, p_id_to_r_size,
+                                    p_id_is_first_tile, p_id_is_last_tile)
+        fields = [r_base, word]
+        # Interleave fields into one array of structs: [rec0_f0, rec0_f1, ...].
+        records = jnp.stack(fields, axis=-1).reshape(-1)
+
         return cls(
             num_tiles=num_tiles,
-            p_id_to_s_idx=SmemWrapper(p_id_to_s_idx, shape),
-            p_id_to_r_base=SmemWrapper(p_id_to_r_base, shape),
-            p_id_to_r_size=SmemWrapper(p_id_to_r_size, shape),
-            p_id_is_first_tile=SmemWrapper(p_id_is_first_tile, shape),
-            p_id_is_last_tile=SmemWrapper(p_id_is_last_tile, shape),
+            records=records,
             s_idx_has_initial_state=s_idx_has_initial_state,
             s_idx_to_state_indices=s_idx_to_state_indices,
             s_idx_to_read_offset=s_idx_to_read_offset,
+            shape=shape,
         )
 
     def __len__(self) -> int:
@@ -166,8 +252,9 @@ class InBufferedRef(BaseBufferedRef):
         p_id = grid_indices[0]
 
         for idx in range(self.cfg.seq_tile_size):
-            r_base = self.metadata_ref.p_id_to_r_base[p_id, idx]
-            dma_size = self.metadata_ref.p_id_to_r_size[p_id, idx]
+            record = self.metadata_ref.get_record(p_id, idx)
+            r_base = record.r_base
+            dma_size = record.r_size
             pltpu.make_async_copy(
                 src_ref.at[pl.ds(r_base, dma_size)],
                 vmem_ref.at[idx, pl.ds(0, dma_size)],
@@ -184,7 +271,7 @@ class InBufferedRef(BaseBufferedRef):
 
         dma_size = 0
         for idx in range(self.cfg.seq_tile_size):
-            dma_size += self.metadata_ref.p_id_to_r_size[p_id, idx]
+            dma_size += self.metadata_ref.get_record(p_id, idx).r_size
 
         pltpu.make_async_copy(
             vmem_ref.at[0, pl.ds(0, dma_size)],
@@ -206,8 +293,9 @@ class OutBufferedRef(BaseBufferedRef):
         p_id = grid_indices[0]
 
         for idx in range(self.cfg.seq_tile_size):
-            r_base = self.metadata_ref.p_id_to_r_base[p_id, idx]
-            dma_size = self.metadata_ref.p_id_to_r_size[p_id, idx]
+            record = self.metadata_ref.get_record(p_id, idx)
+            r_base = record.r_base
+            dma_size = record.r_size
             pltpu.make_async_copy(
                 vmem_ref.at[idx, pl.ds(0, dma_size)],
                 dst_ref.at[pl.ds(r_base, dma_size)],
@@ -224,7 +312,7 @@ class OutBufferedRef(BaseBufferedRef):
 
         dma_size = 0
         for idx in range(self.cfg.seq_tile_size):
-            dma_size += self.metadata_ref.p_id_to_r_size[p_id, idx]
+            dma_size += self.metadata_ref.get_record(p_id, idx).r_size
 
         pltpu.make_async_copy(
             vmem_ref.at[0, pl.ds(0, dma_size)],
@@ -259,9 +347,9 @@ class StateBufferedRef(BaseBufferedRef):
         p_id = grid_indices[0]
 
         for idx in range(self.cfg.seq_tile_size):
-
-            is_first_tile = self.metadata_ref.p_id_is_first_tile[p_id, idx]
-            s_idx = self.metadata_ref.p_id_to_s_idx[p_id, idx]
+            record = self.metadata_ref.get_record(p_id, idx)
+            is_first_tile = record.is_first_tile
+            s_idx = record.s_idx
             state_idx = self.metadata_ref.s_idx_to_state_indices[s_idx]
             has_initial_state = self.metadata_ref.s_idx_has_initial_state[
                 s_idx]
@@ -287,8 +375,9 @@ class StateBufferedRef(BaseBufferedRef):
 
         dma_size = 0
         for idx in range(self.cfg.seq_tile_size):
-            is_first_tile = self.metadata_ref.p_id_is_first_tile[p_id, idx]
-            s_idx = self.metadata_ref.p_id_to_s_idx[p_id, idx]
+            record = self.metadata_ref.get_record(p_id, idx)
+            is_first_tile = record.is_first_tile
+            s_idx = record.s_idx
             has_initial_state = self.metadata_ref.s_idx_has_initial_state[
                 s_idx]
             should_read = jnp.logical_and(is_first_tile, has_initial_state)
@@ -309,14 +398,15 @@ class StateBufferedRef(BaseBufferedRef):
         p_id = grid_indices[0]
 
         for idx in range(self.cfg.seq_tile_size):
-            is_last_tile = self.metadata_ref.p_id_is_last_tile[p_id, idx]
-            s_idx = self.metadata_ref.p_id_to_s_idx[p_id, idx]
+            record = self.metadata_ref.get_record(p_id, idx)
+            is_last_tile = record.is_last_tile
+            s_idx = record.s_idx
+            r_size = record.r_size
             state_idx = self.metadata_ref.s_idx_to_state_indices[s_idx]
             # Write one checkpoint per valid window position, starting at the
             # group's base slot. `r_size` never exceeds `window_size` for
             # windowed sequences; the clamp is for PER_SEQ tiles, which hold
             # many tokens but keep only the final state.
-            r_size = self.metadata_ref.p_id_to_r_size[p_id, idx]
             num_ckpts = jnp.minimum(r_size, self.cfg.window_size)
             dma_size = jnp.where(is_last_tile, num_ckpts, 0)
 
@@ -336,8 +426,9 @@ class StateBufferedRef(BaseBufferedRef):
 
         dma_size = 0
         for idx in range(self.cfg.seq_tile_size):
-            is_last_tile = self.metadata_ref.p_id_is_last_tile[p_id, idx]
-            r_size = self.metadata_ref.p_id_to_r_size[p_id, idx]
+            record = self.metadata_ref.get_record(p_id, idx)
+            is_last_tile = record.is_last_tile
+            r_size = record.r_size
             num_ckpts = jnp.minimum(r_size, self.cfg.window_size)
             dma_size += jnp.where(is_last_tile, num_ckpts, 0)
 

--- a/tpu_inference/kernels/gdn/v3/vmem_ldst.py
+++ b/tpu_inference/kernels/gdn/v3/vmem_ldst.py
@@ -176,9 +176,10 @@ def load_and_select_states(
     prev_recurrent_state_list = []
 
     for idx in range(cfg.seq_tile_size):
-        s_idx = metadata_ref.p_id_to_s_idx[p_id, idx]
-        real_sizes = metadata_ref.p_id_to_r_size[p_id, idx]
-        is_first_tile = metadata_ref.p_id_is_first_tile[p_id, idx]
+        record = metadata_ref.get_record(p_id, idx)
+        s_idx = record.s_idx
+        real_sizes = record.r_size
+        is_first_tile = record.is_first_tile
         has_initial_state = metadata_ref.s_idx_has_initial_state[s_idx]
 
         # NOTE: The VMEM window holds one state per window position and the


### PR DESCRIPTION
# Description

Re-lands #3349 (reverted by #3405) 

## Root cause

The halt is an out-of-bounds metadata read that predates #3349. #3349 changed what that read produces.

`fused_conv1d_gdn_batched` runs `cdiv(end_seq, tile_size)` tiles, and every tile reads all `seq_tile_size` of its records unconditionally. So the kernel reads `round_up(end_seq, tile_size)` records while the metadata only defines `max_num_reqs` of them. The failing configuration hits this on essentially every decode step:

- `max_num_seqs=10` → `max_num_reqs = max(1*10, MIN_NUM_SEQS=8) = 10`
- `decode_tile_size = 4` (default)
- `test_mtp_correctness`'s baseline fixture drives 100 prompts at `max_num_seqs=10`, so 9-10 requests are decoding almost continuously

Those reads land on whatever SMEM follows the record array, and `disable_bounds_checks=True` means the resulting `s_idx`, `r_base` and `r_size` reach the DMA descriptors and the per-sequence SMEM loads unvalidated.

## Fix

The fix is in the prologue outside `pallas_call`.

Round the record count up to a multiple of `seq_tile_size` and zero-fill, so every index the grid can reach is a real record. A zero word is `s_idx=0`, `r_size=0` and both tile flags false, so a padding tile issues no DMA and indexes the per-sequence arrays at 0.

Cost: `records` grows by 2 entries (16 B) when the sequence count is not a multiple of the decode tile size, and by nothing otherwise — PER_SEQ, where #3349 does its saving, is unchanged. 

The out-of-bounds read exists on `main` today; this is the first change to close it.

# Tests

**Bit-exactness against #3349.** 

**End-to-end quality** (from #3349, unchanged by this fix):

Online MMLU pro:

| Groups |Version|    Filter    |n-shot|  Metric   |   |Value |   |Stderr|
|--------|------:|--------------|-----:|-----------|---|-----:|---|-----:|
|mmlu_pro|      2|custom-extract|     5|exact_match|↑  |0.8343|±  |0.0138|


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
