### PR TITLE
Enable prefix caching for mamba/linear-attention layers

### DIFF
--- a/tests/e2e/test_mamba_prefix_caching.py
+++ b/tests/e2e/test_mamba_prefix_caching.py
@@ -1,0 +1,160 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Prefix caching for linear-attention (mamba/GDN) layers.
+
+Qwen3.5 interleaves full attention with gated-delta-net linear attention.
+With prefix caching on, vLLM puts the linear-attention layers in
+`mamba_cache_mode="align"`: the recurrent state is checkpointed into
+prefix-cacheable blocks addressed by the mamba block table, so a request
+that shares a prefix with an earlier one resumes from that request's state
+instead of recomputing it.
+
+The failure mode this guards against is silent: if the state slots are
+misaddressed, a cache hit resumes from another request's recurrent state
+and generation degrades into fluent nonsense rather than crashing. So the
+check compares against a prefix-caching-off baseline, and asserts a
+non-zero hit count so it cannot pass without exercising state reuse.
+
+Each engine runs in its own subprocess: building a second `LLM` in a
+process that already built one fails the engine-core handshake on TPU.
+"""
+import json
+import os
+import subprocess
+import sys
+import tempfile
+
+
+MODEL_NAME = "Qwen/Qwen3.5-4B"
+
+# Long enough that the shared part spans several mamba blocks, so a cache
+# hit has to carry recurrent state across block boundaries rather than
+# landing inside the first partial block.
+SHARED_PREFIX = (
+    "You are a meticulous technical editor. Below is an excerpt from a "
+    "reference manual describing a distributed key-value store. The store "
+    "partitions keys across a consistent hash ring, replicates each "
+    "partition to three nodes, and serves reads from any replica while "
+    "routing writes through a per-partition leader. Leaders are elected by "
+    "a majority quorum and hold a lease that must be renewed before it "
+    "expires. Clients cache the partition map and refresh it lazily when a "
+    "request is rejected with a stale-map error. Compaction runs in the "
+    "background and never blocks foreground traffic. Read the excerpt "
+    "carefully and answer the question that follows, using only the "
+    "information given above and nothing else. ") * 4
+
+QUESTIONS = [
+    "How many replicas does each partition have?",
+    "What happens when a client's partition map is stale?",
+    "Who serves writes for a partition?",
+    "Does compaction block foreground traffic?",
+    "How are leaders elected?",
+    "What must a leader do before its lease expires?",
+    "Where can reads be served from?",
+    "How are keys distributed across nodes?",
+]
+
+
+def _generate(mode: str, out_path: str) -> None:
+    """Generate the prompt set in this process and dump the result.
+
+    Only called in the child process (see `__main__` below), so vllm is
+    imported here rather than at module scope: the engine core is spawned,
+    and a spawned child re-imports this file.
+    """
+    from vllm import LLM, SamplingParams
+
+    llm = LLM(
+        model=MODEL_NAME,
+        max_model_len=2048,
+        tensor_parallel_size=1,
+        gpu_memory_utilization=0.85,
+        max_num_batched_tokens=1024,
+        max_num_seqs=8,
+        enable_prefix_caching=(mode == "on"),
+        # Qwen3.5 carries a vision tower, but these prompts are text-only.
+        limit_mm_per_prompt={"image": 0, "video": 0},
+        disable_log_stats=False,  # get_metrics() needs the stat loggers
+    )
+    outputs = llm.generate([SHARED_PREFIX + q for q in QUESTIONS],
+                           SamplingParams(temperature=0.0, max_tokens=32))
+
+    metrics: dict[str, float] = {}
+    for m in llm.get_metrics():
+        if m.name in ("vllm:prefix_cache_queries", "vllm:prefix_cache_hits"):
+            value = getattr(m, "value", None)
+            if value is None:
+                value = sum(getattr(m, "values", []) or [])
+            metrics[m.name] = metrics.get(m.name, 0) + value
+
+    with open(out_path, "w") as f:
+        json.dump(
+            {
+                "metrics": metrics,
+                "token_ids": [list(o.outputs[0].token_ids) for o in outputs],
+                "texts": [o.outputs[0].text for o in outputs],
+            }, f)
+
+
+def _run_case(mode: str) -> dict:
+    """Run one engine in a subprocess and return its result."""
+    with tempfile.TemporaryDirectory() as tmp:
+        out_path = os.path.join(tmp, f"{mode}.json")
+        env = dict(os.environ,
+                   MODEL_IMPL_TYPE="vllm",
+                   SKIP_JAX_PRECOMPILE="1",
+                   VLLM_XLA_CHECK_RECOMPILATION="0")
+        proc = subprocess.run([sys.executable, __file__, mode, out_path],
+                              env=env,
+                              capture_output=True,
+                              text=True,
+                              timeout=1800)
+        if not os.path.exists(out_path):
+            raise AssertionError(
+                f"prefix-caching-{mode} run produced no output\n"
+                f"--- stdout ---\n{proc.stdout[-4000:]}\n"
+                f"--- stderr ---\n{proc.stderr[-4000:]}")
+        with open(out_path) as f:
+            return json.load(f)
+
+
+def test_mamba_prefix_caching_matches_baseline():
+    """Greedy output must not change when prefix caching is enabled.
+
+    All prompts share a long prefix, so every request after the first hits
+    the cache and resumes its linear-attention state from a block another
+    request wrote. Any mis-addressing of those state blocks shows up as a
+    token divergence here.
+    """
+    baseline = _run_case("off")
+    cached = _run_case("on")
+
+    queries = cached["metrics"].get("vllm:prefix_cache_queries", 0)
+    hits = cached["metrics"].get("vllm:prefix_cache_hits", 0)
+    print(f"  prefix cache: {hits:.0f}/{queries:.0f} tokens hit "
+          f"({hits / queries if queries else 0:.1%})")
+
+    # Without hits the comparison below would pass trivially, having
+    # exercised none of the state-reuse path.
+    assert hits > 0, (
+        "no prefix cache hits: the shared prefix was never reused, so this "
+        "test did not exercise mamba state reuse")
+
+    mismatched = [
+        i for i, (b, c) in enumerate(
+            zip(baseline["token_ids"], cached["token_ids"])) if b != c
+    ]
+    for i in mismatched:
+        print(f"Token mismatch for prompt {i} ({QUESTIONS[i]!r}):")
+        print(f"  prefix caching off: {baseline['texts'][i]!r}")
+        print(f"  prefix caching on:  {cached['texts'][i]!r}")
+
+    assert not mismatched, (
+        f"{len(mismatched)}/{len(QUESTIONS)} prompts changed when prefix "
+        f"caching was enabled; linear-attention state is not being reused "
+        f"correctly")
+
+
+if __name__ == "__main__":
+    # Child entry point for `_run_case`.
+    _generate(sys.argv[1], sys.argv[2])

--- a/tests/kernels/gdn_attention_v3_test.py
+++ b/tests/kernels/gdn_attention_v3_test.py
@@ -857,3 +857,124 @@ class GDNAttentionTest(parameterized.TestCase):
                                    output_ref[half:],
                                    rtol=2e-2,
                                    atol=2e-2)
+
+    def test_split_read_write_state_slots(self):
+        """Resume from one state slot while checkpointing into another.
+
+        This is the mamba prefix-caching path (`mamba_cache_mode="align"`):
+        a request continues from the state block cached at the last block
+        boundary and writes its new checkpoint into the block covering the
+        current position. The continuation must be numerically identical to
+        reading and writing one slot, and the slot that was read must be
+        left untouched so other requests can still hit it in the cache.
+        """
+
+        kq_head_dim = 128
+        v_head_dim = 128
+        n_kq = 2
+        n_v = 8
+        kernel_size = 4
+
+        half = 32
+        full = 64
+        # Slot 0 is the null block; step A writes slot 1, step B reads slot 1
+        # and writes slot 2.
+        read_slot, write_slot = 1, 2
+        num_blocks = 3
+
+        rngs = iter(jax.random.split(jax.random.key(23), 12))
+        query = jax.random.normal(next(rngs), (full, n_kq * kq_head_dim))
+        key = jax.random.normal(next(rngs), (full, n_kq * kq_head_dim))
+        value = jax.random.normal(next(rngs), (full, n_v * v_head_dim))
+        b = jax.random.normal(next(rngs), (full, n_v))
+        a = jax.random.normal(next(rngs), (full, n_v))
+
+        conv_dim = (n_kq * kq_head_dim) * 2 + n_v * v_head_dim
+        conv_weight = jax.random.normal(next(rngs), (conv_dim, 1, kernel_size))
+        conv_bias = jax.random.normal(next(rngs), (conv_dim, ))
+        A_log = jax.random.normal(next(rngs), (n_v, ))
+        dt_bias = jax.random.normal(next(rngs), (n_v, ))
+
+        mixed_qkv_full = jnp.concatenate([query, key, value], axis=-1)
+
+        conv_state_zero = jnp.zeros((num_blocks, kernel_size - 1, conv_dim))
+        recurrent_state_zero = jnp.zeros(
+            (num_blocks, n_v, kq_head_dim, v_head_dim))
+
+        run_jitted = jax.jit(
+            wrapper.fused_conv1d_gdn,
+            static_argnames=["n_kq", "n_v", "d_k", "d_v", "kernel_size"],
+        )
+        common_static = dict(
+            conv_weight=conv_weight,
+            conv_bias=conv_bias,
+            a_log=A_log,
+            dt_bias=dt_bias,
+            n_kq=n_kq,
+            n_v=n_v,
+            d_k=kq_head_dim,
+            d_v=v_head_dim,
+            kernel_size=kernel_size,
+        )
+
+        # Single-shot reference over all 64 tokens from a zero state.
+        (_, _), output_ref = run_jitted(
+            qkv=mixed_qkv_full,
+            b=b,
+            a=a,
+            conv_state=conv_state_zero,
+            recurrent_state=recurrent_state_zero,
+            query_start_loc=jnp.array([0, full]),
+            state_indices=jnp.array([read_slot]),
+            distribution=jnp.array([0, 1, 1], dtype=jnp.int32),
+            seq_lens=jnp.array([full], dtype=jnp.int32),
+            **common_static,
+        )
+
+        # Step A: first half from a zero state, checkpointing into read_slot.
+        (conv_after_a, rec_after_a), _ = run_jitted(
+            qkv=mixed_qkv_full[:half],
+            b=b[:half],
+            a=a[:half],
+            conv_state=conv_state_zero,
+            recurrent_state=recurrent_state_zero,
+            query_start_loc=jnp.array([0, half]),
+            state_indices=jnp.array([read_slot]),
+            distribution=jnp.array([0, 1, 1], dtype=jnp.int32),
+            seq_lens=jnp.array([half], dtype=jnp.int32),
+            **common_static,
+        )
+
+        # Step B: second half, resuming from read_slot but checkpointing into
+        # write_slot — the block-boundary crossing that align mode performs.
+        (conv_after_b, rec_after_b), output_b = run_jitted(
+            qkv=mixed_qkv_full[half:],
+            b=b[half:],
+            a=a[half:],
+            conv_state=conv_after_a,
+            recurrent_state=rec_after_a,
+            query_start_loc=jnp.array([0, half]),
+            state_indices=jnp.array([write_slot]),
+            read_state_indices=jnp.array([read_slot]),
+            distribution=jnp.array([0, 1, 1], dtype=jnp.int32),
+            seq_lens=jnp.array([full], dtype=jnp.int32),
+            **common_static,
+        )
+
+        # Splitting the slots must not change the numerics.
+        np.testing.assert_allclose(output_b,
+                                   output_ref[half:],
+                                   rtol=2e-2,
+                                   atol=2e-2)
+
+        # The slot that was read is the cached prefix state; leaving it intact
+        # is what lets a later request hit it.
+        np.testing.assert_array_equal(conv_after_b[read_slot],
+                                      conv_after_a[read_slot])
+        np.testing.assert_array_equal(rec_after_b[read_slot],
+                                      rec_after_a[read_slot])
+
+        # The new checkpoint landed in write_slot, which started out zeroed.
+        self.assertTrue(
+            np.any(np.asarray(rec_after_b[write_slot]) != 0.0),
+            "write_slot should hold the step's final recurrent state")

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -231,9 +231,12 @@ class TestTpuPlatform:
 
         assert mm_cfg.mm_device_do_normalize == expected_flag
 
-    @pytest.mark.parametrize("is_hybrid,expected_prefix_caching", [
-        (True, False),
-        (False, True),
+    @pytest.mark.parametrize("is_hybrid,unsupported,expected_prefix_caching", [
+        (True, None, True),
+        (True, "dp", False),
+        (True, "spec", False),
+        (True, "continue_decode", False),
+        (False, None, True),
     ])
     @patch("tpu_inference.platforms.tpu_platform.envs.TPU_MULTIHOST_BACKEND",
            "")
@@ -243,10 +246,14 @@ class TestTpuPlatform:
     )
     def test_check_and_update_config_hybrid_prefix_caching(
             self, mock_update, mock_sharding, vllm_config, is_hybrid,
-            expected_prefix_caching):
-        """Prefix caching is force-disabled for hybrid (mamba/linear-attention)
-        models on TPU — cached-prefix reuse garbles GDN outputs — and left
-        untouched for non-hybrid models."""
+            unsupported, expected_prefix_caching):
+        """Hybrid (mamba/linear-attention) models keep prefix caching.
+
+        Their recurrent state is addressed by block id in
+        `mamba_cache_mode="align"`. It is turned off only for the setups that
+        addressing scheme cannot serve, so those keep working rather than
+        failing at runtime.
+        """
         vllm_config.parallel_config.pipeline_parallel_size = 1
         vllm_config.scheduler_config.is_multimodal_model = False
         vllm_config.compilation_config.mode = "dummy"
@@ -260,11 +267,21 @@ class TestTpuPlatform:
         vllm_config.cache_config.mamba_cache_mode = "align"
         vllm_config.cache_config.mamba_block_size = 256
 
+        # check_and_update_config replaces sharding_config with the manager's
+        # output, so the DP size has to come from the patched manager.
+        mock_sharding.from_vllm_config.return_value.total_dp_size = (
+            2 if unsupported == "dp" else 1)
+        vllm_config.speculative_config = (object()
+                                          if unsupported == "spec" else None)
+        vllm_config.additional_config = {
+            "enable_continue_decode": unsupported == "continue_decode"
+        }
+
         TpuPlatform.check_and_update_config(vllm_config)
 
         assert (vllm_config.cache_config.enable_prefix_caching ==
                 expected_prefix_caching)
-        if is_hybrid:
+        if not expected_prefix_caching:
             # Derived mamba fields must be reset to their prefix-caching-off
             # defaults or vLLM's "--mamba-block-size can only be set with
             # --enable-prefix-caching" validator rejects the config.

--- a/tests/runner/test_mamba_align_state_indices.py
+++ b/tests/runner/test_mamba_align_state_indices.py
@@ -1,0 +1,183 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the vLLM project
+"""Mamba prefix caching: read/write state slot derivation.
+
+`build_align_state_indices` turns the mamba group's block table into the pair
+of slots a step reads its recurrent state from and writes its checkpoint to.
+It touches no device state, so it is checked here against hand-worked block
+tables rather than on a TPU.
+
+The invariant it encodes comes from vLLM's
+`Scheduler._mamba_block_aligned_split`: block row `p` holds the state after
+exactly `(p + 1) * block_size` tokens.
+"""
+import numpy as np
+import pytest
+# torch and vllm must be imported before tpu_inference, as in the other
+# runner tests: tpu_inference preloads an XLA copy whose static initializers
+# collide with jaxlib's if the two load in the other order.
+import torch  # noqa: F401
+from vllm.sampling_params import SamplingParams  # noqa: F401
+
+from tpu_inference.runner.mamba_prefix_caching import \
+    build_align_state_indices
+
+BLOCK_SIZE = 16
+MAX_NUM_REQS = 4
+
+
+def _build(block_table: np.ndarray, num_computed: list[int],
+           num_scheduled: list[int]) -> tuple[np.ndarray, np.ndarray]:
+    """Run the derivation over `block_table` for the given token counts."""
+    num_reqs = len(num_computed)
+    computed = np.zeros(MAX_NUM_REQS, dtype=np.int32)
+    computed[:num_reqs] = num_computed
+
+    return build_align_state_indices(
+        block_table=block_table,
+        num_computed_tokens=computed,
+        num_scheduled_tokens=np.array(num_scheduled, dtype=np.int32),
+        block_size=BLOCK_SIZE,
+        max_num_reqs=MAX_NUM_REQS,
+        req_indices=np.arange(num_reqs),
+    )
+
+
+def test_first_chunk_writes_first_row():
+    """A fresh request has no state to resume from.
+
+    Its read row clamps to row 0 — the request's own first block. That slot
+    is never actually read: the kernel gates the load on `has_initial_state`
+    (`seq_lens - query_lens > 0`), which is false here. The clamp only has to
+    keep the index in range.
+    """
+    block_table = np.zeros((MAX_NUM_REQS, 8), dtype=np.int32)
+    block_table[0, 0] = 7
+
+    write, read = _build(block_table, num_computed=[0], num_scheduled=[16])
+
+    assert write[0] == 7, "state after 16 tokens belongs in row 0"
+    assert read[0] == 7
+
+
+def test_step_inside_a_block_reads_and_writes_the_same_slot():
+    """Not every step crosses a boundary; those keep one slot."""
+    block_table = np.zeros((MAX_NUM_REQS, 8), dtype=np.int32)
+    block_table[0, 0] = 7
+
+    # Tokens 4..12 of a 16-token block: both endpoints sit in row 0.
+    write, read = _build(block_table, num_computed=[4], num_scheduled=[8])
+
+    assert write[0] == 7
+    assert read[0] == 7
+
+
+def test_boundary_crossing_reads_previous_row_and_writes_the_new_one():
+    """The case the whole design exists for.
+
+    Resuming at a block boundary must read the checkpoint the previous step
+    left behind and write into the freshly allocated block, so the cached
+    state survives for another request to hit.
+    """
+    block_table = np.zeros((MAX_NUM_REQS, 8), dtype=np.int32)
+    block_table[0, 0] = 7  # holds the state after 16 tokens
+    block_table[0, 1] = 9  # allocated for the state after 32 tokens
+
+    write, read = _build(block_table, num_computed=[16], num_scheduled=[16])
+
+    assert read[0] == 7
+    assert write[0] == 9
+
+
+def test_prefix_cache_hit_resumes_from_the_cached_block():
+    """A cache hit admits a request with num_computed_tokens > 0.
+
+    Its read slot must be the block the *earlier* request populated, which
+    is what makes the shared prefix free rather than recomputed.
+    """
+    block_table = np.zeros((MAX_NUM_REQS, 8), dtype=np.int32)
+    # Rows 0-1 came from the prefix cache; row 2 is newly allocated.
+    block_table[0, 0] = 21
+    block_table[0, 1] = 22
+    block_table[0, 2] = 30
+
+    write, read = _build(block_table, num_computed=[32], num_scheduled=[10])
+
+    assert read[0] == 22, "must resume from the last cached checkpoint"
+    assert write[0] == 30
+
+
+def test_decode_step_stays_on_its_block():
+    """A single decode token rarely crosses a boundary."""
+    block_table = np.zeros((MAX_NUM_REQS, 8), dtype=np.int32)
+    block_table[0, 2] = 30
+
+    write, read = _build(block_table, num_computed=[40], num_scheduled=[1])
+
+    assert read[0] == 30
+    assert write[0] == 30
+
+
+def test_decode_step_that_crosses_a_boundary():
+    """...but when it does, it must still move to the new block."""
+    block_table = np.zeros((MAX_NUM_REQS, 8), dtype=np.int32)
+    block_table[0, 2] = 30
+    block_table[0, 3] = 31
+
+    # 48 computed tokens = exactly 3 blocks, so the next token opens row 3.
+    write, read = _build(block_table, num_computed=[48], num_scheduled=[1])
+
+    assert read[0] == 30
+    assert write[0] == 31
+
+
+def test_padded_requests_point_at_the_null_block():
+    """Unused persistent-batch slots must not alias a live request's state.
+
+    Positions past `num_reqs` are padding the kernel still walks over, so
+    they have to land on block id 0 rather than on whatever the block table
+    happens to hold.
+    """
+    block_table = np.full((MAX_NUM_REQS, 8), 99, dtype=np.int32)
+    block_table[0, 0] = 7
+    block_table[1, 0] = 8
+
+    write, read = _build(block_table,
+                         num_computed=[0, 0],
+                         num_scheduled=[16, 16])
+
+    assert list(write) == [7, 8, 0, 0]
+    assert list(read) == [7, 8, 0, 0]
+
+
+def test_no_requests_yields_all_null_blocks():
+    block_table = np.full((MAX_NUM_REQS, 8), 5, dtype=np.int32)
+
+    write, read = _build(block_table, num_computed=[], num_scheduled=[])
+
+    assert not write.any()
+    assert not read.any()
+
+
+@pytest.mark.parametrize("num_computed", [16, 32, 48, 64])
+def test_read_row_matches_vllm_preprocess_mamba(num_computed: int):
+    """Cross-check against the formula GPU uses to pick its copy source.
+
+    `vllm/v1/worker/mamba_utils.py::preprocess_mamba` computes
+    `prev = (num_computed_tokens - 1) // block_size` and
+    `curr = cdiv(num_computed + num_scheduled, block_size) - 1`, then copies
+    prev into curr. The TPU path must select the same two rows.
+    """
+    num_scheduled = 16
+    block_table = np.arange(MAX_NUM_REQS * 8, dtype=np.int32).reshape(
+        MAX_NUM_REQS, 8) + 1
+
+    write, read = _build(block_table,
+                         num_computed=[num_computed],
+                         num_scheduled=[num_scheduled])
+
+    expected_read_row = (num_computed - 1) // BLOCK_SIZE
+    expected_write_row = -(-(num_computed + num_scheduled) // BLOCK_SIZE) - 1
+
+    assert read[0] == block_table[0, expected_read_row]
+    assert write[0] == block_table[0, expected_write_row]

--- a/tpu_inference/kernels/gdn/v3/memory_ref.py
+++ b/tpu_inference/kernels/gdn/v3/memory_ref.py
@@ -78,10 +78,15 @@ class MetadataRef:
     s_idx_has_initial_state: Any
     s_idx_to_state_indices: Any
     # Per-sequence state read offset for speculative decoding: the initial
-    # state is read from `s_idx_to_state_indices[s] + s_idx_to_read_offset[s]`
+    # state is read from `s_idx_to_read_indices[s] + s_idx_to_read_offset[s]`
     # (the checkpoint of the last accepted token). Zero everywhere without
     # speculative decoding.
     s_idx_to_read_offset: Any
+    # Slot the initial state is read from. Equal to `s_idx_to_state_indices`
+    # unless mamba prefix caching is on, where a sequence resumes from the
+    # cached state block of the previous block boundary and checkpoints into
+    # a different block (see `cache_config.mamba_cache_mode == "align"`).
+    s_idx_to_read_indices: Any
 
     @classmethod
     def create(
@@ -96,6 +101,7 @@ class MetadataRef:
         s_idx_has_initial_state: jax.Array,
         s_idx_to_state_indices: jax.Array,
         s_idx_to_read_offset: jax.Array,
+        s_idx_to_read_indices: jax.Array,
     ):
         # NOTE: First dim does not matter when it comes to calculating stride.
         shape = (1, cfgs.seq_tile_size)
@@ -109,6 +115,7 @@ class MetadataRef:
             s_idx_has_initial_state=s_idx_has_initial_state,
             s_idx_to_state_indices=s_idx_to_state_indices,
             s_idx_to_read_offset=s_idx_to_read_offset,
+            s_idx_to_read_indices=s_idx_to_read_indices,
         )
 
     def __len__(self) -> int:
@@ -262,7 +269,7 @@ class StateBufferedRef(BaseBufferedRef):
 
             is_first_tile = self.metadata_ref.p_id_is_first_tile[p_id, idx]
             s_idx = self.metadata_ref.p_id_to_s_idx[p_id, idx]
-            state_idx = self.metadata_ref.s_idx_to_state_indices[s_idx]
+            state_idx = self.metadata_ref.s_idx_to_read_indices[s_idx]
             has_initial_state = self.metadata_ref.s_idx_has_initial_state[
                 s_idx]
             should_read = jnp.logical_and(is_first_tile, has_initial_state)

--- a/tpu_inference/kernels/gdn/v3/metadata.py
+++ b/tpu_inference/kernels/gdn/v3/metadata.py
@@ -26,18 +26,22 @@ def compute_batched_seq_metadata(
     state_indices: jax.Array,
     read_offsets: jax.Array,
     end_seq: jax.Array,
+    read_indices: jax.Array | None = None,
 ) -> memory_ref.MetadataRef:
     """Metadata for computing multiple sequences per tile.
 
     A sequence contributes exactly one tile holding all of its query tokens:
     a single decoded token, or a speculative verify window of up to
     `cfg.window_size` of them. The initial state is read from
