### PR TITLE
[CI] Remove obsolete transformers>=5.5.0 gate from gemma-4 26B/31B unit tests

### DIFF
--- a/.buildkite/models/google_gemma-4-26B-A4B-it.yml
+++ b/.buildkite/models/google_gemma-4-26B-A4B-it.yml
@@ -18,15 +18,9 @@ steps:
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
-    # use 'pip install "transformers>=5.5.0" --dry-run' to check if transformers 5.5.0 is satisfied.
-    # if the output contains "Would install transformers-", it means transformers 5.5.0 is not satisfied, and we should skip the test.
     # TODO(#2333): enable on v6e
     commands:
       - |
-        if pip install "transformers>=5.5.0" --dry-run | grep -q "Would install transformers-"; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_UnitTest" "transformers version too low"
-          exit 0
-        fi
         if [ "${TPU_VERSION:-tpu6e}" = "tpu6e" ]; then
           buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-26B-A4B-it_UnitTest" "not enough HBM"
           exit 0

--- a/.buildkite/models/google_gemma-4-31B-it.yml
+++ b/.buildkite/models/google_gemma-4-31B-it.yml
@@ -18,14 +18,8 @@ steps:
     agents:
       queue: "${TPU_QUEUE_MULTI:-tpu_v6e_8_queue}"
     soft_fail: true
-    # use 'pip install "transformers>=5.5.0" --dry-run' to check if transformers 5.5.0 is satisfied.
-    # if the output contains "Would install transformers-", it means transformers 5.5.0 is not satisfied, and we should skip the test.
     commands:
       - |
-        if pip install "transformers>=5.5.0" --dry-run | grep -q "Would install transformers-"; then
-          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-31B-it_UnitTest" "transformers version too low"
-          exit 0
-        fi
         .buildkite/scripts/run_in_docker.sh \
           bash -c 'USE_BATCHED_RPA_KERNEL=1 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" SKIP_JAX_PRECOMPILE=1 VLLM_XLA_CHECK_RECOMPILATION=0 python /workspace/tpu_inference/examples/offline_inference.py --model google/gemma-4-31B-it --tensor-parallel-size 8 --max-num-batched-tokens 4096 --max-model-len 4096'
 


### PR DESCRIPTION
## What

Removes the `pip install "transformers>=5.5.0" --dry-run | grep -q "Would install transformers-"` skip-gate (and its explanatory comment) from the gemma-4 26B-A4B and 31B unit-test steps.

## Why

1. **The gate is broken.** It runs `pip` on the Buildkite agent host, where Python is PEP 668 externally-managed, so the command always fails with `error: externally-managed-environment` — visible in every gemma-4 unit-test job log (e.g. [nightly 24546](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24546#01a018d2-51ef-4df8-8cac-0ee78fbfb9cf)). The grep never matches, so the skip branch is unreachable and the gate is a no-op that only pollutes logs with a scary error.

2. **The gate is obsolete.** It also checks the wrong environment: the test runs inside the docker image, where `requirements.txt` pins `transformers>=5.8.0` and the pinned vLLM requires `transformers>=5.5.3`, so a transformers older than 5.5.0 is impossible.

## Test

CI-only change; the affected steps run in the nightly model suite. Removing an always-false condition cannot change which tests run.