### PR TITLE
fix: Add ec_connector attribute to DPScheduler to match vLLM ec_transfer interface

### DIFF
--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -430,6 +430,7 @@ class DPScheduler(SchedulerInterface):
         self.hash_block_size = hash_block_size if hash_block_size is not None else block_size
         self.log_stats = log_stats
         self.connector = None
+        self.ec_connector = None
         self.structured_output_manager = structured_output_manager
 
         # DP state


### PR DESCRIPTION
# Description

Adds `ec_connector = None` to `DPScheduler.__init__` to satisfy vLLM `ec_transfer` attribute checks on the scheduler.

In vLLM v1 (`vllm/v1/engine/core.py`), the engine inspects the scheduler's `ec_connector` attribute during step execution and initialization (e.g., checking `if self.scheduler.ec_connector is not None:` at `v1/engine/core.py:176`). Without `ec_connector` defined on `DPScheduler`, running with `DPScheduler` raises an `AttributeError` when the engine attempts to access `self.scheduler.ec_connector`.

This one-line fix initializes `self.ec_connector = None` in `DPScheduler.__init__` alongside `self.connector`, aligning `DPScheduler` with vLLM's expected scheduler interface.

# Tests

- Verified attribute initialization (`self.ec_connector = None`) in `DPScheduler.__init__`.
- Verified alignment against vLLM v1 engine scheduler attribute usage (`v1/engine/core.py`).

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