-    `state_indices[s] + read_offsets[s]` and one state checkpoint per window
-    position is written back to `state_indices[s] + t`.
+    `read_indices[s] + read_offsets[s]` and one state checkpoint per window
+    position is written back to `state_indices[s] + t`. `read_indices`
+    defaults to `state_indices` (read and write the same slot).
     """
 
     max_seqs = seq_lens.size
     all_seqs = jnp.arange(max_seqs)
+    if read_indices is None:
+        read_indices = state_indices
 
     # NOTE: Only supports use case where query_lens[i] <= cfg.window_size where
     # i < end_seq. This must be guaranteed by the function caller.
@@ -58,6 +62,7 @@ def compute_batched_seq_metadata(
         s_idx_has_initial_state=has_initial_state,
         s_idx_to_state_indices=state_indices,
         s_idx_to_read_offset=read_offsets,
+        s_idx_to_read_indices=read_indices,
     )
 
 
@@ -68,6 +73,7 @@ def compute_per_seq_metadata(
     state_indices: jax.Array,
     start_seq: jax.Array,
     end_seq: jax.Array,
+    read_indices: jax.Array | None = None,
 ) -> memory_ref.MetadataRef:
     """Metadata for computing single sequence per tile."""
 
@@ -75,11 +81,14 @@ def compute_per_seq_metadata(
     max_tokens = cfg.batch_size
     all_seqs = jnp.arange(max_seqs)
     all_tokens = jnp.arange(max_tokens)
+    if read_indices is None:
+        read_indices = state_indices
 
     # Shift to ensure first element is for start_seq.
     query_start_loc = jnp.roll(query_start_loc, shift=-start_seq)
     seq_lens = jnp.roll(seq_lens, shift=-start_seq)
     state_indices = jnp.roll(state_indices, shift=-start_seq)
+    read_indices = jnp.roll(read_indices, shift=-start_seq)
 
     query_lens = query_start_loc[1:] - query_start_loc[:-1]
     # NOTE: query_lens is used for calculating num_tiles. Defensive programming
@@ -144,4 +153,5 @@ def compute_per_seq_metadata(
         s_idx_to_state_indices=state_indices,
         # Prefill/mixed sequences always resume from the group's base slot.
         s_idx_to_read_offset=jnp.zeros_like(state_indices),
+        s_idx_to_read_indices=read_indices,
     )

--- a/tpu_inference/kernels/gdn/v3/wrapper.py
+++ b/tpu_inference/kernels/gdn/v3/wrapper.py
@@ -286,6 +286,7 @@ def fused_conv1d_gdn(
     distribution: jax.Array,  # [3]
     seq_lens: jax.Array,  # [num_seqs]
     read_offsets: jax.Array | None = None,  # [num_seqs]
+    read_state_indices: jax.Array | None = None,  # [num_seqs]
     *,
     n_kq: int,
     n_v: int,
@@ -334,6 +335,12 @@ def fused_conv1d_gdn(
             `state_indices[s] + read_offsets[s]` and write one checkpoint
             per window position to `state_indices[s] + t`. Required when
             `num_spec_tokens > 0`.
+        read_state_indices: Optional [num_seqs] int32 — slot each sequence
+            reads its initial state from, defaulting to `state_indices`.
+            Mamba prefix caching ("align" mode) resumes a sequence from the
+            cached state block of the last block boundary and checkpoints
+            into the block that covers the current position, so the read and
+            write slots differ. `read_offsets` still applies on top of it.
         n_kq: Number of key/query heads.
         n_v: Number of value heads.
         d_k: Key/query dimension.
@@ -379,6 +386,10 @@ def fused_conv1d_gdn(
         read_offsets = jnp.zeros((num_seqs, ), dtype=jnp.int32)
     assert read_offsets.shape == (num_seqs, )
     read_offsets = read_offsets.astype(jnp.int32)
+    if read_state_indices is None:
+        read_state_indices = state_indices
+    assert read_state_indices.shape == (num_seqs, )
+    read_state_indices = read_state_indices.astype(state_indices.dtype)
     act_in_dtype = qkv.dtype
     assert a.dtype == b.dtype == qkv.dtype == act_in_dtype
 
@@ -486,6 +497,7 @@ def fused_conv1d_gdn(
                 state_indices=state_indices,
                 read_offsets=read_offsets,
                 end_seq=distribution[0],
+                read_indices=read_state_indices,
             )
         else:
             metadata_obj = metadata.compute_per_seq_metadata(
@@ -495,6 +507,7 @@ def fused_conv1d_gdn(
                 state_indices=state_indices,
                 start_seq=distribution[0],
                 end_seq=distribution[-1],
+                read_indices=read_state_indices,
             )
 
         metadata_spec = jax.tree.map(lambda _: smem_spec, metadata_obj)

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -55,6 +55,7 @@ class PCPMetadata:
         "query_start_loc",
         "request_distribution",
         "mamba_state_indices",
+        "mamba_read_state_indices",
         "pcp",
     ],
     meta_fields=["padded_num_reqs", "pcp_cache_pages"],
@@ -80,6 +81,13 @@ class AttentionMetadata(object):
     # None for models without mamba layers; pure-mamba models would also
     # use this field, only hybrid models exercise it today.
     mamba_state_indices: jax.Array | None = None
+    # (max_num_seqs,) int32 — slot each request reads its initial recurrent
+    # state from. None means "same as `mamba_state_indices`", which is the
+    # case unless mamba prefix caching is on: in `mamba_cache_mode="align"`
+    # a request resumes from the state block cached at the last block
+    # boundary and checkpoints into the block covering its current position,
+    # so the read and write slots differ.
+    mamba_read_state_indices: jax.Array | None = None
 
     # PCP-specific metadata. None when not running prefill context parallelism.
     pcp: PCPMetadata | None = None
@@ -103,6 +111,7 @@ class AttentionMetadata(object):
         "query_start_loc",
         "request_distribution",
         "mamba_state_indices",
+        "mamba_read_state_indices",
     ],
     meta_fields=["padded_num_reqs"],
 )
@@ -124,6 +133,10 @@ class SharedAttentionMetadata(object):
     # None for models without mamba layers; pure-mamba models would also
     # use this field, only hybrid models exercise it today.
     mamba_state_indices: jax.Array | None = None
+    # (max_num_seqs,) int32 — slot each request reads its initial recurrent
+    # state from; None means "same as `mamba_state_indices`". See the
+    # matching field on `AttentionMetadata`.
+    mamba_read_state_indices: jax.Array | None = None
 
     # The actual number of requests padded to the compiled buckets. The bucket
     # contains only max_reqs by default to reduce model precompilation time.

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -15,7 +15,6 @@
 Bridge the torch gdn_attention_core op for gated deltanet attention TPU impl
 
 """
