### PR TITLE
[Fix] Scope jax.set_mesh context to get_flax_model

### DIFF
--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -656,28 +656,28 @@ def get_model(
 
     match impl:
         case "flax_nnx":
-            with jax.set_mesh(mesh):
-                arch = getattr(vllm_config.model_config.hf_config,
-                               "architectures", [None])[0]
-                if vllm_config.parallel_config.pipeline_parallel_size > 1 and arch in _PP_DISABLED_MODELS:
-                    logger.warning(
-                        "PP is not fully supported on Jax flax_nnx %s models yet, fallback to vllm models.",
-                        arch)
-                    return get_vllm_model(vllm_config, rng, mesh,
-                                          is_draft_model, shared_params)
-                try:
-                    # Try to load the flax model first
+            arch = getattr(vllm_config.model_config.hf_config, "architectures",
+                           [None])[0]
+            if vllm_config.parallel_config.pipeline_parallel_size > 1 and arch in _PP_DISABLED_MODELS:
+                logger.warning(
+                    "PP is not fully supported on Jax flax_nnx %s models yet, fallback to vllm models.",
+                    arch)
+                return get_vllm_model(vllm_config, rng, mesh, is_draft_model,
+                                      shared_params)
+            try:
+                # Try to load the flax model first
+                with jax.set_mesh(mesh):
                     return get_flax_model(vllm_config, rng, mesh,
                                           is_draft_model)
-                except UnsupportedArchitectureError as e:
-                    # Convert the error message to a string to check its contents
-                    error_msg = str(e)
+            except UnsupportedArchitectureError as e:
+                # Convert the error message to a string to check its contents
+                error_msg = str(e)
 
-                    logger.warning(error_msg)
+                logger.warning(error_msg)
 
-                    # Fall back to the vLLM model and updating the dtype accordingly
-                    return get_vllm_model(vllm_config, rng, mesh,
-                                          is_draft_model, shared_params)
+                # Fall back to the vLLM model and updating the dtype accordingly
+                return get_vllm_model(vllm_config, rng, mesh, is_draft_model,
+                                      shared_params)
         case "vllm":
             return get_vllm_model(vllm_config, rng, mesh, is_draft_model,
                                   shared_params)


### PR DESCRIPTION
## What this PR contains

**Bug fix** — scopes `with jax.set_mesh(mesh)` strictly within `get_flax_model` in `model_loader.py` so that falling back to `get_vllm_model` on `UnsupportedArchitectureError` does not inherit an active global mesh context during weight loading.

## Problem

The multi-host correctness test (`tpu7x_multi-host_CorrectnessTest` in `.buildkite/features/multi-host.yml`, running on `tpu_v7x_16_queue`) has failed deterministically every night under `MODEL_IMPL_TYPE=flax_nnx` with:
```text
Terminating the libtpu controller process because an anomalous TPUworker process is detected: SLICE_FAILURE_SW_INJECT_ERROR.
```
The crash kills the Ray worker (`RayWorkerProc pid=2122`), triggering `ActorDiedError` in `EngineCore` and aborting `vllm serve`. The plain `MODEL_IMPL_TYPE=vllm` path passes.

*Note: Prior to commit `6e0384d58` (#3182), `run_multihost.sh` hardcoded `-e MODEL_IMPL_TYPE=vllm`, masking this issue by running all multi-host tests as `vllm`. Once `6e0384d58` forwarded `MODEL_IMPL_TYPE`, the `flax_nnx` nightly pipeline exposed this 100% deterministic regression.*

## Root cause

When serving `Qwen/Qwen3-30B-A3B` (`Qwen3MoeForCausalLM`) with `MODEL_IMPL_TYPE=flax_nnx`:

1. In `model_loader.py:get_model()`, `case "flax_nnx"` wrapped the entire block in `with jax.set_mesh(mesh):`.
2. `get_flax_model` raises `UnsupportedArchitectureError` because `Qwen3MoeForCausalLM` is not a registered JAX-native architecture. The exception handler catches this and falls back to `get_vllm_model(vllm_config, rng, mesh, ...)`, **while still inside the active multi-host mesh context**.
3. Under `--load-format=runai_streamer`, `RunaiIncrementalModelLoader` uses `SafetensorsStreamer` to download weight shards asynchronously across network threads.
4. As each linear layer completes download, `maybe_process_linear_weights` triggers `process_weights_after_loading` $\to$ `general_device_put`. Because `TPU_MULTIHOST_BACKEND=ray` and an outer mesh is active, `general_device_put` immediately executes `jax.make_array_from_callback` across all 16 TPU chips in the slice.
5. In JAX multi-host SPMD, `jax.make_array_from_callback` is an inter-host collective operation requiring all nodes to call it in the exact same sequence. Because `runai_streamer` yields tensors asynchronously:
   - Worker node (`10.128.0.113`) streamed faster (reached 6% / 1128 weights) and invoked collectives for Layer $N$.
   - Head node (`10.128.0.107`) streamed slower (reached 4% / 716 weights) and invoked collectives for Layer $M$ (or was idle waiting on I/O).
6. The mismatched collective calls across the slice caused an ICI communication protocol stall, prompting `libtpu` to abort the controller process via `SLICE_FAILURE_SW_INJECT_ERROR`.

## Fix

Move `with jax.set_mesh(mesh)` inside `try:` around `get_flax_model`:

- When loading JAX-native models, `get_flax_model` retains the expected mesh context.
- When falling back to `get_vllm_model` on `UnsupportedArchitectureError`, execution exits the mesh context. `runai_streamer` safely streams weights into CPU host memory without triggering premature inter-host collective calls mid-download.
- Once all weights are fully loaded, `VllmModelWrapper.load_weights()` invokes `shard_model_to_tpu(self.model, self.mesh)` in a single, deterministic, lockstep pass across all nodes.

# Tests

[CI test](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/905) of multi-host_CorrectnessTest.
