### PR TITLE
[Fix] Reduce shared-expert output over in-group TP under attention DP

### DIFF
--- a/tests/layers/vllm/test_fused_moe.py
+++ b/tests/layers/vllm/test_fused_moe.py
@@ -158,15 +158,11 @@ class TestMaybeReduceSharedExpertOutput:
              patch.object(fm, "_all_reduce_over_tp",
                           return_value=reduced) as reduce:
             out = runner._maybe_reduce_shared_expert_output(shared)
-        reduce.assert_called_once_with(shared, mesh)
+        reduce.assert_called_once_with(shared, mesh,
+                                       fm.ShardingAxisName.MLP_TENSOR)
         assert out is reduced
 
     def test_reduces_shared_output_under_attention_dp(self):
-        # Under attention DP the fused kernel reduces its own output, so the
-        # shared-expert output is reduced separately on the early path. Unlike
-        # the test above this drives the real ``_fused_output_is_reduced``
-        # property (via ``is_attn_dp``) instead of mocking it, exercising the
-        # attn-DP -> early-reduce routing end to end.
         runner = _make_runner(shared_experts=object())
         shared = torch.ones(2, 3)
         reduced = torch.full((2, 3), 7.0)
@@ -175,8 +171,10 @@ class TestMaybeReduceSharedExpertOutput:
              patch.object(fm, "is_attn_dp", return_value=True), \
              patch.object(fm, "_all_reduce_over_tp",
                           return_value=reduced) as reduce:
-            runner._maybe_reduce_shared_expert_output(shared)
-        reduce.assert_not_called()
+            out = runner._maybe_reduce_shared_expert_output(shared)
+        reduce.assert_called_once_with(shared, mesh,
+                                       fm.ShardingAxisName.ATTN_HEAD)
+        assert out is reduced
 
 
 # ---------------------------------------------------------------------------

--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -41,8 +41,16 @@ def _get_mesh() -> Mesh | None:
 
 def _all_reduce_over_tp(t: torch.Tensor,
                         mesh: Mesh,
-                        axis_name=ShardingAxisName.MLP_TENSOR) -> torch.Tensor:
-    """All-reduce an unreduced local sum over the TP axis."""
+                        axis_name=None) -> torch.Tensor:
+    """All-reduce an unreduced local sum over the TP axis.
+
+    ``axis_name`` is resolved inside the function on purpose: ``ShardingAxisName``
+    is lazily initialized from the environment on first attribute access, so
+    reading it in a default argument (at import time, before NEW_MODEL_DESIGN is
+    set) would latch the 2D axis set for the whole process.
+    """
+    if axis_name is None:
+        axis_name = ShardingAxisName.MLP_TENSOR
     spec = P(ShardingAxisName.ATTN_DATA, None)
 
     @shard_map(mesh=mesh, in_specs=spec, out_specs=spec, check_vma=False)

--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -42,13 +42,7 @@ def _get_mesh() -> Mesh | None:
 def _all_reduce_over_tp(t: torch.Tensor,
                         mesh: Mesh,
                         axis_name=None) -> torch.Tensor:
-    """All-reduce an unreduced local sum over the TP axis.
-
-    ``axis_name`` is resolved inside the function on purpose: ``ShardingAxisName``
-    is lazily initialized from the environment on first attribute access, so
-    reading it in a default argument (at import time, before NEW_MODEL_DESIGN is
-    set) would latch the 2D axis set for the whole process.
-    """
+    """All-reduce an unreduced local sum over the TP axis."""
     if axis_name is None:
         axis_name = ShardingAxisName.MLP_TENSOR
     spec = P(ShardingAxisName.ATTN_DATA, None)

--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -39,13 +39,15 @@ def _get_mesh() -> Mesh | None:
         return None
 
 
-def _all_reduce_over_tp(t: torch.Tensor, mesh: Mesh) -> torch.Tensor:
+def _all_reduce_over_tp(t: torch.Tensor,
+                        mesh: Mesh,
+                        axis_name=ShardingAxisName.MLP_TENSOR) -> torch.Tensor:
     """All-reduce an unreduced local sum over the TP axis."""
     spec = P(ShardingAxisName.ATTN_DATA, None)
 
     @shard_map(mesh=mesh, in_specs=spec, out_specs=spec, check_vma=False)
     def _reduce(x):
-        return jax.lax.psum(x, axis_name=ShardingAxisName.MLP_TENSOR)
+        return jax.lax.psum(x, axis_name=axis_name)
 
     return torch_view(_reduce(jax_view(t)))
 
@@ -131,9 +133,10 @@ class VllmMoERunner(MoERunner):
             fused_output_is_reduced = self._fused_output_is_reduced
 
         if (shared_output is not None and fused_output_is_reduced
-                and not self.moe_config.is_sequence_parallel
-                and not is_attn_dp(mesh)):
-            shared_output = _all_reduce_over_tp(shared_output, mesh)
+                and not self.moe_config.is_sequence_parallel):
+            axis_name = (ShardingAxisName.ATTN_HEAD
+                         if is_attn_dp(mesh) else ShardingAxisName.MLP_TENSOR)
+            shared_output = _all_reduce_over_tp(shared_output, mesh, axis_name)
         return shared_output
 
     def _maybe_reduce_final_output(


### PR DESCRIPTION
## Problem

With attention DP and in-group TP > 1 (e.g. `--tensor-parallel-size 8` + `attn_dp_size=4` → mesh `model=2`), Qwen3.5-MoE produces degraded / garbled output. `attn_dp_size == tp` (model=1) and plain TP are fine. 

## Root cause

Qwen3.5-MoE's shared expert is built with `reduce_results=False`, so the shared-expert output is a partial sum over the in-group tp axis. Under attention DP the routed experts reduces and scatters its own output, but the shared experts do not. Net effect: `result = shared_partial + routed_full` — the shared expert contributes 1/`model` of its value.

## Fix

Reduce the shared-expert output over `ShardingAxisName.ATTN_HEAD` (the in-group tp axis) under attention DP instead of skipping it. 


## Validation

Qwen3.5-35B-A3B-FP8, tp=8, EP, gsm8k 5-shot, v7x-8:

| config | mesh `model` | before | after |
|---|---|---|---|
| plain tp=8 | 8 | 96.0% | — |
| attn_dp=8 | 1 | 96.1% | — (reduce is a no-op) |
| attn_dp=4 | 2 | 86.1% | **96.3%** |
| attn_dp=2 | 4 | 23.9% | **96.2%** |

Baseline (main branch): Qwen3.5-4B (dense: GDN + full attention, no MoE) scores 91.1% at both attn_dp=4 and attn_dp=8, and Qwen3-30B-A3B-FP8 (MoE without a shared expert, no GDN) scores 91.7% / 91.6% at attn_dp=4 / 8 