-import functools
 from typing import Optional, Tuple
 
 import jax
@@ -47,6 +46,7 @@ def run_jax_gdn_attention(
     d_v: int,
     kernel_size: int,
     mesh: jax.sharding.Mesh,
+    read_state_indices: Optional[jnp.ndarray] = None,
 ) -> Tuple[Tuple[jnp.ndarray, jnp.ndarray], jnp.ndarray]:
     """Runs the Jax GDN attention mechanism.
 
@@ -81,6 +81,12 @@ def run_jax_gdn_attention(
         kernel_size: Convolution kernel size.
         mesh: The device mesh for distributed computation.
         config: Configuration for implementation selection.
+        read_state_indices: Optional tensor of shape `(max_reqs,)` mapping
+          request index to the state index its initial state is read from.
+          Defaults to `state_indices` (read and write the same slot). Mamba
+          prefix caching passes a different slot here, since a request
+          resumes from the cached state block of the last block boundary and
+          checkpoints into the block covering its current position.
 
     Returns:
         A tuple containing:
@@ -108,6 +114,8 @@ def run_jax_gdn_attention(
         P(ShardingAxisName.ATTN_DATA),  # distribution
         P(ShardingAxisName.ATTN_DATA),  # seq_lens
     )
+    if read_state_indices is not None:
+        in_specs += (P(ShardingAxisName.ATTN_DATA), )  # read_state_indices
 
     out_specs = (
         (
@@ -121,14 +129,25 @@ def run_jax_gdn_attention(
 
     tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
 
-    p_run_jax_gdn_attention_local = functools.partial(
-        wrapper.fused_conv1d_gdn,
-        n_kq=n_kq // tp_size,
-        n_v=n_v // tp_size,
-        d_k=d_k,
-        d_v=d_v,
-        kernel_size=kernel_size,
-    )
+    # `read_state_indices` is the trailing shard_map argument, present only
+    # when the caller supplies one, so the non-prefix-caching graph keeps the
+    # exact argument list it had before.
+    def _fused_conv1d_gdn_local(*kernel_args):
+        read_indices = kernel_args[-1] if read_state_indices is not None \
+            else None
+        if read_state_indices is not None:
+            kernel_args = kernel_args[:-1]
+        return wrapper.fused_conv1d_gdn(
+            *kernel_args,
+            read_state_indices=read_indices,
+            n_kq=n_kq // tp_size,
+            n_v=n_v // tp_size,
+            d_k=d_k,
+            d_v=d_v,
+            kernel_size=kernel_size,
+        )
+
+    p_run_jax_gdn_attention_local = _fused_conv1d_gdn_local
 
     mapped_fn = jax.shard_map(
         p_run_jax_gdn_attention_local,
@@ -138,7 +157,7 @@ def run_jax_gdn_attention(
         check_vma=False,
     )
 
-    (new_conv_state, new_recurrent_state), output = mapped_fn(
+    mapped_args = (
         j_mixed_qkv,
         j_b,
         j_a,
@@ -153,5 +172,9 @@ def run_jax_gdn_attention(
         distribution,
         seq_lens,
     )
+    if read_state_indices is not None:
+        mapped_args += (read_state_indices, )
+
+    (new_conv_state, new_recurrent_state), output = mapped_fn(*mapped_args)
 
     return (new_conv_state, new_recurrent_state), output

--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -68,6 +68,7 @@ def gdn_attention_core_tpu(
     query_start_loc = first_attn_metadata.query_start_loc
     seq_lens = first_attn_metadata.seq_lens
     state_indices = first_attn_metadata.mamba_state_indices
+    read_state_indices = first_attn_metadata.mamba_read_state_indices
 
     layer_module = fc.no_compile_layers[layer_name]
     vllm_context = get_vllm_model_wrapper_context()
@@ -130,6 +131,13 @@ def gdn_attention_core_tpu(
     state_indices_sliced = truncate_sharded_tensor(state_indices,
                                                    padded_num_reqs_per_dp,
                                                    dp_size)
+    read_state_indices_sliced = None
+    if read_state_indices is not None:
+        # Mamba prefix caching: resume from the block cached at the last
+        # block boundary while checkpointing into `state_indices`.
+        read_state_indices_sliced = truncate_sharded_tensor(
+            read_state_indices.astype(jnp.int32), padded_num_reqs_per_dp,
+            dp_size)
     query_start_loc_sliced = truncate_sharded_tensor(
         query_start_loc, padded_num_reqs_per_dp + 1, dp_size)
     seq_lens_sliced = truncate_sharded_tensor(seq_lens, padded_num_reqs_per_dp,
@@ -156,6 +164,7 @@ def gdn_attention_core_tpu(
          d_v,
          kernel_size,
          mesh=mesh,
+         read_state_indices=read_state_indices_sliced,
      )
     if state_len > kernel_size - 1:
         remaining_old_state = conv_state[:, kernel_size - 1:, :]

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -284,17 +284,31 @@ class TpuPlatform(Platform):
         cls._initialize_sharding_config(vllm_config)
 
         cache_config = vllm_config.cache_config
-        # The TPU hybrid (mamba/linear-attention) path does not support
-        # reusing cached prefixes yet — cache hits garble the output. Keep
-        # prefix caching disabled for hybrid models until the GDN/mamba
-        # kernels handle cached prefixes.
+        # Hybrid (mamba/linear-attention) models now reuse cached prefixes
+        # via `mamba_cache_mode="align"`, which addresses recurrent state by
+        # block id (see `runner/mamba_prefix_caching.py`). Three setups still
+        # cannot: DP attention shards the mamba state over the DP axis while
+        # block ids address the whole pool, speculative decoding needs
+        # consecutive state slots for its verify window, and continue_decode
+        # reuses one set of slots for every step of its on-device loop.
+        # Turning prefix caching off here keeps those configurations working
+        # instead of failing at runtime.
+        unsupported_reason = None
         if (cache_config and cache_config.enable_prefix_caching
                 and vllm_config.model_config is not None
                 and getattr(vllm_config.model_config, "is_hybrid", False)):
+            if vllm_config.sharding_config.total_dp_size > 1:
+                unsupported_reason = "DP attention"
+            elif vllm_config.speculative_config is not None:
+                unsupported_reason = "speculative decoding"
+            elif vllm_config.additional_config.get("enable_continue_decode",
+                                                   False):
+                unsupported_reason = "continue_decode"
+        if unsupported_reason is not None:
             logger.warning(
                 "[tpu_platform] Disabling prefix caching: hybrid "
                 "(mamba/linear-attention) models do not support cached "
-                "prefixes on TPU yet (accuracy garbles on cache hits).")
+                "prefixes with %s on TPU.", unsupported_reason)
             cache_config.enable_prefix_caching = False
             # Reset the mamba cache fields derived from the enabled state to
             # their prefix-caching-off defaults; stale values trip vLLM's

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -435,12 +435,28 @@ class TpuPlatform(Platform):
     def update_block_size_for_backend(cls, vllm_config: VllmConfig) -> None:
         # TODO: TPU still sets block_size in check_and_update_config.
         # Move that logic here so block_size is chosen by the backend.
+        cache_config = vllm_config.cache_config
         logger.info(f"Using cache_config.block_size: "
-                    f"{vllm_config.cache_config.block_size} "
+                    f"{cache_config.block_size} "
                     f"instead of overriding with _align_hybrid_block_size() "
                     f"since we set mamba_page_size_padded in "
                     f"kv_cache_manager.py")
-        pass
+
+        # `_align_hybrid_block_size` is where upstream ties the mamba block
+        # size to the (now final) attention block size in align mode. Skipping
+        # that function leaves `mamba_block_size` at whatever it was when
+        # `MambaModelConfig` ran, which is the pre-TPU default rather than the
+        # block size we settled on. The two must agree: a mamba group whose
+        # block size divides the attention one drives `hash_block_size` below
+        # the block size, which turns on partial prefix-cache hits and their
+        # copy-on-write state copies (unimplemented on TPU).
+        if getattr(cache_config, "mamba_cache_mode", "none") == "align":
+            if cache_config.mamba_block_size != cache_config.block_size:
+                logger.info(
+                    "Setting mamba_block_size to %d to match the attention "
+                    "block size (was %d) for mamba prefix caching.",
+                    cache_config.block_size, cache_config.mamba_block_size)
+                cache_config.mamba_block_size = cache_config.block_size
 
     @classmethod
     def is_pin_memory_available(cls):

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -442,6 +442,15 @@ class CompilationManager:
                                                sharding=metadata_attn_sharding)
         else:
             mamba_state_indices = None
+        # Mamba prefix caching passes a second slot array at runtime; the
+        # primer must carry it too or the cached HLO is not reused.
+        if self.runner.mamba_align_group_id is not None:
+            mamba_read_state_indices = device_array(
+                self.runner.mesh,
+                np.zeros(self.runner.max_num_reqs, dtype=np.int32),
+                sharding=metadata_attn_sharding)
+        else:
+            mamba_read_state_indices = None
 
         def build_block_table(kv_cache_gid: int) -> jax.Array:
             block_table_obj = self.runner.input_batch.block_table[kv_cache_gid]
@@ -462,6 +471,7 @@ class CompilationManager:
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                mamba_read_state_indices=mamba_read_state_indices,
                 padded_num_reqs=num_reqs,
                 pcp=pcp,
             )
@@ -475,6 +485,7 @@ class CompilationManager:
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                mamba_read_state_indices=mamba_read_state_indices,
                 padded_num_reqs=num_reqs,
             )
 

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -349,6 +349,20 @@ class KVCacheManager:
         if cache_config.num_gpu_blocks_override is not None:
             return
 
+        if getattr(cache_config, "mamba_cache_mode", "none") == "align":
+            # Mamba prefix caching addresses recurrent state by block id from
+            # the mamba block table, so every layer's mamba array must span
+            # the whole block pool. The compact layout deliberately makes it
+            # smaller than the pool, which would put valid block ids out of
+            # range. Fall back to the uniform sizing, which already charges
+            # each block for its mamba pages.
+            logger.info(
+                "Compact-mamba sizing skipped: mamba_cache_mode='align' "
+                "needs one mamba slot per block id. Attention capacity is "
+                "lower than with prefix caching off; raise --block-size to "
+                "trade prefix-cache granularity for capacity.")
+            return
+
         devices = self.runner.mesh.devices.flatten()
         try:
             hbm_usage = utils.hbm_usage_bytes(devices)

--- a/tpu_inference/runner/mamba_prefix_caching.py
+++ b/tpu_inference/runner/mamba_prefix_caching.py
@@ -1,0 +1,91 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Slot bookkeeping for mamba prefix caching (`mamba_cache_mode="align"`).
+
+With prefix caching on, a hybrid model's recurrent state no longer lives in
+the per-request slot pool `InputBatch` hands out — it lives in
+prefix-cacheable blocks addressed by the mamba group's block table, so a
+request sharing a prefix resumes from the state an earlier request wrote.
+
+Kept free of JAX and runner imports so the addressing can be tested on its
+own; the runner only supplies the block table and token counts.
+"""
+import numpy as np
+
+__all__ = ["build_align_state_indices"]
+
+
+def build_align_state_indices(
+    block_table: np.ndarray,
+    num_computed_tokens: np.ndarray,
+    num_scheduled_tokens: np.ndarray,
+    block_size: int,
+    max_num_reqs: int,
+    req_indices: np.ndarray,
+) -> tuple[np.ndarray, np.ndarray]:
+    """Derive the mamba state slots a step reads from and writes to.
+
+    `align` mode keeps one recurrent-state checkpoint per mamba block. vLLM's
+    invariant (see `Scheduler._mamba_block_aligned_split`) is that block row
+    `p` holds the state after exactly `(p + 1) * block_size` tokens, so the
+    state after `pos` tokens lives in row `(pos - 1) // block_size`.
+
+    A step therefore reads the checkpoint covering `num_computed_tokens` and
+    writes the one covering its last scheduled token. Those rows differ
+    exactly when the step crosses a block boundary. GPU handles that by
+    copying the state between the two blocks before the forward pass
+    (`vllm/v1/worker/mamba_utils.py::preprocess_mamba`); the TPU kernel reads
+    the first and writes the second in a single launch instead, which is
+    equivalent and skips a round-trip of the state through HBM.
+
+    On a prefix-cache hit the read row lands on a block another request
+    populated, which is the state reuse that makes the shared prefix free.
+
+    Args:
+        block_table: `[max_num_reqs, max_num_blocks_per_req]` block ids of
+            the mamba kv-cache group, indexed by persistent-batch position.
+        num_computed_tokens: `[>= max_num_reqs]` tokens already computed per
+            persistent-batch position.
+        num_scheduled_tokens: `[>= num_reqs]` tokens scheduled this step, in
+            `req_indices` order.
+        block_size: mamba block size in tokens.
+        max_num_reqs: length of the returned arrays.
+        req_indices: `[num_reqs]` persistent-batch positions of the requests
+            scheduled this step, in the order the kernel sees them.
+
+    Returns:
+        `(write_indices, read_indices)`, both `[max_num_reqs]` int32 and
+        padded with block id 0 (vLLM's null block) so unused persistent-batch
+        positions cannot alias a live request's state.
+    """
+    write_indices = np.zeros(max_num_reqs, dtype=np.int32)
+    read_indices = np.zeros(max_num_reqs, dtype=np.int32)
+
+    rows = np.asarray(req_indices, dtype=np.intp)
+    num_reqs = rows.size
+    if num_reqs == 0:
+        return write_indices, read_indices
+
+    num_computed = np.asarray(num_computed_tokens)[rows]
+    seq_lens = num_computed + np.asarray(num_scheduled_tokens)[:num_reqs]
+
+    # The read row goes unused when nothing has been computed yet (the
+    # kernel's `has_initial_state` guard is false), so clamping the negative
+    # row to 0 only has to keep it in range.
+    write_rows = np.maximum(seq_lens - 1, 0) // block_size
+    read_rows = np.maximum(num_computed - 1, 0) // block_size
+
+    write_indices[:num_reqs] = block_table[rows, write_rows]
+    read_indices[:num_reqs] = block_table[rows, read_rows]
+    return write_indices, read_indices

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -38,7 +38,7 @@ from vllm.tasks import SupportedTask
 from vllm.utils.math_utils import cdiv
 from vllm.v1.core.sched.output import GrammarOutput
 from vllm.v1.core.sched.output import SchedulerOutput as VllmSchedulerOutput
