### PR TITLE
Add TPU_UNSAFE_HYBRID_PREFIX_CACHING to benchmark hybrid prefix caching

### DIFF
--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -271,6 +271,36 @@ class TestTpuPlatform:
             assert vllm_config.cache_config.mamba_cache_mode == "none"
             assert vllm_config.cache_config.mamba_block_size == 4096
 
+    @patch(
+        "tpu_inference.platforms.tpu_platform.envs."
+        "TPU_UNSAFE_HYBRID_PREFIX_CACHING", True)
+    @patch("tpu_inference.platforms.tpu_platform.envs.TPU_MULTIHOST_BACKEND",
+           "")
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    @patch(
+        "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
+    )
+    def test_hybrid_prefix_caching_unsafe_override(self, mock_update,
+                                                   mock_sharding, vllm_config):
+        """TPU_UNSAFE_HYBRID_PREFIX_CACHING keeps prefix caching (and the
+        derived mamba fields) untouched for hybrid models, so the throughput
+        ceiling can be measured. Output is wrong in this mode by design."""
+        vllm_config.parallel_config.pipeline_parallel_size = 1
+        vllm_config.scheduler_config.is_multimodal_model = False
+        vllm_config.compilation_config.mode = "dummy"
+        vllm_config.compilation_config.backend = ""
+        vllm_config.model_config.is_hybrid = True
+        vllm_config.model_config.max_model_len = 4096
+        vllm_config.cache_config.enable_prefix_caching = True
+        vllm_config.cache_config.mamba_cache_mode = "align"
+        vllm_config.cache_config.mamba_block_size = 256
+
+        TpuPlatform.check_and_update_config(vllm_config)
+
+        assert vllm_config.cache_config.enable_prefix_caching is True
+        assert vllm_config.cache_config.mamba_cache_mode == "align"
+        assert vllm_config.cache_config.mamba_block_size == 256
+
     @patch("tpu_inference.platforms.tpu_platform.envs.TPU_MULTIHOST_BACKEND",
            "")
     @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -20,6 +20,7 @@ if TYPE_CHECKING:
     MODEL_IMPL_TYPE: str = "auto"
     DRAFT_MODEL_IMPL_TYPE: str = "auto"
     NEW_MODEL_DESIGN: bool = False
+    TPU_UNSAFE_HYBRID_PREFIX_CACHING: bool = False
     PHASED_PROFILING_DIR: str = ""
     AGGREGATED_STATS_DIR: str = ""
     PYTHON_TRACER_LEVEL: int = 1
@@ -262,6 +263,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable new experimental model design
     "NEW_MODEL_DESIGN":
     env_bool("NEW_MODEL_DESIGN", default=False),
+    # Keep prefix caching enabled for hybrid (mamba/linear-attention) models
+    # instead of force-disabling it. UNSAFE: the TPU GDN/mamba path cannot
+    # resume from a cached prefix, so cache hits produce wrong output
+    # (Qwen3.5-397B-A17B-FP8 scores 0.01 on gsm8k). Benchmarking only, to
+    # measure the throughput ceiling that correct cached prefixes would give.
+    "TPU_UNSAFE_HYBRID_PREFIX_CACHING":
+    env_bool("TPU_UNSAFE_HYBRID_PREFIX_CACHING", default=False),
     # Directory to store phased profiling output
     "PHASED_PROFILING_DIR":
     lambda: os.getenv("PHASED_PROFILING_DIR", ""),

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -134,6 +134,7 @@ class TpuPlatform(Platform):
         "JAX_PROFILER_SERVER_PORT",
         "ENABLE_RS_KERNEL",
         "MOE_ALL_GATHER_ACTIVATION_DTYPE",
+        "TPU_UNSAFE_HYBRID_PREFIX_CACHING",
     ]
 
     @classmethod
