### PR TITLE
[DeepSeek-V4] Fix NaN errors in mla_swa unnormalized output buffers

### DIFF
--- a/tpu_inference/kernels/experimental/deepseek_v4/core_attention/mla_swa.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/core_attention/mla_swa.py
@@ -1110,18 +1110,13 @@ def mla_sliding_window_ragged_paged_attention(
             in_m,
         )
 
-    # Decode-only
+    # Initialize carry-in buffers for input-output aliasing across decode,
+    # prefill, and mixed stages. Zero initialization ensures unused/padding
+    # token slots do not contain NaNs.
     num_l_heads = align_to(num_q_heads, 128)
-    if unnormalized_output:
-        # output of swa attn is consumed by csa, hca attn, padding tokens'
-        # data won't be used downstream at all, so un-initialized buffer is fine.
-        l_sum = jnp.empty((q.shape[0], num_l_heads), dtype=jnp.float32)
-        m = jnp.empty((q.shape[0], num_l_heads), dtype=jnp.float32)
-        in_output = jnp.empty_like(q)
-    else:
-        l_sum = jnp.zeros((q.shape[0], num_l_heads), dtype=jnp.float32)
-        m = jnp.zeros((q.shape[0], num_l_heads), dtype=jnp.float32)
-        in_output = jnp.zeros_like(q)
+    l_sum = jnp.zeros((q.shape[0], num_l_heads), dtype=jnp.float32)
+    m = jnp.zeros((q.shape[0], num_l_heads), dtype=jnp.float32)
+    in_output = jnp.zeros_like(q)
     output, updated_kv, out_l, out_m = run_mla_kernel(
         q,
         new_kv,


### PR DESCRIPTION
# Description

This PR fixes NaN generation in `mla_swa` by unconditionally zero-initializing the carry-in buffers (`l`, `m`, and `in_output`) instead of using `jnp.empty` when `unnormalized_output=True`.

### Context & Problem
Previously, when `unnormalized_output=True`, `l`, `m`, and `in_output` were allocated with `jnp.empty` under the assumption that uninitialized buffers for padding/unused tokens would be safe. However, uninitialized HBM memory on TPUs frequently contains arbitrary bit patterns that decode to `NaN` or `±Inf`. 

### Solution & Implementation
- Replaced the conditional `jnp.empty` allocation with unconditional `jnp.zeros` and `jnp.zeros_like(q)`.
- Provides a clean, neutral identity state ($l = 0, m = 0, acc = 0$) across all sequence stages (`Decode` $\to$ `Prefill` $\to$ `Mixed`).
- XLA mutates these buffers in-place across subsequent kernel stages via `input_output_aliases={11: 0, 12: 2, 13: 3}` with negligible one-time memory initialization overhead.

---

# Tests

### 1. Correctness Tests
Ran the unit test suite to verify kernel correctness and ensure no NaN regressions:
```bash
blaze test //experimental/tpu_perf_showcase/vllm/tests/kernels/deepseek_v4:mla_swa_test

**Without this FIX**:
```bash
(vllm_env) hwanginho_google_com@t1v-n-af3903b1-w-0:~/tpu-inference$ curl http://localhost:8000/v1/completions   -H "Content-Type: application/json"   -d '{
      "model": "deepseek-ai/DeepSeek-V4-Pro",
       "prompt": "The capital of France is",
       "max_tokens": 10,
       "temperature": 0.0,
       "logprobs": 1
     }'
{"error":{"message":"Out of range float values are not JSON compliant: nan","type":"BadRequestError","param":null,"code":400}}(vllm_env)
```

**With the FIX:**
```bash
curl http://localhost:8000/v1/completions   -H "Content-Type: application/json"   -d '{
      "model": "deepseek-ai/DeepSeek-V4-Pro",
       "prompt": "The capital of France is",
       "max_tokens": 10,
       "temperature": 0.0,
       "logprobs": 1
     }'
{"id":"cmpl-8fa87874764e5963","object":"text_completion","created":1787031366,"model":"deepseek-ai/DeepSeek-V4-Pro","choices":[{"index":0,"text":"ntосновним embarassingосновнимKahanayKaginharianKaginharian يتيمه","logprobs":{"text_offset":[0,2,10,16,22,30,37,48,59,65],"token_logprobs":[-0.9310144782066345,-1.341226577758789,-2.8166799545288086,-0.6617730259895325,-1.6432856321334839,-1.0648488998413086,-1.7659844160079956,-0.577293872833252,-1.15477454662323,-2.215587615966797],"tokens":["nt","основним"," embar","assing","основним","Kahanay","Kaginharian","Kaginharian"," يتيمه",""],"top_logprobs":[{"nt":-0.9310144782066345},{"основним":-1.341226577758789},{" embar":-2.8166799545288086},{"assing":-0.6617730259895325},{"основним":-1.6432856321334839},{"Kahanay":-1.0648488998413086},{"Kaginharian":-1.7659844160079956},{"Kaginharian":-0.577293872833252},{" يتيمه":-1.15477454662323},{"":-2.215587615966797}]},"finish_reason":"length","stop_reason":null,"token_ids":null,"prompt_logprobs":null,"prompt_token_ids":null,"routed_experts":null}],"service_tier":null,"system_fingerprint":"vllm-0.26.1rc1.dev297+gc81093757.d20260818-tp16-ep-d4c9e233","usage":{"prompt_tokens":5,"total_tokens":15,"completion_tokens":10,"prompt_tokens_details":null},"kv_transfer_par(vllm_env)
```
Checklist
 [x]I have performed a self-review of my code.
 [x]I have necessary comments in my code, particularly in hard-to-understand areas.
 [ ]I have made or will make corresponding changes to any relevant documentation - NA
