### PR TITLE
Fix compatibility with upstream vLLM AutoWeightsLoader and tied embeddings

### DIFF
--- a/tests/models/jax/utils/test_weight_utils.py
+++ b/tests/models/jax/utils/test_weight_utils.py
@@ -116,6 +116,21 @@ class TestJaxAutoWeightsLoader:
                                    rtol=1e-3,
                                    atol=1e-2)
 
+    def test_skip_lists_survive_init(self):
+        """skip_prefixes/skip_substrs must survive construction regardless of
+        whether the vLLM AutoWeightsLoader base class still owns (and resets)
+        those attributes in its own __init__."""
+        from tpu_inference.models.jax.utils.weight_utils import \
+            JaxAutoWeightsLoader
+
+        jax_model = JaxMLP(rngs=nnx.Rngs(0))
+        loader = JaxAutoWeightsLoader(jax_model,
+                                      skip_prefixes=["lm_head"],
+                                      skip_substrs=["vision", "audio"])
+        assert "lm_head" in loader.skip_prefixes
+        assert "vision" in loader.skip_substrs
+        assert "audio" in loader.skip_substrs
+
     def test_weight_prefix_mapping(self):
         """Test that 'model.' is prepended correctly based on module structure."""
         from unittest.mock import MagicMock, patch

--- a/tpu_inference/models/jax/utils/weight_utils.py
+++ b/tpu_inference/models/jax/utils/weight_utils.py
@@ -882,8 +882,6 @@ class JaxAutoWeightsLoader(AutoWeightsLoader):
         assert isinstance(model, JaxModule)
         self.pytorch_pooler = pytorch_pooler
         self.pooler_weights = {}
-        self.skip_prefixes = list(skip_prefixes) if skip_prefixes else []
-        self.skip_substrs = list(skip_substrs) if skip_substrs else []
 
         for name, param in model.named_parameters():
             if not hasattr(param, "weight_loader"):
@@ -938,6 +936,14 @@ class JaxAutoWeightsLoader(AutoWeightsLoader):
                 loader_kwargs[k] = v
 
         super().__init__(model, **loader_kwargs)
+        # Older vLLM AutoWeightsLoader versions still own skip_prefixes /
+        # skip_substrs and reset them in __init__ (newer versions removed the
+        # kwargs and never touch the attributes), so ours must be assigned
+        # after super().__init__ and merged with whatever it set.
+        self.skip_prefixes = getattr(self, "skip_prefixes", []) + (
+            list(skip_prefixes) if skip_prefixes else [])
+        self.skip_substrs = getattr(self, "skip_substrs", []) + (
+            list(skip_substrs) if skip_substrs else [])
         # Book mark those already done processing, skip if visited.
         self._process_weights_after_loading_per_module = defaultdict(
             lambda: False)

--- a/tpu_inference/models/jax/utils/weight_utils.py
+++ b/tpu_inference/models/jax/utils/weight_utils.py
@@ -38,7 +38,7 @@ from safetensors import safe_open
 from vllm.config import ModelConfig, VllmConfig, get_current_vllm_config
 from vllm.model_executor.model_loader import register_model_loader
 from vllm.model_executor.model_loader.dummy_loader import DummyModelLoader
-from vllm.model_executor.models.utils import AutoWeightsLoader
+from vllm.model_executor.models.utils import AutoWeightsLoader, WeightsMapper
 
 from tpu_inference import envs, utils
 from tpu_inference.layers.common.utils import (cpu_mesh_context,
@@ -874,10 +874,16 @@ class JaxAutoWeightsLoader(AutoWeightsLoader):
     def __init__(self,
                  model,
                  pytorch_pooler: Optional[torch.nn.Module] = None,
+                 skip_prefixes: Optional[list[str]] = None,
+                 skip_substrs: Optional[list[str]] = None,
+                 ignore_unexpected_prefixes: Optional[list[str]] = None,
+                 ignore_unexpected_suffixes: Optional[list[str]] = None,
                  **kwargs):
         assert isinstance(model, JaxModule)
         self.pytorch_pooler = pytorch_pooler
         self.pooler_weights = {}
+        self.skip_prefixes = list(skip_prefixes) if skip_prefixes else []
+        self.skip_substrs = list(skip_substrs) if skip_substrs else []
 
         for name, param in model.named_parameters():
             if not hasattr(param, "weight_loader"):
@@ -920,7 +926,18 @@ class JaxAutoWeightsLoader(AutoWeightsLoader):
                                       permute_dims=permute_dims,
                                       param_name=name))
 
