### PR TITLE
[DSv4] Accept backend_cls in VllmDeepseekV4SWACache for vLLM #47808

### DIFF
--- a/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_attention.py
+++ b/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_attention.py
@@ -109,8 +109,16 @@ class VllmDeepseekV4SWACache(DeepseekV4SWACache):
         dtype: torch.dtype,
         prefix: str,
         cache_config,
+        backend_cls=None,
     ):
-        super().__init__(head_dim, window_size, dtype, prefix, cache_config)
+        # vLLM #47808 added ``backend_cls`` to DeepseekV4SWACache and the base
+        # attention ctor always passes it; None keeps the default SWA backend.
+        super().__init__(head_dim,
+                         window_size,
+                         dtype,
+                         prefix,
+                         cache_config,
+                         backend_cls=backend_cls)
         compressed_kv_cache_bz = cache_config.block_size
         # We would like to overlay the SWA cache with CSA's main NOPE cache
         # on the same KV-Tensor, whose shape is [num_pages, page_size, 4, 128]


### PR DESCRIPTION
## What

vLLM commit `7f7a32cfec` ([vllm-project/vllm#47808](https://github.com/vllm-project/vllm/pull/47808)) added a `backend_cls` parameter to `DeepseekV4SWACache.__init__` and made `DeepseekV4Attention.__init__` always pass `backend_cls=self.swa_backend_cls` when constructing the SWA cache layer. The TPU subclass `VllmDeepseekV4SWACache` kept the old 5-arg signature, so model init crashes:

```
TypeError: VllmDeepseekV4SWACache.__init__() got an unexpected keyword argument 'backend_cls'
```

This broke the nightly `tpu7x E2E MMLU for DeepSeek-V4-Flash torchax backend` job ([build 24546](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24546)) when the vLLM LKG advanced to `9842d70145`.

## Fix

Accept the kwarg and forward it to the base class. Behavior on TPU is unchanged: with `backend_cls=None` the upstream base falls back to `DeepseekSparseSWABackend`, which is exactly what the previous hardcoded `get_attn_backend` returned, and the TPU subclass overrides `get_kv_cache_spec` independently.

## Test

Dev pipeline run of the exact failing nightly step (tpu7x, `MODEL_IMPL_TYPE=vllm`, `NEW_MODEL_DESIGN=1`, DeepSeek-V4-Flash MMLU) with this fix applied on top of current main / LKG vLLM:
https://buildkite.com/tpu-commons/tpu-inference-dev/builds/907
