### PR TITLE
[CI] Gate record_verified_commit_hashes step to MODEL_IMPL_TYPE=auto

### DIFF
--- a/.buildkite/nightly_verify.yml
+++ b/.buildkite/nightly_verify.yml
@@ -96,7 +96,7 @@ steps:
 
    - label: "Record verified commit hashes"
      # GITHUB_PAT is main/tag-only - see commit_support_matrices above.
-     if: build.env("NIGHTLY") == "1" && build.branch == "main"
+     if: build.env("NIGHTLY") == "1" && build.branch == "main" && "${MODEL_IMPL_TYPE:-auto}" == "auto"
      key: record_verified_commit_hashes
      depends_on:
        - notify_test_results


### PR DESCRIPTION
## Why
When running nightly pipelines with non-auto backends (e.g., `MODEL_IMPL_TYPE=flax_nnx` or `vllm`), `pipeline_jax.yml` is not uploaded. As a result, the dependent steps `tpu6e_tpu_test_notification` and `tpu7x_tpu_test_notification` do not exist, causing `record_verified_commit_hashes` to fail dependency resolution.

## What
- Gate the `record_verified_commit_hashes` step in `.buildkite/nightly_verify.yml` with `"${MODEL_IMPL_TYPE:-auto}" == "auto"`.
- Ensures the step only runs during standard JAX nightly pipeline runs on `main`.

## Test Plan
- [x] Verified the Buildkite syntax via a [small test](https://buildkite.com/tpu-commons/tpu-inference-dev/builds?branch=dennis%2Ffix_record_verified_commit_hashes)
