### PR TITLE
[Docker] Install vLLM and tpu_inference non-editable in release images

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -63,7 +63,15 @@ RUN git clone $VLLM_REPO . && \
 
 RUN --mount=type=cache,target=/root/.cache/pip pip install --extra-index-url https://download.pytorch.org/whl/cpu -r requirements/tpu.txt --retries 3
 RUN --mount=type=cache,target=/root/.cache/pip pip install setuptools-rust>=1.9.0
-RUN --mount=type=cache,target=/root/.cache/pip VLLM_TARGET_DEVICE="tpu" pip install --no-build-isolation -e .
+# Editable only for test images. An editable install leaves no package in
+# site-packages, so /workspace/vllm shadows it as a namespace package for any
+# process whose cwd is /workspace, and `from vllm import LLM` then fails.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "$IS_TEST" = "true" ]; then \
+        VLLM_TARGET_DEVICE="tpu" pip install --no-build-isolation -e .; \
+    else \
+        VLLM_TARGET_DEVICE="tpu" pip install --no-build-isolation .; \
+    fi
 
 # Install test dependencies
 RUN --mount=type=cache,target=/root/.cache/pip python3 -m pip install -e tests/vllm_test_utils
@@ -88,7 +96,13 @@ RUN  --mount=type=cache,target=/root/.cache/pip if [ "$IS_TEST" = "true" ]; then
         pip install -r requirements_test.txt --retries 3; \
     fi
 COPY . .
-RUN --mount=type=cache,target=/root/.cache/pip pip install -e .
+# Editable only for test images, for the same reason as the vLLM install above.
+RUN --mount=type=cache,target=/root/.cache/pip \
+    if [ "$IS_TEST" = "true" ]; then \
+        pip install -e .; \
+    else \
+        pip install .; \
+    fi
 
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh


### PR DESCRIPTION
If you run Python from `/workspace` inside the docker image, importing vLLM is broken:

```bash
docker run --rm -w /workspace --entrypoint python3 vllm/vllm-tpu:v0.26.0 -c "from vllm import LLM"
# ImportError: cannot import name 'LLM' from 'vllm' (unknown location)
```

The confusing part is that `import vllm` works, that makes it hard to reason about the problem.
```bash
docker run --rm -w /workspace --entrypoint python3 vllm/vllm-tpu:v0.26.0 -c "import vllm"
$ echo $?
0
```

## The problem

The problem is because the dockerfile install vLLM and `tpu_inference` with `pip install -e .`. An editable install does not copy the package into `site-packages` — it only leaves a small pointer file to the source folder.

Those source folders sit directly under `/workspace`:

```
/workspace/vllm
/workspace/tpu_inference
```

Python always looks in the current directory first. So when you are in `/workspace`, it finds a folder named `vllm`, and because there is no real `vllm` package in `site-packages` to take priority, it uses that folder. But that folder is the git checkout, not the Python package — the actual package is one level deeper, in `/workspace/vllm/vllm`. The result is an empty module.

Both packages hit this:

| from `/workspace` | result |
|---|---|
| `import vllm` | empty module |
| `import tpu_inference` | empty module |
| `import vllm_test_utils` | fine (its folder is not directly under `/workspace`) |

The image's default working directory is `/workspace/tpu_inference`, not `/workspace`, which is why is never noticed unless you use an image that builds on top of it.

## The fix

Install both packages normally (without `-e`) in release images. The package then really lives in `site-packages`, and Python finds it from any directory.

Test images keep `-e`, so **CI does not change**. There is already a `IS_TEST` ARG for this in the Dockerfile.

- CI builds with `IS_TEST=true`
- The nightly release build does not set it 

`Dockerfile.pypi` already installs from a wheel, so it was never affected.

I also considered moving the source folders somewhere else, but `/workspace/tpu_inference` is hard-coded in a lot of benchmark JSON files as an artifacts path.

## How to repro
Small standalone example showing the cause and the fix. No TPU needed, runs in about 10 seconds:

```dockerfile
ARG MODE=editable
FROM python:3.12-slim-bookworm
ARG MODE
WORKDIR /workspace/demo
RUN mkdir -p demo && touch demo/__init__.py && \
    printf 'from setuptools import setup\nsetup(name="demo", version="0.1", packages=["demo"])\n' > setup.py
RUN if [ "$MODE" = "editable" ]; then pip install -e . ; else pip install . ; fi
WORKDIR /workspace
CMD ["python3", "-c", "import demo; print(demo.__file__)"]
```

```
pip install -e .  ->  demo.__file__ = None
pip install .     ->  demo.__file__ = /usr/local/lib/python3.12/site-packages/demo/__init__.py
```

I built both variants of the real image, using the same vLLM commit that is in `v0.26.0`:

```bash
docker build --build-arg VLLM_COMMIT_HASH=0ba2aa35a --build-arg IS_TEST=true -f docker/Dockerfile -t tpuinf:test .
docker build --build-arg VLLM_COMMIT_HASH=0ba2aa35a                          -f docker/Dockerfile -t tpuinf:fix  .
```

| | current image | test image (`IS_TEST=true`) | release image |
|---|---|---|---|
| `import vllm` from `/workspace` | empty module | empty module | works |
| `from vllm import LLM` from `/workspace` | ImportError | ImportError | works, `platform = tpu` |
| package in `site-packages` | no | no | yes |

The test image behaves exactly like the current one, which is the point — CI is untouched.

I also checked that nothing else changed in the release image. The version, package metadata, entrypoint and working directory are all identical to `v0.26.0`, including the `+g0ba2aa35a.tpu` version suffix. `docker build --check` reports no warnings.

## Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation. *(nothing in docs mentions how these are installed)*
