### PR TITLE
[Jax][Qwix] Quantize large NNX models submodule-by-submodule to avoid a peak-HBM OOM

### DIFF
--- a/tests/layers/jax/test_qwix.py
+++ b/tests/layers/jax/test_qwix.py
@@ -221,12 +221,30 @@ class TestApplyQwixQuantization(unittest.TestCase):
                       "Model should be returned as-is.")
         mock_nnx.jit.assert_not_called()
 
-    @patch('tpu_inference.models.common.model_loader.jax.jit')
-    def test_quantization_applied_from_dict(self, mock_jit):
+    def test_quantization_applied_from_dict(self):
         """
         Test that quantization is applied correctly when the config is a dictionary.
+
+        Quantization for the concrete-model path is dispatched to
+        `qwix_quantize_nnx_model_streaming`, which quantizes one submodule
+        (embed_tokens / each decoder layer / norm) at a time via its own
+        `jax.jit` call rather than one `jax.jit` over the whole model -- see
+        that function's docstring for why (avoiding a peak-HBM blowup on
+        large models). This test asserts dispatch happens, not the specific
+        jit call count, since that's an implementation detail of the
+        streaming function itself (covered separately).
+
+        NOTE: this class is decorated with `@patch.dict('sys.modules',
+        module_mocks)`, which replaces
+        `sys.modules['...qwix_utils']` with a bare `MagicMock` for the
+        duration of every test here. A string-path `@patch(...)` on a
+        `qwix_utils` attribute would re-resolve the module through that
+        mocked `sys.modules` entry and silently patch the mock instead of
+        the real module `apply_qwix_quantization` actually runs in -- use
+        `patch.object` on the real, already-imported `quantize_qwix` module
+        object instead, which bypasses that re-resolution.
         """