-from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.outputs import (EMPTY_MODEL_RUNNER_OUTPUT, AsyncModelRunnerOutput,
                              DraftTokenIds, KVConnectorOutput, LogprobsLists,
                              LogprobsTensors, ModelRunnerOutput,
@@ -70,6 +70,7 @@ from tpu_inference.logger import init_logger
 from tpu_inference.models.common.model_loader import get_model
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
+from tpu_inference.runner import mamba_prefix_caching
 from tpu_inference.runner import utils as runner_utils
 from tpu_inference.runner.compilation_manager import CompilationManager
 from tpu_inference.runner.decode_loop import TpuSamplingState, continue_decode
@@ -814,6 +815,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.rank = rank
         self.is_first_rank = is_first_rank
         self.is_last_rank = is_last_rank
+        # Set for real in `_init_mamba_prefix_caching` once the kv cache
+        # config is known; None means mamba state is addressed by the
+        # per-request slot pool rather than by prefix-cacheable blocks.
+        self.mamba_align_group_id: int | None = None
+        self.mamba_align_block_size: int = 0
 
         self._init_random()
         self._init_mesh()
@@ -1291,6 +1297,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             self.input_batch.init_mamba_pools(
                 self.kv_cache_manager.actual_mamba_num_blocks)
 
+        self._init_mamba_prefix_caching(kv_cache_config)
+
         # This buffer grows dynamically to accommodate metadata and block tables.
         # We re-initialize with a precise capacity now that kv_cache_config is known.
         num_kv_groups = len(kv_cache_config.kv_cache_groups)
@@ -1310,6 +1318,78 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         if has_kv_transfer_group():
             get_kv_transfer_group().register_runner(self)
+
+    def _init_mamba_prefix_caching(self,
+                                   kv_cache_config: KVCacheConfig) -> None:
+        """Set up mamba prefix caching (`mamba_cache_mode == "align"`).
+
+        In align mode a request's recurrent state lives in prefix-cacheable
+        blocks addressed by the mamba group's block table, not in the
+        per-request slot pool that `InputBatch` hands out. Record the group
+        id and block size so `_prepare_inputs` can derive the read/write
+        state slots from that block table.
+        """
+        self.mamba_align_group_id = None
+        self.mamba_align_block_size = 0
+
+        if not kv_cache_config.has_mamba_layers:
+            return
+        if getattr(self.cache_config, "mamba_cache_mode", "none") != "align":
+            return
+
+        for gid, group in enumerate(kv_cache_config.kv_cache_groups):
+            if isinstance(group.kv_cache_spec, MambaSpec):
+                self.mamba_align_group_id = gid
+                self.mamba_align_block_size = group.kv_cache_spec.block_size
+                break
+
+        if self.mamba_align_group_id is None:
+            return
+
+        unsupported = None
+        if self.dp_size > 1:
+            unsupported = (
+                "DP attention: the mamba state arrays are sharded over the "
+                "DP axis and hold a slice of the slots, while vLLM's block "
+                "ids address the whole pool")
+        elif self.speculative_config is not None:
+            # A verify window checkpoints one state per window position into
+            # consecutive slots; block ids from the block table are not
+            # consecutive, so the two schemes cannot both hold.
+            unsupported = ("speculative decoding: verify windows need "
+                           "consecutive state slots")
+        elif self.enable_continue_decode:
+            # The on-device decode loop reuses one set of state slots for all
+            # of its steps, so a request crossing a mamba block boundary
+            # mid-loop would checkpoint into the block it already left.
+            unsupported = ("continue_decode: the on-device decode loop "
+                           "cannot re-address state mid-loop")
+        if unsupported is not None:
+            raise NotImplementedError(
+                f"Mamba prefix caching (mamba_cache_mode='align') is not "
+                f"supported with {unsupported}. Pass "
+                f"--no-enable-prefix-caching to run this configuration.")
+
+        logger.info(
+            "Mamba prefix caching enabled: recurrent state is addressed by "
+            "the block table of kv-cache group %d (mamba block size %d).",
+            self.mamba_align_group_id, self.mamba_align_block_size)
+
+    def _build_mamba_align_state_indices(
+        self,
+        req_indices: np.ndarray,
+        num_scheduled_tokens_per_req: np.ndarray,
+    ) -> tuple[np.ndarray, np.ndarray]:
+        """Mamba read/write state slots for this step, from the block table."""
+        return mamba_prefix_caching.build_align_state_indices(
+            block_table=self.input_batch.block_table[
+                self.mamba_align_group_id].get_cpu_tensor(),
+            num_computed_tokens=self.input_batch.num_computed_tokens_cpu,
+            num_scheduled_tokens=num_scheduled_tokens_per_req,
+            block_size=self.mamba_align_block_size,
+            max_num_reqs=self.max_num_reqs,
+            req_indices=req_indices,
+        )
 
     def delete_kv_cache(self) -> None:
         self.kv_cache_manager.delete_kv_cache()
@@ -1331,6 +1411,19 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                                "after execute_model() returns None.")
         reqs = self.input_batch.num_reqs
         toks = scheduler_output.total_num_scheduled_tokens
