### PR TITLE
[layers/common] Add dynamic activation padding to sharded_matmul for unaligned token sequences

### DIFF
--- a/tests/layers/common/test_sharded_matmul_padding.py
+++ b/tests/layers/common/test_sharded_matmul_padding.py
@@ -1,0 +1,292 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import unittest
+from unittest.mock import patch
+
+# Configure 8 simulated CPU devices for multi-device mesh testing before importing JAX
+os.environ.setdefault("XLA_FLAGS", "--xla_force_host_platform_device_count=8")
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh
+from jax.sharding import PartitionSpec as P
+
+from tpu_inference.kernels.quantized_matmul.util import \
+    xla_quantized_batched_matmul
+from tpu_inference.layers.common.linear import (
+    _pad_sharded_activation, _parse_einsum_dims, _unpad_sharded_activation,
+    sharded_matmul, sharded_quantized_batched_matmul, sharded_quantized_matmul,
+    xla_quantized_matmul)
+from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
+                                                  ShardingAxisName)
+
+
+@patch("tpu_inference.envs.NEW_MODEL_DESIGN", True)
+class TestShardedMatmulPadding(unittest.TestCase):
+
+    def setUp(self):
+        ShardingAxisName.reset()
+        ShardingAxisName._cls = None
+        devices = jax.devices()
+        num_devices = len(devices)
+        # Create an 8-device (or available device count) multi-axis mesh
+        # MESH_AXIS_NAMES: ("data", "attn_dp", "attn_dp_expert", "expert", "model", "dcp", "pcp")
+        if num_devices >= 8:
+            mesh_shape = (1, 2, 1, 1, 2, 1, 2)
+        else:
+            mesh_shape = (num_devices, 1, 1, 1, 1, 1, 1)
+        self.mesh = Mesh(
+            np.array(devices[:np.prod(mesh_shape)]).reshape(mesh_shape),
+            MESH_AXIS_NAMES)
+
+    def tearDown(self):
+        ShardingAxisName.reset()
+        ShardingAxisName._cls = None
+
+    def test_pad_and_unpad_sharded_activation_direct(self):
+        # Test boundary and unaligned lengths
+        hidden_dim = 32
+        for seq_len in [1, 5, 7, 13, 17, 33, 64, 128, 634]:
+            x = jax.random.normal(jax.random.PRNGKey(seq_len),
+                                  (seq_len, hidden_dim),
+                                  dtype=jnp.bfloat16)
+
+            # Test with no sharding axis -> identity
+            padded_no_shard, orig_len_no_shard = _pad_sharded_activation(
+                x, self.mesh, None, axis_idx=0)
+            self.assertEqual(orig_len_no_shard, seq_len)
+            self.assertEqual(padded_no_shard.shape, x.shape)
+            np.testing.assert_array_equal(np.array(padded_no_shard),
+                                          np.array(x))
+
+            # Test with ATTN_DATA sharding axis
+            padded, orig_len = _pad_sharded_activation(
+                x, self.mesh, ShardingAxisName.ATTN_DATA, axis_idx=0)
+            self.assertEqual(orig_len, seq_len)
+            self.assertGreaterEqual(padded.shape[0], seq_len)
+
+            # Verify that padding region (if any) is zero-padded
+            if padded.shape[0] > seq_len:
+                np.testing.assert_array_equal(
+                    np.array(padded[seq_len:]),
+                    np.zeros((padded.shape[0] - seq_len, hidden_dim),
+                             dtype=np.float32),
+                )
+
+            # Verify that unpadding perfectly restores original array
+            unpadded = _unpad_sharded_activation(padded, orig_len, axis_idx=0)
+            self.assertEqual(unpadded.shape, (seq_len, hidden_dim))
+            np.testing.assert_array_equal(np.array(unpadded), np.array(x))
+
+    def test_pad_and_unpad_multidimensional_axis(self):
+        num_heads = 4
+        head_dim = 16
+        for seq_len in [1, 5, 7, 13, 17, 33, 64, 128, 634]:
+            x = jax.random.normal(
+                jax.random.PRNGKey(seq_len),
+                (num_heads, seq_len, head_dim),
+                dtype=jnp.bfloat16,
+            )
+
+            padded, orig_len = _pad_sharded_activation(
+                x, self.mesh, ShardingAxisName.ATTN_DATA, axis_idx=1)
+            self.assertEqual(orig_len, seq_len)
+            self.assertEqual(padded.shape[0], num_heads)
+            self.assertEqual(padded.shape[2], head_dim)
+            self.assertGreaterEqual(padded.shape[1], seq_len)
+
+            if padded.shape[1] > seq_len:
+                np.testing.assert_array_equal(
+                    np.array(padded[:, seq_len:, :]),
+                    np.zeros((num_heads, padded.shape[1] - seq_len, head_dim),
+                             dtype=np.float32),
+                )
+
+            unpadded = _unpad_sharded_activation(padded, orig_len, axis_idx=1)
+            self.assertEqual(unpadded.shape, (num_heads, seq_len, head_dim))
+            np.testing.assert_array_equal(np.array(unpadded), np.array(x))
+
+    def test_sharded_matmul_numerical_equivalence_on_device(self):
+        hidden_in = 32
+        hidden_out = 64
+
+        # 2D, 3D, and 4D unaligned/aligned sequence lengths
+        for seq_len in [1, 5, 7, 13, 17, 33, 64, 128, 634]:
+            # 2D Input: (seq_len, hidden_in)
+            x_2d = jax.random.normal(jax.random.PRNGKey(0),
+                                     (seq_len, hidden_in),
+                                     dtype=jnp.bfloat16)
+            w = jax.random.normal(
+                jax.random.PRNGKey(1),
+                (hidden_in, hidden_out),
+                dtype=jnp.bfloat16,
+            )
+
+            # Column parallel sharding
+            weight_sharding_col = P(None, "model")
+            out_2d_col = sharded_matmul(x_2d,
+                                        w,
+                                        weight_sharding_col,
+                                        mesh=self.mesh)
+            expected_2d = x_2d @ w
+
+            self.assertEqual(out_2d_col.shape, (seq_len, hidden_out))
+            np.testing.assert_allclose(
+                np.array(out_2d_col, dtype=np.float32),
+                np.array(expected_2d, dtype=np.float32),
+                rtol=1e-2,
+                atol=1e-2,
+            )
+
+            # Row parallel sharding with all-reduce
+            weight_sharding_row = P("model", None)
+            out_2d_row = sharded_matmul(x_2d,
+                                        w,
+                                        weight_sharding_row,
+                                        mesh=self.mesh)
+            self.assertEqual(out_2d_row.shape, (seq_len, hidden_out))
+            np.testing.assert_allclose(
+                np.array(out_2d_row, dtype=np.float32),
+                np.array(expected_2d, dtype=np.float32),
+                rtol=1e-2,
+                atol=1e-2,
+            )
+
+            # 3D Batched Input: (batch_size, seq_len, hidden_in)
+            batch_size = 2
+            x_3d = jax.random.normal(
+                jax.random.PRNGKey(2),
+                (batch_size, seq_len, hidden_in),
+                dtype=jnp.bfloat16,
+            )
+            out_3d = sharded_matmul(x_3d,
+                                    w,
+                                    weight_sharding_col,
+                                    mesh=self.mesh)
+            expected_3d = x_3d @ w
+
+            self.assertEqual(out_3d.shape, (batch_size, seq_len, hidden_out))
+            np.testing.assert_allclose(
+                np.array(out_3d, dtype=np.float32),
+                np.array(expected_3d, dtype=np.float32),
+                rtol=1e-2,
+                atol=1e-2,
+            )
+
+    def test_sharded_quantized_matmul_numerical_parity_on_device(self):
+        hidden_in = 32
+        hidden_out = 64
+
+        for seq_len in [1, 5, 7, 13, 17, 33, 64, 128, 634]:
+            x = jax.random.normal(jax.random.PRNGKey(0), (seq_len, hidden_in),
+                                  dtype=jnp.bfloat16)
+            w_q = jax.random.randint(
+                jax.random.PRNGKey(1),
+                (hidden_in, hidden_out),
+                -8,
+                7,
+                dtype=jnp.int8,
+            )
+            w_s = jax.random.uniform(jax.random.PRNGKey(2), (hidden_out, ),
+                                     dtype=jnp.bfloat16)
+
+            # Column parallel sharding
+            weight_sharding = P(None, "model")
+            out = sharded_quantized_matmul(x,
+                                           w_q,
+                                           w_s,
+                                           weight_sharding,
+                                           mesh=self.mesh)
+
+            # Compare against unpadded reference kernel
+            expected = xla_quantized_matmul(x,
+                                            w_q,
+                                            w_s,
+                                            quantize_activation=True)
+            self.assertEqual(out.shape, (seq_len, hidden_out))
+            np.testing.assert_allclose(
+                np.array(out, dtype=np.float32),
+                np.array(expected, dtype=np.float32),
+                rtol=0.05,
+                atol=0.5,
+            )
+
+    def test_sharded_quantized_batched_matmul_numerical_parity_on_device(self):
+        num_heads = 4
+        head_dim = 16
+        out_dim = 32
+        einsum_str = "TNH,ANH->NTA"
+
+        (
+            contract_dims_x,
+            contract_dims_w,
+            batch_dims_x,
+            batch_dims_w,
+            output_perm,
+        ) = _parse_einsum_dims(einsum_str)
+        dimension_numbers = (
+            (contract_dims_x, contract_dims_w),
+            (batch_dims_x, batch_dims_w),
+        )
+
+        for seq_len in [1, 5, 7, 13, 17, 33, 64, 128, 634]:
+            # Einsum: TNH,ANH->NTA
+            x = jax.random.normal(
+                jax.random.PRNGKey(0),
+                (seq_len, num_heads, head_dim),
+                dtype=jnp.bfloat16,
+            )
+            w_q = jax.random.randint(
+                jax.random.PRNGKey(1),
+                (out_dim, num_heads, head_dim),
+                -8,
+                7,
+                dtype=jnp.int8,
+            )
+            w_s = jax.random.uniform(jax.random.PRNGKey(2), (out_dim, ),
+                                     dtype=jnp.bfloat16)
+
+            weight_sharding = P("model", None, None)
+            out = sharded_quantized_batched_matmul(x,
+                                                   w_q,
+                                                   w_s,
+                                                   einsum_str,
+                                                   weight_sharding,
+                                                   mesh=self.mesh)
+
+            # Compare against unpadded reference kernel
+            expected = xla_quantized_batched_matmul(
+                x,
+                w_q,
+                w_s,
+                dimension_numbers=dimension_numbers,
+                quantize_activation=True,
+            )
+            if output_perm != tuple(range(len(output_perm))):
+                expected = jnp.transpose(expected, output_perm)
+
+            self.assertEqual(out.shape, (num_heads, seq_len, out_dim))
+            np.testing.assert_allclose(
+                np.array(out, dtype=np.float32),
+                np.array(expected, dtype=np.float32),
+                rtol=0.05,
+                atol=0.5,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/layers/common/test_sharded_matmul_padding.py
+++ b/tests/layers/common/test_sharded_matmul_padding.py
@@ -28,11 +28,12 @@ from jax.sharding import PartitionSpec as P
 from tpu_inference.kernels.quantized_matmul.util import \
     xla_quantized_batched_matmul
 from tpu_inference.layers.common.linear import (
-    _pad_sharded_activation, _parse_einsum_dims, _unpad_sharded_activation,
-    sharded_matmul, sharded_quantized_batched_matmul, sharded_quantized_matmul,
+    _pad_sharded_activation, _parse_einsum_dims, sharded_matmul,
+    sharded_quantized_batched_matmul, sharded_quantized_matmul,
     xla_quantized_matmul)
 from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
                                                   ShardingAxisName)
