### PR TITLE
Skip Pallas-backed tests when not running on TPU

### DIFF
--- a/tests/offload/tpu_offload_utils_test.py
+++ b/tests/offload/tpu_offload_utils_test.py
@@ -144,6 +144,9 @@ class TestTPUOffloadUtilsFn(unittest.TestCase):
         """
         Verify update_kv_caches function.
         """
+        if jax.default_backend() != "tpu":
+            self.skipTest("Pallas TPU kernel needs TPU hardware")
+
         num_blocks_to_update = 2
         update_indices = [1, 3]
 
@@ -309,6 +312,9 @@ class TestTPUOffloadUtilsFn(unittest.TestCase):
         """
         Verify update_kv_caches function with hybrid shapes.
         """
+        if jax.default_backend() != "tpu":
+            self.skipTest("Pallas TPU kernel needs TPU hardware")
+
         num_blocks_to_update = 2
         update_indices = [1, 3]
 


### PR DESCRIPTION
  # Description

  `test_update_kv_caches` and `test_update_kv_caches_hybrid` call `update_kv_caches`,
  which dispatches to the `kv_transfer.multi_layer_copy` Pallas kernel. Off TPU that
  raises `ValueError: Only interpret mode is supported on CPU backend.`, so the two
  tests fail instead of skipping and `tests/offload/tpu_offload_utils_test.py` can't
  be run locally — even though the other nine tests in the file pass on CPU.

  Guards those two tests with the same `jax.default_backend()` check already used in
  `tests/kernels/deepseek_v4/mhc_test.py`. Applied per-test rather than in `setUp`,
  since a class-level skip would also disable the nine tests that don't need TPU.

  Test-only change.

  # Tests

  `JAX_PLATFORMS=cpu pytest tests/offload/tpu_offload_utils_test.py -q`

  Before: `2 failed, 9 passed`. After: `9 passed, 2 skipped`.
  On TPU the condition is false, so both tests run as before.

  # Checklist

  - [x] I have performed a self-review of my code.
  - [x] I have necessary comments in my code, particularly in hard-to-understand areas.
  - [x] I have made or will make corresponding changes to any relevant documentation.