### PR TITLE
[DPScheduler] Add missing ec_connector attribute to DPScheduler

### DIFF
--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -113,6 +113,8 @@ class TestDPScheduler:
 
                 # Verify processes and connections were created
                 assert scheduler.dp_size == 2
+                assert scheduler.connector is None
+                assert scheduler.ec_connector is None
                 assert len(scheduler.processes) == 2
                 # One input conn and one output conn per rank
                 assert len(scheduler.input_conns) == 2

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -430,6 +430,7 @@ class DPScheduler(SchedulerInterface):
         self.hash_block_size = hash_block_size if hash_block_size is not None else block_size
         self.log_stats = log_stats
         self.connector = None
+        self.ec_connector = None
         self.structured_output_manager = structured_output_manager
 
         # DP state


### PR DESCRIPTION
# Description

Upstream vLLM recently added EC Connector (Encoder Cache Connector) support in [vllm#49585](https://github.com/vllm-project/vllm/pull/49585), where `EngineCore.__init__` checks `self.scheduler.ec_connector`.
When running inference with Data Parallelism (`dp_size >= 2`, e.g., DeepSeek-R1 with DP attention enabled on TPU7x), `EngineCore` instantiates `DPScheduler`. Because `DPScheduler` lacked the `ec_connector` attribute, it failed during startup with: `AttributeError: 'DPScheduler' object has no attribute 'ec_connector'. Did you mean: 'connector'?`

### Changes
- Added `self.ec_connector = None` to `DPScheduler.__init__` in `tpu_inference/core/sched/dp_scheduler.py`.
- Added assertions for `connector` and `ec_connector` attribute initialization in `tests/core/test_dp_scheduler.py`.

# Tests

- Unit tests: `pytest tests/core/test_dp_scheduler.py`

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