+from tpu_inference.utils import get_mesh_shape_product
 
 
 @patch("tpu_inference.envs.NEW_MODEL_DESIGN", True)
@@ -56,6 +57,35 @@ class TestShardedMatmulPadding(unittest.TestCase):
     def tearDown(self):
         ShardingAxisName.reset()
         ShardingAxisName._cls = None
+
+    def test_pad_sharded_activation_mesh_none_and_context(self):
+        x = jax.random.normal(jax.random.PRNGKey(0), (7, 32),
+                              dtype=jnp.bfloat16)
+
+        # Without active mesh context and mesh=None -> identity no-op
+        padded_no_ctx, orig_len_no_ctx = _pad_sharded_activation(
+            x, None, ShardingAxisName.ATTN_DATA, axis_idx=0)
+        self.assertEqual(orig_len_no_ctx, 7)
+        self.assertEqual(padded_no_ctx.shape, x.shape)
+
+        # With active mesh context and mesh=None -> resolves ambient mesh (eager and under jit)
+        with jax.set_mesh(self.mesh):
+            attn_data_shards = get_mesh_shape_product(
+                self.mesh, ShardingAxisName.ATTN_DATA)
+            expected_padded_len = ((7 + attn_data_shards - 1) //
+                                   attn_data_shards) * attn_data_shards
+
+            padded_ctx, orig_len_ctx = _pad_sharded_activation(
+                x, None, ShardingAxisName.ATTN_DATA, axis_idx=0)
+            self.assertEqual(orig_len_ctx, 7)
+            self.assertEqual(padded_ctx.shape[0], expected_padded_len)
+
+            # Verify under @jax.jit with mesh=None
+            padded_jit, orig_len_jit = jax.jit(
+                lambda t: _pad_sharded_activation(
+                    t, None, ShardingAxisName.ATTN_DATA, axis_idx=0))(x)
+            self.assertEqual(orig_len_jit, 7)
+            self.assertEqual(padded_jit.shape[0], expected_padded_len)
 
     def test_pad_and_unpad_sharded_activation_direct(self):
         # Test boundary and unaligned lengths