+
+        if getattr(scheduler_output, "kv_cache_block_copies", None):
+            # Mamba prefix caching asks the worker to copy state between
+            # blocks when a request partially hits a cached block, which
+            # only arises when block hashes are finer than the block size
+            # (DCP, or an explicit --prefix-match-unit). Nothing on the TPU
+            # side performs those copies, and skipping them would resume a
+            # request from an unwritten block.
+            raise NotImplementedError(
+                "Scheduler requested KV cache block copies, which the TPU "
+                "runner does not implement. This happens with mamba prefix "
+                "caching when prefix_match_unit is smaller than the block "
+                "size; leave --prefix-match-unit unset.")
 
         req_id_kwargs = {}
         if jax.profiler.TraceAnnotation.is_enabled():
@@ -3011,7 +3104,20 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         # pure-attention models, leaving the field None keeps AttentionMetadata
         # byte-identical to the pre-compact-mamba layout (so the model_fn
         # signature on those models is unchanged).
-        if self.kv_cache_config.has_mamba_layers:
+        mamba_read_state_indices = None
+        if self.mamba_align_group_id is not None:
+            # Mamba prefix caching: the state slots come from the mamba block
+            # table, so no slot-pool remap (and no DP-local wrap) applies.
+            (mamba_state_indices_cpu,
+             mamba_read_state_indices_cpu) = self._build_mamba_align_state_indices(
+                 req_indices_dp[0], scheduled_tokens_per_dp_rank[0])
+            (request_distribution, mamba_state_indices,
+             mamba_read_state_indices, dev_arrays_payload) = device_array(
+                 self.mesh,
+                 (request_distribution, mamba_state_indices_cpu,
+                  mamba_read_state_indices_cpu, metadata_blob),
+                 sharding=metadata_attn_sharding)
+        elif self.kv_cache_config.has_mamba_layers:
             # Reorder mamba_state_indices per DP rank (like block_tables)
             # and convert global slot ids to rank-local indices so they
             # index correctly into the per-rank shard of the mamba state.