@@ -290,11 +291,14 @@ class TpuPlatform(Platform):
         # kernels handle cached prefixes.
         if (cache_config and cache_config.enable_prefix_caching
                 and vllm_config.model_config is not None
-                and getattr(vllm_config.model_config, "is_hybrid", False)):
+                and getattr(vllm_config.model_config, "is_hybrid", False)
+                and not envs.TPU_UNSAFE_HYBRID_PREFIX_CACHING):
             logger.warning(
                 "[tpu_platform] Disabling prefix caching: hybrid "
                 "(mamba/linear-attention) models do not support cached "
-                "prefixes on TPU yet (accuracy garbles on cache hits).")
+                "prefixes on TPU yet (accuracy garbles on cache hits). Set "
+                "TPU_UNSAFE_HYBRID_PREFIX_CACHING=1 to keep it on for "
+                "throughput measurements (output will be wrong).")
             cache_config.enable_prefix_caching = False
             # Reset the mamba cache fields derived from the enabled state to
             # their prefix-caching-off defaults; stale values trip vLLM's
@@ -307,6 +311,15 @@ class TpuPlatform(Platform):
                                     "user_specified_mamba_block_size", False)):
                 cache_config.mamba_block_size = (
                     vllm_config.model_config.max_model_len)
+        elif (cache_config and cache_config.enable_prefix_caching
+              and vllm_config.model_config is not None
+              and getattr(vllm_config.model_config, "is_hybrid", False)):
+            logger.warning(
+                "[tpu_platform] TPU_UNSAFE_HYBRID_PREFIX_CACHING is set: "
+                "keeping prefix caching on for a hybrid model. GENERATED "
+                "OUTPUT WILL BE WRONG on cache hits -- use this for "
+                "throughput measurements only, never for accuracy runs or "
+                "serving.")
 
         # vLLM's mm_device_do_normalize skips do_rescale/do_normalize in the
         # CPU processor and instead normalizes inside the vLLM model's vision


### PR DESCRIPTION
## Why

#3358 force-disables prefix caching for hybrid (mamba/linear-attention) models on TPU, because the GDN path cannot resume from a cached prefix — cache hits garble the output, and Qwen3.5-397B-A17B-FP8 drops to 0.01 on gsm8k. That default is correct and this PR does not change it.

It does, however, leave no way to measure what *correct* cached prefixes would be worth. That number is what sizing the GDN state-checkpointing work needs: recurrent state is `S_t = f(S_{t-1}, x_t)`, so resuming at prefix length L needs the snapshot `S_L`, and TPU currently allocates one state slot per *active request* (`max_num_reqs + 1`, see `_maybe_set_compact_mamba_num_blocks_override`) with nowhere to keep per-block checkpoints. Deciding whether to spend HBM on a block-indexed state pool needs the payoff quantified first.

## What

`TPU_UNSAFE_HYBRID_PREFIX_CACHING=1` skips the guard, leaving prefix caching (and the derived `mamba_cache_mode` / `mamba_block_size`) untouched for hybrid models.

- **Off by default** — no behaviour change unless explicitly set.
- **Loud warning when set**, stating that generated output will be wrong, so a benchmark run can't be mistaken for a valid one.
- The existing disable path now also names the flag, so anyone who hits the warning knows the measurement escape hatch exists.

`UNSAFE` is in the name deliberately: this is not a performance tuning knob.

## Measured payoff

v7x-8, Qwen3.5-397B-A17B-FP8, TP=8 with `attn_dp_size=4`, replaying a recorded agentic RL trace (16 concurrent streams, 480 turns, ~95% of context repeated across turns):

| | output tok/s | E2E | TPOT | prefix hit |
|---|---|---|---|---|
| guard on (today) | 116.5 | 612 s | 123.5 ms | 0.0% |
| guard bypassed | **417.1** | **171 s** | 36.3 ms | 95.5% |

**~3.6x.** Turns-2+ TTFT drops 2441 ms → 387 ms. So on multi-turn agentic workloads the correctness fix is expensive, which argues for prioritising hybrid state checkpointing rather than treating it as a nice-to-have.

## Testing

`tests/platforms/test_tpu_platform.py` 44/44. Added `test_hybrid_prefix_caching_unsafe_override`, asserting the flag leaves `enable_prefix_caching`, `mamba_cache_mode`, and `mamba_block_size` all untouched for a hybrid model; the existing parametrized test still covers the default-off behaviour. pre-commit clean on the changed files.

Numbers above came from running with this flag on a real server, not from the unit test.