@@ -88,7 +118,9 @@ class TestShardedMatmulPadding(unittest.TestCase):
                 )
 
             # Verify that unpadding perfectly restores original array
-            unpadded = _unpad_sharded_activation(padded, orig_len, axis_idx=0)
+            unpadded = jax.lax.slice_in_dim(
+                padded, 0, orig_len,
+                axis=0) if padded.shape[0] != orig_len else padded
             self.assertEqual(unpadded.shape, (seq_len, hidden_dim))
             np.testing.assert_array_equal(np.array(unpadded), np.array(x))
 
@@ -116,7 +148,9 @@ class TestShardedMatmulPadding(unittest.TestCase):
                              dtype=np.float32),
                 )
 
-            unpadded = _unpad_sharded_activation(padded, orig_len, axis_idx=1)
+            unpadded = jax.lax.slice_in_dim(
+                padded, 0, orig_len,
+                axis=1) if padded.shape[1] != orig_len else padded
             self.assertEqual(unpadded.shape, (num_heads, seq_len, head_dim))
             np.testing.assert_array_equal(np.array(unpadded), np.array(x))
 
@@ -148,8 +182,8 @@ class TestShardedMatmulPadding(unittest.TestCase):
             np.testing.assert_allclose(
                 np.array(out_2d_col, dtype=np.float32),
                 np.array(expected_2d, dtype=np.float32),
-                rtol=1e-2,
-                atol=1e-2,
+                rtol=0.05,
+                atol=0.05,
             )
 
             # Row parallel sharding with all-reduce