@@ -3061,6 +3167,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                mamba_read_state_indices=mamba_read_state_indices,
                 padded_num_reqs=attn_padded_num_reqs,
                 pcp=pcp_metadata,
             )
@@ -3074,6 +3181,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 query_start_loc=query_start_loc,
                 request_distribution=request_distribution,
                 mamba_state_indices=mamba_state_indices,
+                mamba_read_state_indices=mamba_read_state_indices,
                 padded_num_reqs=attn_padded_num_reqs,
             )
 


### PR DESCRIPTION
## Summary

Hybrid models with linear attention (Qwen3.5 / GDN) could not use prefix caching on TPU. This enables it by implementing vLLM's `mamba_cache_mode="align"` rather than a TPU-specific scheme, so vLLM's scheduler, block manager and cache-hit logic are reused as-is.

## Why this matters

The workaround in #3358 is expensive. Measured on v7x-8 (TP=8, attn_dp=4, gbs1024 trace, 16 streams): **116.5 output tok/s with prefix caching off vs 417.1 with it on — ~3.5x**. That upper figure was obtained by patching the guard out, so its output was incorrect; it bounds what correct prefix caching can recover rather than reporting it.

The correctness problem it works around is severe, not marginal: #3358 measured Qwen3.5-397B-A17B-FP8 at gsm8k **0.01** with prefix caching on vs **0.97** off, same commit.

