### PR TITLE
[Fix] Min-sync KV-cache HBM budget across hosts for multi-host determinism

### DIFF
--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -566,6 +566,53 @@ class TPUWorker(WorkerBase):
                              f"{-total_hbm_avail_gb}GiB. Please consider "
                              f"increasing --gpu-memory-utilization from "
                              f"{gpu_memory_utilization} to a larger value.")
+
+        # Cross-host KV-cache-shape determinism (multi-host / plain-SPMD):
+        # each host measures its OWN live HBM (utils.hbm_usage_bytes does NO
+        # cross-host reduction), so total_hbm_avail can differ per host due to
+        # topology-correlated resident runtime/allocator buffers. That budget
+        # flows into kv_cache_manager.initialize_kv_cache()
+        # num_blocks = size // page_bytes, which becomes the paged-KV-cache
+        # leading dim fed as a traced sharded array into the RPA jax.shard_map.
+        # Divergent per-host num_blocks => divergent StableHLO body shape =>
+        # divergent jit(run_model) XLA cache key => the launch-group validator
+        # ("different launch id in the launch group") halts the mesh. Observed
+        # as a clean z-slab split (e.g. 1850 vs 1861 num_kv_pages across 16
+        # hosts). Min-synchronize the budget across ALL hosts so every host
+        # allocates the SAME num_blocks => identical RPA KV shard shape => ONE
+        # cache key. Mirrors vLLM's min-across-workers KV budget; numerically
+        # inert (only lowers total KV capacity to the min-host budget; touches
+        # no weights/logits/optimizer state).
+        try:
+            from jax.experimental import multihost_utils as _mhu
+
+            if jax.process_count() > 1:
+                # int32-overflow safe: JAX runs x64 OFF by default, so a plain
+                # process_allgather of an int64 ~5.6e11-byte scalar truncates to
+                # int32 -> garbage/negative min -> the sync would silently no-op.
+                # Gather in MiB (~5e5, well within int32), min, then scale back.
+                # floor is monotone: min(floor(B_i/M)) == floor(min(B_i)/M), so
+                # no inter-host one-page difference can survive the round-trip.
+                _MIB = 1024 * 1024
+                _local_mib = int(total_hbm_avail) // _MIB
+                _gathered = _mhu.process_allgather(
+                    jax.numpy.asarray(_local_mib, dtype=jax.numpy.int32))
+                _synced_mib = int(jax.numpy.min(_gathered))
+                _synced = _synced_mib * _MIB
+                if _synced > 0 and _synced != total_hbm_avail:
+                    logger.info(
+                        "Cross-host KV-budget min-sync across "
+                        f"{jax.process_count()} hosts: "
+                        f"local total_hbm_avail={total_hbm_avail} -> "
+                        f"synced={_synced} "
+                        f"(delta={total_hbm_avail - _synced} bytes)")
+                if _synced > 0:
+                    total_hbm_avail = _synced
+        except Exception as _e:  # pragma: no cover - defensive
+            logger.warning(
+                "Cross-host KV-budget min-sync skipped (falling back to "
+                f"per-host budget; KV shard shapes may diverge): {_e}")
+
         return total_hbm_avail
 
     def execute_model(


### PR DESCRIPTION
# Description

On a multi-host / plain-SPMD TPU deployment, `TPUWorker.determine_available_memory()` returns a **per-host** value — `utils.hbm_usage_bytes()` does no cross-host reduction, so `total_hbm_avail` can differ per host due to topology-correlated resident runtime/allocator buffers.

That budget flows into `KVCacheManager.initialize_kv_cache()` (`num_blocks = size // page_bytes`), and `num_blocks` becomes the leading dim of the paged KV cache, which is fed as a **traced sharded array** into the ragged-paged-attention `jax.shard_map`.

A per-host-divergent `num_blocks` therefore produces a per-host-divergent StableHLO body shape for `jit(run_model)`, hence a divergent XLA persistent-compile cache key. The hosts then present **different launch ids** to the launch-group validator:

```
scheckne: An unexpected peer shows up in the launch group with a different launch id ...
HLO module: jit_run_model
tpu_program_termination_validation.cc
```

and the mesh halts before generation.

We observed this as a clean **z-slab split** across a 4x4x4 / 16-host slice: the lower half computed `num_kv_pages=1850` and the upper half `1861`, purely from a ~3.35 GB per-host live-HBM delta. We root-caused it by dumping per-host `jit_run_model.before_optimizations` HLO and diffing — the first (and only) diverging node was the RPA decode `pallas_call` leading dim.

**Fix:** min-synchronize `total_hbm_avail` across all hosts (`process_allgather` + `min`) so every host allocates the SAME `num_blocks` → identical RPA KV shard shape → one `jit(run_model)` cache key. This mirrors vLLM's engine-core min-across-workers KV budget and is **numerically inert** (only lowers total KV capacity to the min-host budget; touches no weights/logits/optimizer state).

Why this is a good solution:
- It fixes the root cause (divergent static shape baked into the compiled program) rather than a symptom.
- `min` is the tightest always-backable budget across workers — never over-allocates on any host.
- It runs at profiling time, outside any `jit`/`shard_map`, so it cannot perturb the traced program.

Implementation notes / shortcomings:
- Gated on `jax.process_count() > 1` (no-op single-host).
- **int32-overflow safe:** JAX runs x64 OFF by default, so a plain `process_allgather` of an int64 ~5.6e11-byte scalar truncates to int32 (→ garbage/negative min → silent no-op). We gather in **MiB** (~5e5, well within int32), `min`, then scale back to bytes. `floor` is monotone, so `min(floor(B_i/M)) == floor(min(B_i)/M)` and no inter-host one-page difference can survive the round-trip.
- Exception-safe: falls back to the per-host budget with a warning if the collective is unavailable.
- Possible future improvement: reconcile the final integer `num_blocks` immediately before allocation (plus a fail-fast unanimity assert on the KV cache shape across hosts) to protect against any future downstream per-host reservation between the budget and the block count. For the observed incident the byte-level min is sufficient (the only diverging HLO term was `num_kv_pages`; `page_size` etc. were host-identical).

# Tests

Verified on a 64-chip TPU v7x / 128-device / 16-host 4x4x4 slice (plain-SPMD, non-Pathways):
- **Before:** three distinct per-host budgets (558.87 / 562.21 / 562.41 GB) → divergent `num_kv_pages` (1850 vs 1861) → `jit_run_model` launch-group halt (`tpu_program_termination_validation`) before generation.
- **After:** all three per-host budgets reconcile to a single `global_min` (558866890752 bytes) on **every** host; `jit(run_model)` compiles on all 16 workers with **zero** launch-group / termination_validation halt, and the rollout proceeds to generation.

Repro (multi-host TPU, ≥2 processes): launch any model whose per-host resident HBM differs across the slice (topology-correlated) and observe the RPA decode `pallas_call` leading dim diverge across hosts in per-host `jit_run_model` HLO dumps; the launch-group validator then halts the mesh. With this change all hosts derive one `num_blocks` and the halt disappears.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [ ] I have made or will make corresponding changes to any relevant documentation. (No user-facing doc change; behavior is internal and transparent.)

---
*Authored with agent assistance (Navi) on behalf of @lokic233; root-caused and verified on real multi-host TPU silicon. Happy to adjust the approach (e.g. integer-`num_blocks` reconcile or an explicit unanimity assert) per maintainer preference.*