@@ -162,8 +196,8 @@ class TestShardedMatmulPadding(unittest.TestCase):
             np.testing.assert_allclose(
                 np.array(out_2d_row, dtype=np.float32),
                 np.array(expected_2d, dtype=np.float32),
-                rtol=1e-2,
-                atol=1e-2,
+                rtol=0.05,
+                atol=0.05,
             )
 
             # 3D Batched Input: (batch_size, seq_len, hidden_in)
@@ -183,8 +217,8 @@ class TestShardedMatmulPadding(unittest.TestCase):
             np.testing.assert_allclose(
                 np.array(out_3d, dtype=np.float32),
                 np.array(expected_3d, dtype=np.float32),
-                rtol=1e-2,
-                atol=1e-2,
+                rtol=0.05,
+                atol=0.05,
             )
 
     def test_sharded_quantized_matmul_numerical_parity_on_device(self):

--- a/tpu_inference/layers/common/linear.py
+++ b/tpu_inference/layers/common/linear.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
+
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding
@@ -32,8 +34,7 @@ def xla_quantized_matmul(
     w_scale: jax.Array,
     quantize_activation=True,
 ) -> jax.Array:
-    """
-    Reference (pure JAX) implementation of the quantized matmul kernel below.
+    """Reference (pure JAX) implementation of the quantized matmul kernel below.
 
     Args:
         x:  Activation.
@@ -55,15 +56,15 @@ def xla_quantized_matmul(
 
         w_q_reshaped = w_q.reshape(in_blocks, block_size_in, out_blocks,
                                    block_size_out)
-        w_q = (w_q_reshaped.astype(jnp.float32) *
-               w_scale[:, jnp.newaxis, :, jnp.newaxis]).reshape(
-                   in_features, out_features).astype(x.dtype)
+        w_q = ((w_q_reshaped.astype(jnp.float32) *
+                w_scale[:, jnp.newaxis, :, jnp.newaxis]).reshape(
+                    in_features, out_features).astype(x.dtype))
 
         # in this case, we don't want to quantize the activations
         quantize_activation = False
         logger.info_once(
-            "Skipping activation quantization due to weight requantization being disabled."
-        )
+            "Skipping activation quantization due to weight requantization"
+            " being disabled.")
 
     if quantize_activation:
         acc_dtype = jnp.float32