## The problem

tpu-inference stores recurrent state in a **per-request slot pool** (`InputBatch.mamba_state_indices_cpu`), capped at `max_num_reqs + 1` slots by `_maybe_set_compact_mamba_num_blocks_override`. A request admitted with `num_computed_tokens > 0` from a prefix-cache hit sets `has_initial_state` and reads a slot that was just popped fresh — holding another request's state. Nothing crashes; generation just degrades.

On `main` today the bug is masked rather than absent: #3358 force-disables prefix caching for hybrid models. Before that guard, `enable_prefix_caching` defaulted to `True` and Qwen3.5 is hybrid, so vLLM set `mamba_cache_mode="align"` while tpu-inference ignored it entirely — building a real engine config for `Qwen/Qwen3.5-4B` on that base gave:

```
is_hybrid = True, enable_prefix_caching = True
mamba_cache_mode = align, block_size = 128, mamba_block_size = 16
```

Note `mamba_block_size = 16` against `block_size = 128` — a second bug, fixed below.

## Approach

In align mode the state lives in prefix-cacheable blocks addressed by the mamba group's block table. vLLM's invariant (`Scheduler._mamba_block_aligned_split`) is that block row `p` holds the state after exactly `(p + 1) * block_size` tokens, so per step:

- read row = `(num_computed_tokens - 1) // block_size`
- write row = `cdiv(num_computed + num_scheduled, block_size) - 1`