-        qwix_rules = {"weights": "int8", "activations": None}
+        qwix_rules = [{"module_path": ".*", "weight_qtype": "int8"}]
         self.mock_vllm_config.additional_config = {
             "quantization": {
                 "qwix": {
@@ -235,14 +253,17 @@ class TestApplyQwixQuantization(unittest.TestCase):
             }
         }
 
-        with patch('tpu_inference.utils.get_padded_num_heads',
+        with patch.object(quantize_qwix,
+                          'qwix_quantize_nnx_model_streaming',
+                          return_value=self.mock_model) as mock_quantize_streaming, \
+             patch('tpu_inference.utils.get_padded_num_heads',
                    return_value=128):
             apply_qwix_quantization(self.mock_vllm_config,
                                     self.mock_model,
                                     self.mock_rng,
                                     self.mock_mesh,
                                     apply_to_abstract_model=False)
-        mock_jit.assert_called_once()
+        mock_quantize_streaming.assert_called_once()
 
 
 class TestQuantizationConfigFileToDict(unittest.TestCase):

--- a/tpu_inference/models/jax/deepseek_v3.py
+++ b/tpu_inference/models/jax/deepseek_v3.py
@@ -581,6 +581,15 @@ class MLAEinsum(JaxEinsum):
         delattr(self, 'weight')
         delattr(self, 'weight_scale_inv')
         delattr(self, 'quant_method')
+        # `mla_layer` was only needed to perform the k/v split above; keeping
+        # it creates a permanent reference cycle (mla_layer.kv_b_proj.mla_layer
+        # is mla_layer). nnx's own graph traversal is cycle-safe (see
+        # `named_children` override above), but raw `jax.jit`/`jax.tree_util`
+        # pytree flattening (e.g. qwix's quantization path, or any other code
+        # that passes the model through a plain `jax.jit` instead of
+        # `nnx.jit`) is not, and recurses infinitely over this cycle until it
+        # hits `RecursionError`. Drop it now that it's unused.
+        delattr(self, 'mla_layer')
 
 
 @dataclass(kw_only=True)

--- a/tpu_inference/models/jax/utils/qwix/qwix_utils.py
+++ b/tpu_inference/models/jax/utils/qwix/qwix_utils.py
@@ -22,6 +22,7 @@ if TYPE_CHECKING:
 from tpu_inference import utils
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.jax.pp_utils import PPMissingLayer
 from tpu_inference.logger import init_logger
 from tpu_inference.runner.kv_cache import (DEFAULT_KV_CACHE_DTYPE,
                                            create_kv_caches)
@@ -217,6 +218,155 @@ def qwix_quantize_nnx_model(model: nnx.Module, qwix_config: List[dict],
     return model
 
 
+def qwix_quantize_nnx_model_streaming(
+        model: nnx.Module, qwix_config: List[dict], rng: jax.Array,
+        mesh: Mesh, num_hidden_layers: int, kv_cache_block_size: int,
+        kv_cache_num_kv_heads: int | tuple[int, ...],
+        kv_cache_head_size: int | tuple[int, ...],
+        kv_cache_dtype: str) -> nnx.Module:
+    """
+    Layer-by-layer streaming variant of `qwix_quantize_nnx_model`.
+
+    `qwix.quantize_model` internally does `nnx.clone(model)`, which
+    allocates a full duplicate copy of every weight it's given. Calling it
+    once on the whole model (inside a single `jax.jit`) therefore requires
+    the original bf16 weights and the cloned bf16-on-its-way-to-int8
+    weights to be resident in HBM at the same time for the *entire* model
+    at once. For a model that's already using a large fraction of a chip's
+    HBM just for its bf16 weights, this overflows available HBM even
+    though the final int8 model is much smaller than the original.
+
+    This variant instead quantizes one submodule (embed_tokens, one
+    decoder layer, or norm) at a time, each via its own `jax.jit` call with
+    `donate_argnums=(0,)`. Each call fully executes and returns before the
+    next one starts, so only one submodule's weights are ever doubled at a
+    time -- peak extra HBM is bounded by the largest single submodule (one
+    decoder layer) instead of the whole model.
+
+    qwix's per-instance interception (it swaps `instance.__class__` to run
+    quantized ops) is why this composes correctly: the unmodified parent
+    `__call__` methods just do `self.submodule(...)`, which dispatches to
+    whatever `type(submodule).__call__` is at call time -- quantizing a
+    submodule in place is enough, no changes needed to any parent module.
+
+    lm_head is intentionally left unquantized, matching this model's
+    existing convention (see `quant_config=None` in
+    `Glm4MoeLiteForCausalLM.__init__`).
+    """
+    qwix_rules = parse_qwix_config_to_rules(qwix_config)
+    logger.info(f"Qwix rules (streaming): {qwix_rules}")
+    logger.info(f"Memory usage before applying quantization of params: "
+                f"hbm={utils.hbm_usage_gb(jax.local_devices())}Gb")
+
+    if kv_cache_dtype != "auto":
+        kv_cache_jnp_dtype = utils.to_jax_dtype(kv_cache_dtype)
+    else:
+        kv_cache_jnp_dtype = DEFAULT_KV_CACHE_DTYPE
+
+    head_sizes = kv_cache_head_size
+    if isinstance(head_sizes, int):
+        head_sizes = (head_sizes, ) * num_hidden_layers
+
+    num_kv_heads_tuple = kv_cache_num_kv_heads
+    if isinstance(num_kv_heads_tuple, int):
+        num_kv_heads_tuple = (num_kv_heads_tuple, ) * num_hidden_layers
+
+    use_mla = model.vllm_config.model_config.use_mla
+    hidden_size = model.vllm_config.model_config.hf_config.hidden_size
+    dp_size = model.vllm_config.sharding_config.total_dp_size
+
+    # NOTE: the inputs don't need to match the actual ones, as long as the
+    # consumed weights are the same (same convention as
+    # `qwix_quantize_nnx_model` above).
+    input_ids = jax.random.randint(rng,
+                                   (DEFAULT_NUM_TOKENS_FOR_MODEL_INPUTS, ),
+                                   0,
+                                   100,
+                                   dtype=jnp.int32)
+    positions = jax.random.randint(rng,
+                                   (DEFAULT_NUM_TOKENS_FOR_MODEL_INPUTS, ),
+                                   0,
+                                   100,
+                                   dtype=jnp.int32)
+    block_tables = jax.random.randint(rng,
+                                      (DEFAULT_MAX_NUM_SEQS_FOR_MODEL_INPUTS *
+                                       DEFAULT_MAX_NUM_BLOCKS_PER_REQ, ),
+                                      0,
+                                      100,
+                                      dtype=jnp.int32)
+    query_start_loc = jax.random.randint(
+        rng, (DEFAULT_MAX_NUM_SEQS_FOR_MODEL_INPUTS + dp_size, ),
+        0,
+        100,
+        dtype=jnp.int32)
+    seq_lens = jax.random.randint(rng,
+                                  (DEFAULT_MAX_NUM_SEQS_FOR_MODEL_INPUTS, ),
+                                  0,
+                                  100,
+                                  dtype=jnp.int32)
+    num_seqs = jax.random.randint(rng, (1, ), 0, 100, dtype=jnp.int32)
+    request_distribution = jnp.array([0, 0, num_seqs[0]] * dp_size,
+                                     dtype=jnp.int32)
+
+    (input_ids, positions, block_tables,
+     query_start_loc, seq_lens, request_distribution) = device_array(
+         mesh, (input_ids, positions, block_tables, query_start_loc, seq_lens,
+                request_distribution))
+
+    attention_metadata = AttentionMetadata(
+        input_positions=positions,
+        block_tables=block_tables,
+        seq_lens=seq_lens,
+        query_start_loc=query_start_loc,
+        request_distribution=request_distribution)
+
+    x_dummy = device_array(
+        mesh,
+        jax.random.normal(rng,
+                          (DEFAULT_NUM_TOKENS_FOR_MODEL_INPUTS, hidden_size),
+                          dtype=model.vllm_config.model_config.dtype))
+
+    def _quantize_submodule(submodule, *args, **kwargs):
+        return qwix.quantize_model(submodule, qwix.PtqProvider(qwix_rules),
+                                   *args, **kwargs)
+
+    jit_quantize = jax.jit(_quantize_submodule, donate_argnums=(0, ))
+
+    inner_model = model.model
+
+    if not isinstance(inner_model.embed_tokens, PPMissingLayer):
+        inner_model.embed_tokens = jit_quantize(inner_model.embed_tokens,
+                                                input_ids)
+        logger.info("Quantized embed_tokens; hbm="
+                   f"{utils.hbm_usage_gb(jax.local_devices())}Gb")
+
+    for i in range(num_hidden_layers):
+        layer = inner_model.layers[i]
+        if isinstance(layer, PPMissingLayer):
+            continue
+        layer_cache = create_kv_caches(
+            num_blocks=DEFAULT_NUM_BLOCKS_FOR_JIT_KV_CACHE,
+            block_size=kv_cache_block_size,
+            num_kv_heads=num_kv_heads_tuple[i],
+            head_size=head_sizes[i],
+            mesh=mesh,
+            layer_names=[f"layer.{i}"],
+            cache_dtype=kv_cache_jnp_dtype,
+            use_mla=use_mla,
+        )
+        inner_model.layers[i] = jit_quantize(layer, layer_cache[0], x_dummy,
+                                             attention_metadata)
+        logger.info(f"Quantized layer {i + 1}/{num_hidden_layers}; hbm="
+                   f"{utils.hbm_usage_gb(jax.local_devices())}Gb")
+
+    if not isinstance(inner_model.norm, PPMissingLayer):
+        inner_model.norm = jit_quantize(inner_model.norm, x_dummy)
+        logger.info("Quantized norm; hbm="
+                   f"{utils.hbm_usage_gb(jax.local_devices())}Gb")
+
+    return model
+
+
 def quantization_config_file_path_to_dict(
         quantization_config_file_path: str) -> dict:
     """
@@ -372,27 +522,25 @@ def apply_qwix_quantization(
 
     if not apply_to_abstract_model:
         assert isinstance(model_or_model_fn, nnx.Module)
-        qwix_quantize_nnx_model_with_config = functools.partial(
-            qwix_quantize_nnx_model, qwix_config=qwix_config)
-        # NOTE: it's REALLY important `qwix_quantize_nnx_model_with_config` is jitted
-        # or else you'll run into hanging
-        model_or_model_fn = jax.jit(qwix_quantize_nnx_model_with_config,
-                                    donate_argnums=(0, ),
-                                    static_argnames=(
-                                        "mesh",
-                                        "num_hidden_layers",
-                                        "kv_cache_block_size",
-                                        "kv_cache_num_kv_heads",
-                                        "kv_cache_head_size",
-                                        "kv_cache_dtype",
-                                    ))(model=model_or_model_fn,
-                                       rng=rng,
-                                       mesh=mesh,
-                                       num_hidden_layers=num_hidden_layers,
-                                       kv_cache_block_size=block_size,
-                                       kv_cache_num_kv_heads=num_kv_heads,
-                                       kv_cache_head_size=head_size,
-                                       kv_cache_dtype=kv_cache_dtype)
+        # NOTE: this must NOT be wrapped in an outer `jax.jit` -- the whole
+        # point of `qwix_quantize_nnx_model_streaming` is to quantize one
+        # submodule at a time via its own `jax.jit` call that fully executes
+        # (freeing that submodule's temporary bf16 copy) before moving to the
+        # next one. Wrapping it in an outer `jax.jit` would inline all of
+        # those nested calls into a single XLA program again, defeating the
+        # peak-HBM reduction this is for (see the docstring on
+        # `qwix_quantize_nnx_model_streaming` for why the non-streaming,
+        # single-`jax.jit` version above needs ~2x the model's HBM footprint).
+        model_or_model_fn = qwix_quantize_nnx_model_streaming(
+            model_or_model_fn,
+            qwix_config=qwix_config,
+            rng=rng,
+            mesh=mesh,
+            num_hidden_layers=num_hidden_layers,
+            kv_cache_block_size=block_size,
+            kv_cache_num_kv_heads=num_kv_heads,
+            kv_cache_head_size=head_size,
+            kv_cache_dtype=kv_cache_dtype)
 
         return model_or_model_fn
 


### PR DESCRIPTION
### Description

Online Qwix quantization (`additional_config={"quantization": "int8_default.yaml"}` etc.) OOMs on large MoE models whose bf16 weights already use a large fraction of a chip's HBM, even though the quantized model would be much smaller.

Repro: GLM-4.7-Flash (~62GB bf16, MoE, 47 layers) on v6e-4, `--tensor-parallel-size 4`. bf16 weights already use ~17GB/31GB HBM per chip before quantization starts. Both `int8_default.yaml` (w8a8) and `int8_all_modules_w_only.yaml` (w8a16) fail identically:

```
jax.errors.JaxRuntimeError: RESOURCE_EXHAUSTED: Ran out of memory on HBM, the total memory
required for HLO temporaries (33.40G) exceeds available HBM (31.24G).
```

### Root cause

`qwix_quantize_nnx_model` calls `qwix.quantize_model(model, ...)` once on the whole model inside one `jax.jit(..., donate_argnums=(0,))`. `qwix.quantize_model`'s NNX path internally does `model = nnx.clone(model)`, so the original bf16 weights and the cloned bf16-on-its-way-to-int8 weights are resident at the same time for the entire model at once — roughly 2x the model's HBM footprint.

`donate_argnums` doesn't rescue this: donation only lets XLA alias a buffer when input and output have identical shape/dtype, and quantization changes both (bf16 array → int8 array + scale array). We also tried Qwix's documented large-model pattern (`quantize_params` + an abstract `nnx.eval_shape` template) — it doesn't help either, because this all runs inside `create_jit_model`'s outer `@nnx.jit(donate_argnums=(0,))` (`model_loader.py`), so it's still one fused program with the same non-aliasable structural change, and it OOMs at essentially the same HBM figure.

### Fix

Quantize one submodule at a time (`embed_tokens`, each decoder layer, `norm`), each via its own `jax.jit(..., donate_argnums=(0,))` call, dispatched and consumed before moving to the next. This bounds peak extra HBM to one submodule instead of the whole model. Works because Qwix's PTQ interception is per-instance (swaps `type(instance)`), so an unmodified parent's `self.submodule(...)` call picks up the quantized submodule automatically.

`lm_head` stays unquantized, matching this model's existing convention.

Only the concrete-model branch (`apply_to_abstract_model=False`) in `apply_qwix_quantization` changes. The abstract-model path (pre-quantized checkpoints) is untouched.

### Tests

- Updated `tests/layers/jax/test_qwix.py::TestApplyQwixQuantization::test_quantization_applied_from_dict` — it was asserting `jax.jit` gets called once, which no longer holds; now asserts the new streaming function is dispatched.
- `pytest tests/layers/jax/test_qwix.py`: 36 passed.
- Manually verified end-to-end on GLM-4.7-Flash (v6e-4, TP=4): both w8a8 and w8a16 now load and serve correctly (HBM flat at ~17GB through all 47 layers, vs. OOM before), output matches the bf16 baseline.
- Could not run `tests/models/jax/test_deepseek_v3.py` locally (`ModuleNotFoundError: tokamax`, unrelated to this change).