-        super().__init__(model, **kwargs)
+        loader_kwargs = {}
+        if ignore_unexpected_prefixes is not None:
+            loader_kwargs[
+                "ignore_unexpected_prefixes"] = ignore_unexpected_prefixes
+        if ignore_unexpected_suffixes is not None:
+            loader_kwargs[
+                "ignore_unexpected_suffixes"] = ignore_unexpected_suffixes
+        for k, v in kwargs.items():
+            if k not in ("skip_prefixes", "skip_substrs"):
+                loader_kwargs[k] = v
+
+        super().__init__(model, **loader_kwargs)
         # Book mark those already done processing, skip if visited.
         self._process_weights_after_loading_per_module = defaultdict(
             lambda: False)
@@ -943,7 +960,10 @@ class JaxAutoWeightsLoader(AutoWeightsLoader):
                 remap.append((fused_name, shard_name, shard_id))
         return remap
 
-    def load_weights(self, weights: Iterable, **kwargs) -> set:
+    def load_weights(self,
+                     weights: Iterable,
+                     mapper: Optional[WeightsMapper] = None,
+                     **kwargs) -> set:
         """Route packed (e.g. fused gate_up_proj) checkpoint weights, then
         delegate the rest to the standard recursive auto-loader.
 
@@ -954,13 +974,23 @@ class JaxAutoWeightsLoader(AutoWeightsLoader):
         and fuses them. Weights whose fused param does not exist (e.g. the
         vision tower's unfused gate/up projections) fall through unchanged.
         """
+        if self.skip_prefixes or self.skip_substrs:
+            skip_prefix_dict = {p: None for p in self.skip_prefixes}
+            skip_substr_dict = {s: None for s in self.skip_substrs}
+            skip_mapper = WeightsMapper(
+                orig_to_new_prefix=skip_prefix_dict,
+                orig_to_new_substr=skip_substr_dict,
+            )
+            mapper = (mapper
+                      | skip_mapper) if mapper is not None else skip_mapper
+
         remap = self._packed_remap()
         if not remap:
             # No packed/fused params to route. Skip building the full param
             # dict: materializing the entire parameter tree up front
             # transiently doubles device HBM, so go straight to the streaming
             # recursive loader.
-            return super().load_weights(weights, **kwargs)
+            return super().load_weights(weights, mapper=mapper, **kwargs)
         params_dict = dict(self.module.named_parameters())
         routed_loaded: set = set()
 
@@ -981,7 +1011,9 @@ class JaxAutoWeightsLoader(AutoWeightsLoader):
                 else:
                     yield name, weight
 
-        autoloaded = super().load_weights(_route(weights), **kwargs)
+        autoloaded = super().load_weights(_route(weights),
+                                          mapper=mapper,
+                                          **kwargs)
 
         # Routed weights are written directly into their fused param via
         # `weight_loader` above and never re-enter the streaming weights

--- a/tpu_inference/models/vllm/experimental/deepseek_v4.py
+++ b/tpu_inference/models/vllm/experimental/deepseek_v4.py
@@ -738,7 +738,6 @@ def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:
             "embed.": "model.embed.",
             "norm.": "model.norm.",
             "hc_head": "model.hc_head",
-            "mtp.": "model.mtp.",
         },
         orig_to_new_regex=scale_regex,
         orig_to_new_suffix={
@@ -748,6 +747,7 @@ def _make_deepseek_v4_weights_mapper(expert_dtype: str) -> WeightsMapper:
         },
         orig_to_new_substr={
             ".shared_experts.w2": ".shared_experts.down_proj",
+            "mtp.": None,
         },
     )
 
@@ -812,7 +812,7 @@ class DeepseekV4ForCausalLM(nn.Module, SupportsPP):
 
     def load_weights(self, weights: Iterable[tuple[str,
                                                    torch.Tensor]]) -> set[str]:
-        loader = AutoWeightsLoader(self, skip_substrs=["mtp."])
+        loader = AutoWeightsLoader(self)
         loaded_params = loader.load_weights(weights,
                                             mapper=self.hf_to_vllm_mapper)
 

--- a/tpu_inference/models/vllm/vllm_model_loader.py
+++ b/tpu_inference/models/vllm/vllm_model_loader.py
@@ -24,9 +24,17 @@ from vllm.model_executor.model_loader.runai_streamer_loader import \
     RunaiModelStreamerLoader
 from vllm.model_executor.model_loader.utils import (
     initialize_model, process_weights_after_loading)