These differ exactly when the step crosses a block boundary. GPU copies state between the two blocks before each forward (`vllm/v1/worker/mamba_utils.py::preprocess_mamba`); the TPU kernel instead **reads the first and writes the second in a single launch** — equivalent, and it avoids a round-trip of the whole state through HBM. The GDN v3 kernel already separated its read slot from its write slot for speculative verify windows, so this only needed an extra read-slot array (defaulting to the write slots, leaving existing callers unchanged).

Also fixed: `mamba_block_size` was left at `16` against `block_size = 128`, because `tpu_platform` skips upstream's `_align_hybrid_block_size` — which is where the two are tied together. That drove `hash_block_size = gcd(128, 16) = 16`, which switches on partial prefix-cache hits and the copy-on-write state copies (`SchedulerOutput.kv_cache_block_copies`) that the TPU runner cannot perform.

Finally, #3358 added a blanket "disable prefix caching for every hybrid model" guard as a workaround for the garbled output described above. This narrows it to the three setups that block-id addressing genuinely cannot serve, so they degrade gracefully instead of hitting the runner's `NotImplementedError`.

## Validation

On TPU (v7x, `Qwen/Qwen3.5-4B`, tp=1), greedy output over 8 prompts sharing a long prefix:

```
prefix cache: 3584/4222 tokens hit (84.9%)
tokens vs prefix-caching-off baseline: IDENTICAL
```

The hit count is asserted in the test, so the comparison cannot pass without actually exercising state reuse.

- `tests/e2e/test_mamba_prefix_caching.py` — passes (87s)
- `tests/kernels/gdn_attention_v3_test.py::test_split_read_write_state_slots` — passes; the split slots are numerically identical to the single-slot continuation and leave the read block intact for reuse
- `tests/runner/test_mamba_align_state_indices.py` — 12 tests, no hardware needed, including a cross-check that the read/write rows match the `prev`/`curr` rows `preprocess_mamba` copies between
- `tests/platforms/test_tpu_platform.py` — 46 pass, covering which setups keep prefix caching

All of the above was re-run on this branch after rebasing onto current `main` and narrowing #3358's guard, and reproduces exactly (84.9%, identical tokens). Config resolution on this base: `enable_prefix_caching=True`, `mamba_cache_mode=align`, `block_size = mamba_block_size = 128`.

## Scope / limitations

- Raises `NotImplementedError` for **DP attention** (mamba arrays are sharded over the DP axis while block ids address the whole pool), **speculative decoding** (verify windows need consecutive slots) and **continue_decode** (the on-device loop cannot re-address state mid-loop).
- With the compact-mamba pool disabled, every block also pays for its mamba pages, which lowers attention capacity at the default block size (measured: 130k tokens KV, 1398 blocks at `block_size=128`). Raising `--block-size` trades prefix-cache granularity back for capacity; not tuned here.
- Partial-hit copy-on-write is unimplemented and explicitly rejected. It is unreachable with the default config and only arises under DCP or an explicit `--prefix-match-unit`.

## Before merging

- Re-run the e2e on this exact base (pending TPU availability).
- An accuracy run on Qwen3.5-397B-A17B-FP8 — gsm8k should return to ~0.97 with prefix caching on, which is the number #3358 regressed to 0.01 and the most direct proof this fixes the underlying bug.
- A throughput benchmark to see how much of the ~3.5x is actually recovered, given the attention-capacity trade-off above, and to pick a `--block-size` default.
