### PR TITLE
[CI] Mark gemma-4 E2B/E4B benchmark as unverified on the vllm (torchax) nightly variant

### DIFF
--- a/.buildkite/models/google_gemma-4-E2B-it.yml
+++ b/.buildkite/models/google_gemma-4-E2B-it.yml
@@ -122,7 +122,15 @@ steps:
       MINIMUM_THROUGHPUT_THRESHOLD: 0.0
     commands:
       - |
-        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
+        if [ "${MODEL_IMPL_TYPE:-auto}" = "vllm" ]; then
+          echo "gemma-4 E2B on the vllm (torchax) path has never passed" \
+               "accuracy: the model's per_layer_embeddings CUDA-graph buffer" \
+               "is incompatible with torchax and its KV-shared layers corrupt" \
+               "the target layer's cache. Recording as unverified until the" \
+               "torchax path is fixed."
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-E2B-it_Benchmark" "unverified"
+         else
+          .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-E2B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E2B-it_Benchmark"

--- a/.buildkite/models/google_gemma-4-E4B-it.yml
+++ b/.buildkite/models/google_gemma-4-E4B-it.yml
@@ -117,7 +117,15 @@ steps:
       MINIMUM_THROUGHPUT_THRESHOLD: 0.0
     commands:
       - |
-        .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
+        if [ "${MODEL_IMPL_TYPE:-auto}" = "vllm" ]; then
+          echo "gemma-4 E4B on the vllm (torchax) path has never passed" \
+               "accuracy: the model's per_layer_embeddings CUDA-graph buffer" \
+               "is incompatible with torchax and its KV-shared layers corrupt" \
+               "the target layer's cache. Recording as unverified until the" \
+               "torchax path is fixed."
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_google_gemma-4-E4B-it_Benchmark" "unverified"
+        else
+          .buildkite/scripts/run_in_docker.sh bash -c 'TIMEOUT_SECONDS=960 JITTED_MM_MODULE_KEYS="model.vision_tower.encoder" REGISTER_MM_MODULE_CUSTOM_PYTREE_CLASSES="transformers.modeling_outputs.BaseModelOutputWithPast" /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh'
 
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for google/gemma-4-E4B-it"
     key: "${TPU_VERSION:-tpu6e}_record_google_gemma-4-E4B-it_Benchmark"


### PR DESCRIPTION
## Problem

Similar as PR #3414 The `MODEL_IMPL_TYPE=vllm` nightly's "Benchmark for google/gemma-4-E2B-it / E4B-it" jobs have **never passed**

- vLLM's `Gemma4ForConditionalGeneration` caches per-layer embeddings in a plain-attribute CUDA-graph buffer; `shard_model_to_tpu` never converts it, so engine-init precompile crashes in torchax's `_aten_copy` (`AttributeError: 'Tensor' object has no attribute '_elem'`).
- Even past that, E2B/E4B's KV-shared layers (last 20/18 layers) overwrite their target layer's cache in the torchax attention backend, so generation is garbage.

A permanently-red job is not a regression signal; it only hides real regressions in the nightly report.

## Change

On the vllm variant only, skip the E2B/E4B Benchmark run and record the step as `unverified` via buildkite-agent meta-data — the same pattern #3404 established for DFlash. The default (JAX) and flax_nnx variants are untouched and keep running  as before.

Once the torchax path is fixed (#3406 implements the PLE + KV-share fixes), this gate should be reverted so the vllm variant tests accuracy for real.