+from vllm.model_executor.models.utils import WeightsMapper
 from vllm.utils.torch_utils import set_default_torch_dtype
 
 from tpu_inference.layers.vllm.quantization.base import VllmQuantizationMethod
+
+
+def _patch_tied_embedding_mapper(model: torch.nn.Module) -> None:
+    """Ensure checkpoint weights targeting lm_head are skipped when word embeddings are tied but self.lm_head is not defined."""
+    if hasattr(model, "hf_to_vllm_mapper") and not hasattr(model, "lm_head"):
+        model.hf_to_vllm_mapper = model.hf_to_vllm_mapper | WeightsMapper(
+            orig_to_new_prefix={"lm_head.": None})
 
 
 def attach_incremental_weight_loader(model: torch.nn.Module) -> None:
@@ -102,6 +110,7 @@ class IncrementalModelLoader(DefaultModelLoader):
                                          model_config=model_config)
             # Override weight loader logic of each parameter to support incremental loading.
             attach_incremental_weight_loader(model)
+            _patch_tied_embedding_mapper(model)
             # Quantization does not happen in `load_weights` but after it
             self.load_weights(model, model_config)
             process_weights_after_loading(model, model_config, target_device)
@@ -142,6 +151,7 @@ class RunaiIncrementalModelLoader(RunaiModelStreamerLoader):
                                          model_config=model_config)
             # Override weight loader logic of each parameter to support incremental loading.
             attach_incremental_weight_loader(model)
+            _patch_tied_embedding_mapper(model)
             # Quantization does not happen in `load_weights` but after it
             self.load_weights(model, model_config)
             process_weights_after_loading(model, model_config, target_device)


### PR DESCRIPTION
## Summary

Fixes the integration-test failures introduced in [tpu-vllm-integration build 1971](https://buildkite.com/tpu-commons/tpu-vllm-integration/builds/1971/list) (17 soft failures) and build 1970 (4 soft failures), caused by two upstream vLLM changes:

1. **vllm-project/vllm@`1fe3a1571a`** (*Reduce `AutoWeightsLoader` kwargs*) removed `skip_prefixes` / `skip_substrs` from `AutoWeightsLoader.__init__()`, consolidating skip logic into `WeightsMapper` entries that map to `None`. `JaxAutoWeightsLoader` and `DeepseekV4ForCausalLM` were still passing these kwargs, raising `TypeError: AutoWeightsLoader.__init__() got an unexpected keyword argument 'skip_prefixes'` across the JAX weight-loading tests.
2. **vllm-project/vllm@`f0c14b4f77`** (*Fix weight tying*) removed the explicit `lm_head` skip from `GemmaForCausalLM.load_weights`, relying on `_get_tied_embedding_params()` — which cannot discover `lm_head` because the module never defines it when embeddings are tied. Loading checkpoints that contain `lm_head.weight` via `RunaiModelStreamer` failed with `ValueError: There is no module or parameter named 'lm_head' in GemmaForCausalLM`.

## Changes

- **`tpu_inference/models/jax/utils/weight_utils.py`**: `JaxAutoWeightsLoader` keeps accepting `skip_prefixes` / `skip_substrs` for its existing JAX-model callers (gemma4, gemma4_mm, gemma4_mtp, deepseek_v3), strips them before calling `super().__init__()`, and converts them in `load_weights()` into a `WeightsMapper` (`orig_to_new_prefix={p: None}`, `orig_to_new_substr={s: None}`) merged with any caller-supplied mapper.
- **`tpu_inference/models/vllm/experimental/deepseek_v4.py`**: drop MTP weights via `"mtp.": None` in the weights mapper instead of `skip_substrs=["mtp."]`.
- **`tpu_inference/models/vllm/vllm_model_loader.py`**: new `_patch_tied_embedding_mapper()` extends `hf_to_vllm_mapper` with `orig_to_new_prefix={"lm_head.": None}` for models that tie embeddings without defining `self.lm_head`; applied in both `IncrementalModelLoader.load_model` and `RunaiIncrementalModelLoader.load_model`.

## Test plan

Run in the build-1971 CI image (`vllm-tpu:3bd526987...-7c8b68b9c...-tpu7x`):

- `pytest tests/models/jax/utils/test_weight_utils.py tests/models/common/test_model_loader.py` — **31 passed**
- `pytest tests/layers/jax/test_linear.py` (exercises `JaxAutoWeightsLoader` routing directly) — **14 passed**