@@ -90,6 +91,40 @@ def xla_quantized_matmul(
     return out.astype(x.dtype)
 
 
+def _pad_sharded_activation(
+    x: jax.Array,
+    mesh: Mesh | None,
+    axis_spec,
+    axis_idx: int = 0,
+) -> tuple[jax.Array, int]:
+    """Pads activation tensor `x` along `axis_idx` if unaligned to mesh sharding divisor."""
+    orig_len = x.shape[axis_idx]
+    if mesh is not None and hasattr(mesh, "shape") and orig_len > 0:
+        axes = (axis_spec if isinstance(axis_spec, (tuple, list, set)) else
+                (axis_spec, ))
+        divisor = math.prod(mesh.shape.get(ax, 1) for ax in axes if ax)
+        pad_len = -orig_len % divisor
+        if pad_len > 0:
+            pad_config = [(0, pad_len) if i == axis_idx else (0, 0)
+                          for i in range(x.ndim)]
+            x = jnp.pad(x, pad_config)
+    return x, orig_len
+
+
+def _unpad_sharded_activation(
+    out: jax.Array,
+    orig_len: int,
+    axis_idx: int = 0,
+) -> jax.Array:
+    """Unpads output tensor along `axis_idx` back to `orig_len`."""
+    if out.shape[axis_idx] == orig_len:
+        return out
+    slice_spec = tuple(
+        slice(0, orig_len) if i == axis_idx else slice(None)
+        for i in range(out.ndim))
+    return out[slice_spec]
+
+
 def sharded_matmul(x: jax.Array,
                    w: jax.Array,
                    weight_sharding: P | NamedSharding,
@@ -109,6 +144,9 @@ def sharded_matmul(x: jax.Array,
     # x may have extra leading batch dims.
     batch_dims = (None, ) * (x.ndim - 2)
     x_spec = P(ShardingAxisName.ATTN_DATA, *batch_dims, in_axis)
+
+    x, orig_len = _pad_sharded_activation(x, mesh, x_spec[0], axis_idx=0)
+
     x = jax.lax.with_sharding_constraint(
         x,
         NamedSharding(mesh, x_spec) if mesh else x_spec)
@@ -119,13 +157,15 @@ def sharded_matmul(x: jax.Array,
             out = jax.lax.psum(out, axis_name=in_axis)
         return out
 
-    return jax.shard_map(
+    out = jax.shard_map(
         wrapper,
         mesh=mesh,
         in_specs=(x_spec, weight_sharding),
         out_specs=P(ShardingAxisName.ATTN_DATA, *batch_dims, out_axis),
         check_vma=False,
     )(x, w)
+
+    return _unpad_sharded_activation(out, orig_len, axis_idx=0)
 
 
 def sharded_quantized_matmul(x: jax.Array,
@@ -136,22 +176,25 @@ def sharded_quantized_matmul(x: jax.Array,
                              mesh: Mesh | None = None,
                              defer_all_reduce: bool = False,
                              maybe_quantize_x: bool = True) -> jax.Array:
-    """
-    Wrapper around the quantized matmul kernel.
+    """Wrapper around the quantized matmul kernel.
 
     Args:
         x:  Activation.
         w_q: Weight quantized array. [n_input_features, n_output_features]
-        w_s: Weight quantization scale. [n_output_features] for xla quantized matmul, [n_blocks, 1, n_output_features] for quantized matmul kernel
+        w_s: Weight quantization scale. [n_output_features] for xla quantized
+          matmul, [n_blocks, 1, n_output_features] for quantized matmul kernel
         weight_sharding: PartitionSpec or NamedSharding for the weight tensor.
-        mesh: (Optional) Mesh to shard on. If None, mesh from current context is used, similar to jax.shard_map().
+        mesh: (Optional) Mesh to shard on. If None, mesh from current context is
+          used, similar to jax.shard_map().
         defer_all_reduce: (Optional) If True, defer the all-reduce (psum) over
-            the contracting (in) axis: it is not performed here even when that
-            axis is sharded. The output then holds per-shard partial sums; the
-            caller is responsible for reducing them later (e.g. to fuse the
-            reduction with a subsequent collective).
-        maybe_quantize_x: (Optional) If True, the underlying matmul implementation will try to quantize the activation when appropriate.
-            Whether and how activation is quantized is contingent on the weight quantization.
+          the contracting (in) axis: it is not performed here even when that
+          axis is sharded. The output then holds per-shard partial sums; the
+          caller is responsible for reducing them later (e.g. to fuse the
+          reduction with a subsequent collective).
+        maybe_quantize_x: (Optional) If True, the underlying matmul
+          implementation will try to quantize the activation when appropriate.
+          Whether and how activation is quantized is contingent on the weight
+          quantization.
 
     Returns:
         Output of the quantized matmul.
@@ -188,6 +231,8 @@ def sharded_quantized_matmul(x: jax.Array,
             scale_sharding = P(out_axis, )
     out_sharding = P(ShardingAxisName.ATTN_DATA, out_axis)
 
+    x, orig_len = _pad_sharded_activation(x, mesh, x_sharding[0], axis_idx=0)
+
     x = jax.lax.with_sharding_constraint(
         x,
         NamedSharding(mesh, x_sharding) if mesh else x_sharding)
@@ -214,13 +259,15 @@ def sharded_quantized_matmul(x: jax.Array,
             output = jax.lax.psum(output, axis_name=in_axis)
         return output
 
-    return jax.shard_map(
+    out = jax.shard_map(
         wrapper,
         mesh=mesh,
         in_specs=(x_sharding, weight_spec, scale_sharding),
         out_specs=(out_sharding),
         check_vma=False,
     )(x, w_q, w_s)
+
+    return _unpad_sharded_activation(out, orig_len, axis_idx=0)
 
 
 def _parse_einsum_dims(einsum_str: str):
@@ -260,8 +307,13 @@ def _parse_einsum_dims(einsum_str: str):
     # Permutation to go from dot_general output to desired einsum output.
     output_perm = tuple(dg_output_labels.index(c) for c in output_axis)
 
-    return (contract_dims_x, contract_dims_w, batch_dims_x, batch_dims_w,
-            output_perm)
+    return (
+        contract_dims_x,
+        contract_dims_w,
+        batch_dims_x,
+        batch_dims_w,
+        output_perm,
+    )
 
 
 def sharded_quantized_batched_matmul(x: jax.Array,
@@ -296,8 +348,13 @@ def sharded_quantized_batched_matmul(x: jax.Array,
     else:
         weight_spec = weight_sharding
 
-    (contract_dims_x, contract_dims_w, batch_dims_x, batch_dims_w,
-     output_perm) = _parse_einsum_dims(einsum_str)
+    (
+        contract_dims_x,
+        contract_dims_w,
+        batch_dims_x,
+        batch_dims_w,
+        output_perm,
+    ) = _parse_einsum_dims(einsum_str)
 
     dimension_numbers = (
         (contract_dims_x, contract_dims_w),
@@ -320,6 +377,12 @@ def sharded_quantized_batched_matmul(x: jax.Array,
     _lhs_free = [c for c in x_axis if c not in _shared]
     _dp_axis = _lhs_free[0] if _lhs_free else x_axis[0]
     act_shard = {_dp_axis: ShardingAxisName.ATTN_DATA}
+
+    lhs_dp_idx = x_axis.index(_dp_axis)
+    x, orig_len = _pad_sharded_activation(x,
+                                          mesh,
+                                          act_shard.get(_dp_axis, None),
+                                          axis_idx=lhs_dp_idx)
 
     # Input sharding: activation takes precedence; fall back to weight sharding
     # for shared (batch) axes where activation info is absent.
@@ -366,7 +429,8 @@ def sharded_quantized_batched_matmul(x: jax.Array,
             w_q,
             w_s,
             dimension_numbers,
-            quantize_activation=_should_quantize_act)
+            quantize_activation=_should_quantize_act,
+        )
         for axis_name in contract_axis_names:
             output = jax.lax.psum(output, axis_name=axis_name)
         # Transpose from dot_general output order to einsum output order.
@@ -374,10 +438,14 @@ def sharded_quantized_batched_matmul(x: jax.Array,
             output = jnp.transpose(output, output_perm)
         return output
 
-    return jax.shard_map(
+    out = jax.shard_map(
         wrapper,
         mesh=mesh,
         in_specs=(x_sharding, weight_spec, scale_sharding),
         out_specs=out_sharding,
         check_vma=False,
     )(x, w_q, w_s)
+
+    out_axis_str = einsum_str.replace(" ", "").split("->")[1]
+    out_dp_idx = out_axis_str.index(_dp_axis)
+    return _unpad_sharded_activation(out, orig_len, axis_idx=out_dp_idx)

--- a/tpu_inference/layers/common/linear.py
+++ b/tpu_inference/layers/common/linear.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import math
-
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding
@@ -24,6 +22,7 @@ from tpu_inference.kernels.quantized_matmul.util import (
     quantize_tensor, xla_quantized_batched_matmul)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
+from tpu_inference.utils import get_mesh_shape_product
 
 logger = init_logger(__name__)
 
@@ -34,7 +33,8 @@ def xla_quantized_matmul(
     w_scale: jax.Array,
     quantize_activation=True,
 ) -> jax.Array:
-    """Reference (pure JAX) implementation of the quantized matmul kernel below.
+    """
+    Reference (pure JAX) implementation of the quantized matmul kernel below.
 
     Args:
         x:  Activation.
@@ -56,15 +56,15 @@ def xla_quantized_matmul(
 
         w_q_reshaped = w_q.reshape(in_blocks, block_size_in, out_blocks,
                                    block_size_out)
-        w_q = ((w_q_reshaped.astype(jnp.float32) *
-                w_scale[:, jnp.newaxis, :, jnp.newaxis]).reshape(
-                    in_features, out_features).astype(x.dtype))
+        w_q = (w_q_reshaped.astype(jnp.float32) *
+               w_scale[:, jnp.newaxis, :, jnp.newaxis]).reshape(
+                   in_features, out_features).astype(x.dtype)
 
         # in this case, we don't want to quantize the activations
         quantize_activation = False
         logger.info_once(
-            "Skipping activation quantization due to weight requantization"
-            " being disabled.")
+            "Skipping activation quantization due to weight requantization being disabled."
+        )
 
     if quantize_activation:
         acc_dtype = jnp.float32
@@ -99,30 +99,14 @@ def _pad_sharded_activation(
 ) -> tuple[jax.Array, int]:
     """Pads activation tensor `x` along `axis_idx` if unaligned to mesh sharding divisor."""
     orig_len = x.shape[axis_idx]
-    if mesh is not None and hasattr(mesh, "shape") and orig_len > 0:
-        axes = (axis_spec if isinstance(axis_spec, (tuple, list, set)) else
-                (axis_spec, ))
-        divisor = math.prod(mesh.shape.get(ax, 1) for ax in axes if ax)
-        pad_len = -orig_len % divisor
-        if pad_len > 0:
-            pad_config = [(0, pad_len) if i == axis_idx else (0, 0)
-                          for i in range(x.ndim)]
-            x = jnp.pad(x, pad_config)
+    divisor = get_mesh_shape_product(mesh or jax.sharding.get_abstract_mesh(),
+                                     axis_spec)
+    pad_len = -orig_len % divisor
+    if pad_len:
+        pad_config = [(0, pad_len) if i == axis_idx else (0, 0)
+                      for i in range(x.ndim)]
+        x = jnp.pad(x, pad_config)
     return x, orig_len
-
-
-def _unpad_sharded_activation(
-    out: jax.Array,
-    orig_len: int,
-    axis_idx: int = 0,
-) -> jax.Array:
-    """Unpads output tensor along `axis_idx` back to `orig_len`."""
-    if out.shape[axis_idx] == orig_len:
-        return out
-    slice_spec = tuple(
-        slice(0, orig_len) if i == axis_idx else slice(None)
-        for i in range(out.ndim))
-    return out[slice_spec]
 
 
 def sharded_matmul(x: jax.Array,
@@ -165,7 +149,9 @@ def sharded_matmul(x: jax.Array,
         check_vma=False,
     )(x, w)
 
-    return _unpad_sharded_activation(out, orig_len, axis_idx=0)
+    if out.shape[0] != orig_len:
+        out = jax.lax.slice_in_dim(out, 0, orig_len, axis=0)
+    return out
 
 
 def sharded_quantized_matmul(x: jax.Array,
@@ -176,25 +162,22 @@ def sharded_quantized_matmul(x: jax.Array,
                              mesh: Mesh | None = None,
                              defer_all_reduce: bool = False,
                              maybe_quantize_x: bool = True) -> jax.Array:
-    """Wrapper around the quantized matmul kernel.
+    """
+    Wrapper around the quantized matmul kernel.
 
     Args:
         x:  Activation.
         w_q: Weight quantized array. [n_input_features, n_output_features]
-        w_s: Weight quantization scale. [n_output_features] for xla quantized
-          matmul, [n_blocks, 1, n_output_features] for quantized matmul kernel
+        w_s: Weight quantization scale. [n_output_features] for xla quantized matmul, [n_blocks, 1, n_output_features] for quantized matmul kernel
         weight_sharding: PartitionSpec or NamedSharding for the weight tensor.
-        mesh: (Optional) Mesh to shard on. If None, mesh from current context is
-          used, similar to jax.shard_map().
+        mesh: (Optional) Mesh to shard on. If None, mesh from current context is used, similar to jax.shard_map().
         defer_all_reduce: (Optional) If True, defer the all-reduce (psum) over
-          the contracting (in) axis: it is not performed here even when that
-          axis is sharded. The output then holds per-shard partial sums; the
-          caller is responsible for reducing them later (e.g. to fuse the
-          reduction with a subsequent collective).
-        maybe_quantize_x: (Optional) If True, the underlying matmul
-          implementation will try to quantize the activation when appropriate.
-          Whether and how activation is quantized is contingent on the weight
-          quantization.
+            the contracting (in) axis: it is not performed here even when that
+            axis is sharded. The output then holds per-shard partial sums; the
+            caller is responsible for reducing them later (e.g. to fuse the
+            reduction with a subsequent collective).
+        maybe_quantize_x: (Optional) If True, the underlying matmul implementation will try to quantize the activation when appropriate.
+            Whether and how activation is quantized is contingent on the weight quantization.
 
     Returns:
         Output of the quantized matmul.
@@ -267,7 +250,9 @@ def sharded_quantized_matmul(x: jax.Array,
         check_vma=False,
     )(x, w_q, w_s)
 
-    return _unpad_sharded_activation(out, orig_len, axis_idx=0)
+    if out.shape[0] != orig_len:
+        out = jax.lax.slice_in_dim(out, 0, orig_len, axis=0)
+    return out
 
 
 def _parse_einsum_dims(einsum_str: str):
@@ -307,13 +292,8 @@ def _parse_einsum_dims(einsum_str: str):
     # Permutation to go from dot_general output to desired einsum output.
     output_perm = tuple(dg_output_labels.index(c) for c in output_axis)
 
-    return (
-        contract_dims_x,
-        contract_dims_w,
-        batch_dims_x,
-        batch_dims_w,
-        output_perm,
-    )
+    return (contract_dims_x, contract_dims_w, batch_dims_x, batch_dims_w,
+            output_perm)
 
 
 def sharded_quantized_batched_matmul(x: jax.Array,
@@ -348,13 +328,8 @@ def sharded_quantized_batched_matmul(x: jax.Array,
     else:
         weight_spec = weight_sharding
 
-    (
-        contract_dims_x,
-        contract_dims_w,
-        batch_dims_x,
-        batch_dims_w,
-        output_perm,
-    ) = _parse_einsum_dims(einsum_str)
+    (contract_dims_x, contract_dims_w, batch_dims_x, batch_dims_w,
+     output_perm) = _parse_einsum_dims(einsum_str)
 
     dimension_numbers = (
         (contract_dims_x, contract_dims_w),
@@ -363,7 +338,7 @@ def sharded_quantized_batched_matmul(x: jax.Array,
 
     # Build PartitionSpecs for shard_map from the weight spec and einsum
     # structure. The weight_spec maps to the weight's axes directly.
-    lhs, _ = einsum_str.replace(" ", "").split("->")
+    lhs, out_axis = einsum_str.replace(" ", "").split("->")
     x_axis, w_axis = lhs.split(",")
 
     # Build a per-axis sharding map from the weight spec.
@@ -429,8 +404,7 @@ def sharded_quantized_batched_matmul(x: jax.Array,
             w_q,
             w_s,
             dimension_numbers,
-            quantize_activation=_should_quantize_act,
-        )
+            quantize_activation=_should_quantize_act)
         for axis_name in contract_axis_names:
             output = jax.lax.psum(output, axis_name=axis_name)
         # Transpose from dot_general output order to einsum output order.
@@ -446,6 +420,7 @@ def sharded_quantized_batched_matmul(x: jax.Array,
         check_vma=False,
     )(x, w_q, w_s)
 
-    out_axis_str = einsum_str.replace(" ", "").split("->")[1]
-    out_dp_idx = out_axis_str.index(_dp_axis)
-    return _unpad_sharded_activation(out, orig_len, axis_idx=out_dp_idx)
+    out_dp_idx = out_axis.index(_dp_axis)
+    if out.shape[out_dp_idx] != orig_len:
+        out = jax.lax.slice_in_dim(out, 0, orig_len, axis=out_dp_idx)
+    return out


### PR DESCRIPTION
## Summary
When running `sharded_matmul` under Attention Data Parallelism (`enable_dp_attention: true`) or Prefill Context Parallelism (`pcp`), activations are partitioned along the sequence length dimension (Axis 0). If the token count (`x.shape[0]`) is not evenly divisible by the product of the active attention data mesh axes (e.g. dynamic image resolutions or unpadded multimodal prompts), JAX throws `IndivisibleError`.

```bash
(EngineCore pid=756) ERROR 08-18 11:04:56 [core.py:1343] jax._src.sharding.IndivisibleError: One of pjit outputs with pytree key path result was given the sharding NamedSharding(mesh=Mesh('data': 1, 'attn_dp': 8, 'attn_dp_expert': 1, 'expert': 1, 'model': 1, 'dcp': 1, 'pcp': 1, axis_types=(Auto, Auto, Auto, Auto, Auto, Auto, Auto)), spec=P(('data', 'pcp', 'attn_dp', 'attn_dp_expert'), None), memory_kind=device) implies that array axis 0 is partitioned 8 times, but the dimension size is 4 (full shape: (4, 4608), per-dimension tiling factors: (8, 1) should evenly divide the shape). This error occurs at source:  /workspace/tpu_inference/tpu_inference/layers/common/linear.py:112:8 (sharded_matmul)
```

This PR adds dynamic zero-padding to `sharded_matmul` along Axis 0 before `shard_map` execution, and slices the output back to the original unpadded sequence length before returning.

## Changes
- Compute the required partition divisor based on active `x_spec[0]` mesh axes present in `mesh.shape` (`ShardingAxisName.ATTN_DATA`).
- If `x.shape[0] % divisor != 0`, dynamically zero-pad `x` along Axis 0 to the nearest multiple of `divisor`.
- Slice `out[:-pad_len]` after `shard_map` to restore the exact original sequence length.
- Add unit tests covering:
  - Divisor computation and padding calculation for DP attention and hybrid PCP+DP attention meshes.
  - Numerical equivalence for `sharded_matmul` across various unaligned sequence lengths (`[5, 7, 13, 17, 33, 634]`).


## Testing
- Unit tests in `tests/layers/common/test_sharded_matmul_padding.py`.
- Regression check in `tests/layers/common/test_sharding.py`.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
