### PR TITLE
Grant/fast dllm v2 v7

### DIFF
--- a/tests/core/test_diffusion_cohort_scheduler.py
+++ b/tests/core/test_diffusion_cohort_scheduler.py
@@ -77,6 +77,12 @@ def _load_scheduler_with_fake_vllm(monkeypatch):
             self.schedule_calls += 1
             return args, kwargs
 
+        def update_from_output(self, request_ids):
+            self.base_unfinished.difference_update(request_ids)
+            for request_id in request_ids:
+                self.requests.pop(request_id, None)
+            return list(request_ids)
+
         def finish_requests(self, request_ids, finished_status):
             self.finished.append((list(request_ids), finished_status))
             finished_requests = []
@@ -323,6 +329,199 @@ def test_strict_waves_accumulate_continuous_arrivals_for_next_full_wave(
     scheduler.schedule()
 
     assert scheduler.admitted == ["first", "second", "third"]
+
+
+def test_strict_waves_first_partial_cohort_uses_quiet_wait(monkeypatch):
+    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(module, "monotonic", clock)
+    scheduler = _scheduler(
+        module,
+        _vllm_config(max_num_seqs=4,
+                     max_wait_ms=10.0,
+                     quiet_wait_ms=2.0,
+                     strict_waves=True))
+    scheduler.add_request(Request("first"))
+
+    clock.now = 0.001
+    scheduler.schedule()
+    assert scheduler.admitted == []
+
+    clock.now = 0.002
+    scheduler.schedule()
+    assert scheduler.admitted == ["first"]
+    assert not scheduler._last_admitted_cohort_was_full
+
+
+def test_strict_waves_hold_partial_refill_past_quiet_wait(monkeypatch):
+    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(module, "monotonic", clock)
+    scheduler = _scheduler(
+        module,
+        _vllm_config(max_num_seqs=3,
+                     max_wait_ms=10.0,
+                     quiet_wait_ms=2.0,
+                     strict_waves=True))
+    first_wave = ["first", "second", "third"]
+    for request_id in first_wave:
+        scheduler.add_request(Request(request_id))
+    scheduler.schedule()
+
+    clock.now = 0.001
+    scheduler.add_request(Request("refill"))
+    clock.now = 0.003
+    scheduler.update_from_output(first_wave)
+    scheduler.schedule()
+
+    assert scheduler.admitted == first_wave
+    assert scheduler._last_admitted_cohort_was_full
+
+
+def test_strict_waves_admit_full_refill_only_after_base_is_idle(monkeypatch):
+    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    scheduler = _scheduler(module,
+                           _vllm_config(max_num_seqs=2, strict_waves=True))
+    first_wave = ["first", "second"]
+    refill_wave = ["third", "fourth"]
+    for request_id in first_wave:
+        scheduler.add_request(Request(request_id))
+    scheduler.schedule()
+
+    for request_id in refill_wave:
+        scheduler.add_request(Request(request_id))
+    scheduler.schedule()
+    assert scheduler.admitted == first_wave
+
+    scheduler.update_from_output(first_wave)
+    scheduler.schedule()
+    assert scheduler.admitted == first_wave + refill_wave
+    assert scheduler._last_admitted_cohort_was_full
+
+
+def test_strict_waves_hard_timeout_partial_refill_then_restore_quiet_wait(
+        monkeypatch):
+    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(module, "monotonic", clock)
+    scheduler = _scheduler(
+        module,
+        _vllm_config(max_num_seqs=2,
+                     max_wait_ms=10.0,
+                     quiet_wait_ms=2.0,
+                     strict_waves=True))
+    first_wave = ["first", "second"]
+    for request_id in first_wave:
+        scheduler.add_request(Request(request_id))
+    scheduler.schedule()
+
+    clock.now = 0.001
+    scheduler.add_request(Request("timed-out-refill"))
+    scheduler.update_from_output(first_wave)
+    clock.now = 0.003
+    scheduler.schedule()
+    assert scheduler.admitted == first_wave
+
+    clock.now = 0.011
+    scheduler.schedule()
+    assert scheduler.admitted == first_wave + ["timed-out-refill"]
+    assert not scheduler._last_admitted_cohort_was_full
+
+    scheduler.update_from_output(["timed-out-refill"])
+    clock.now = 0.012
+    scheduler.add_request(Request("next-partial"))
+    clock.now = 0.014
+    scheduler.schedule()
+    assert scheduler.admitted == first_wave + [
+        "timed-out-refill", "next-partial"
+    ]
+
+
+def test_strict_waves_full_refill_requirement_expires_while_idle(monkeypatch):
+    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(module, "monotonic", clock)
+    scheduler = _scheduler(
+        module,
+        _vllm_config(max_num_seqs=2,
+                     max_wait_ms=10.0,
+                     quiet_wait_ms=2.0,
+                     strict_waves=True))
+    first_wave = ["first", "second"]
+    for request_id in first_wave:
+        scheduler.add_request(Request(request_id))
+    scheduler.schedule()
+
+    clock.now = 0.001
+    scheduler.update_from_output(first_wave)
+    clock.now = 0.020
+    scheduler.add_request(Request("new-first"))
+    scheduler.schedule()
+    assert scheduler.admitted == first_wave
+
+    clock.now = 0.022
+    scheduler.schedule()
+    assert scheduler.admitted == first_wave + ["new-first"]
+    assert not scheduler._last_admitted_cohort_was_full
+
+
+def test_strict_waves_abort_all_resets_full_refill_requirement(monkeypatch):
+    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+        monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(module, "monotonic", clock)
+    scheduler = _scheduler(
+        module,
+        _vllm_config(max_num_seqs=2,
+                     max_wait_ms=10.0,
+                     quiet_wait_ms=2.0,
+                     strict_waves=True))
+    scheduler.add_request(Request("first"))
+    scheduler.add_request(Request("second"))
+    scheduler.schedule()
+    scheduler.add_request(Request("held"))
+
+    scheduler.finish_requests(None, RequestStatus)
+    clock.now = 0.001
+    scheduler.add_request(Request("new-first"))
+    clock.now = 0.003
+    scheduler.schedule()
+
+    assert scheduler.admitted == ["first", "second", "new-first"]
+    assert not scheduler._last_admitted_cohort_was_full
+
+
+def test_strict_waves_cancelled_refill_uses_remaining_hard_deadline(
+        monkeypatch):
+    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+        monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(module, "monotonic", clock)
+    scheduler = _scheduler(
+        module,
+        _vllm_config(max_num_seqs=2,
+                     max_wait_ms=10.0,
+                     quiet_wait_ms=2.0,
+                     strict_waves=True))
+    first_wave = ["first", "second"]
+    for request_id in first_wave:
+        scheduler.add_request(Request(request_id))
+    scheduler.schedule()
+
+    clock.now = 0.001
+    scheduler.add_request(Request("cancelled"))
+    clock.now = 0.002
+    scheduler.add_request(Request("remaining"))
+    scheduler.update_from_output(first_wave)
+    scheduler.finish_requests("cancelled", RequestStatus)
+
+    clock.now = 0.011
+    scheduler.schedule()
+    assert scheduler.admitted == first_wave
+
+    clock.now = 0.012
+    scheduler.schedule()
+    assert scheduler.admitted == first_wave + ["remaining"]
 
 
 def test_strict_waves_pass_continuation_for_admitted_request_to_base(

--- a/tests/core/test_diffusion_cohort_scheduler.py
+++ b/tests/core/test_diffusion_cohort_scheduler.py
@@ -1,0 +1,264 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+from types import SimpleNamespace
+
+
+class _Clock:
+
+    def __init__(self) -> None:
+        self.now = 0.0
+
+    def __call__(self) -> float:
+        return self.now
+
+
+def _load_scheduler_with_fake_vllm(monkeypatch):
+
+    class Request:
+
+        def __init__(self, request_id):
+            self.request_id = request_id
+
+    class RequestStatus:
+        pass
+
+    class Scheduler:
+
+        def __init__(
+            self,
+            vllm_config,
+            kv_cache_config,
+            structured_output_manager,
+            block_size,
+            hash_block_size=None,
+            mm_registry=None,
+            include_finished_set=False,
+            log_stats=False,
+        ):
+            del (
+                vllm_config,
+                kv_cache_config,
+                structured_output_manager,
+                block_size,
+                hash_block_size,
+                mm_registry,
+                include_finished_set,
+                log_stats,
+            )
+            self.admitted = []
+            self.finished = []
+            self.schedule_calls = 0
+            self.base_unfinished = set()
+            self.requests = {}
+
+        def add_request(self, request):
+            self.admitted.append(request.request_id)
+            self.base_unfinished.add(request.request_id)
+            self.requests[request.request_id] = request
+
+        def schedule(self, *args, **kwargs):
+            self.schedule_calls += 1
+            return args, kwargs
+
+        def finish_requests(self, request_ids, finished_status):
+            self.finished.append((list(request_ids), finished_status))
+            self.base_unfinished.difference_update(request_ids)
+            for request_id in request_ids:
+                self.requests.pop(request_id, None)
+
+        def get_num_unfinished_requests(self):
+            return len(self.base_unfinished)
+
+        def has_unfinished_requests(self):
+            return bool(self.base_unfinished)
+
+    class Placeholder:
+        pass
+
+    def resolve_generation_strategy(vllm_config):
+        max_wait_ms = vllm_config.additional_config["diffusion"][
+            "cohort_max_wait_ms"]
+        return SimpleNamespace(diffusion=SimpleNamespace(
+            runtime=SimpleNamespace(cohort_max_wait_ms=max_wait_ms)))
+
+    modules = {
+        "vllm":
+        types.ModuleType("vllm"),
+        "vllm.config":
+        types.ModuleType("vllm.config"),
+        "vllm.multimodal":
+        types.ModuleType("vllm.multimodal"),
+        "vllm.v1":
+        types.ModuleType("vllm.v1"),
+        "vllm.v1.core":
+        types.ModuleType("vllm.v1.core"),
+        "vllm.v1.core.sched":
+        types.ModuleType("vllm.v1.core.sched"),
+        "vllm.v1.core.sched.output":
+        types.ModuleType("vllm.v1.core.sched.output"),
+        "vllm.v1.core.sched.scheduler":
+        types.ModuleType("vllm.v1.core.sched.scheduler"),
+        "vllm.v1.kv_cache_interface":
+        types.ModuleType("vllm.v1.kv_cache_interface"),
+        "vllm.v1.request":
+        types.ModuleType("vllm.v1.request"),
+        "vllm.v1.structured_output":
+        types.ModuleType("vllm.v1.structured_output"),
+        "tpu_inference":
+        types.ModuleType("tpu_inference"),
+        "tpu_inference.runner":
+        types.ModuleType("tpu_inference.runner"),
+        "tpu_inference.runner.diffusion":
+        types.ModuleType("tpu_inference.runner.diffusion"),
+        "tpu_inference.runner.diffusion.config":
+        types.ModuleType("tpu_inference.runner.diffusion.config"),
+    }
+    modules["vllm.config"].VllmConfig = Placeholder
+    modules["vllm.multimodal"].MULTIMODAL_REGISTRY = Placeholder()
+    modules["vllm.multimodal"].MultiModalRegistry = Placeholder
+    modules["vllm.v1.core.sched.output"].SchedulerOutput = Placeholder
+    modules["vllm.v1.core.sched.scheduler"].Scheduler = Scheduler
+    modules["vllm.v1.kv_cache_interface"].KVCacheConfig = Placeholder
+    modules["vllm.v1.request"].Request = Request
+    modules["vllm.v1.request"].RequestStatus = RequestStatus
+    modules["vllm.v1.structured_output"].StructuredOutputManager = Placeholder
+    modules[
+        "tpu_inference.runner.diffusion.config"].resolve_generation_strategy = resolve_generation_strategy
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    path = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+            "core" / "sched" / "diffusion_cohort_scheduler.py")
+    spec = importlib.util.spec_from_file_location(
+        "diffusion_cohort_scheduler_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    monkeypatch.setitem(sys.modules, spec.name, module)
+    spec.loader.exec_module(module)
+    return module, Request, RequestStatus
+
+
+def _vllm_config(max_num_seqs=2, max_wait_ms=10.0):
+    return SimpleNamespace(
+        additional_config={
+            "diffusion": {
+                "cohort_max_wait_ms": max_wait_ms,
+            },
+        },
+        scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs),
+    )
+
+
+def _scheduler(module, vllm_config):
+    return module.BlockDiffusionCohortScheduler(
+        vllm_config=vllm_config,
+        kv_cache_config=object(),
+        structured_output_manager=object(),
+        block_size=16,
+    )
+
+
+def test_cohort_queue_releases_fifo_at_capacity(monkeypatch):
+    module, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    clock = _Clock()
+    queue = module.CohortAdmissionQueue(max_size=3,
+                                        max_wait_ms=10.0,
+                                        clock=clock)
+
+    for item in range(5):
+        queue.add(item)
+
+    assert queue.drain_ready() == [0, 1, 2]
+    assert len(queue) == 2
+    assert not queue.is_ready()
+
+    clock.now = 0.01
+    assert queue.drain_ready() == [3, 4]
+
+
+def test_cohort_queue_deadline_tracks_oldest_remaining_item(monkeypatch):
+    module, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    clock = _Clock()
+    queue = module.CohortAdmissionQueue(max_size=3,
+                                        max_wait_ms=10.0,
+                                        clock=clock)
+    queue.add("cancelled")
+    clock.now = 0.004
+    queue.add("remaining")
+
+    assert queue.discard(lambda item: item == "cancelled") == ["cancelled"]
+    assert queue.deadline == 0.014
+    clock.now = 0.013
+    assert not queue.is_ready()
+    clock.now = 0.014
+    assert queue.drain_ready() == ["remaining"]
+
+
+def test_scheduler_keeps_running_work_moving_before_cohort_is_ready(
+        monkeypatch):
+    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(module, "monotonic", clock)
+    scheduler = _scheduler(module, _vllm_config())
+    scheduler.base_unfinished.add("running")
+    scheduler.add_request(Request("new"))
+
+    assert scheduler.schedule("step") == (("step", ), {})
+    assert scheduler.schedule_calls == 1
+    assert scheduler.admitted == []
+    assert scheduler.get_num_unfinished_requests() == 2
+    assert scheduler.has_unfinished_requests()
+
+    clock.now = 0.01
+    scheduler.schedule()
+    assert scheduler.admitted == ["new"]
+
+
+def test_scheduler_releases_full_cohort_and_cancels_held_requests(monkeypatch):
+    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+        monkeypatch)
+    scheduler = _scheduler(module, _vllm_config())
+    scheduler.base_unfinished.add("running")
+    scheduler.add_request(Request("first"))
+    scheduler.add_request(Request("cancelled"))
+
+    scheduler.finish_requests(["cancelled", "running"], RequestStatus)
+
+    assert scheduler.finished == [(["running"], RequestStatus)]
+    assert scheduler.get_num_unfinished_requests() == 1
+    scheduler.schedule()
+    assert scheduler.admitted == []
+
+    scheduler.add_request(Request("second"))
+    scheduler.schedule()
+    assert scheduler.admitted == ["first", "second"]
+
+
+def test_scheduler_cancel_all_removes_held_and_admitted_requests(monkeypatch):
+    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+        monkeypatch)
+    scheduler = _scheduler(module, _vllm_config())
+    scheduler.base_unfinished.add("running")
+    scheduler.requests["running"] = Request("running")
+    scheduler.add_request(Request("held"))
+
+    scheduler.finish_requests(None, RequestStatus)
+
+    assert scheduler.finished == [(["running"], RequestStatus)]
+    assert scheduler.get_num_unfinished_requests() == 0
+    assert not scheduler.has_unfinished_requests()

--- a/tests/core/test_diffusion_cohort_scheduler.py
+++ b/tests/core/test_diffusion_cohort_scheduler.py
@@ -94,8 +94,11 @@ def _load_scheduler_with_fake_vllm(monkeypatch):
     def resolve_generation_strategy(vllm_config):
         max_wait_ms = vllm_config.additional_config["diffusion"][
             "cohort_max_wait_ms"]
+        quiet_wait_ms = vllm_config.additional_config["diffusion"].get(
+            "cohort_quiet_wait_ms", 0.0)
         return SimpleNamespace(diffusion=SimpleNamespace(
-            runtime=SimpleNamespace(cohort_max_wait_ms=max_wait_ms)))
+            runtime=SimpleNamespace(cohort_max_wait_ms=max_wait_ms,
+                                    cohort_quiet_wait_ms=quiet_wait_ms)))
 
     modules = {
         "vllm":
@@ -153,11 +156,12 @@ def _load_scheduler_with_fake_vllm(monkeypatch):
     return module, Request, RequestStatus
 
 
-def _vllm_config(max_num_seqs=2, max_wait_ms=10.0):
+def _vllm_config(max_num_seqs=2, max_wait_ms=10.0, quiet_wait_ms=0.0):
     return SimpleNamespace(
         additional_config={
             "diffusion": {
                 "cohort_max_wait_ms": max_wait_ms,
+                "cohort_quiet_wait_ms": quiet_wait_ms,
             },
         },
         scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs),
@@ -209,6 +213,31 @@ def test_cohort_queue_deadline_tracks_oldest_remaining_item(monkeypatch):
     assert queue.drain_ready() == ["remaining"]
 
 
+def test_cohort_queue_releases_after_quiet_period_with_hard_cap(monkeypatch):
+    module, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    clock = _Clock()
+    queue = module.CohortAdmissionQueue(max_size=32,
+                                        max_wait_ms=20.0,
+                                        quiet_wait_ms=2.0,
+                                        clock=clock)
+    queue.add("first")
+    clock.now = 0.004
+    queue.add("second")
+
+    assert queue.deadline == 0.006
+    clock.now = 0.005
+    assert not queue.is_ready()
+    clock.now = 0.006
+    assert queue.drain_ready() == ["first", "second"]
+
+    clock.now = 1.0
+    queue.add("hard-cap-first")
+    for index, now in enumerate((1.005, 1.010, 1.015, 1.019)):
+        clock.now = now
+        queue.add(index)
+    assert queue.deadline == 1.02
+
+
 def test_scheduler_keeps_running_work_moving_before_cohort_is_ready(
         monkeypatch):
     module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
@@ -227,6 +256,25 @@ def test_scheduler_keeps_running_work_moving_before_cohort_is_ready(
     clock.now = 0.01
     scheduler.schedule()
     assert scheduler.admitted == ["new"]
+
+
+def test_scheduler_uses_quiet_period_for_burst_admission(monkeypatch):
+    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(module, "monotonic", clock)
+    scheduler = _scheduler(
+        module,
+        _vllm_config(max_num_seqs=32, max_wait_ms=20.0, quiet_wait_ms=2.0))
+    scheduler.add_request(Request("first"))
+    clock.now = 0.004
+    scheduler.add_request(Request("second"))
+
+    clock.now = 0.005
+    scheduler.schedule()
+    assert scheduler.admitted == []
+    clock.now = 0.006
+    scheduler.schedule()
+    assert scheduler.admitted == ["first", "second"]
 
 
 def test_scheduler_releases_full_cohort_and_cancels_held_requests(monkeypatch):

--- a/tests/core/test_diffusion_cohort_scheduler.py
+++ b/tests/core/test_diffusion_cohort_scheduler.py
@@ -32,8 +32,9 @@ def _load_scheduler_with_fake_vllm(monkeypatch):
 
     class Request:
 
-        def __init__(self, request_id):
+        def __init__(self, request_id, client_index=0):
             self.request_id = request_id
+            self.client_index = client_index
 
     class RequestStatus:
         pass
@@ -78,15 +79,25 @@ def _load_scheduler_with_fake_vllm(monkeypatch):
 
         def finish_requests(self, request_ids, finished_status):
             self.finished.append((list(request_ids), finished_status))
+            finished_requests = []
+            for request_id in request_ids:
+                request = self.requests.get(request_id)
+                if request is not None:
+                    finished_requests.append(
+                        (request.request_id, request.client_index))
             self.base_unfinished.difference_update(request_ids)
             for request_id in request_ids:
                 self.requests.pop(request_id, None)
+            return finished_requests
 
         def get_num_unfinished_requests(self):
             return len(self.base_unfinished)
 
+        def get_request_counts(self):
+            return len(self.base_unfinished), 0
+
         def has_unfinished_requests(self):
-            return bool(self.base_unfinished)
+            return self.get_num_unfinished_requests() > 0
 
     class Placeholder:
         pass
@@ -96,9 +107,12 @@ def _load_scheduler_with_fake_vllm(monkeypatch):
             "cohort_max_wait_ms"]
         quiet_wait_ms = vllm_config.additional_config["diffusion"].get(
             "cohort_quiet_wait_ms", 0.0)
+        strict_waves = vllm_config.additional_config["diffusion"].get(
+            "cohort_strict_waves", False)
         return SimpleNamespace(diffusion=SimpleNamespace(
             runtime=SimpleNamespace(cohort_max_wait_ms=max_wait_ms,
-                                    cohort_quiet_wait_ms=quiet_wait_ms)))
+                                    cohort_quiet_wait_ms=quiet_wait_ms,
+                                    cohort_strict_waves=strict_waves)))
 
     modules = {
         "vllm":
@@ -156,12 +170,16 @@ def _load_scheduler_with_fake_vllm(monkeypatch):
     return module, Request, RequestStatus
 
 
-def _vllm_config(max_num_seqs=2, max_wait_ms=10.0, quiet_wait_ms=0.0):
+def _vllm_config(max_num_seqs=2,
+                 max_wait_ms=10.0,
+                 quiet_wait_ms=0.0,
+                 strict_waves=False):
     return SimpleNamespace(
         additional_config={
             "diffusion": {
                 "cohort_max_wait_ms": max_wait_ms,
                 "cohort_quiet_wait_ms": quiet_wait_ms,
+                "cohort_strict_waves": strict_waves,
             },
         },
         scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs),
@@ -258,6 +276,126 @@ def test_scheduler_keeps_running_work_moving_before_cohort_is_ready(
     assert scheduler.admitted == ["new"]
 
 
+def test_strict_waves_keep_running_work_moving_without_admitting_full_cohort(
+        monkeypatch):
+    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    scheduler = _scheduler(module, _vllm_config(strict_waves=True))
+    scheduler.base_unfinished.add("running")
+    scheduler.add_request(Request("first"))
+    scheduler.add_request(Request("second"))
+
+    assert scheduler.schedule("step") == (("step", ), {})
+    assert scheduler.schedule_calls == 1
+    assert scheduler.admitted == []
+    assert scheduler.get_num_unfinished_requests() == 3
+    assert scheduler.get_request_counts() == (1, 2)
+
+
+def test_strict_waves_admit_first_ready_wave_when_held_requests_are_unfinished(
+        monkeypatch):
+    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    scheduler = _scheduler(module, _vllm_config(strict_waves=True))
+    scheduler.add_request(Request("first"))
+    scheduler.add_request(Request("second"))
+
+    assert scheduler.has_unfinished_requests()
+    assert scheduler.get_num_unfinished_requests() == 2
+
+    scheduler.schedule()
+
+    assert scheduler.admitted == ["first", "second"]
+
+
+def test_strict_waves_accumulate_continuous_arrivals_for_next_full_wave(
+        monkeypatch):
+    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+        monkeypatch)
+    scheduler = _scheduler(module,
+                           _vllm_config(max_num_seqs=3, strict_waves=True))
+    scheduler.base_unfinished.add("running")
+
+    for request_id in ("first", "second", "third"):
+        scheduler.add_request(Request(request_id))
+        scheduler.schedule()
+        assert scheduler.admitted == []
+
+    scheduler.finish_requests("running", RequestStatus)
+    scheduler.schedule()
+
+    assert scheduler.admitted == ["first", "second", "third"]
+
+
+def test_strict_waves_pass_continuation_for_admitted_request_to_base(
+        monkeypatch):
+    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    scheduler = _scheduler(module, _vllm_config(strict_waves=True))
+    scheduler.add_request(Request("streaming"))
+    scheduler.add_request(Request("peer"))
+    scheduler.schedule()
+
+    scheduler.add_request(Request("streaming"))
+
+    assert scheduler.admitted == ["streaming", "peer", "streaming"]
+    assert scheduler._cohort_request_ids == set()
+    assert scheduler.get_num_unfinished_requests() == 2
+
+
+def test_strict_waves_release_timed_out_cohort_only_after_base_is_idle(
+        monkeypatch):
+    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+        monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(module, "monotonic", clock)
+    scheduler = _scheduler(
+        module,
+        _vllm_config(max_num_seqs=4, max_wait_ms=10.0, strict_waves=True))
+    scheduler.base_unfinished.add("running")
+    scheduler.add_request(Request("timed-out"))
+
+    clock.now = 0.01
+    scheduler.schedule()
+    assert scheduler.admitted == []
+
+    scheduler.finish_requests("running", RequestStatus)
+    scheduler.schedule()
+    assert scheduler.admitted == ["timed-out"]
+
+
+def test_strict_waves_cancel_held_request_without_blocking_remaining_timeout(
+        monkeypatch):
+    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+        monkeypatch)
+    clock = _Clock()
+    monkeypatch.setattr(module, "monotonic", clock)
+    scheduler = _scheduler(
+        module,
+        _vllm_config(max_num_seqs=2, max_wait_ms=10.0, strict_waves=True))
+    scheduler.base_unfinished.add("running")
+    scheduler.add_request(Request("remaining"))
+    scheduler.add_request(Request("cancelled"))
+
+    scheduler.finish_requests("cancelled", RequestStatus)
+    clock.now = 0.01
+    scheduler.finish_requests("running", RequestStatus)
+    scheduler.schedule()
+
+    assert scheduler.admitted == ["remaining"]
+    assert scheduler.finished == [(["running"], RequestStatus)]
+
+
+def test_default_cohort_mode_admits_full_cohort_while_base_is_running(
+        monkeypatch):
+    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    scheduler = _scheduler(module, _vllm_config(strict_waves=False))
+    scheduler.base_unfinished.add("running")
+    scheduler.add_request(Request("first"))
+    scheduler.add_request(Request("second"))
+
+    scheduler.schedule()
+
+    assert scheduler.admitted == ["first", "second"]
+
+
 def test_scheduler_uses_quiet_period_for_burst_admission(monkeypatch):
     module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     clock = _Clock()
@@ -302,11 +440,12 @@ def test_scheduler_cancel_all_removes_held_and_admitted_requests(monkeypatch):
         monkeypatch)
     scheduler = _scheduler(module, _vllm_config())
     scheduler.base_unfinished.add("running")
-    scheduler.requests["running"] = Request("running")
-    scheduler.add_request(Request("held"))
+    scheduler.requests["running"] = Request("running", client_index=1)
+    scheduler.add_request(Request("held", client_index=2))
 
-    scheduler.finish_requests(None, RequestStatus)
+    finished_requests = scheduler.finish_requests(None, RequestStatus)
 
+    assert finished_requests == [("held", 2), ("running", 1)]
     assert scheduler.finished == [(["running"], RequestStatus)]
     assert scheduler.get_num_unfinished_requests() == 0
     assert not scheduler.has_unfinished_requests()

--- a/tests/core/test_diffusion_cohort_scheduler.py
+++ b/tests/core/test_diffusion_cohort_scheduler.py
@@ -16,7 +16,11 @@ import importlib.util
 import pathlib
 import sys
 import types
+from collections import defaultdict
+from enum import Enum
 from types import SimpleNamespace
+
+import pytest
 
 
 class _Clock:
@@ -30,14 +34,28 @@ class _Clock:
 
 def _load_scheduler_with_fake_vllm(monkeypatch):
 
+    class PauseState(Enum):
+        UNPAUSED = "unpaused"
+        PAUSED_NEW = "paused_new"
+        PAUSED_ALL = "paused_all"
+
+    class RequestStatus(Enum):
+        WAITING = "waiting"
+        FINISHED_ABORTED = "finished_aborted"
+
+        @staticmethod
+        def is_finished(status):
+            return status == RequestStatus.FINISHED_ABORTED
+
     class Request:
 
         def __init__(self, request_id, client_index=0):
             self.request_id = request_id
             self.client_index = client_index
+            self.status = RequestStatus.WAITING
 
-    class RequestStatus:
-        pass
+        def is_finished(self):
+            return RequestStatus.is_finished(self.status)
 
     class Scheduler:
 
@@ -59,14 +77,18 @@ def _load_scheduler_with_fake_vllm(monkeypatch):
                 block_size,
                 hash_block_size,
                 mm_registry,
-                include_finished_set,
                 log_stats,
             )
             self.admitted = []
             self.finished = []
             self.schedule_calls = 0
             self.base_unfinished = set()
+            self.base_running = self.base_unfinished
             self.requests = {}
+            self.finished_req_ids = set()
+            self.finished_req_ids_dict = (defaultdict(set)
+                                          if include_finished_set else None)
+            self._pause_state = PauseState.UNPAUSED
 
         def add_request(self, request):
             self.admitted.append(request.request_id)
@@ -79,31 +101,54 @@ def _load_scheduler_with_fake_vllm(monkeypatch):
 
         def update_from_output(self, request_ids):
             self.base_unfinished.difference_update(request_ids)
+            self.base_running.difference_update(request_ids)
             for request_id in request_ids:
                 self.requests.pop(request_id, None)
             return list(request_ids)
 
         def finish_requests(self, request_ids, finished_status):
+            assert RequestStatus.is_finished(finished_status)
             self.finished.append((list(request_ids), finished_status))
             finished_requests = []
             for request_id in request_ids:
                 request = self.requests.get(request_id)
-                if request is not None:
+                if request is not None and not request.is_finished():
+                    request.status = finished_status
+                    self.finished_req_ids.add(request_id)
+                    if self.finished_req_ids_dict is not None:
+                        self.finished_req_ids_dict[request.client_index].add(
+                            request_id)
                     finished_requests.append(
                         (request.request_id, request.client_index))
             self.base_unfinished.difference_update(request_ids)
+            self.base_running.difference_update(request_ids)
             for request_id in request_ids:
                 self.requests.pop(request_id, None)
             return finished_requests
 
         def get_num_unfinished_requests(self):
+            if self._pause_state == PauseState.PAUSED_ALL:
+                return 0
+            if self._pause_state == PauseState.PAUSED_NEW:
+                return len(self.base_running)
             return len(self.base_unfinished)
 
         def get_request_counts(self):
-            return len(self.base_unfinished), 0
+            return (len(self.base_running),
+                    len(self.base_unfinished - self.base_running))
 
         def has_unfinished_requests(self):
             return self.get_num_unfinished_requests() > 0
+
+        def has_finished_requests(self):
+            return bool(self.finished_req_ids)
+
+        @property
+        def pause_state(self):
+            return self._pause_state
+
+        def set_pause_state(self, pause_state):
+            self._pause_state = pause_state
 
     class Placeholder:
         pass
@@ -133,6 +178,8 @@ def _load_scheduler_with_fake_vllm(monkeypatch):
         types.ModuleType("vllm.v1.core"),
         "vllm.v1.core.sched":
         types.ModuleType("vllm.v1.core.sched"),
+        "vllm.v1.core.sched.interface":
+        types.ModuleType("vllm.v1.core.sched.interface"),
         "vllm.v1.core.sched.output":
         types.ModuleType("vllm.v1.core.sched.output"),
         "vllm.v1.core.sched.scheduler":
@@ -155,6 +202,7 @@ def _load_scheduler_with_fake_vllm(monkeypatch):
     modules["vllm.config"].VllmConfig = Placeholder
     modules["vllm.multimodal"].MULTIMODAL_REGISTRY = Placeholder()
     modules["vllm.multimodal"].MultiModalRegistry = Placeholder
+    modules["vllm.v1.core.sched.interface"].PauseState = PauseState
     modules["vllm.v1.core.sched.output"].SchedulerOutput = Placeholder
     modules["vllm.v1.core.sched.scheduler"].Scheduler = Scheduler
     modules["vllm.v1.kv_cache_interface"].KVCacheConfig = Placeholder
@@ -173,7 +221,7 @@ def _load_scheduler_with_fake_vllm(monkeypatch):
     module = importlib.util.module_from_spec(spec)
     monkeypatch.setitem(sys.modules, spec.name, module)
     spec.loader.exec_module(module)
-    return module, Request, RequestStatus
+    return module, Request, RequestStatus, PauseState
 
 
 def _vllm_config(max_num_seqs=2,
@@ -192,17 +240,18 @@ def _vllm_config(max_num_seqs=2,
     )
 
 
-def _scheduler(module, vllm_config):
+def _scheduler(module, vllm_config, *, include_finished_set=False):
     return module.BlockDiffusionCohortScheduler(
         vllm_config=vllm_config,
         kv_cache_config=object(),
         structured_output_manager=object(),
         block_size=16,
+        include_finished_set=include_finished_set,
     )
 
 
 def test_cohort_queue_releases_fifo_at_capacity(monkeypatch):
-    module, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, _, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     clock = _Clock()
     queue = module.CohortAdmissionQueue(max_size=3,
                                         max_wait_ms=10.0,
@@ -220,7 +269,7 @@ def test_cohort_queue_releases_fifo_at_capacity(monkeypatch):
 
 
 def test_cohort_queue_deadline_tracks_oldest_remaining_item(monkeypatch):
-    module, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, _, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     clock = _Clock()
     queue = module.CohortAdmissionQueue(max_size=3,
                                         max_wait_ms=10.0,
@@ -238,7 +287,7 @@ def test_cohort_queue_deadline_tracks_oldest_remaining_item(monkeypatch):
 
 
 def test_cohort_queue_releases_after_quiet_period_with_hard_cap(monkeypatch):
-    module, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, _, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     clock = _Clock()
     queue = module.CohortAdmissionQueue(max_size=32,
                                         max_wait_ms=20.0,
@@ -264,7 +313,7 @@ def test_cohort_queue_releases_after_quiet_period_with_hard_cap(monkeypatch):
 
 def test_scheduler_keeps_running_work_moving_before_cohort_is_ready(
         monkeypatch):
-    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, Request, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     clock = _Clock()
     monkeypatch.setattr(module, "monotonic", clock)
     scheduler = _scheduler(module, _vllm_config())
@@ -284,7 +333,7 @@ def test_scheduler_keeps_running_work_moving_before_cohort_is_ready(
 
 def test_strict_waves_keep_running_work_moving_without_admitting_full_cohort(
         monkeypatch):
-    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, Request, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     scheduler = _scheduler(module, _vllm_config(strict_waves=True))
     scheduler.base_unfinished.add("running")
     scheduler.add_request(Request("first"))
@@ -299,7 +348,7 @@ def test_strict_waves_keep_running_work_moving_without_admitting_full_cohort(
 
 def test_strict_waves_admit_first_ready_wave_when_held_requests_are_unfinished(
         monkeypatch):
-    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, Request, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     scheduler = _scheduler(module, _vllm_config(strict_waves=True))
     scheduler.add_request(Request("first"))
     scheduler.add_request(Request("second"))
@@ -314,7 +363,7 @@ def test_strict_waves_admit_first_ready_wave_when_held_requests_are_unfinished(
 
 def test_strict_waves_accumulate_continuous_arrivals_for_next_full_wave(
         monkeypatch):
-    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+    module, Request, RequestStatus, _ = _load_scheduler_with_fake_vllm(
         monkeypatch)
     scheduler = _scheduler(module,
                            _vllm_config(max_num_seqs=3, strict_waves=True))
@@ -325,14 +374,14 @@ def test_strict_waves_accumulate_continuous_arrivals_for_next_full_wave(
         scheduler.schedule()
         assert scheduler.admitted == []
 
-    scheduler.finish_requests("running", RequestStatus)
+    scheduler.finish_requests("running", RequestStatus.FINISHED_ABORTED)
     scheduler.schedule()
 
     assert scheduler.admitted == ["first", "second", "third"]
 
 
 def test_strict_waves_first_partial_cohort_uses_quiet_wait(monkeypatch):
-    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, Request, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     clock = _Clock()
     monkeypatch.setattr(module, "monotonic", clock)
     scheduler = _scheduler(
@@ -354,7 +403,7 @@ def test_strict_waves_first_partial_cohort_uses_quiet_wait(monkeypatch):
 
 
 def test_strict_waves_hold_partial_refill_past_quiet_wait(monkeypatch):
-    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, Request, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     clock = _Clock()
     monkeypatch.setattr(module, "monotonic", clock)
     scheduler = _scheduler(
@@ -379,7 +428,7 @@ def test_strict_waves_hold_partial_refill_past_quiet_wait(monkeypatch):
 
 
 def test_strict_waves_admit_full_refill_only_after_base_is_idle(monkeypatch):
-    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, Request, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     scheduler = _scheduler(module,
                            _vllm_config(max_num_seqs=2, strict_waves=True))
     first_wave = ["first", "second"]
@@ -401,7 +450,7 @@ def test_strict_waves_admit_full_refill_only_after_base_is_idle(monkeypatch):
 
 def test_strict_waves_hard_timeout_partial_refill_then_restore_quiet_wait(
         monkeypatch):
-    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, Request, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     clock = _Clock()
     monkeypatch.setattr(module, "monotonic", clock)
     scheduler = _scheduler(
@@ -438,7 +487,7 @@ def test_strict_waves_hard_timeout_partial_refill_then_restore_quiet_wait(
 
 
 def test_strict_waves_full_refill_requirement_expires_while_idle(monkeypatch):
-    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, Request, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     clock = _Clock()
     monkeypatch.setattr(module, "monotonic", clock)
     scheduler = _scheduler(
@@ -466,7 +515,7 @@ def test_strict_waves_full_refill_requirement_expires_while_idle(monkeypatch):
 
 
 def test_strict_waves_abort_all_resets_full_refill_requirement(monkeypatch):
-    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+    module, Request, RequestStatus, _ = _load_scheduler_with_fake_vllm(
         monkeypatch)
     clock = _Clock()
     monkeypatch.setattr(module, "monotonic", clock)
@@ -481,7 +530,7 @@ def test_strict_waves_abort_all_resets_full_refill_requirement(monkeypatch):
     scheduler.schedule()
     scheduler.add_request(Request("held"))
 
-    scheduler.finish_requests(None, RequestStatus)
+    scheduler.finish_requests(None, RequestStatus.FINISHED_ABORTED)
     clock.now = 0.001
     scheduler.add_request(Request("new-first"))
     clock.now = 0.003
@@ -493,7 +542,7 @@ def test_strict_waves_abort_all_resets_full_refill_requirement(monkeypatch):
 
 def test_strict_waves_cancelled_refill_uses_remaining_hard_deadline(
         monkeypatch):
-    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+    module, Request, RequestStatus, _ = _load_scheduler_with_fake_vllm(
         monkeypatch)
     clock = _Clock()
     monkeypatch.setattr(module, "monotonic", clock)
@@ -513,7 +562,7 @@ def test_strict_waves_cancelled_refill_uses_remaining_hard_deadline(
     clock.now = 0.002
     scheduler.add_request(Request("remaining"))
     scheduler.update_from_output(first_wave)
-    scheduler.finish_requests("cancelled", RequestStatus)
+    scheduler.finish_requests("cancelled", RequestStatus.FINISHED_ABORTED)
 
     clock.now = 0.011
     scheduler.schedule()
@@ -526,7 +575,7 @@ def test_strict_waves_cancelled_refill_uses_remaining_hard_deadline(
 
 def test_strict_waves_pass_continuation_for_admitted_request_to_base(
         monkeypatch):
-    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, Request, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     scheduler = _scheduler(module, _vllm_config(strict_waves=True))
     scheduler.add_request(Request("streaming"))
     scheduler.add_request(Request("peer"))
@@ -541,7 +590,7 @@ def test_strict_waves_pass_continuation_for_admitted_request_to_base(
 
 def test_strict_waves_release_timed_out_cohort_only_after_base_is_idle(
         monkeypatch):
-    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+    module, Request, RequestStatus, _ = _load_scheduler_with_fake_vllm(
         monkeypatch)
     clock = _Clock()
     monkeypatch.setattr(module, "monotonic", clock)
@@ -555,14 +604,14 @@ def test_strict_waves_release_timed_out_cohort_only_after_base_is_idle(
     scheduler.schedule()
     assert scheduler.admitted == []
 
-    scheduler.finish_requests("running", RequestStatus)
+    scheduler.finish_requests("running", RequestStatus.FINISHED_ABORTED)
     scheduler.schedule()
     assert scheduler.admitted == ["timed-out"]
 
 
 def test_strict_waves_cancel_held_request_without_blocking_remaining_timeout(
         monkeypatch):
-    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+    module, Request, RequestStatus, _ = _load_scheduler_with_fake_vllm(
         monkeypatch)
     clock = _Clock()
     monkeypatch.setattr(module, "monotonic", clock)
@@ -573,18 +622,19 @@ def test_strict_waves_cancel_held_request_without_blocking_remaining_timeout(
     scheduler.add_request(Request("remaining"))
     scheduler.add_request(Request("cancelled"))
 
-    scheduler.finish_requests("cancelled", RequestStatus)
+    scheduler.finish_requests("cancelled", RequestStatus.FINISHED_ABORTED)
     clock.now = 0.01
-    scheduler.finish_requests("running", RequestStatus)
+    scheduler.finish_requests("running", RequestStatus.FINISHED_ABORTED)
     scheduler.schedule()
 
     assert scheduler.admitted == ["remaining"]
-    assert scheduler.finished == [(["running"], RequestStatus)]
+    assert scheduler.finished == [(["running"], RequestStatus.FINISHED_ABORTED)
+                                  ]
 
 
 def test_default_cohort_mode_admits_full_cohort_while_base_is_running(
         monkeypatch):
-    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, Request, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     scheduler = _scheduler(module, _vllm_config(strict_waves=False))
     scheduler.base_unfinished.add("running")
     scheduler.add_request(Request("first"))
@@ -596,7 +646,7 @@ def test_default_cohort_mode_admits_full_cohort_while_base_is_running(
 
 
 def test_scheduler_uses_quiet_period_for_burst_admission(monkeypatch):
-    module, Request, _ = _load_scheduler_with_fake_vllm(monkeypatch)
+    module, Request, _, _ = _load_scheduler_with_fake_vllm(monkeypatch)
     clock = _Clock()
     monkeypatch.setattr(module, "monotonic", clock)
     scheduler = _scheduler(
@@ -615,16 +665,18 @@ def test_scheduler_uses_quiet_period_for_burst_admission(monkeypatch):
 
 
 def test_scheduler_releases_full_cohort_and_cancels_held_requests(monkeypatch):
-    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+    module, Request, RequestStatus, _ = _load_scheduler_with_fake_vllm(
         monkeypatch)
     scheduler = _scheduler(module, _vllm_config())
     scheduler.base_unfinished.add("running")
     scheduler.add_request(Request("first"))
     scheduler.add_request(Request("cancelled"))
 
-    scheduler.finish_requests(["cancelled", "running"], RequestStatus)
+    scheduler.finish_requests(["cancelled", "running"],
+                              RequestStatus.FINISHED_ABORTED)
 
-    assert scheduler.finished == [(["running"], RequestStatus)]
+    assert scheduler.finished == [(["running"], RequestStatus.FINISHED_ABORTED)
+                                  ]
     assert scheduler.get_num_unfinished_requests() == 1
     scheduler.schedule()
     assert scheduler.admitted == []
@@ -635,16 +687,150 @@ def test_scheduler_releases_full_cohort_and_cancels_held_requests(monkeypatch):
 
 
 def test_scheduler_cancel_all_removes_held_and_admitted_requests(monkeypatch):
-    module, Request, RequestStatus = _load_scheduler_with_fake_vllm(
+    module, Request, RequestStatus, _ = _load_scheduler_with_fake_vllm(
         monkeypatch)
     scheduler = _scheduler(module, _vllm_config())
     scheduler.base_unfinished.add("running")
     scheduler.requests["running"] = Request("running", client_index=1)
     scheduler.add_request(Request("held", client_index=2))
 
-    finished_requests = scheduler.finish_requests(None, RequestStatus)
+    finished_requests = scheduler.finish_requests(
+        None, RequestStatus.FINISHED_ABORTED)
 
     assert finished_requests == [("held", 2), ("running", 1)]
-    assert scheduler.finished == [(["running"], RequestStatus)]
+    assert scheduler.finished == [(["running"], RequestStatus.FINISHED_ABORTED)
+                                  ]
     assert scheduler.get_num_unfinished_requests() == 0
     assert not scheduler.has_unfinished_requests()
+
+
+def test_paused_all_does_not_count_or_admit_held_requests(monkeypatch):
+    module, Request, _, PauseState = _load_scheduler_with_fake_vllm(
+        monkeypatch)
+    scheduler = _scheduler(module, _vllm_config(max_num_seqs=1))
+    scheduler.add_request(Request("held"))
+
+    scheduler.set_pause_state(PauseState.PAUSED_ALL)
+
+    assert scheduler.get_num_unfinished_requests() == 0
+    assert not scheduler.has_unfinished_requests()
+    assert scheduler.get_request_counts() == (0, 1)
+    scheduler.schedule()
+    assert scheduler.admitted == []
+
+    scheduler.set_pause_state(PauseState.UNPAUSED)
+    scheduler.schedule()
+    assert scheduler.admitted == ["held"]
+
+
+def test_paused_new_keeps_held_wave_out_of_running_work(monkeypatch):
+    module, Request, RequestStatus, PauseState = \
+        _load_scheduler_with_fake_vllm(monkeypatch)
+    scheduler = _scheduler(module,
+                           _vllm_config(max_num_seqs=2, strict_waves=True))
+    scheduler.base_unfinished.add("running")
+    scheduler.requests["running"] = Request("running")
+    scheduler.add_request(Request("first"))
+    scheduler.add_request(Request("second"))
+
+    scheduler.set_pause_state(PauseState.PAUSED_NEW)
+
+    assert scheduler.get_num_unfinished_requests() == 1
+    assert scheduler.get_request_counts() == (1, 2)
+    scheduler.schedule()
+    assert scheduler.admitted == []
+
+    scheduler.finish_requests("running", RequestStatus.FINISHED_ABORTED)
+    assert scheduler.get_num_unfinished_requests() == 0
+    assert not scheduler.has_unfinished_requests()
+    scheduler.schedule()
+    assert scheduler.admitted == []
+
+    scheduler.set_pause_state(PauseState.UNPAUSED)
+    scheduler.schedule()
+    assert scheduler.admitted == ["first", "second"]
+
+
+def test_paused_new_base_waiting_request_is_not_physical_idle(monkeypatch):
+    module, Request, _, PauseState = _load_scheduler_with_fake_vllm(
+        monkeypatch)
+    scheduler = _scheduler(module,
+                           _vllm_config(max_num_seqs=1, strict_waves=True))
+    scheduler.base_running = set()
+    scheduler.base_unfinished.add("waiting")
+    scheduler.requests["waiting"] = Request("waiting")
+    scheduler.add_request(Request("held"))
+
+    scheduler.set_pause_state(PauseState.PAUSED_NEW)
+    assert scheduler.get_num_unfinished_requests() == 0
+    assert scheduler.get_request_counts() == (0, 2)
+    scheduler.schedule()
+    assert scheduler.admitted == []
+
+    scheduler.set_pause_state(PauseState.UNPAUSED)
+    scheduler.schedule()
+    assert scheduler.admitted == []
+
+
+def test_paused_all_does_not_mix_held_and_existing_strict_waves(monkeypatch):
+    module, Request, RequestStatus, PauseState = \
+        _load_scheduler_with_fake_vllm(monkeypatch)
+    scheduler = _scheduler(module,
+                           _vllm_config(max_num_seqs=2, strict_waves=True))
+    scheduler.base_unfinished.add("running")
+    scheduler.requests["running"] = Request("running")
+    scheduler.add_request(Request("first"))
+    scheduler.add_request(Request("second"))
+
+    scheduler.set_pause_state(PauseState.PAUSED_ALL)
+    scheduler.schedule()
+    scheduler.set_pause_state(PauseState.UNPAUSED)
+    scheduler.schedule()
+
+    assert scheduler.admitted == []
+
+    scheduler.finish_requests("running", RequestStatus.FINISHED_ABORTED)
+    scheduler.schedule()
+    assert scheduler.admitted == ["first", "second"]
+
+
+@pytest.mark.parametrize("include_finished_set", [False, True])
+def test_explicit_abort_of_held_request_publishes_finished_ids(
+        monkeypatch, include_finished_set):
+    module, Request, RequestStatus, _ = _load_scheduler_with_fake_vllm(
+        monkeypatch)
+    scheduler = _scheduler(module,
+                           _vllm_config(),
+                           include_finished_set=include_finished_set)
+    held = Request("held", client_index=7)
+    scheduler.add_request(held)
+
+    finished = scheduler.finish_requests(["held", "held"],
+                                         RequestStatus.FINISHED_ABORTED)
+
+    assert finished == [("held", 7)]
+    assert held.status == RequestStatus.FINISHED_ABORTED
+    assert scheduler.finished_req_ids == {"held"}
+    if include_finished_set:
+        assert scheduler.finished_req_ids_dict == {7: {"held"}}
+    else:
+        assert scheduler.finished_req_ids_dict is None
+    assert scheduler.has_finished_requests()
+    assert scheduler.finish_requests("held",
+                                     RequestStatus.FINISHED_ABORTED) == []
+
+
+def test_abort_all_returns_held_request_without_deferred_publication(
+        monkeypatch):
+    module, Request, RequestStatus, _ = _load_scheduler_with_fake_vllm(
+        monkeypatch)
+    scheduler = _scheduler(module, _vllm_config(), include_finished_set=True)
+    held = Request("held", client_index=7)
+    scheduler.add_request(held)
+
+    finished = scheduler.finish_requests(None, RequestStatus.FINISHED_ABORTED)
+
+    assert finished == [("held", 7)]
+    assert held.status == RequestStatus.FINISHED_ABORTED
+    assert scheduler.finished_req_ids == set()
+    assert scheduler.finished_req_ids_dict == {}

--- a/tests/core/test_diffusion_dp_router.py
+++ b/tests/core/test_diffusion_dp_router.py
@@ -1,0 +1,411 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import asyncio
+import functools
+import importlib.util
+import pathlib
+import sys
+import types
+from collections import defaultdict
+from types import SimpleNamespace
+
+import pytest
+
+
+def _load_router(monkeypatch):
+    repository_root = pathlib.Path(__file__).resolve().parents[2]
+    config_path = (repository_root / "tpu_inference" / "runner" / "diffusion" /
+                   "config.py")
+    config_spec = importlib.util.spec_from_file_location(
+        "tpu_inference.runner.diffusion.config", config_path)
+    config_module = importlib.util.module_from_spec(config_spec)
+
+    packages = {
+        "tpu_inference":
+        types.ModuleType("tpu_inference"),
+        "tpu_inference.core":
+        types.ModuleType("tpu_inference.core"),
+        "tpu_inference.runner":
+        types.ModuleType("tpu_inference.runner"),
+        "tpu_inference.runner.diffusion":
+        types.ModuleType("tpu_inference.runner.diffusion"),
+        config_spec.name:
+        config_module,
+    }
+    for name, module in packages.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    config_spec.loader.exec_module(config_module)
+
+    router_path = (repository_root / "tpu_inference" / "core" /
+                   "diffusion_dp_router.py")
+    router_spec = importlib.util.spec_from_file_location(
+        "tpu_inference.core.diffusion_dp_router", router_path)
+    router_module = importlib.util.module_from_spec(router_spec)
+    monkeypatch.setitem(sys.modules, router_spec.name, router_module)
+    router_spec.loader.exec_module(router_module)
+    return router_module
+
+
+def _config(round_robin_enabled: bool,
+            max_num_seqs: int = 16) -> SimpleNamespace:
+    return SimpleNamespace(
+        additional_config={
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "block_size": 32,
+                "mask_token_id": 151669,
+                "sub_block_size": 8,
+                "cohort_round_robin_dp": round_robin_enabled,
+            },
+        },
+        model_config=SimpleNamespace(hf_config=SimpleNamespace()),
+        scheduler_config=SimpleNamespace(max_num_seqs=max_num_seqs),
+    )
+
+
+def _request(request_id: str,
+             data_parallel_rank: int | None = None,
+             late_interaction_rank: int | None = None) -> SimpleNamespace:
+    pooling_params = (None if late_interaction_rank is None else
+                      SimpleNamespace(engine_index=late_interaction_rank))
+    return SimpleNamespace(
+        request_id=request_id,
+        data_parallel_rank=data_parallel_rank,
+        pooling_params=pooling_params,
+    )
+
+
+def _factory_template(
+    vllm_config,
+    executor_class,
+    log_stats,
+    client_addresses=None,
+    client_count=1,
+    client_index=0,
+):
+    return DPLBAsyncMPClient(  # noqa: F821
+        vllm_config,
+        executor_class,
+        log_stats,
+        client_addresses,
+        client_count,
+        client_index,
+    )
+
+
+def _install_fake_vllm(monkeypatch, *, router_has_extra_parameter=False):
+    core_client = types.ModuleType("vllm.v1.engine.core_client")
+
+    class DPLBAsyncMPClient:
+
+        def __init__(
+            self,
+            vllm_config,
+            executor_class,
+            log_stats,
+            client_addresses=None,
+            client_count=1,
+            client_index=0,
+        ):
+            del executor_class, log_stats, client_addresses
+            self.vllm_config = vllm_config
+            self.client_count = client_count
+            self.client_index = client_index
+            self.core_engines = [b"engine-0", b"engine-1"]
+            self.eng_start_index = client_index
+            self.lb_engines = [[0, 0], [0, 0]]
+            self.reqs_in_flight = {}
+            self.added_engines = []
+            self.aborted_by_engine = []
+            self.original_router_calls = 0
+
+        def get_core_engine_for_request(self, request):
+            self.original_router_calls += 1
+            engine_index = request.data_parallel_rank
+            if engine_index is None and request.pooling_params is not None:
+                engine_index = request.pooling_params.engine_index
+            if engine_index is None:
+                engine_index = min(
+                    range(len(self.core_engines)),
+                    key=lambda index: (self.lb_engines[index][0] * 4 + self.
+                                       lb_engines[index][1]),
+                )
+                self.lb_engines[engine_index][0] += self.client_count
+            chosen_engine = self.core_engines[engine_index]
+            self.reqs_in_flight[request.request_id] = chosen_engine
+            return chosen_engine
+
+        async def add_request_async(self, request):
+            chosen_engine = self.get_core_engine_for_request(request)
+            self.added_engines.append(chosen_engine)
+
+        async def abort_requests_async(self, request_ids):
+            by_engine = defaultdict(list)
+            for request_id in request_ids:
+                engine = self.reqs_in_flight.get(request_id)
+                if engine is not None:
+                    by_engine[engine].append(request_id)
+            self.aborted_by_engine.extend(by_engine.items())
+
+        @staticmethod
+        async def process_engine_outputs(self, outputs):
+            for request_id in outputs.finished_requests:
+                self.reqs_in_flight.pop(request_id, None)
+
+    if router_has_extra_parameter:
+
+        def get_core_engine_for_request(self, request, unexpected=None):
+            del unexpected
+            return DPLBAsyncMPClient.get_core_engine_for_request(self, request)
+
+        DPLBAsyncMPClient.get_core_engine_for_request = \
+            get_core_engine_for_request
+
+    core_client.DPLBAsyncMPClient = DPLBAsyncMPClient
+    factory = types.FunctionType(
+        _factory_template.__code__,
+        core_client.__dict__,
+        name="make_async_mp_client",
+        argdefs=_factory_template.__defaults__,
+    )
+
+    @functools.wraps(factory)
+    def instrumented_factory(*args, **kwargs):
+        return factory(*args, **kwargs)
+
+    class EngineCoreClient:
+        make_async_mp_client = staticmethod(instrumented_factory)
+
+    core_client.EngineCoreClient = EngineCoreClient
+
+    engine = types.ModuleType("vllm.v1.engine")
+    engine.core_client = core_client
+    late_interaction = types.ModuleType("vllm.v1.pool.late_interaction")
+    late_interaction.get_late_interaction_engine_index = (
+        lambda pooling_params, _: None
+        if pooling_params is None else pooling_params.engine_index)
+
+    modules = {
+        "vllm": types.ModuleType("vllm"),
+        "vllm.v1": types.ModuleType("vllm.v1"),
+        "vllm.v1.engine": engine,
+        "vllm.v1.engine.core_client": core_client,
+        "vllm.v1.pool": types.ModuleType("vllm.v1.pool"),
+        "vllm.v1.pool.late_interaction": late_interaction,
+    }
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    return core_client
+
+
+async def _add_requests(client, requests):
+    for request in requests:
+        await client.add_request_async(request)
+
+
+def test_round_robin_routes_complete_cohort_blocks(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.EngineCoreClient.make_async_mp_client(
+        _config(True), object, False)
+
+    asyncio.run(
+        _add_requests(client, [_request(f"request-{i}") for i in range(64)]))
+
+    assert client.added_engines == ([b"engine-0"] * 16 + [b"engine-1"] * 16 +
+                                    [b"engine-0"] * 16 + [b"engine-1"] * 16)
+    assert client.original_router_calls == 0
+
+
+def test_next_cohort_follows_engine_that_clears_first(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(True), object, False)
+    initial_requests = [_request(f"initial-{i}") for i in range(32)]
+    asyncio.run(_add_requests(client, initial_requests))
+
+    asyncio.run(
+        type(client).process_engine_outputs(
+            client,
+            SimpleNamespace(finished_requests=[
+                request.request_id for request in initial_requests[16:]
+            ]),
+        ))
+    asyncio.run(
+        _add_requests(client, [_request(f"refill-{i}") for i in range(16)]))
+
+    assert client.added_engines[:32] == ([b"engine-0"] * 16 +
+                                         [b"engine-1"] * 16)
+    assert client.added_engines[32:] == [b"engine-1"] * 16
+
+
+def test_equal_in_flight_counts_rotate_tie_break(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(True, max_num_seqs=2),
+                                           object, False)
+
+    for wave in range(4):
+        requests = [_request(f"wave-{wave}-{i}") for i in range(2)]
+        asyncio.run(_add_requests(client, requests))
+        asyncio.run(
+            type(client).process_engine_outputs(
+                client,
+                SimpleNamespace(finished_requests=[
+                    request.request_id for request in requests
+                ]),
+            ))
+
+    assert client.added_engines == ([b"engine-0"] * 2 + [b"engine-1"] * 2 +
+                                    [b"engine-0"] * 2 + [b"engine-1"] * 2)
+
+
+@pytest.mark.parametrize("request_count", [1, 4])
+def test_partial_cohort_stays_on_one_engine(monkeypatch, request_count):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(True), object, False)
+
+    asyncio.run(
+        _add_requests(client,
+                      [_request(f"request-{i}")
+                       for i in range(request_count)]))
+
+    assert client.added_engines == [b"engine-0"] * request_count
+
+
+def test_explicit_late_and_existing_requests_do_not_advance_cohort_block(
+        monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(True), object, False)
+
+    asyncio.run(
+        _add_requests(
+            client,
+            [
+                _request("automatic-0"),
+                _request("automatic-0"),
+                _request("explicit", data_parallel_rank=1),
+                _request("late", late_interaction_rank=0),
+            ] + [_request(f"automatic-{i}")
+                 for i in range(1, 16)] + [_request("next-cohort")],
+        ))
+
+    assert client.added_engines[:4] == [
+        b"engine-0", b"engine-0", b"engine-1", b"engine-0"
+    ]
+    assert client.added_engines[4:19] == [b"engine-0"] * 15
+    assert client.added_engines[19] == b"engine-1"
+    assert client.original_router_calls == 2
+
+
+def test_abort_uses_round_robin_request_mapping(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(True), object, False)
+    requests = [_request(f"request-{i}") for i in range(17)]
+    asyncio.run(_add_requests(client, requests))
+
+    asyncio.run(client.abort_requests_async(["request-16", "request-0"]))
+
+    assert client.reqs_in_flight["request-0"] == b"engine-0"
+    assert client.reqs_in_flight["request-16"] == b"engine-1"
+    assert dict(client.aborted_by_engine) == {
+        b"engine-0": ["request-0"],
+        b"engine-1": ["request-16"],
+    }
+
+
+def test_finished_request_id_can_be_reused_on_next_engine(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(True), object, False)
+    request = _request("reused")
+    asyncio.run(
+        _add_requests(client, [request] +
+                      [_request(f"request-{i}") for i in range(1, 16)]))
+
+    asyncio.run(
+        type(client).process_engine_outputs(
+            client, SimpleNamespace(finished_requests=[request.request_id])))
+    asyncio.run(client.add_request_async(request))
+
+    assert client.added_engines[:16] == [b"engine-0"] * 16
+    assert client.added_engines[16] == b"engine-1"
+    assert client.reqs_in_flight["reused"] == b"engine-1"
+
+
+def test_patch_is_idempotent(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    patched_client = core_client.DPLBAsyncMPClient
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+
+    assert core_client.DPLBAsyncMPClient is patched_client
+
+
+def test_patched_client_preserves_default_load_balancing(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(False), object, False)
+    client.lb_engines = [[3, 1], [0, 0]]
+
+    asyncio.run(client.add_request_async(_request("request-default")))
+
+    assert client.added_engines == [b"engine-1"]
+    assert client.original_router_calls == 1
+
+
+def test_round_robin_rejects_multiple_api_clients(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+
+    with pytest.raises(ValueError, match="requires client_count=1"):
+        core_client.DPLBAsyncMPClient(_config(True),
+                                      object,
+                                      False,
+                                      client_count=2)
+
+
+def test_round_robin_rejects_invalid_cohort_size(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+
+    with pytest.raises(ValueError, match="requires positive scheduler_config"):
+        core_client.DPLBAsyncMPClient(_config(True, max_num_seqs=0), object,
+                                      False)
+
+
+def test_patch_fails_closed_on_unknown_vllm_router_signature(monkeypatch):
+    router = _load_router(monkeypatch)
+    _install_fake_vllm(monkeypatch, router_has_extra_parameter=True)
+
+    with pytest.raises(RuntimeError,
+                       match="Unsupported vLLM DPLBAsyncMPClient"):
+        router.patch_vllm_dp_client_for_block_diffusion_round_robin()

--- a/tests/core/test_diffusion_dp_router.py
+++ b/tests/core/test_diffusion_dp_router.py
@@ -291,6 +291,146 @@ def test_partial_cohort_stays_on_one_engine(monkeypatch, request_count):
     assert client.added_engines == [b"engine-0"] * request_count
 
 
+def test_completed_partial_cohort_starts_next_engine(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(True, max_num_seqs=4),
+                                           object, False)
+    partial = [_request("partial-0"), _request("partial-1")]
+    asyncio.run(_add_requests(client, partial))
+
+    asyncio.run(
+        type(client).process_engine_outputs(
+            client,
+            SimpleNamespace(
+                finished_requests=[request.request_id for request in partial]),
+        ))
+    asyncio.run(
+        _add_requests(client,
+                      [_request(f"next-{index}") for index in range(4)]))
+
+    assert client.added_engines == [b"engine-0"] * 2 + [b"engine-1"] * 4
+
+
+def test_partial_cohort_resets_only_after_all_members_finish(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(True, max_num_seqs=4),
+                                           object, False)
+    asyncio.run(
+        _add_requests(client, [_request("partial-0"),
+                               _request("partial-1")]))
+
+    asyncio.run(
+        type(client).process_engine_outputs(
+            client, SimpleNamespace(finished_requests=["partial-0"])))
+    asyncio.run(client.add_request_async(_request("partial-2")))
+    asyncio.run(
+        type(client).process_engine_outputs(
+            client,
+            SimpleNamespace(finished_requests=["partial-1", "partial-2"]),
+        ))
+    asyncio.run(client.add_request_async(_request("next")))
+
+    assert client.added_engines == [
+        b"engine-0", b"engine-0", b"engine-0", b"engine-1"
+    ]
+
+
+def test_successful_batched_abort_resets_partial_cohort(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(True, max_num_seqs=4),
+                                           object, False)
+    partial = [_request("partial-0"), _request("partial-1")]
+    asyncio.run(_add_requests(client, partial))
+
+    asyncio.run(
+        client.abort_requests_async(
+            [request.request_id for request in partial]))
+    asyncio.run(client.add_request_async(_request("next")))
+
+    assert client.added_engines == [b"engine-0", b"engine-0", b"engine-1"]
+    assert client.reqs_in_flight["partial-0"] == b"engine-0"
+    assert client.reqs_in_flight["partial-1"] == b"engine-0"
+
+
+def test_failed_abort_does_not_reset_partial_cohort(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(True, max_num_seqs=4),
+                                           object, False)
+    asyncio.run(client.add_request_async(_request("partial")))
+
+    async def fail_abort(_self, _request_ids):
+        raise RuntimeError("abort failed")
+
+    monkeypatch.setattr(
+        type(client).__mro__[1], "abort_requests_async", fail_abort)
+    with pytest.raises(RuntimeError, match="abort failed"):
+        asyncio.run(client.abort_requests_async(["partial"]))
+    asyncio.run(client.add_request_async(_request("same-cohort")))
+
+    assert client.added_engines == [b"engine-0", b"engine-0"]
+    assert client._cohort_round_robin_dp_active_request_ids == {
+        "partial", "same-cohort"
+    }
+
+
+def test_abort_completion_race_does_not_clear_reused_id_from_new_cohort(
+        monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(True, max_num_seqs=4),
+                                           object, False)
+    asyncio.run(client.add_request_async(_request("reused")))
+
+    async def finish_and_reuse(_self, _request_ids):
+        await type(client).process_engine_outputs(
+            client, SimpleNamespace(finished_requests=["reused"]))
+        await client.add_request_async(_request("reused"))
+
+    monkeypatch.setattr(
+        type(client).__mro__[1], "abort_requests_async", finish_and_reuse)
+    asyncio.run(client.abort_requests_async(["reused"]))
+    asyncio.run(client.add_request_async(_request("same-new-cohort")))
+
+    assert client.added_engines == [b"engine-0", b"engine-1", b"engine-1"]
+    assert client._cohort_round_robin_dp_active_request_ids == {
+        "reused", "same-new-cohort"
+    }
+
+
+def test_full_cohort_late_completions_do_not_reset_next_partial(monkeypatch):
+    router = _load_router(monkeypatch)
+    core_client = _install_fake_vllm(monkeypatch)
+    router.patch_vllm_dp_client_for_block_diffusion_round_robin()
+    client = core_client.DPLBAsyncMPClient(_config(True, max_num_seqs=2),
+                                           object, False)
+    first_wave = [_request("full-0"), _request("full-1")]
+    asyncio.run(_add_requests(client, first_wave))
+    asyncio.run(client.add_request_async(_request("partial-0")))
+
+    asyncio.run(
+        type(client).process_engine_outputs(
+            client,
+            SimpleNamespace(finished_requests=[
+                request.request_id for request in first_wave
+            ]),
+        ))
+    asyncio.run(client.add_request_async(_request("partial-1")))
+    asyncio.run(client.add_request_async(_request("next")))
+
+    assert client.added_engines == [
+        b"engine-0", b"engine-0", b"engine-1", b"engine-1", b"engine-0"
+    ]
+
+
 def test_explicit_late_and_existing_requests_do_not_advance_cohort_block(
         monkeypatch):
     router = _load_router(monkeypatch)
@@ -316,6 +456,7 @@ def test_explicit_late_and_existing_requests_do_not_advance_cohort_block(
     assert client.added_engines[4:19] == [b"engine-0"] * 15
     assert client.added_engines[19] == b"engine-1"
     assert client.original_router_calls == 2
+    assert client._cohort_round_robin_dp_active_request_ids == {"next-cohort"}
 
 
 def test_abort_uses_round_robin_request_mapping(monkeypatch):

--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -14,6 +14,7 @@
 
 from unittest.mock import MagicMock, patch
 
+import cloudpickle
 import numpy as np
 import pytest
 from vllm.config import VllmConfig
@@ -27,7 +28,7 @@ from vllm.v1.request import Request
 
 from tpu_inference.core.sched.dp_scheduler import (
     DPScheduler, DPSchedulerOutput, SchedulerCommand,
-    update_vllm_config_for_dp_scheduler)
+    _scheduler_worker_process, update_vllm_config_for_dp_scheduler)
 
 
 def _make_mock_mp_context():
@@ -525,28 +526,152 @@ class TestDPScheduler:
         assert combined.num_computed_tokens == [5, 4]
         assert combined.num_output_tokens == [3, 2]
 
-    def test_finish_requests_routes_to_workers(self, mock_vllm_config,
-                                               mock_kv_cache_config,
-                                               mock_structured_output_manager):
-        """Test finish_requests sends FINISH_REQUESTS command to appropriate workers."""
+    def test_finish_requests_returns_mixed_results_in_caller_order(
+            self, mock_vllm_config, mock_kv_cache_config,
+            mock_structured_output_manager):
+        """Test assigned, pending, duplicate, and unknown request IDs."""
         scheduler = self._create_scheduler(mock_vllm_config,
                                            mock_kv_cache_config,
                                            mock_structured_output_manager)
 
         scheduler._send_command = MagicMock()
-        scheduler._get_result = MagicMock(return_value=None)
+        scheduler._get_result = MagicMock(side_effect=[
+            [("req1", 10)],
+            [("req2", 20)],
+        ])
 
-        scheduler.assigned_dp_rank = {"req1": 0, "req2": 1, "req3": 0}
+        scheduler.assigned_dp_rank = {
+            "req1": 0,
+            "stale": 0,
+            "req2": 1,
+        }
+        pending = MagicMock(spec=Request)
+        pending.request_id = "pending"
+        pending.client_index = 30
+        scheduler._pending_new_requests = [pending]
 
-        # Test with list of requests
-        scheduler.finish_requests(["req1", "req2"],
-                                  finished_status="completed")
+        finished = scheduler.finish_requests(
+            ["req2", "pending", "unknown", "req1", "req2", "stale"],
+            finished_status="completed")
 
-        # Verify FINISH_REQUESTS commands were sent to correct ranks
         scheduler._send_command.assert_any_call(
-            0, SchedulerCommand.FINISH_REQUESTS, (["req1"], "completed"))
+            0, SchedulerCommand.FINISH_REQUESTS,
+            (["req1", "stale"], "completed"))
         scheduler._send_command.assert_any_call(
             1, SchedulerCommand.FINISH_REQUESTS, (["req2"], "completed"))
+        assert finished == [("req2", 20), ("pending", 30), ("req1", 10)]
+        assert scheduler._pending_new_requests == []
+        assert scheduler.assigned_dp_rank == {"stale": 0}
+
+    def test_finish_requests_accepts_single_unknown_id(
+            self, mock_vllm_config, mock_kv_cache_config,
+            mock_structured_output_manager):
+        scheduler = self._create_scheduler(mock_vllm_config,
+                                           mock_kv_cache_config,
+                                           mock_structured_output_manager)
+        scheduler._send_command = MagicMock()
+        scheduler._get_result = MagicMock()
+
+        assert scheduler.finish_requests("unknown", "completed") == []
+        scheduler._send_command.assert_not_called()
+        scheduler._get_result.assert_not_called()
+
+    def test_finish_requests_none_cancels_all_known_requests(
+            self, mock_vllm_config, mock_kv_cache_config,
+            mock_structured_output_manager):
+        scheduler = self._create_scheduler(mock_vllm_config,
+                                           mock_kv_cache_config,
+                                           mock_structured_output_manager)
+        scheduler._send_command = MagicMock()
+        scheduler._get_result = MagicMock(side_effect=[
+            [("req0", 10)],
+            [("req1", 11)],
+        ])
+        scheduler.assigned_dp_rank = {
+            "req0": 0,
+            "stale": 0,
+            "req1": 1,
+        }
+        pending0 = MagicMock(spec=Request)
+        pending0.request_id = "pending0"
+        pending0.client_index = 20
+        pending1 = MagicMock(spec=Request)
+        pending1.request_id = "pending1"
+        pending1.client_index = 21
+        scheduler._pending_new_requests = [pending0, pending1]
+
+        finished = scheduler.finish_requests(None, "completed")
+
+        scheduler._send_command.assert_any_call(
+            0, SchedulerCommand.FINISH_REQUESTS,
+            (["req0", "stale"], "completed"))
+        scheduler._send_command.assert_any_call(
+            1, SchedulerCommand.FINISH_REQUESTS, (["req1"], "completed"))
+        assert finished == [
+            ("req0", 10),
+            ("req1", 11),
+            ("pending0", 20),
+            ("pending1", 21),
+        ]
+        assert scheduler._pending_new_requests == []
+        assert scheduler.assigned_dp_rank == {"stale": 0}
+
+    def test_finish_requests_worker_returns_scheduler_result(self):
+
+        class WorkerExit(BaseException):
+            pass
+
+        class WorkerScheduler:
+
+            def __init__(
+                self,
+                vllm_config,
+                kv_cache_config,
+                structured_output_manager,
+                block_size,
+                mm_registry,
+                include_finished_set,
+                log_stats,
+            ):
+                pass
+
+            def finish_requests(self, request_ids, finished_status):
+                assert request_ids == ["req"]
+                assert finished_status == "completed"
+                return [("req", 7)]
+
+            def shutdown(self):
+                pass
+
+        input_conn = MagicMock()
+        input_conn.recv_bytes.side_effect = [
+            cloudpickle.dumps(
+                (SchedulerCommand.FINISH_REQUESTS, (["req"], "completed"))),
+            KeyboardInterrupt(),
+        ]
+        output_conn = MagicMock()
+
+        with patch("atexit._clear"), patch(
+                "tpu_inference.core.sched.dp_scheduler.os._exit",
+                side_effect=WorkerExit):
+            with pytest.raises(WorkerExit):
+                _scheduler_worker_process(
+                    rank=0,
+                    input_conn=input_conn,
+                    output_conn=output_conn,
+                    vllm_config=object(),
+                    kv_cache_config=object(),
+                    structured_output_manager=object(),
+                    block_size=16,
+                    hash_block_size=16,
+                    mm_registry=object(),
+                    include_finished_set=False,
+                    log_stats=False,
+                    original_scheduler_cls=WorkerScheduler,
+                )
+
+        result = cloudpickle.loads(output_conn.send_bytes.call_args.args[0])
+        assert result == [("req", 7)]
 
     def test_get_num_unfinished_requests(self, mock_vllm_config,
                                          mock_kv_cache_config,

--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import cloudpickle
@@ -536,8 +537,8 @@ class TestDPScheduler:
 
         scheduler._send_command = MagicMock()
         scheduler._get_result = MagicMock(side_effect=[
-            [("req1", 10)],
-            [("req2", 20)],
+            ([("req2", 20)], {"req2"}),
+            ([("req1", 10)], {"req1"}),
         ])
 
         scheduler.assigned_dp_rank = {
@@ -561,7 +562,7 @@ class TestDPScheduler:
             1, SchedulerCommand.FINISH_REQUESTS, (["req2"], "completed"))
         assert finished == [("req2", 20), ("pending", 30), ("req1", 10)]
         assert scheduler._pending_new_requests == []
-        assert scheduler.assigned_dp_rank == {"stale": 0}
+        assert scheduler.assigned_dp_rank == {"req1": 0, "req2": 1}
 
     def test_finish_requests_accepts_single_unknown_id(
             self, mock_vllm_config, mock_kv_cache_config,
@@ -584,8 +585,8 @@ class TestDPScheduler:
                                            mock_structured_output_manager)
         scheduler._send_command = MagicMock()
         scheduler._get_result = MagicMock(side_effect=[
-            [("req0", 10)],
-            [("req1", 11)],
+            ([("req0", 10)], {"req0"}),
+            ([("req1", 11)], {"req1"}),
         ])
         scheduler.assigned_dp_rank = {
             "req0": 0,
@@ -603,10 +604,9 @@ class TestDPScheduler:
         finished = scheduler.finish_requests(None, "completed")
 
         scheduler._send_command.assert_any_call(
-            0, SchedulerCommand.FINISH_REQUESTS,
-            (["req0", "stale"], "completed"))
+            0, SchedulerCommand.FINISH_REQUESTS, (None, "completed"))
         scheduler._send_command.assert_any_call(
-            1, SchedulerCommand.FINISH_REQUESTS, (["req1"], "completed"))
+            1, SchedulerCommand.FINISH_REQUESTS, (None, "completed"))
         assert finished == [
             ("req0", 10),
             ("req1", 11),
@@ -614,7 +614,54 @@ class TestDPScheduler:
             ("pending1", 21),
         ]
         assert scheduler._pending_new_requests == []
-        assert scheduler.assigned_dp_rank == {"stale": 0}
+        assert scheduler.assigned_dp_rank == {"req0": 0, "req1": 1}
+
+    def test_finish_requests_releases_stale_assignment_for_request_id_reuse(
+            self, mock_vllm_config, mock_kv_cache_config,
+            mock_structured_output_manager):
+        scheduler = self._create_scheduler(mock_vllm_config,
+                                           mock_kv_cache_config,
+                                           mock_structured_output_manager)
+        scheduler._send_command = MagicMock()
+        scheduler._get_result = MagicMock(return_value=([], set()))
+        scheduler.assigned_dp_rank = {"reused": 0}
+
+        assert scheduler.finish_requests("reused", "completed") == []
+        assert scheduler.assigned_dp_rank == {}
+
+        scheduler._find_best_rank_for_request = MagicMock(return_value=1)
+        scheduler._get_result = MagicMock(return_value=None)
+        replacement = MagicMock(spec=Request)
+        replacement.request_id = "reused"
+        scheduler.add_request(replacement)
+
+        assert scheduler.assigned_dp_rank == {"reused": 1}
+        scheduler._send_command.assert_called_with(
+            1, SchedulerCommand.ADD_REQUEST, replacement)
+
+    def test_finish_requests_keeps_assignment_until_old_finish_is_consumed(
+            self, mock_vllm_config, mock_kv_cache_config,
+            mock_structured_output_manager):
+        scheduler = self._create_scheduler(mock_vllm_config,
+                                           mock_kv_cache_config,
+                                           mock_structured_output_manager)
+        scheduler._send_command = MagicMock()
+        scheduler._get_result = MagicMock(return_value=([], {"reused"}))
+        scheduler.assigned_dp_rank = {"reused": 0}
+
+        assert scheduler.finish_requests("reused", "completed") == []
+        assert scheduler.assigned_dp_rank == {"reused": 0}
+
+        replacement = MagicMock(spec=Request)
+        replacement.request_id = "reused"
+        with pytest.raises(AssertionError, match="already assigned"):
+            scheduler.add_request(replacement)
+
+        scheduler._cleanup_finished_requests({"reused"})
+        scheduler._find_best_rank_for_request = MagicMock(return_value=1)
+        scheduler._get_result = MagicMock(return_value=None)
+        scheduler.add_request(replacement)
+        assert scheduler.assigned_dp_rank == {"reused": 1}
 
     def test_finish_requests_worker_returns_scheduler_result(self):
 
@@ -633,7 +680,8 @@ class TestDPScheduler:
                 include_finished_set,
                 log_stats,
             ):
-                pass
+                self.requests = {}
+                self.finished_req_ids = {"req"}
 
             def finish_requests(self, request_ids, finished_status):
                 assert request_ids == ["req"]
@@ -671,7 +719,61 @@ class TestDPScheduler:
                 )
 
         result = cloudpickle.loads(output_conn.send_bytes.call_args.args[0])
-        assert result == [("req", 7)]
+        assert result == ([("req", 7)], {"req"})
+
+    def test_finish_worker_retains_ids_in_cached_scheduler_output(self):
+
+        class WorkerExit(BaseException):
+            pass
+
+        class WorkerScheduler:
+
+            def __init__(self, **_kwargs):
+                self.requests = {}
+                self.finished_req_ids = set()
+
+            def schedule(self):
+                return SimpleNamespace(finished_req_ids={"reused"})
+
+            def finish_requests(self, request_ids, finished_status):
+                assert request_ids == ["reused"]
+                assert finished_status == "completed"
+                return []
+
+            def shutdown(self):
+                pass
+
+        input_conn = MagicMock()
+        input_conn.recv_bytes.side_effect = [
+            cloudpickle.dumps((SchedulerCommand.SCHEDULE, ((), {}))),
+            cloudpickle.dumps(
+                (SchedulerCommand.FINISH_REQUESTS, (["reused"], "completed"))),
+            KeyboardInterrupt(),
+        ]
+        output_conn = MagicMock()
+
+        with patch("atexit._clear"), patch(
+                "tpu_inference.core.sched.dp_scheduler.os._exit",
+                side_effect=WorkerExit):
+            with pytest.raises(WorkerExit):
+                _scheduler_worker_process(
+                    rank=0,
+                    input_conn=input_conn,
+                    output_conn=output_conn,
+                    vllm_config=object(),
+                    kv_cache_config=object(),
+                    structured_output_manager=object(),
+                    block_size=16,
+                    hash_block_size=16,
+                    mm_registry=object(),
+                    include_finished_set=False,
+                    log_stats=False,
+                    original_scheduler_cls=WorkerScheduler,
+                )
+
+        finish_result = cloudpickle.loads(
+            output_conn.send_bytes.call_args_list[1].args[0])
+        assert finish_result == ([], {"reused"})
 
     def test_get_num_unfinished_requests(self, mock_vllm_config,
                                          mock_kv_cache_config,

--- a/tests/core/test_multi_token_scheduler.py
+++ b/tests/core/test_multi_token_scheduler.py
@@ -1,0 +1,162 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+from types import SimpleNamespace
+
+
+def _load_utils_with_fake_vllm(monkeypatch):
+
+    class Scheduler:
+
+        def __init__(self, vllm_config):
+            del vllm_config
+            self.num_lookahead_tokens = 2
+
+        def _update_request_with_output(self, request, new_token_ids):
+            retained = list(new_token_ids[:request.retain_tokens])
+            request.output_token_ids.extend(retained)
+            return retained, len(retained) != len(new_token_ids)
+
+    class AsyncScheduler:
+
+        def _update_request_with_output(self, request, new_token_ids):
+            request.num_output_placeholders -= len(new_token_ids)
+            return list(new_token_ids), False
+
+    modules = {
+        "vllm":
+        types.ModuleType("vllm"),
+        "vllm.v1":
+        types.ModuleType("vllm.v1"),
+        "vllm.v1.core":
+        types.ModuleType("vllm.v1.core"),
+        "vllm.v1.core.sched":
+        types.ModuleType("vllm.v1.core.sched"),
+        "vllm.v1.core.sched.scheduler":
+        types.ModuleType("vllm.v1.core.sched.scheduler"),
+        "vllm.v1.core.sched.async_scheduler":
+        types.ModuleType("vllm.v1.core.sched.async_scheduler"),
+    }
+    modules["vllm.v1.core.sched.scheduler"].Scheduler = Scheduler
+    modules[
+        "vllm.v1.core.sched.async_scheduler"].AsyncScheduler = AsyncScheduler
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    path = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+            "core" / "sched" / "utils.py")
+    spec = importlib.util.spec_from_file_location("scheduler_utils_under_test",
+                                                  path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module, Scheduler, AsyncScheduler
+
+
+def test_continue_decode_lookahead_is_preserved(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_continue_decode()
+
+    scheduler = Scheduler(
+        SimpleNamespace(additional_config={
+            "enable_continue_decode": True,
+            "max_decode_steps": 10,
+        }))
+
+    assert scheduler.num_lookahead_tokens == 9
+
+
+def test_explicit_multi_token_lookahead_takes_precedence(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+
+    scheduler = Scheduler(
+        SimpleNamespace(
+            additional_config={
+                "enable_continue_decode": True,
+                utils.MULTI_TOKEN_LOOKAHEAD_CONFIG: 31,
+            }))
+
+    assert scheduler.num_lookahead_tokens == 31
+
+
+def test_output_accounting_uses_tokens_retained_after_eos(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = Scheduler(
+        SimpleNamespace(additional_config={
+            utils.MULTI_TOKEN_LOOKAHEAD_CONFIG: 3,
+        }))
+    request = SimpleNamespace(
+        retain_tokens=2,
+        output_token_ids=[],
+        num_computed_tokens=1,
+    )
+
+    retained, stopped = scheduler._update_request_with_output(
+        request, [10, 11, 12, 13])
+
+    assert retained == [10, 11]
+    assert stopped is True
+    assert request.num_computed_tokens == 2
+
+
+def test_async_placeholder_accounting_consumes_one_scheduled_step(monkeypatch):
+    utils, _, AsyncScheduler = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = AsyncScheduler()
+    scheduler._multi_token_decode_enabled = True
+    request = SimpleNamespace(num_output_placeholders=1)
+
+    scheduler._update_request_with_output(request, [10, 11, 12, 13])
+
+    assert request.num_output_placeholders == 0
+
+
+def test_normal_scheduler_is_unchanged_after_class_patch(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = Scheduler(SimpleNamespace(additional_config={}))
+    request = SimpleNamespace(
+        retain_tokens=3,
+        output_token_ids=[],
+        num_computed_tokens=1,
+    )
+
+    scheduler._update_request_with_output(request, [1, 2, 3])
+
+    assert request.num_computed_tokens == 1
+
+
+def test_patch_is_idempotent(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    utils.patch_vllm_scheduler_for_continue_decode()
+    scheduler = Scheduler(
+        SimpleNamespace(additional_config={
+            "enable_continue_decode": True,
+        }))
+    request = SimpleNamespace(
+        retain_tokens=3,
+        output_token_ids=[],
+        num_computed_tokens=1,
+    )
+
+    scheduler._update_request_with_output(request, [1, 2, 3])
+
+    assert request.num_computed_tokens == 3

--- a/tests/core/test_multi_token_scheduler.py
+++ b/tests/core/test_multi_token_scheduler.py
@@ -27,14 +27,24 @@ def _load_utils_with_fake_vllm(monkeypatch):
             del vllm_config
             self.num_lookahead_tokens = 2
 
-        def _update_request_with_output(self, request, new_token_ids):
+        def _update_request_with_output(self,
+                                        request,
+                                        new_token_ids,
+                                        *,
+                                        is_stale=False):
+            request.is_stale = is_stale
             retained = list(new_token_ids[:request.retain_tokens])
             request.output_token_ids.extend(retained)
             return retained, len(retained) != len(new_token_ids)
 
     class AsyncScheduler:
 
-        def _update_request_with_output(self, request, new_token_ids):
+        def _update_request_with_output(self,
+                                        request,
+                                        new_token_ids,
+                                        *,
+                                        is_stale=False):
+            request.is_stale = is_stale
             request.num_output_placeholders -= len(new_token_ids)
             return list(new_token_ids), False
 
@@ -114,6 +124,24 @@ def test_output_accounting_uses_tokens_retained_after_eos(monkeypatch):
     assert retained == [10, 11]
     assert stopped is True
     assert request.num_computed_tokens == 2
+
+
+def test_output_accounting_forwards_scheduler_keywords(monkeypatch):
+    utils, Scheduler, _ = _load_utils_with_fake_vllm(monkeypatch)
+    utils.patch_vllm_scheduler_for_multi_token_decode()
+    scheduler = Scheduler(
+        SimpleNamespace(additional_config={
+            utils.MULTI_TOKEN_LOOKAHEAD_CONFIG: 3,
+        }))
+    request = SimpleNamespace(
+        retain_tokens=2,
+        output_token_ids=[],
+        num_computed_tokens=1,
+    )
+
+    scheduler._update_request_with_output(request, [10, 11], is_stale=True)
+
+    assert request.is_stale is True
 
 
 def test_async_placeholder_accounting_consumes_one_scheduled_step(monkeypatch):

--- a/tests/kernels/ragged_paged_attention_kernel_v3_test.py
+++ b/tests/kernels/ragged_paged_attention_kernel_v3_test.py
@@ -628,12 +628,16 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         return (q, k, v, kv_cache, kv_lens_arr, page_indices, cu_q_lens_arr,
                 distribution)
 
-    def _kv_share_kwargs(self, head_dim: int = 128):
-        return dict(
+    def _kv_share_kwargs(self, q_len: int, head_dim: int = 128):
+        kwargs = dict(
             sm_scale=1.0 / float(head_dim)**0.5,
             update_kv_cache=False,
             m_block_sizes=(64, 256, 32, 128),
         )
+        if q_len > 1:
+            kwargs["chunk_prefill_size"] = q_len
+            kwargs["p_block_sizes"] = (64, 256, 32, 128)
+        return kwargs
 
     def test_kv_share_prefill_input_kv_is_ignored(self):
         """q_len == kv_len. Two calls with different input k,v but the same
@@ -656,10 +660,10 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         self.assertFalse(np.array_equal(args1[2], args2[2]))
         cache_before = np.asarray(args1[3])
 
-        out1, cache_after_1 = ragged_paged_attention(*args1,
-                                                     **self._kv_share_kwargs())
-        out2, cache_after_2 = ragged_paged_attention(*args2,
-                                                     **self._kv_share_kwargs())
+        out1, cache_after_1 = ragged_paged_attention(
+            *args1, **self._kv_share_kwargs(16))
+        out2, cache_after_2 = ragged_paged_attention(
+            *args2, **self._kv_share_kwargs(16))
 
         # Output invariant to input k,v.
         self.assertArraysEqual(out1, out2)
@@ -691,10 +695,10 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
                                             kv_input_seed=99)
         cache_before = np.asarray(args1[3])
 
-        out1, cache_after_1 = ragged_paged_attention(*args1,
-                                                     **self._kv_share_kwargs())
-        out2, cache_after_2 = ragged_paged_attention(*args2,
-                                                     **self._kv_share_kwargs())
+        out1, cache_after_1 = ragged_paged_attention(
+            *args1, **self._kv_share_kwargs(8))
+        out2, cache_after_2 = ragged_paged_attention(
+            *args2, **self._kv_share_kwargs(8))
 
         # Output invariant to input k,v. The pre-fix kernel would mix
         # source K,V (past 16 positions from cache) with shared raw K,V
@@ -710,6 +714,44 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         np.testing.assert_array_equal(
             np.asarray(cache_after_1)[mask], cache_before[mask])
 
+    @parameterized.parameters(True, False)
+    def test_static_prefill_matches_mixed_bidirectional(self, update_kv_cache):
+        if not jtu.is_device_tpu_at_least(version=4):
+            self.skipTest("Expect TPUv4+")
+        prefill_args = self._build_kv_share_inputs(q_len=8,
+                                                   kv_len=24,
+                                                   kv_input_seed=11)
+        mixed_args = self._build_kv_share_inputs(q_len=8,
+                                                 kv_len=24,
+                                                 kv_input_seed=11)
+        mixed_args = (*mixed_args[:-1], jnp.array([0, 0, 1], dtype=jnp.int32))
+        common = dict(
+            sm_scale=1.0 / 128.0**0.5,
+            update_kv_cache=update_kv_cache,
+            use_causal_mask=False,
+        )
+        prefill_out, prefill_cache = ragged_paged_attention(
+            *prefill_args,
+            chunk_prefill_size=8,
+            p_block_sizes=(64, 256, 32, 128),
+            **common,
+        )
+        mixed_out, mixed_cache = ragged_paged_attention(
+            *mixed_args,
+            m_block_sizes=(64, 256, 32, 128),
+            **common,
+        )
+
+        self.assertAllClose(prefill_out[:8],
+                            mixed_out[:8],
+                            rtol=3e-2,
+                            atol=3e-2)
+        finite = np.isfinite(np.asarray(prefill_cache))
+        self.assertAllClose(np.asarray(prefill_cache)[finite],
+                            np.asarray(mixed_cache)[finite],
+                            rtol=3e-2,
+                            atol=3e-2)
+
     def test_kv_share_decode_input_kv_is_ignored(self):
         """q_len == 1, kv_len > 1 (decode step). Same invariance."""
         if not jtu.is_device_tpu_at_least(version=4):
@@ -722,10 +764,10 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
                                             kv_input_seed=99)
         cache_before = np.asarray(args1[3])
 
-        out1, cache_after_1 = ragged_paged_attention(*args1,
-                                                     **self._kv_share_kwargs())
-        out2, cache_after_2 = ragged_paged_attention(*args2,
-                                                     **self._kv_share_kwargs())
+        out1, cache_after_1 = ragged_paged_attention(
+            *args1, **self._kv_share_kwargs(1))
+        out2, cache_after_2 = ragged_paged_attention(
+            *args2, **self._kv_share_kwargs(1))
 
         # Decode emits q_len = 1 token. Compare just that token (the rest of
         # the max_num_batched_tokens buffer is junk padding).

--- a/tests/kernels/ragged_paged_attention_kernel_v3_test.py
+++ b/tests/kernels/ragged_paged_attention_kernel_v3_test.py
@@ -57,6 +57,7 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         use_causal_mask: bool = True,
         block_causal_size: int | None = None,
         chunk_prefill_size: int | None = None,
+        out_dtype=None,
     ):
         rng = np.random.default_rng(1234)
 
@@ -174,6 +175,7 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
             "q_scale": q_scale,
             "k_scale": k_scale,
             "v_scale": v_scale,
+            "out_dtype": out_dtype,
         }
 
         expected, expected_kv_cache = ref_ragged_paged_attention(
@@ -200,6 +202,7 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         }
         tol = tols[dtype_bits]
         self.assertAllClose(output, expected, atol=tol, rtol=tol)
+        self.assertEqual(output.dtype, q.dtype)
         mask = ~jnp.isnan(expected_kv_cache)
         self.assertArraysEqual(updated_kv_cache[mask], expected_kv_cache[mask])
         self.assertEqual(output.shape[-1], head_dim)
@@ -250,6 +253,25 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
             use_causal_mask=False,
             block_causal_size=32,
             chunk_prefill_size=128,
+        )
+
+    def test_ragged_paged_attention_fp32_accumulator_bfloat16_output(self):
+        self._test_ragged_paged_attention(
+            [(8, 8)],
+            (8, 4),
+            128,
+            16,
+            jnp.bfloat16,
+            jnp.bfloat16,
+            16,
+            bq_sz=8,
+            bkv_sz=16,
+            bq_csz=8,
+            bkv_csz=16,
+            max_num_batched_tokens=128,
+            use_causal_mask=False,
+            chunk_prefill_size=8,
+            out_dtype=jnp.float32,
         )
 
     # TODO: support integer (int8, int4) and fp4 kv cache

--- a/tests/kernels/ragged_paged_attention_kernel_v3_test.py
+++ b/tests/kernels/ragged_paged_attention_kernel_v3_test.py
@@ -55,6 +55,8 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         k_scale: float | None = None,
         v_scale: float | None = None,
         use_causal_mask: bool = True,
+        block_causal_size: int | None = None,
+        chunk_prefill_size: int | None = None,
     ):
         rng = np.random.default_rng(1234)
 
@@ -149,7 +151,9 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
                             (0, max_num_seq + 1 - cu_q_lens.shape[0]))
         kv_lens = jnp.array(kv_lens, dtype=jnp.int32)
         kv_lens = jnp.pad(kv_lens, (0, max_num_seq - kv_lens.shape[0]))
-        distribution = jnp.array([0, 0, len(seq_lens)], dtype=jnp.int32)
+        prefill_end = len(seq_lens) if chunk_prefill_size is not None else 0
+        distribution = jnp.array(
+            [0, prefill_end, len(seq_lens)], dtype=jnp.int32)
 
         args = (
             q,
@@ -164,6 +168,7 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
 
         kwargs = {
             "use_causal_mask": use_causal_mask,
+            "block_causal_size": block_causal_size,
             "sliding_window": sliding_window,
             "soft_cap": soft_cap,
             "q_scale": q_scale,
@@ -179,6 +184,8 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
         output, updated_kv_cache = ragged_paged_attention(
             *args,
             **kwargs,
+            chunk_prefill_size=chunk_prefill_size,
+            p_block_sizes=(bq_sz, bkv_sz, bq_csz, bkv_csz),
             m_block_sizes=(bq_sz, bkv_sz, bq_csz, bkv_csz),
             vmem_limit_bytes=vmem_limit_bytes,
         )
@@ -229,6 +236,20 @@ class RaggedPagedAttentionKernelTest(jtu.JaxTestCase):
             bq_csz=bq_csz,
             bkv_csz=bkv_csz,
             use_causal_mask=use_causal_mask,
+        )
+
+    def test_ragged_paged_attention_block_causal(self):
+        self._test_ragged_paged_attention(
+            [(128, 128), (128, 128)],
+            (32, 8),
+            128,
+            16,
+            jnp.bfloat16,
+            jnp.bfloat16,
+            1000,
+            use_causal_mask=False,
+            block_causal_size=32,
+            chunk_prefill_size=128,
         )
 
     # TODO: support integer (int8, int4) and fp4 kv cache

--- a/tests/kernels/test_rpa_block_causal_reference.py
+++ b/tests/kernels/test_rpa_block_causal_reference.py
@@ -1,0 +1,99 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+def _load_kernel_module():
+    root = pathlib.Path(__file__).resolve().parents[2]
+    package_paths = {
+        "tpu_inference":
+        root / "tpu_inference",
+        "tpu_inference.kernels":
+        root / "tpu_inference" / "kernels",
+        "tpu_inference.kernels.ragged_paged_attention":
+        root / "tpu_inference" / "kernels" / "ragged_paged_attention",
+        "tpu_inference.kernels.ragged_paged_attention.v3":
+        root / "tpu_inference" / "kernels" / "ragged_paged_attention" / "v3",
+    }
+    previous_modules = {name: sys.modules.get(name) for name in package_paths}
+    for name, path in package_paths.items():
+        module = types.ModuleType(name)
+        module.__path__ = [str(path)]
+        sys.modules[name] = module
+
+    module_name = "rpa_block_causal_kernel_under_test"
+    path = package_paths["tpu_inference.kernels.ragged_paged_attention.v3"] / \
+        "kernel.py"
+    spec = importlib.util.spec_from_file_location(module_name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[module_name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        sys.modules.pop(module_name, None)
+        for name, previous in previous_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+    return module
+
+
+kernel = _load_kernel_module()
+
+
+def _reference_inputs():
+    head_dim = 128
+    queries = jnp.zeros((4, 1, head_dim), dtype=jnp.float32)
+    keys = jnp.zeros((4, 1, head_dim), dtype=jnp.float32)
+    values = jnp.zeros((4, 1, head_dim), dtype=jnp.float32)
+    values = values.at[:, 0, 0].set(jnp.array([1.0, 2.0, 4.0, 8.0]))
+    kv_cache = jnp.zeros((1, 4, 2, 1, head_dim), dtype=jnp.float32)
+    return (
+        queries,
+        keys,
+        values,
+        kv_cache,
+        jnp.array([4], dtype=jnp.int32),
+        jnp.array([0], dtype=jnp.int32),
+        jnp.array([0, 4], dtype=jnp.int32),
+        jnp.array([0, 0, 1], dtype=jnp.int32),
+    )
+
+
+def test_reference_block_causal_attention_is_bidirectional_within_blocks():
+    output, _ = kernel.ref_ragged_paged_attention(
+        *_reference_inputs(),
+        use_causal_mask=False,
+        block_causal_size=2,
+    )
+
+    np.testing.assert_allclose(output[:, 0, 0], [1.5, 1.5, 3.75, 3.75])
+
+
+def test_block_causal_and_token_causal_are_mutually_exclusive():
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        kernel.ref_ragged_paged_attention(
+            *_reference_inputs(),
+            use_causal_mask=True,
+            block_causal_size=2,
+        )

--- a/tests/kernels/test_rpa_block_causal_reference.py
+++ b/tests/kernels/test_rpa_block_causal_reference.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import importlib.util
+import inspect
 import pathlib
 import sys
 import types
@@ -97,3 +98,19 @@ def test_block_causal_and_token_causal_are_mutually_exclusive():
             use_causal_mask=True,
             block_causal_size=2,
         )
+
+
+def test_block_causal_size_must_be_a_power_of_two():
+    with pytest.raises(ValueError, match="power of two"):
+        kernel.ref_ragged_paged_attention(
+            *_reference_inputs(),
+            use_causal_mask=False,
+            block_causal_size=3,
+        )
+
+
+def test_pallas_block_causal_mask_avoids_vector_integer_division():
+    source = inspect.getsource(kernel._ragged_paged_attention_kernel_loop)
+
+    assert "// block_causal_size" not in source
+    assert "bitwise_and" in source

--- a/tests/kernels/test_rpa_block_causal_reference.py
+++ b/tests/kernels/test_rpa_block_causal_reference.py
@@ -81,6 +81,16 @@ def _reference_inputs():
     )
 
 
+def _bfloat16_reference_inputs():
+    inputs = list(_reference_inputs())
+    inputs[:3] = [value.astype(jnp.bfloat16) for value in inputs[:3]]
+    inputs[3] = jnp.zeros(
+        kernel.get_kv_cache_shape(1, 4, 1, 128, jnp.bfloat16),
+        dtype=jnp.bfloat16,
+    )
+    return tuple(inputs)
+
+
 def test_reference_block_causal_attention_is_bidirectional_within_blocks():
     output, _ = kernel.ref_ragged_paged_attention(
         *_reference_inputs(),
@@ -89,6 +99,16 @@ def test_reference_block_causal_attention_is_bidirectional_within_blocks():
     )
 
     np.testing.assert_allclose(output[:, 0, 0], [1.5, 1.5, 3.75, 3.75])
+
+
+def test_reference_fp32_accumulator_preserves_bfloat16_output_storage():
+    output, _ = kernel.ref_ragged_paged_attention(
+        *_bfloat16_reference_inputs(),
+        use_causal_mask=False,
+        out_dtype=jnp.float32,
+    )
+
+    assert output.dtype == jnp.bfloat16
 
 
 def test_block_causal_and_token_causal_are_mutually_exclusive():
@@ -114,3 +134,13 @@ def test_pallas_block_causal_mask_avoids_vector_integer_division():
 
     assert "// block_causal_size" not in source
     assert "bitwise_and" in source
+
+
+def test_pallas_fp32_accumulator_casts_to_output_storage_before_packed_store():
+    source = inspect.getsource(kernel._ragged_paged_attention_kernel_loop)
+
+    assert "accumulator_dtype = acc_ref.dtype" in source
+    assert "output_dtype = o_hbm_ref.dtype" in source
+    assert ").astype(output_dtype)" in source
+    assert source.index(").astype(output_dtype)") < source.index(
+        "pltpu.bitcast(out, out_ref.dtype)")

--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -23,7 +23,8 @@ from jax.sharding import Mesh
 from tpu_inference.layers.common.attention_interface import (
     attention, mla_attention, sharded_ragged_paged_attention)
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, SharedAttentionMetadata)
+    AttentionMaskKind, AttentionMaskSpec, AttentionMetadata,
+    SharedAttentionMetadata)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.runner.kv_cache import get_kv_cache_shape_with_mesh
 
@@ -62,7 +63,11 @@ def mesh():
 # ---- Test for `attention` ----
 
 
-def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
+def _test_attention(monkeypatch,
+                    mesh,
+                    head_dim,
+                    use_sinks=False,
+                    attention_mask_spec=None):
     """
     Tests the main `attention` function.
 
@@ -106,6 +111,9 @@ def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
         )
 
     # Create AttentionMetadata
+    metadata_kwargs = {}
+    if attention_mask_spec is not None:
+        metadata_kwargs["attention_mask_spec"] = attention_mask_spec
     attention_metadata = AttentionMetadata(
         input_positions=jnp.arange(TOTAL_TOKENS, dtype=jnp.int32),
         block_tables=jnp.zeros((MAX_NUM_SEQS * MAX_BLOCKS_PER_SEQ, ),
@@ -113,6 +121,7 @@ def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
         seq_lens=jnp.array([5, 5, 0, 0], dtype=jnp.int32),
         query_start_loc=jnp.array([0, 5, 10, 10, 10], dtype=jnp.int32),
         request_distribution=jnp.array([0, 0, NUM_SEQS], dtype=jnp.int32),
+        **metadata_kwargs,
     )
     shared_attention_metadata = SharedAttentionMetadata(
         input_positions=jnp.arange(TOTAL_TOKENS, dtype=jnp.int32),
@@ -137,6 +146,11 @@ def _test_attention(monkeypatch, mesh, head_dim, use_sinks=False):
     # 3. Assert
     # Check that both mocked kernels were called
     mock_paged_attn_kernel.assert_called_once()
+    expected_causal = (attention_mask_spec is None
+                       or attention_mask_spec.kind is AttentionMaskKind.CAUSAL)
+    if head_dim != 64:
+        assert mock_paged_attn_kernel.call_args.kwargs[
+            "use_causal_mask"] is expected_causal
 
     # Check output shapes
     assert final_kv_cache.shape == kv_cache.shape
@@ -156,6 +170,26 @@ def test_attention_hd64(monkeypatch, mesh):
 
 def test_attention_sink(monkeypatch, mesh):
     _test_attention(monkeypatch, mesh, 64, True)
+
+
+def test_attention_bidirectional_from_metadata(monkeypatch, mesh):
+    _test_attention(
+        monkeypatch,
+        mesh,
+        128,
+        attention_mask_spec=AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL),
+    )
+
+
+def test_attention_bidirectional_hd64_fails_loudly(monkeypatch, mesh):
+    with pytest.raises(NotImplementedError, match="head_dim==64"):
+        _test_attention(
+            monkeypatch,
+            mesh,
+            64,
+            attention_mask_spec=AttentionMaskSpec(
+                AttentionMaskKind.BIDIRECTIONAL),
+        )
 
 
 def test_attention_sink_no_64_raises_error(monkeypatch, mesh):

--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -20,6 +20,8 @@ import numpy as np
 import pytest
 from jax.sharding import Mesh
 
+from tpu_inference import envs
+from tpu_inference.layers.common import attention_interface
 from tpu_inference.layers.common.attention_interface import (
     attention, mla_attention, sharded_ragged_paged_attention)
 from tpu_inference.layers.common.attention_metadata import (
@@ -416,13 +418,13 @@ def test_sharded_ragged_paged_attention_gqa_incompatible_raises_error(
 def _run_sharded_rpa_capturing_kwargs(monkeypatch,
                                       gqa_mesh,
                                       update_kv_cache,
-                                      out_dtype=None):
+                                      out_dtype=None,
+                                      head_dim=128):
     """Helper: run `sharded_ragged_paged_attention` with a stubbed
     `ragged_paged_attention` (the module-level binding) and a passthrough
     `jax.shard_map`. Returns the kwargs forwarded by the closure to the
     underlying kernel.
     """
-    head_dim = 128  # non-hd64
     num_kv_heads = 4
     q = jnp.ones((TOTAL_TOKENS, NUM_HEADS, head_dim))
     k = jnp.ones((TOTAL_TOKENS, num_kv_heads, head_dim))
@@ -440,10 +442,9 @@ def _run_sharded_rpa_capturing_kwargs(monkeypatch,
         captured.update(kwargs)
         return jnp.ones_like(q), kv_cache
 
-    monkeypatch.setattr(
-        "tpu_inference.layers.common.attention_interface.ragged_paged_attention",
-        fake_kernel,
-    )
+    kernel_name = ("ragged_paged_attention_hd64"
+                   if head_dim == 64 else "ragged_paged_attention")
+    monkeypatch.setattr(attention_interface, kernel_name, fake_kernel)
 
     # Passthrough shard_map so the closure actually executes.
     def passthrough_shard_map(inner_fn, **_):
@@ -467,6 +468,82 @@ def _run_sharded_rpa_capturing_kwargs(monkeypatch,
         out_dtype=out_dtype,
     )
     return captured
+
+
+def test_sharded_rpa_forwards_only_mixed_block_sizes_from_env(
+        monkeypatch, gqa_mesh):
+    monkeypatch.setenv("RPA_V3_MIXED_BLOCK_SIZES", "32,2048,32,512")
+    monkeypatch.setattr(envs, "RPA_V3_DECODE_BLOCK_SIZES", [])
+    monkeypatch.setattr(envs, "RPA_V3_PREFILL_BLOCK_SIZES", [])
+    monkeypatch.setattr(
+        envs,
+        "RPA_V3_MIXED_BLOCK_SIZES",
+        envs.environment_variables["RPA_V3_MIXED_BLOCK_SIZES"](),
+    )
+
+    captured = _run_sharded_rpa_capturing_kwargs(monkeypatch,
+                                                 gqa_mesh,
+                                                 update_kv_cache=True)
+
+    assert captured["m_block_sizes"] == (32, 2048, 32, 512)
+    assert "d_block_sizes" not in captured
+    assert "p_block_sizes" not in captured
+
+
+def test_sharded_rpa_omits_unset_block_size_kwargs(monkeypatch, gqa_mesh):
+    monkeypatch.setattr(envs, "RPA_V3_DECODE_BLOCK_SIZES", [])
+    monkeypatch.setattr(envs, "RPA_V3_PREFILL_BLOCK_SIZES", [])
+    monkeypatch.setattr(envs, "RPA_V3_MIXED_BLOCK_SIZES", [])
+
+    captured = _run_sharded_rpa_capturing_kwargs(monkeypatch,
+                                                 gqa_mesh,
+                                                 update_kv_cache=True)
+
+    assert "d_block_sizes" not in captured
+    assert "p_block_sizes" not in captured
+    assert "m_block_sizes" not in captured
+
+
+@pytest.mark.parametrize(
+    "env_name",
+    [
+        "RPA_V3_DECODE_BLOCK_SIZES",
+        "RPA_V3_PREFILL_BLOCK_SIZES",
+        "RPA_V3_MIXED_BLOCK_SIZES",
+    ],
+)
+def test_sharded_rpa_rejects_invalid_block_size_tuple(monkeypatch, gqa_mesh,
+                                                      env_name):
+    monkeypatch.setattr(envs, "RPA_V3_DECODE_BLOCK_SIZES", [])
+    monkeypatch.setattr(envs, "RPA_V3_PREFILL_BLOCK_SIZES", [])
+    monkeypatch.setattr(envs, "RPA_V3_MIXED_BLOCK_SIZES", [])
+    monkeypatch.setattr(envs, env_name, [32, 2048, 32])
+
+    with pytest.raises(ValueError, match=env_name):
+        _run_sharded_rpa_capturing_kwargs(monkeypatch,
+                                          gqa_mesh,
+                                          update_kv_cache=True)
+
+
+@pytest.mark.parametrize("head_dim,use_batched", [(64, False), (128, True)])
+def test_sharded_rpa_does_not_read_v3_block_sizes_on_other_kernels(
+        monkeypatch, gqa_mesh, head_dim, use_batched):
+    monkeypatch.setattr(envs, "RPA_V3_DECODE_BLOCK_SIZES", [])
+    monkeypatch.setattr(envs, "RPA_V3_PREFILL_BLOCK_SIZES", [])
+    monkeypatch.setattr(envs, "RPA_V3_MIXED_BLOCK_SIZES", [32, 2048, 32])
+    monkeypatch.setattr(attention_interface, "_USE_BATCHED_RPA_KERNEL",
+                        use_batched)
+
+    captured = _run_sharded_rpa_capturing_kwargs(
+        monkeypatch,
+        gqa_mesh,
+        update_kv_cache=True,
+        head_dim=head_dim,
+    )
+
+    assert "d_block_sizes" not in captured
+    assert "p_block_sizes" not in captured
+    assert "m_block_sizes" not in captured
 
 
 def test_sharded_rpa_forwards_update_kv_cache_when_not_hd64(

--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -68,7 +68,8 @@ def _test_attention(monkeypatch,
                     head_dim,
                     use_sinks=False,
                     attention_mask_spec=None,
-                    rpa_static_query_len=None):
+                    rpa_static_query_len=None,
+                    fp32_rpa_accumulator=False):
     """
     Tests the main `attention` function.
 
@@ -79,8 +80,8 @@ def _test_attention(monkeypatch,
     # 1. Arrange
 
     # Create input tensors
-    q_dtype = jnp.float32
-    kv_dtype = jnp.float32
+    q_dtype = jnp.bfloat16 if fp32_rpa_accumulator else jnp.float32
+    kv_dtype = q_dtype
     q = jnp.ones((TOTAL_TOKENS, NUM_HEADS, head_dim), dtype=q_dtype)
     k = jnp.ones((TOTAL_TOKENS, NUM_KV_HEADS, head_dim), dtype=kv_dtype)
     v = jnp.ones((TOTAL_TOKENS, NUM_KV_HEADS, head_dim), dtype=kv_dtype)
@@ -98,7 +99,8 @@ def _test_attention(monkeypatch,
 
     # Mock ragged_paged_attention to return a tensor of the correct shape
     mock_paged_attn_kernel = MagicMock(return_value=(jnp.ones(
-        (TOTAL_TOKENS, NUM_HEADS, head_dim)), kv_cache), )
+        (TOTAL_TOKENS, NUM_HEADS, head_dim),
+        dtype=q_dtype), kv_cache), )
 
     if head_dim == 64:
         monkeypatch.setattr(
@@ -123,6 +125,7 @@ def _test_attention(monkeypatch,
         query_start_loc=jnp.array([0, 5, 10, 10, 10], dtype=jnp.int32),
         request_distribution=jnp.array([0, 0, NUM_SEQS], dtype=jnp.int32),
         rpa_static_query_len=rpa_static_query_len,
+        fp32_rpa_accumulator=fp32_rpa_accumulator,
         **metadata_kwargs,
     )
     shared_attention_metadata = SharedAttentionMetadata(
@@ -159,10 +162,14 @@ def _test_attention(monkeypatch,
             "block_causal_size"] == expected_block_size
         assert mock_paged_attn_kernel.call_args.kwargs[
             "chunk_prefill_size"] == rpa_static_query_len
+        expected_out_dtype = (jnp.float32 if fp32_rpa_accumulator else None)
+        assert mock_paged_attn_kernel.call_args.kwargs[
+            "out_dtype"] == expected_out_dtype
 
     # Check output shapes
     assert final_kv_cache.shape == kv_cache.shape
     assert output.shape == q.shape
+    assert output.dtype == q.dtype
 
     # Check that the output is the one from our mock
     assert jnp.all(output == 1.0)
@@ -187,6 +194,42 @@ def test_attention_bidirectional_from_metadata(monkeypatch, mesh):
         128,
         attention_mask_spec=AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL),
     )
+
+
+def test_attention_fp32_rpa_accumulator_preserves_query_output_dtype(
+        monkeypatch, mesh):
+    _test_attention(
+        monkeypatch,
+        mesh,
+        128,
+        attention_mask_spec=AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL),
+        fp32_rpa_accumulator=True,
+    )
+
+
+@pytest.mark.parametrize("mesh_axis", ["dcp", "pcp"])
+def test_attention_fp32_rpa_accumulator_rejects_context_parallelism(mesh_axis):
+    head_dim = 128
+    q = jnp.ones((1, NUM_HEADS, head_dim), dtype=jnp.bfloat16)
+    k = jnp.ones((1, NUM_KV_HEADS, head_dim), dtype=jnp.bfloat16)
+    v = jnp.ones((1, NUM_KV_HEADS, head_dim), dtype=jnp.bfloat16)
+    metadata = AttentionMetadata(
+        input_positions=jnp.array([0], dtype=jnp.int32),
+        fp32_rpa_accumulator=True,
+    )
+
+    class ContextParallelMesh:
+        shape = {mesh_axis: 2}
+
+    with pytest.raises(NotImplementedError, match=mesh_axis.upper()):
+        attention(
+            kv_cache=jnp.zeros((1, ), dtype=jnp.bfloat16),
+            q=q,
+            k=k,
+            v=v,
+            attention_metadata=metadata,
+            mesh=ContextParallelMesh(),
+        )
 
 
 def test_attention_static_prefill_length(monkeypatch, mesh):
@@ -370,7 +413,10 @@ def test_sharded_ragged_paged_attention_gqa_incompatible_raises_error(
         )
 
 
-def _run_sharded_rpa_capturing_kwargs(monkeypatch, gqa_mesh, update_kv_cache):
+def _run_sharded_rpa_capturing_kwargs(monkeypatch,
+                                      gqa_mesh,
+                                      update_kv_cache,
+                                      out_dtype=None):
     """Helper: run `sharded_ragged_paged_attention` with a stubbed
     `ragged_paged_attention` (the module-level binding) and a passthrough
     `jax.shard_map`. Returns the kwargs forwarded by the closure to the
@@ -418,6 +464,7 @@ def _run_sharded_rpa_capturing_kwargs(monkeypatch, gqa_mesh, update_kv_cache):
         attention_sink=None,
         sm_scale=1.0,
         update_kv_cache=update_kv_cache,
+        out_dtype=out_dtype,
     )
     return captured
 
@@ -434,6 +481,18 @@ def test_sharded_rpa_forwards_update_kv_cache_when_not_hd64(
 
     assert captured.get("update_kv_cache") is False, (
         f"non-hd64 path must forward update_kv_cache=False; got {captured!r}")
+
+
+def test_sharded_rpa_forwards_output_dtype_when_not_hd64(
+        monkeypatch, gqa_mesh):
+    captured = _run_sharded_rpa_capturing_kwargs(
+        monkeypatch,
+        gqa_mesh,
+        update_kv_cache=True,
+        out_dtype=jnp.float32,
+    )
+
+    assert captured.get("out_dtype") == jnp.float32
 
 
 def test_batched_rpa_wrapper_accepts_update_kv_cache():
@@ -487,6 +546,36 @@ def test_sharded_rpa_rejects_update_kv_cache_false_on_hd64(gqa_mesh):
             attention_sink=None,
             sm_scale=1.0,
             update_kv_cache=False,
+        )
+
+
+def test_sharded_rpa_rejects_custom_output_dtype_on_hd64(gqa_mesh):
+    head_dim = 64
+    num_kv_heads = 4
+    q = jnp.ones((TOTAL_TOKENS, NUM_HEADS, head_dim))
+    k = jnp.ones((TOTAL_TOKENS, num_kv_heads, head_dim))
+    v = jnp.ones((TOTAL_TOKENS, num_kv_heads, head_dim))
+    kv_cache = jnp.zeros((num_kv_heads, NUM_BLOCKS, BLOCK_SIZE, head_dim))
+    kv_lens = jnp.zeros((MAX_NUM_SEQS, ), dtype=jnp.int32)
+    page_indices = jnp.zeros((MAX_NUM_SEQS, MAX_BLOCKS_PER_SEQ),
+                             dtype=jnp.int32)
+    cu_q_lens = jnp.zeros((MAX_NUM_SEQS + 1, ), dtype=jnp.int32)
+    distribution = jnp.zeros((3, ), dtype=jnp.int32)
+
+    with pytest.raises(NotImplementedError, match="accumulator dtype"):
+        sharded_ragged_paged_attention(
+            mesh=gqa_mesh,
+            q=q,
+            k=k,
+            v=v,
+            kv_cache=kv_cache,
+            kv_lens=kv_lens,
+            page_indices=page_indices,
+            cu_q_lens=cu_q_lens,
+            distribution=distribution,
+            attention_sink=None,
+            sm_scale=1.0,
+            out_dtype=jnp.float32,
         )
 
 

--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -67,7 +67,8 @@ def _test_attention(monkeypatch,
                     mesh,
                     head_dim,
                     use_sinks=False,
-                    attention_mask_spec=None):
+                    attention_mask_spec=None,
+                    rpa_static_query_len=None):
     """
     Tests the main `attention` function.
 
@@ -121,6 +122,7 @@ def _test_attention(monkeypatch,
         seq_lens=jnp.array([5, 5, 0, 0], dtype=jnp.int32),
         query_start_loc=jnp.array([0, 5, 10, 10, 10], dtype=jnp.int32),
         request_distribution=jnp.array([0, 0, NUM_SEQS], dtype=jnp.int32),
+        rpa_static_query_len=rpa_static_query_len,
         **metadata_kwargs,
     )
     shared_attention_metadata = SharedAttentionMetadata(
@@ -151,6 +153,8 @@ def _test_attention(monkeypatch,
     if head_dim != 64:
         assert mock_paged_attn_kernel.call_args.kwargs[
             "use_causal_mask"] is expected_causal
+        assert mock_paged_attn_kernel.call_args.kwargs[
+            "chunk_prefill_size"] == rpa_static_query_len
 
     # Check output shapes
     assert final_kv_cache.shape == kv_cache.shape
@@ -179,6 +183,10 @@ def test_attention_bidirectional_from_metadata(monkeypatch, mesh):
         128,
         attention_mask_spec=AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL),
     )
+
+
+def test_attention_static_prefill_length(monkeypatch, mesh):
+    _test_attention(monkeypatch, mesh, 128, rpa_static_query_len=8)
 
 
 def test_attention_bidirectional_hd64_fails_loudly(monkeypatch, mesh):

--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -153,6 +153,10 @@ def _test_attention(monkeypatch,
     if head_dim != 64:
         assert mock_paged_attn_kernel.call_args.kwargs[
             "use_causal_mask"] is expected_causal
+        expected_block_size = (attention_mask_spec.block_size
+                               if attention_mask_spec is not None else None)
+        assert mock_paged_attn_kernel.call_args.kwargs[
+            "block_causal_size"] == expected_block_size
         assert mock_paged_attn_kernel.call_args.kwargs[
             "chunk_prefill_size"] == rpa_static_query_len
 
@@ -187,6 +191,16 @@ def test_attention_bidirectional_from_metadata(monkeypatch, mesh):
 
 def test_attention_static_prefill_length(monkeypatch, mesh):
     _test_attention(monkeypatch, mesh, 128, rpa_static_query_len=8)
+
+
+def test_attention_block_causal_from_metadata(monkeypatch, mesh):
+    _test_attention(
+        monkeypatch,
+        mesh,
+        128,
+        attention_mask_spec=AttentionMaskSpec(AttentionMaskKind.BLOCK_CAUSAL,
+                                              block_size=32),
+    )
 
 
 def test_attention_bidirectional_hd64_fails_loudly(monkeypatch, mesh):

--- a/tests/layers/common/test_attention_mask_spec.py
+++ b/tests/layers/common/test_attention_mask_spec.py
@@ -1,0 +1,92 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+import jax
+import jax.numpy as jnp
+
+
+def _cdiv(numerator, denominator):
+    return (numerator + denominator - 1) // denominator
+
+
+def _load_attention_metadata():
+    module_names = ("vllm", "vllm.utils", "vllm.utils.math_utils")
+    previous_modules = {name: sys.modules.get(name) for name in module_names}
+    math_utils = types.ModuleType("vllm.utils.math_utils")
+    math_utils.cdiv = _cdiv
+    sys.modules["vllm"] = types.ModuleType("vllm")
+    sys.modules["vllm.utils"] = types.ModuleType("vllm.utils")
+    sys.modules["vllm.utils.math_utils"] = math_utils
+    path = (pathlib.Path(__file__).resolve().parents[3] / "tpu_inference" /
+            "layers" / "common" / "attention_metadata.py")
+    spec = importlib.util.spec_from_file_location(
+        "attention_metadata_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    finally:
+        for name, previous in previous_modules.items():
+            if previous is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = previous
+    return module
+
+
+attention_metadata = _load_attention_metadata()
+AttentionMaskKind = attention_metadata.AttentionMaskKind
+AttentionMaskSpec = attention_metadata.AttentionMaskSpec
+AttentionMetadata = attention_metadata.AttentionMetadata
+resolve_use_causal_mask = attention_metadata.resolve_use_causal_mask
+
+
+def _metadata(mask_spec=None):
+    kwargs = {}
+    if mask_spec is not None:
+        kwargs["attention_mask_spec"] = mask_spec
+    return AttentionMetadata(
+        input_positions=jnp.arange(4, dtype=jnp.int32),
+        block_tables=jnp.zeros((4, ), dtype=jnp.int32),
+        seq_lens=jnp.array([4], dtype=jnp.int32),
+        query_start_loc=jnp.array([0, 4], dtype=jnp.int32),
+        request_distribution=jnp.array([0, 0, 1], dtype=jnp.int32),
+        **kwargs,
+    )
+
+
+def test_attention_mask_defaults_to_causal():
+    assert resolve_use_causal_mask(_metadata()) is True
+
+
+def test_bidirectional_mask_is_explicit_static_metadata():
+    causal = _metadata()
+    bidirectional = _metadata(
+        AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL))
+
+    assert resolve_use_causal_mask(bidirectional) is False
+    assert jax.tree_util.tree_structure(
+        causal) != jax.tree_util.tree_structure(bidirectional)
+
+
+def test_explicit_kernel_override_takes_precedence():
+    bidirectional = _metadata(
+        AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL))
+
+    assert resolve_use_causal_mask(bidirectional, override=True) is True

--- a/tests/layers/common/test_attention_mask_spec.py
+++ b/tests/layers/common/test_attention_mask_spec.py
@@ -109,6 +109,8 @@ def test_block_causal_mask_requires_positive_block_size():
         AttentionMaskSpec(AttentionMaskKind.BLOCK_CAUSAL)
     with pytest.raises(ValueError, match="positive block_size"):
         AttentionMaskSpec(AttentionMaskKind.BLOCK_CAUSAL, block_size=0)
+    with pytest.raises(ValueError, match="power-of-two"):
+        AttentionMaskSpec(AttentionMaskKind.BLOCK_CAUSAL, block_size=3)
 
 
 def test_non_block_causal_mask_rejects_block_size():

--- a/tests/layers/common/test_attention_mask_spec.py
+++ b/tests/layers/common/test_attention_mask_spec.py
@@ -19,6 +19,7 @@ import types
 
 import jax
 import jax.numpy as jnp
+import pytest
 
 
 def _cdiv(numerator, denominator):
@@ -55,6 +56,7 @@ AttentionMaskKind = attention_metadata.AttentionMaskKind
 AttentionMaskSpec = attention_metadata.AttentionMaskSpec
 AttentionMetadata = attention_metadata.AttentionMetadata
 resolve_use_causal_mask = attention_metadata.resolve_use_causal_mask
+resolve_block_causal_size = attention_metadata.resolve_block_causal_size
 
 
 def _metadata(mask_spec=None):
@@ -90,3 +92,25 @@ def test_explicit_kernel_override_takes_precedence():
         AttentionMaskSpec(AttentionMaskKind.BIDIRECTIONAL))
 
     assert resolve_use_causal_mask(bidirectional, override=True) is True
+
+
+def test_block_causal_mask_carries_static_block_size():
+    block_causal = _metadata(
+        AttentionMaskSpec(AttentionMaskKind.BLOCK_CAUSAL, block_size=32))
+
+    assert resolve_use_causal_mask(block_causal) is False
+    assert resolve_block_causal_size(block_causal) == 32
+    assert resolve_block_causal_size(block_causal,
+                                     use_causal_mask_override=True) is None
+
+
+def test_block_causal_mask_requires_positive_block_size():
+    with pytest.raises(ValueError, match="positive block_size"):
+        AttentionMaskSpec(AttentionMaskKind.BLOCK_CAUSAL)
+    with pytest.raises(ValueError, match="positive block_size"):
+        AttentionMaskSpec(AttentionMaskKind.BLOCK_CAUSAL, block_size=0)
+
+
+def test_non_block_causal_mask_rejects_block_size():
+    with pytest.raises(ValueError, match="only valid"):
+        AttentionMaskSpec(AttentionMaskKind.CAUSAL, block_size=32)

--- a/tests/layers/test_jax.py
+++ b/tests/layers/test_jax.py
@@ -133,6 +133,16 @@ class TestJaxModule(unittest.TestCase):
         # 'a' and 'b' point to the same module; only the first is yielded.
         self.assertEqual(names.count("a") + names.count("b"), 1)
 
+    def test_modules_matches_named_modules_without_names(self):
+        """vLLM cleanup can traverse JAX models through the torch-compatible API."""
+
+        module = NestedModule()
+
+        self.assertEqual(
+            list(module.modules()),
+            [child for _, child in module.named_modules()],
+        )
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/models/common/test_model_loader.py
+++ b/tests/models/common/test_model_loader.py
@@ -276,6 +276,8 @@ def test_get_flax_model(vllm_config, mesh, tie_word_embeddings):
         model = model_loader.get_flax_model(vllm_config, rng, mesh)
 
     assert callable(model.model_fn)
+    assert callable(model.model_fn_no_options)
+    assert model.model_fn_no_options is not model.model_fn
     assert callable(model.compute_logits_fn)
 
     # Verify that JAX model instance possesses the named_modules attribute
@@ -337,6 +339,8 @@ def test_get_vllm_model(mock_get_pp_group, mesh):
     model = model_loader.get_vllm_model(vllm_config, rng, mesh)
 
     assert callable(model.model_fn)
+    assert callable(model.model_fn_no_options)
+    assert model.model_fn_no_options is not model.model_fn
     assert callable(model.compute_logits_fn)
 
 

--- a/tests/models/jax/test_qwen2.py
+++ b/tests/models/jax/test_qwen2.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 import jax
@@ -26,7 +27,8 @@ from vllm.model_executor.model_loader import LoadConfig, get_model_loader
 from tpu_inference.distributed.jax_parallel_state import \
     init_pp_distributed_environment
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
-from tpu_inference.models.jax.qwen2 import Qwen2ForCausalLM
+from tpu_inference.models.jax.qwen2 import (Qwen2ForCausalLM,
+                                            _get_language_config)
 from tpu_inference.runner.kv_cache import create_kv_caches
 
 
@@ -104,6 +106,13 @@ def mock_get_pp_group():
 
 class TestQwen2ForCausalLM:
     """Tests for the main Qwen2ForCausalLM model class."""
+
+    def test_language_config_supports_flat_and_nested_configs(self):
+        flat_config = SimpleNamespace(hidden_size=3584)
+        nested_config = SimpleNamespace(text_config=flat_config)
+
+        assert _get_language_config(flat_config) is flat_config
+        assert _get_language_config(nested_config) is flat_config
 
     @pytest.mark.parametrize("mock_vllm_config", [
         MockVllmConfig("Qwen/Qwen2.5-1.5B", "auto"),

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -82,16 +82,14 @@ class TestTpuPlatform:
         vllm_config.kv_transfer_config = None
         vllm_config.cache_config = None
 
-    @pytest.mark.parametrize("chip_name,expected_dtype", [
-        ("v6e", torch.float8_e5m2),
-        ("v5e", torch.float8_e4m3fn),
+    @pytest.mark.parametrize("accelerator_type,expected_dtype", [
+        ("v6e-8", torch.float8_e5m2),
+        ("v5litepod-4", torch.float8_e4m3fn),
+        ("tpu7x-128", torch.float8_e4m3fn),
     ])
-    def test_fp8_dtype(self, chip_name, expected_dtype):
-        mock_chip_type = MagicMock()
-        mock_chip_type.name = chip_name
-
+    def test_fp8_dtype(self, accelerator_type, expected_dtype):
         with patch('tpu_inference.platforms.tpu_platform.init_logger'), \
-             patch('tpu_info.device.get_local_chips', return_value=(mock_chip_type, None)), \
+             patch('tpu_inference.tpu_info.get_tpu_type', return_value=accelerator_type), \
              patch('vllm.envs.VLLM_TPU_USING_PATHWAYS', False):
             assert TpuPlatform.fp8_dtype() == expected_dtype
 
@@ -148,16 +146,24 @@ class TestTpuPlatform:
         mock_envs.VLLM_TPU_USING_PATHWAYS = True
         assert TpuPlatform.get_device_name() == "TPU v6 lite"
 
+    @pytest.mark.parametrize("accelerator_type,expected_name", [
+        ("v6e-8", "TPU v6e"),
+        ("v5litepod-16", "TPU v5e"),
+        ("tpu7x-128", "TPU v7x"),
+        ("v5p-32", "TPU v5p"),
+    ])
+    @patch('tpu_inference.platforms.tpu_platform.vllm_envs')
+    def test_get_device_name(self, mock_envs, accelerator_type, expected_name):
+        mock_envs.VLLM_TPU_USING_PATHWAYS = False
+        with patch('tpu_inference.tpu_info.get_tpu_type',
+                   return_value=accelerator_type):
+            assert TpuPlatform.get_device_name() == expected_name
+
     @patch('tpu_inference.platforms.tpu_platform.vllm_envs')
     def test_get_device_name_exception(self, mock_envs):
         mock_envs.VLLM_TPU_USING_PATHWAYS = False
-        mock_device = MagicMock()
-        mock_device.get_local_chips.side_effect = Exception("TPU Error")
-
-        with patch.dict('sys.modules', {
-                'tpu_info': MagicMock(),
-                'tpu_info.device': mock_device
-        }):
+        with patch('tpu_inference.tpu_info.get_tpu_type',
+                   side_effect=Exception("TPU Error")):
             assert TpuPlatform.get_device_name() == "TPU"
 
     def test_validate_request_random_seed(self):

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -679,6 +679,25 @@ class TestTpuPlatform:
     @patch(
         "tpu_inference.core.sched.utils.patch_vllm_scheduler_for_multi_token_decode"
     )
+    def test_check_and_update_config_block_diffusion_allows_multiprocess_dp(
+            self, mock_patch, mock_dp_update, mock_sharding, vllm_config,
+            monkeypatch):
+        self._enable_block_diffusion(vllm_config)
+        monkeypatch.setenv("TPU_MULTIPROCESS_DP", "1")
+        vllm_config.parallel_config.data_parallel_size = 4
+        mock_sharding.from_vllm_config.return_value.total_dp_size = 1
+
+        TpuPlatform.check_and_update_config(vllm_config)
+
+        mock_patch.assert_called_once()
+
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    @patch(
+        "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
+    )
+    @patch(
+        "tpu_inference.core.sched.utils.patch_vllm_scheduler_for_multi_token_decode"
+    )
     def test_check_and_update_config_enables_diffusion_cohort_scheduler(
             self, mock_patch, mock_dp_update, mock_sharding, vllm_config):
         original_scheduler_cls = object()
@@ -720,6 +739,7 @@ class TestTpuPlatform:
         mock_dp_update,
         mock_sharding,
         vllm_config,
+        monkeypatch,
         unsupported,
         expected_error,
     ):
@@ -729,6 +749,7 @@ class TestTpuPlatform:
             vllm_config.kv_transfer_config = SimpleNamespace(
                 kv_connector="TPUConnector")
         elif unsupported == "requested_dp":
+            monkeypatch.setenv("TPU_MULTIPROCESS_DP", "0")
             vllm_config.parallel_config.data_parallel_size = 2
         elif unsupported == "sharding_dp":
             mock_sharding.from_vllm_config.return_value.total_dp_size = 2

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -23,7 +23,8 @@ from vllm.config import CacheConfig, ModelConfig, VllmConfig
 
 from tpu_inference.core.sched.diffusion_cohort_scheduler import \
     BlockDiffusionCohortScheduler
-from tpu_inference.platforms.tpu_platform import TpuPlatform
+from tpu_inference.platforms.tpu_platform import (
+    _DIFFUSION_ROUND_ROBIN_VALIDATED_DP_SIZE, TpuPlatform)
 
 
 class TestTpuPlatform:
@@ -690,6 +691,122 @@ class TestTpuPlatform:
         TpuPlatform.check_and_update_config(vllm_config)
 
         mock_patch.assert_called_once()
+
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    @patch(
+        "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
+    )
+    @patch(
+        "tpu_inference.core.sched.utils.patch_vllm_scheduler_for_multi_token_decode"
+    )
+    def test_check_and_update_config_enables_diffusion_round_robin_dp(
+            self, mock_patch, mock_dp_update, mock_sharding, vllm_config,
+            monkeypatch):
+        self._enable_block_diffusion(vllm_config)
+        vllm_config.additional_config["diffusion"][
+            "cohort_round_robin_dp"] = True
+        vllm_config.parallel_config.data_parallel_size = 2
+        vllm_config.parallel_config.data_parallel_external_lb = False
+        vllm_config.parallel_config.data_parallel_hybrid_lb = False
+        vllm_config.parallel_config.data_parallel_index = 0
+        vllm_config.parallel_config._api_process_count = 1
+        monkeypatch.setenv("TPU_MULTIPROCESS_DP", "1")
+        mock_sharding.from_vllm_config.return_value.total_dp_size = 1
+
+        with patch("tpu_inference.core.diffusion_dp_router."
+                   "patch_vllm_dp_client_for_block_diffusion_round_robin"
+                   ) as mock_round_robin_patch:
+            TpuPlatform.check_and_update_config(vllm_config)
+
+        mock_round_robin_patch.assert_called_once_with()
+        assert vllm_config.additional_config[
+            _DIFFUSION_ROUND_ROBIN_VALIDATED_DP_SIZE] == 2
+        mock_patch.assert_called_once()
+
+    @pytest.mark.parametrize("data_parallel_index", [0, 1])
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    @patch(
+        "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
+    )
+    @patch(
+        "tpu_inference.core.sched.utils.patch_vllm_scheduler_for_multi_token_decode"
+    )
+    def test_check_and_update_config_skips_round_robin_hook_in_dp_child(
+            self, mock_patch, mock_dp_update, mock_sharding, vllm_config,
+            monkeypatch, data_parallel_index):
+        self._enable_block_diffusion(vllm_config)
+        vllm_config.additional_config["diffusion"][
+            "cohort_round_robin_dp"] = True
+        vllm_config.additional_config[
+            _DIFFUSION_ROUND_ROBIN_VALIDATED_DP_SIZE] = 2
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.parallel_config.data_parallel_size_local = 1
+        vllm_config.parallel_config.data_parallel_rank = 0
+        vllm_config.parallel_config.data_parallel_index = data_parallel_index
+        vllm_config.parallel_config.data_parallel_external_lb = False
+        vllm_config.parallel_config.data_parallel_hybrid_lb = False
+        vllm_config.parallel_config._api_process_count = 1
+        monkeypatch.setenv("TPU_MULTIPROCESS_DP", "1")
+        mock_sharding.from_vllm_config.return_value.total_dp_size = 1
+
+        with patch("tpu_inference.core.diffusion_dp_router."
+                   "patch_vllm_dp_client_for_block_diffusion_round_robin"
+                   ) as mock_round_robin_patch:
+            TpuPlatform.check_and_update_config(vllm_config)
+
+        mock_round_robin_patch.assert_not_called()
+        mock_patch.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "data_parallel_size,multiprocess_dp,external_lb,hybrid_lb,"
+        "api_process_count,expected_error",
+        [
+            (1, "0", False, False, 1,
+             "requires native multiprocess data parallelism"),
+            (1, "1", False, False, 1,
+             "requires native multiprocess data parallelism"),
+            (2, "0", False, False, 1,
+             "requires native multiprocess data parallelism"),
+            (2, "1", True, False, 1, "requires vLLM's internal data-parallel"),
+            (2, "1", False, True, 1, "does not support data-parallel hybrid"),
+            (2, "1", False, False, 2, "requires --api-server-count=1"),
+        ],
+    )
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    @patch(
+        "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
+    )
+    @patch(
+        "tpu_inference.core.sched.utils.patch_vllm_scheduler_for_multi_token_decode"
+    )
+    def test_check_and_update_config_rejects_invalid_diffusion_round_robin_dp(
+        self,
+        mock_patch,
+        mock_dp_update,
+        mock_sharding,
+        vllm_config,
+        monkeypatch,
+        data_parallel_size,
+        multiprocess_dp,
+        external_lb,
+        hybrid_lb,
+        api_process_count,
+        expected_error,
+    ):
+        self._enable_block_diffusion(vllm_config)
+        vllm_config.additional_config["diffusion"][
+            "cohort_round_robin_dp"] = True
+        vllm_config.parallel_config.data_parallel_size = data_parallel_size
+        vllm_config.parallel_config.data_parallel_external_lb = external_lb
+        vllm_config.parallel_config.data_parallel_hybrid_lb = hybrid_lb
+        vllm_config.parallel_config._api_process_count = api_process_count
+        monkeypatch.setenv("TPU_MULTIPROCESS_DP", multiprocess_dp)
+        mock_sharding.from_vllm_config.return_value.total_dp_size = 1
+
+        with pytest.raises(ValueError, match=expected_error):
+            TpuPlatform.check_and_update_config(vllm_config)
+
+        mock_patch.assert_not_called()
 
     @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
     @patch(

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -21,6 +21,8 @@ import pytest
 import torch
 from vllm.config import CacheConfig, ModelConfig, VllmConfig
 
+from tpu_inference.core.sched.diffusion_cohort_scheduler import \
+    BlockDiffusionCohortScheduler
 from tpu_inference.platforms.tpu_platform import TpuPlatform
 
 
@@ -597,15 +599,19 @@ class TestTpuPlatform:
     )
     def test_check_and_update_config_continue_decode_success(
             self, mock_patch, mock_dp_update, mock_sharding, vllm_config):
+        original_scheduler_cls = object()
         vllm_config.additional_config = {"enable_continue_decode": True}
         vllm_config.parallel_config.pipeline_parallel_size = 1
         vllm_config.model_config.runner_type = "generate"  # not pooling
         vllm_config.scheduler_config.async_scheduling = False
+        vllm_config.scheduler_config.scheduler_cls = original_scheduler_cls
         vllm_config.cache_config = None
 
         TpuPlatform.check_and_update_config(vllm_config)
 
         mock_patch.assert_called_once()
+        assert (vllm_config.scheduler_config.scheduler_cls
+                is original_scheduler_cls)
 
     @pytest.mark.parametrize(
         "pp_size, runner_type, async_sched, expected_error",
@@ -653,13 +659,42 @@ class TestTpuPlatform:
     )
     def test_check_and_update_config_block_diffusion_success(
             self, mock_patch, mock_dp_update, mock_sharding, vllm_config):
+        original_scheduler_cls = object()
         self._enable_block_diffusion(vllm_config)
+        vllm_config.scheduler_config.scheduler_cls = original_scheduler_cls
 
         TpuPlatform.check_and_update_config(vllm_config)
 
         assert vllm_config.additional_config[
             "multi_token_decode_lookahead"] == 31
         assert vllm_config.scheduler_config.max_num_seqs == 64
+        assert (vllm_config.scheduler_config.scheduler_cls
+                is original_scheduler_cls)
+        mock_patch.assert_called_once()
+
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    @patch(
+        "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
+    )
+    @patch(
+        "tpu_inference.core.sched.utils.patch_vllm_scheduler_for_multi_token_decode"
+    )
+    def test_check_and_update_config_enables_diffusion_cohort_scheduler(
+            self, mock_patch, mock_dp_update, mock_sharding, vllm_config):
+        original_scheduler_cls = object()
+        self._enable_block_diffusion(vllm_config)
+        vllm_config.additional_config["diffusion"]["cohort_max_wait_ms"] = 5.0
+        vllm_config.scheduler_config.scheduler_cls = original_scheduler_cls
+        scheduler_classes_seen_by_dp_update = []
+        mock_dp_update.side_effect = lambda config: (
+            scheduler_classes_seen_by_dp_update.append(config.scheduler_config.
+                                                       scheduler_cls))
+
+        TpuPlatform.check_and_update_config(vllm_config)
+
+        assert scheduler_classes_seen_by_dp_update == [original_scheduler_cls]
+        assert (vllm_config.scheduler_config.scheduler_cls
+                is BlockDiffusionCohortScheduler)
         mock_patch.assert_called_once()
 
     @pytest.mark.parametrize(

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import os
+from types import SimpleNamespace
 from unittest.mock import MagicMock, PropertyMock, patch
 
 import jax.numpy as jnp
@@ -53,7 +54,33 @@ class TestTpuPlatform:
         vllm_config.kv_transfer_config = None
         vllm_config.additional_config = {}
         vllm_config.scheduler_config.async_scheduling = False
+        vllm_config.scheduler_config.enable_chunked_prefill = False
         return vllm_config
+
+    @staticmethod
+    def _enable_block_diffusion(vllm_config):
+        vllm_config.additional_config = {
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "block_size": 32,
+                "mask_token_id": 151669,
+                "sub_block_size": 8,
+            },
+        }
+        vllm_config.parallel_config.pipeline_parallel_size = 1
+        vllm_config.parallel_config.data_parallel_size = 1
+        vllm_config.model_config.runner_type = "generate"
+        vllm_config.model_config.is_multimodal_model = False
+        vllm_config.model_config.hf_config.head_dim = 128
+        vllm_config.scheduler_config.async_scheduling = False
+        vllm_config.scheduler_config.enable_chunked_prefill = False
+        vllm_config.scheduler_config.max_num_batched_tokens = 2048
+        vllm_config.scheduler_config.max_num_seqs = 128
+        vllm_config.speculative_config = None
+        vllm_config.lora_config = None
+        vllm_config.kv_transfer_config = None
+        vllm_config.cache_config = None
 
     @pytest.mark.parametrize("chip_name,expected_dtype", [
         ("v6e", torch.float8_e5m2),
@@ -610,3 +637,83 @@ class TestTpuPlatform:
         with pytest.raises(ValueError, match=expected_error):
             TpuPlatform.check_and_update_config(vllm_config)
         mock_patch.assert_not_called()
+
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    @patch(
+        "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
+    )
+    @patch(
+        "tpu_inference.core.sched.utils.patch_vllm_scheduler_for_multi_token_decode"
+    )
+    def test_check_and_update_config_block_diffusion_success(
+            self, mock_patch, mock_dp_update, mock_sharding, vllm_config):
+        self._enable_block_diffusion(vllm_config)
+
+        TpuPlatform.check_and_update_config(vllm_config)
+
+        assert vllm_config.additional_config[
+            "multi_token_decode_lookahead"] == 31
+        assert vllm_config.scheduler_config.max_num_seqs == 64
+        mock_patch.assert_called_once()
+
+    @pytest.mark.parametrize(
+        "unsupported,expected_error",
+        [
+            ("kv_transfer", "does not support KV transfer"),
+            ("requested_dp", "requires data_parallel_size=1"),
+            ("sharding_dp", "requires data_parallel_size=1"),
+            ("chunked_prefill", "requires chunked prefill to be disabled"),
+            ("token_budget", "minimum padded batch"),
+        ],
+    )
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    @patch(
+        "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
+    )
+    @patch(
+        "tpu_inference.core.sched.utils.patch_vllm_scheduler_for_multi_token_decode"
+    )
+    def test_check_and_update_config_block_diffusion_rejects_unsupported_modes(
+        self,
+        mock_patch,
+        mock_dp_update,
+        mock_sharding,
+        vllm_config,
+        unsupported,
+        expected_error,
+    ):
+        self._enable_block_diffusion(vllm_config)
+        mock_sharding.from_vllm_config.return_value.total_dp_size = 1
+        if unsupported == "kv_transfer":
+            vllm_config.kv_transfer_config = SimpleNamespace(
+                kv_connector="TPUConnector")
+        elif unsupported == "requested_dp":
+            vllm_config.parallel_config.data_parallel_size = 2
+        elif unsupported == "sharding_dp":
+            mock_sharding.from_vllm_config.return_value.total_dp_size = 2
+        elif unsupported == "chunked_prefill":
+            vllm_config.scheduler_config.enable_chunked_prefill = True
+        elif unsupported == "token_budget":
+            vllm_config.scheduler_config.max_num_batched_tokens = 255
+
+        with pytest.raises(ValueError, match=expected_error):
+            TpuPlatform.check_and_update_config(vllm_config)
+
+        mock_patch.assert_not_called()
+
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    def test_check_and_update_config_rejects_two_multi_token_modes(
+            self, mock_sharding, vllm_config):
+        vllm_config.additional_config = {
+            "enable_continue_decode": True,
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "block_size": 32,
+                "mask_token_id": 151669,
+            },
+        }
+        vllm_config.cache_config = None
+
+        with pytest.raises(ValueError, match="mutually exclusive"):
+            TpuPlatform.check_and_update_config(vllm_config)

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -703,6 +703,8 @@ class TestTpuPlatform:
         original_scheduler_cls = object()
         self._enable_block_diffusion(vllm_config)
         vllm_config.additional_config["diffusion"]["cohort_max_wait_ms"] = 5.0
+        vllm_config.additional_config["diffusion"][
+            "cohort_strict_waves"] = True
         vllm_config.scheduler_config.scheduler_cls = original_scheduler_cls
         scheduler_classes_seen_by_dp_update = []
         mock_dp_update.side_effect = lambda config: (

--- a/tests/runner/test_diffusion_algorithm.py
+++ b/tests/runner/test_diffusion_algorithm.py
@@ -777,6 +777,55 @@ def test_dual_cache_acceptance_trace_is_opt_in_and_semantics_preserving():
     assert np.all(trace.row0_threshold_margin[:count] < 0.0)
 
 
+def test_dual_cache_donates_kv_cache_buffer():
+    mask_token_id = 3
+    sub_block_size = 2
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], sub_block_size, 4),
+                           dtype=jnp.float32)
+        return logits, kv_caches.at[0].add(1)
+
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], sub_block_size, 4),
+                           dtype=jnp.float32)
+        return logits, kv_caches.at[1].add(1)
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, canvas, positions, active_rows, forward_context
+        return jnp.zeros((1, 4), dtype=jnp.float32), kv_caches.at[2].add(1)
+
+    kv_caches = jnp.zeros((3, ), dtype=jnp.int32)
+    output = denoise_block_dual_cache(
+        full_forward,
+        partial_forward,
+        final_forward,
+        low_confidence_commit,
+        None,
+        jnp.array([[0, mask_token_id]], dtype=jnp.int32),
+        jnp.array([[False, True]]),
+        jnp.arange(2, dtype=jnp.int32)[None, :],
+        kv_caches,
+        jnp.array([True]),
+        _thresholds(1, value=1.0),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SHIFTED,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=mask_token_id,
+        sub_block_size=sub_block_size,
+    )
+    output.kv_caches.block_until_ready()
+
+    assert kv_caches.is_deleted()
+    np.testing.assert_array_equal(output.kv_caches, [1, 0, 1])
+
+
 def test_dual_cache_acceptance_trace_requires_diagnostics_function():
     with pytest.raises(ValueError, match="requires commit_diagnostics_fn"):
         denoise_block_dual_cache(

--- a/tests/runner/test_diffusion_algorithm.py
+++ b/tests/runner/test_diffusion_algorithm.py
@@ -306,6 +306,7 @@ def test_final_forward_refreshes_committed_kv_and_next_anchor():
 
 
 def test_terminal_block_skips_non_dual_cache_final_forward():
+
     def forward(model_state, canvas, positions, kv_caches, active_rows,
                 forward_context):
         del model_state, positions, active_rows, forward_context
@@ -348,6 +349,83 @@ def test_terminal_block_skips_non_dual_cache_final_forward():
                                   nonterminal.denoise_steps)
     assert int(terminal.kv_caches) + 1 == int(nonterminal.kv_caches)
     np.testing.assert_array_equal(terminal.next_anchor, [0])
+
+
+def test_non_dual_cache_stops_after_resolved_eos_prefix():
+    mask_token_id = 4
+    eos_token_id = 2
+    targets = jnp.array([1, eos_token_id, 3, 3], dtype=jnp.int32)
+
+    def forward(model_state, canvas, positions, kv_caches, active_rows,
+                forward_context):
+        del model_state, canvas, positions, forward_context
+        logits = jax.nn.one_hot(targets, 5) * 20.0
+        logits = jnp.broadcast_to(logits, (active_rows.shape[0], 4, 5))
+        return logits, kv_caches + jnp.any(active_rows).astype(jnp.int32)
+
+    output = denoise_block(
+        forward,
+        low_confidence_commit,
+        None,
+        jnp.full((1, 4), mask_token_id, dtype=jnp.int32),
+        jnp.ones((1, 4), dtype=bool),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.array(0, dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1, value=1.0),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=mask_token_id,
+        sub_block_size=4,
+        stop_on_eos_rows=jnp.array([True]),
+        eos_token_ids=(eos_token_id, ),
+    )
+
+    np.testing.assert_array_equal(
+        output.canvas, [[1, eos_token_id, mask_token_id, mask_token_id]])
+    np.testing.assert_array_equal(output.denoise_steps, [2])
+    np.testing.assert_array_equal(output.stopped_rows, [True])
+    np.testing.assert_array_equal(output.next_anchor, [0])
+    assert int(output.kv_caches) == 2
+
+
+def test_eos_in_seed_context_does_not_stop_generation():
+    mask_token_id = 4
+    eos_token_id = 2
+    targets = jnp.array([0, 1, 3, 3], dtype=jnp.int32)
+
+    def forward(model_state, canvas, positions, kv_caches, active_rows,
+                forward_context):
+        del model_state, canvas, positions, active_rows, forward_context
+        logits = jax.nn.one_hot(targets, 5) * 20.0
+        return logits[None, :, :], kv_caches + 1
+
+    output = denoise_block(
+        forward,
+        low_confidence_commit,
+        None,
+        jnp.array(
+            [[eos_token_id, mask_token_id, mask_token_id, mask_token_id]],
+            dtype=jnp.int32),
+        jnp.array([[False, True, True, True]]),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.array(0, dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1, value=1.0),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=mask_token_id,
+        sub_block_size=4,
+        stop_on_eos_rows=jnp.array([True]),
+        eos_token_ids=(eos_token_id, ),
+    )
+
+    np.testing.assert_array_equal(output.canvas, [[eos_token_id, 1, 3, 3]])
+    np.testing.assert_array_equal(output.stopped_rows, [False])
 
 
 def test_step_cap_force_fills_and_final_forward_refreshes_kv():
@@ -515,6 +593,120 @@ def test_dual_cache_terminal_block_skips_final_q32():
     assert int(terminal.q8_forward_calls) == int(nonterminal.q8_forward_calls)
     assert int(terminal.final_q32_forward_calls) == 0
     assert int(nonterminal.final_q32_forward_calls) == 1
+
+
+def test_dual_cache_stops_after_resolved_eos_prefix():
+    mask_token_id = 4
+    eos_token_id = 2
+    targets = jnp.array([1, eos_token_id, 3, 3], dtype=jnp.int32)
+
+    def block_logits(batch_size):
+        logits = jax.nn.one_hot(targets, 5) * 20.0
+        return jnp.broadcast_to(logits, (batch_size, 4, 5))
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        return block_logits(canvas.shape[0]), kv_caches.at[0].add(1)
+
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        return block_logits(canvas.shape[0]), kv_caches.at[1].add(1)
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, canvas, positions, active_rows, forward_context
+        return jnp.zeros((1, 5), dtype=jnp.float32), kv_caches.at[2].add(1)
+
+    output = denoise_block_dual_cache(
+        full_forward,
+        partial_forward,
+        final_forward,
+        low_confidence_commit,
+        None,
+        jnp.full((1, 4), mask_token_id, dtype=jnp.int32),
+        jnp.ones((1, 4), dtype=bool),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.zeros((3, ), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1, value=1.0),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=mask_token_id,
+        sub_block_size=4,
+        stop_on_eos_rows=jnp.array([True]),
+        eos_token_ids=(eos_token_id, ),
+    )
+
+    np.testing.assert_array_equal(
+        output.canvas, [[1, eos_token_id, mask_token_id, mask_token_id]])
+    np.testing.assert_array_equal(output.stopped_rows, [True])
+    np.testing.assert_array_equal(output.kv_caches, [1, 1, 0])
+    assert int(output.q32_forward_calls) == 1
+    assert int(output.q8_forward_calls) == 1
+    assert int(output.final_q32_forward_calls) == 0
+
+
+def test_dual_cache_eos_termination_is_row_local():
+    mask_token_id = 4
+    eos_token_id = 2
+    targets = jnp.array([1, eos_token_id, 3, 3], dtype=jnp.int32)
+
+    def block_logits(batch_size):
+        logits = jax.nn.one_hot(targets, 5) * 20.0
+        return jnp.broadcast_to(logits, (batch_size, 4, 5))
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        return block_logits(canvas.shape[0]), kv_caches.at[0].add(1)
+
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        return block_logits(canvas.shape[0]), kv_caches.at[1].add(1)
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, canvas, positions, forward_context
+        target = jnp.where(active_rows, 1, 0)
+        return jax.nn.one_hot(target, 5) * 20.0, kv_caches.at[2].add(1)
+
+    output = denoise_block_dual_cache(
+        full_forward,
+        partial_forward,
+        final_forward,
+        low_confidence_commit,
+        None,
+        jnp.full((2, 4), mask_token_id, dtype=jnp.int32),
+        jnp.ones((2, 4), dtype=bool),
+        jnp.tile(jnp.arange(4, dtype=jnp.int32), (2, 1)),
+        jnp.zeros((3, ), dtype=jnp.int32),
+        jnp.array([True, True]),
+        _thresholds(2, value=1.0),
+        _temperatures(2),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=mask_token_id,
+        sub_block_size=4,
+        stop_on_eos_rows=jnp.array([True, False]),
+        eos_token_ids=(eos_token_id, ),
+    )
+
+    np.testing.assert_array_equal(
+        output.canvas,
+        [[1, eos_token_id, mask_token_id, mask_token_id],
+         [1, eos_token_id, 3, 3]],
+    )
+    np.testing.assert_array_equal(output.stopped_rows, [True, False])
+    np.testing.assert_array_equal(output.next_anchor, [0, 1])
+    assert int(output.q32_forward_calls) == 2
+    assert int(output.q8_forward_calls) == 3
+    assert int(output.final_q32_forward_calls) == 1
 
 
 def test_dual_cache_mixed_terminal_rows_run_one_batch_final_q32():

--- a/tests/runner/test_diffusion_algorithm.py
+++ b/tests/runner/test_diffusion_algorithm.py
@@ -1,0 +1,371 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+
+def _load_pure_diffusion_modules():
+    root = pathlib.Path(__file__).resolve().parents[2]
+    module_paths = {
+        "tpu_inference.runner.diffusion.config":
+        root / "tpu_inference" / "runner" / "diffusion" / "config.py",
+        "tpu_inference.runner.diffusion.algorithm":
+        root / "tpu_inference" / "runner" / "diffusion" / "algorithm.py",
+        "tpu_inference.runner.diffusion.program":
+        root / "tpu_inference" / "runner" / "diffusion" / "program.py",
+    }
+    for package in ("tpu_inference", "tpu_inference.runner",
+                    "tpu_inference.runner.diffusion"):
+        if package not in sys.modules:
+            module = types.ModuleType(package)
+            module.__path__ = []
+            sys.modules[package] = module
+    loaded = {}
+    for name, path in module_paths.items():
+        spec = importlib.util.spec_from_file_location(name, path)
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[name] = module
+        spec.loader.exec_module(module)
+        loaded[name] = module
+    return loaded
+
+
+_MODULES = _load_pure_diffusion_modules()
+_CONFIG = _MODULES["tpu_inference.runner.diffusion.config"]
+_ALGORITHM = _MODULES["tpu_inference.runner.diffusion.algorithm"]
+_PROGRAM = _MODULES["tpu_inference.runner.diffusion.program"]
+
+LogitAlignment = _CONFIG.LogitAlignment
+NextBlockPolicy = _CONFIG.NextBlockPolicy
+low_confidence_commit = _ALGORITHM.low_confidence_commit
+denoise_block = _PROGRAM.denoise_block
+
+
+def _thresholds(batch_size, value=0.9):
+    return jnp.full((batch_size, ), value, dtype=jnp.float32)
+
+
+def _temperatures(batch_size):
+    return jnp.zeros((batch_size, ), dtype=jnp.float32)
+
+
+def test_low_confidence_commit_threshold_and_forced_progress():
+    logits = jnp.array([
+        [[10.0, 0.0, -10.0], [0.1, 0.0, -10.0], [0.0, 0.1, -10.0]],
+        [[0.1, 0.0, -10.0], [0.0, 0.1, -10.0], [10.0, 0.0, -10.0]],
+    ])
+    eligible = jnp.ones((2, 3), dtype=bool)
+
+    tokens, remaining = low_confidence_commit(
+        logits,
+        eligible,
+        jnp.array([True, True]),
+        _thresholds(2),
+        _temperatures(2),
+        2,
+    )
+
+    np.testing.assert_array_equal(tokens, [[0, 0, 1], [0, 1, 0]])
+    assert remaining[0].sum() == 2
+    assert remaining[1].sum() == 2
+
+
+def test_low_confidence_commit_keeps_inactive_rows_unchanged():
+    logits = jnp.ones((2, 3, 4), dtype=jnp.float32)
+    eligible = jnp.ones((2, 3), dtype=bool)
+
+    _, remaining = low_confidence_commit(
+        logits,
+        eligible,
+        jnp.array([True, False]),
+        _thresholds(2),
+        _temperatures(2),
+        3,
+    )
+
+    assert remaining[0].sum() == 2
+    assert remaining[1].sum() == 0
+
+
+def test_mask_token_is_excluded_from_commits_and_next_anchor():
+    mask_token_id = 7
+    target_token_id = 5
+
+    def mask_favoring_forward(model_state, canvas, positions, kv_caches,
+                              active_rows, forward_context):
+        del model_state, positions, active_rows, forward_context
+        logits = jnp.zeros((*canvas.shape, 8), dtype=jnp.float32)
+        logits = logits.at[..., mask_token_id].set(100.0)
+        logits = logits.at[..., target_token_id].set(20.0)
+        return logits, kv_caches
+
+    output = denoise_block(
+        mask_favoring_forward,
+        low_confidence_commit,
+        None,
+        jnp.array([[4, 7, 7, 7]], dtype=jnp.int32),
+        jnp.array([[False, True, True, True]]),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.zeros((1, 4), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=mask_token_id,
+        sub_block_size=4,
+    )
+
+    np.testing.assert_array_equal(output.canvas, [[4, 5, 5, 5]])
+    np.testing.assert_array_equal(output.next_anchor, [target_token_id])
+
+
+def _position_forward(vocab_size):
+
+    def forward(model_state, canvas, positions, _kv_caches, active_rows,
+                forward_context):
+        del model_state, active_rows, forward_context
+        targets = positions % vocab_size
+        logits = jax.nn.one_hot(targets, vocab_size) * 20.0
+        return logits, canvas
+
+    return forward
+
+
+def test_denoise_block_supports_shifted_logits_and_inactive_rows():
+    initial_canvas = jnp.array([[7, 15, 15, 15], [9, 8, 7, 6]],
+                               dtype=jnp.int32)
+    initial_mask = jnp.array([[False, True, True, True],
+                              [False, False, False, False]])
+    positions = jnp.array([[10, 11, 12, 13], [20, 21, 22, 23]],
+                          dtype=jnp.int32)
+
+    output = denoise_block(
+        _position_forward(vocab_size=16),
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        initial_mask,
+        positions,
+        jnp.zeros_like(initial_canvas),
+        jnp.array([True, False]),
+        _thresholds(2),
+        _temperatures(2),
+        None,
+        logit_alignment=LogitAlignment.SHIFTED,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=15,
+        sub_block_size=2,
+    )
+
+    np.testing.assert_array_equal(output.canvas[0], [7, 10, 11, 12])
+    np.testing.assert_array_equal(output.canvas[1], initial_canvas[1])
+    assert int(output.next_anchor[0]) == 13
+    assert int(output.next_anchor[1]) == 0
+
+
+def test_shifted_logits_reject_a_masked_seed_position():
+    with pytest.raises(ValueError, match="position 0.*unmasked seed"):
+        denoise_block(
+            _position_forward(vocab_size=16),
+            low_confidence_commit,
+            None,
+            jnp.full((1, 4), 15, dtype=jnp.int32),
+            jnp.ones((1, 4), dtype=bool),
+            jnp.arange(4, dtype=jnp.int32)[None, :],
+            jnp.zeros((1, 4), dtype=jnp.int32),
+            jnp.array([True]),
+            _thresholds(1),
+            _temperatures(1),
+            None,
+            logit_alignment=LogitAlignment.SHIFTED,
+            next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+            mask_token_id=15,
+            sub_block_size=2,
+        )
+
+
+def test_sub_blocks_are_denoised_in_order():
+    vocab_size = 32
+
+    def dependent_forward(model_state, canvas, positions, _kv_caches,
+                          active_rows, forward_context):
+        del model_state, positions, active_rows, forward_context
+        first_half_committed = jnp.sum(canvas[:, :2], axis=-1) % vocab_size
+        targets = jnp.stack([
+            jnp.full_like(first_half_committed, 2),
+            jnp.full_like(first_half_committed, 3),
+            first_half_committed,
+            first_half_committed,
+        ],
+                            axis=1)
+        logits = jax.nn.one_hot(targets, vocab_size) * 20.0
+        return logits, canvas
+
+    output = denoise_block(
+        dependent_forward,
+        low_confidence_commit,
+        None,
+        jnp.full((1, 4), 31, dtype=jnp.int32),
+        jnp.ones((1, 4), dtype=bool),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.zeros((1, 4), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.ALL_MASKED,
+        mask_token_id=31,
+        sub_block_size=2,
+    )
+
+    np.testing.assert_array_equal(output.canvas[0], [2, 3, 5, 5])
+
+
+def test_final_forward_refreshes_committed_kv_and_next_anchor():
+    vocab_size = 32
+
+    def canvas_dependent_forward(model_state, canvas, positions, _kv_caches,
+                                 active_rows, forward_context):
+        del model_state, positions, active_rows, forward_context
+        base_targets = jnp.array([[1, 2, 3, 4]], dtype=jnp.int32)
+        next_target = jnp.sum(canvas, axis=-1) % vocab_size
+        targets = base_targets.at[:, -1].set(next_target)
+        logits = jax.nn.one_hot(targets, vocab_size) * 20.0
+        return logits, canvas
+
+    output = denoise_block(
+        canvas_dependent_forward,
+        low_confidence_commit,
+        None,
+        jnp.full((1, 4), 31, dtype=jnp.int32),
+        jnp.ones((1, 4), dtype=bool),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.zeros((1, 4), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=31,
+        sub_block_size=4,
+    )
+
+    np.testing.assert_array_equal(output.kv_caches, output.canvas)
+    assert int(output.next_anchor[0]) == int(output.canvas.sum() % vocab_size)
+
+
+def test_step_cap_force_fills_and_final_forward_refreshes_kv():
+
+    initial_canvas = jnp.array([[4, 7, 7, 7]], dtype=jnp.int32)
+
+    def low_confidence_forward(model_state, canvas, positions, kv_caches,
+                               active_rows, forward_context):
+        del model_state, positions, forward_context
+        logits = jnp.zeros((*canvas.shape, 8), dtype=jnp.float32)
+        updated_kv = jnp.where(active_rows[:, None], canvas, kv_caches)
+        return logits, updated_kv
+
+    output = denoise_block(
+        low_confidence_forward,
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        jnp.array([[False, True, True, True]]),
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.full((1, 4), -1, dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1, value=0.99),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.ALL_MASKED,
+        mask_token_id=7,
+        sub_block_size=4,
+        max_denoise_steps=1,
+    )
+
+    np.testing.assert_array_equal(output.canvas, [[4, 0, 0, 0]])
+    np.testing.assert_array_equal(output.kv_caches, output.canvas)
+    np.testing.assert_array_equal(output.denoise_steps, [1])
+
+    def next_block_token(cache):
+        logits = jax.nn.one_hot(jnp.sum(cache, axis=-1) % 8, 8)
+        return jnp.argmax(logits, axis=-1)
+
+    # The last three positions were bulk-committed after the only denoise
+    # forward. A stale provisional cache still contains MASK values and changes
+    # the next block prediction; the final forward exposes the committed tokens.
+    np.testing.assert_array_equal(next_block_token(output.kv_caches), [4])
+    np.testing.assert_array_equal(next_block_token(initial_canvas), [1])
+
+
+def test_heterogeneous_rows_preserve_inactive_kv():
+
+    def active_aware_forward(model_state, canvas, positions, kv_caches,
+                             active_rows, forward_context):
+        del model_state, positions, forward_context
+        logits = jnp.zeros((*canvas.shape, 8), dtype=jnp.float32)
+        updated_kv = jnp.where(active_rows[:, None], canvas, kv_caches)
+        return logits, updated_kv
+
+    initial_canvas = jnp.array([
+        [4, 7, 6, 5],
+        [3, 7, 7, 7],
+        [9, 8, 7, 6],
+    ],
+                               dtype=jnp.int32)
+    initial_kv = jnp.array([
+        [90, 91, 92, 93],
+        [80, 81, 82, 83],
+        [70, 71, 72, 73],
+    ],
+                           dtype=jnp.int32)
+    output = denoise_block(
+        active_aware_forward,
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        jnp.array([
+            [False, True, False, False],
+            [False, True, True, True],
+            [True, True, True, True],
+        ]),
+        jnp.broadcast_to(jnp.arange(4, dtype=jnp.int32), (3, 4)),
+        initial_kv,
+        jnp.array([True, True, False]),
+        _thresholds(3, value=0.99),
+        _temperatures(3),
+        None,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        next_block_policy=NextBlockPolicy.ALL_MASKED,
+        mask_token_id=7,
+        sub_block_size=4,
+    )
+
+    np.testing.assert_array_equal(output.canvas[2], initial_canvas[2])
+    np.testing.assert_array_equal(output.kv_caches[:2], output.canvas[:2])
+    np.testing.assert_array_equal(output.kv_caches[2], initial_kv[2])
+    np.testing.assert_array_equal(output.denoise_steps, [1, 3, 0])

--- a/tests/runner/test_diffusion_algorithm.py
+++ b/tests/runner/test_diffusion_algorithm.py
@@ -362,8 +362,8 @@ def test_dual_cache_uses_q32_once_then_q8_for_each_sub_block():
                            dtype=jnp.float32)
         return logits, kv_caches.at[0].add(1)
 
-    def partial_forward(model_state, canvas, positions, kv_caches,
-                        active_rows, forward_context, start):
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
         del model_state, positions, active_rows, forward_context, start
         logits = jnp.zeros((canvas.shape[0], sub_block_size, 4),
                            dtype=jnp.float32)
@@ -375,8 +375,8 @@ def test_dual_cache_uses_q32_once_then_q8_for_each_sub_block():
         logits = jnp.zeros((canvas.shape[0], 4), dtype=jnp.float32)
         return logits, kv_caches.at[2].add(1)
 
-    initial_canvas = jnp.array(
-        [[0] + [mask_token_id] * (block_size - 1)], dtype=jnp.int32)
+    initial_canvas = jnp.array([[0] + [mask_token_id] * (block_size - 1)],
+                               dtype=jnp.int32)
     initial_mask = initial_canvas == mask_token_id
     output = denoise_block_dual_cache(
         full_forward,
@@ -407,6 +407,61 @@ def test_dual_cache_uses_q32_once_then_q8_for_each_sub_block():
         output.q8_forward_calls) * sub_block_size == 376
 
 
+def test_dual_cache_keeps_q32_until_shifted_sub_block_anchor_is_committed():
+    mask_token_id = 3
+    sub_block_size = 2
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, active_rows, forward_context
+        first_call_for_second_sub_block = (start == 2) & (kv_caches[0] == 1)
+        confident_position = jnp.where(first_call_for_second_sub_block, 1, 0)
+        logits = jnp.zeros((canvas.shape[0], sub_block_size, 4),
+                           dtype=jnp.float32)
+        logits = logits.at[:, confident_position, 0].set(20.0)
+        return logits, kv_caches.at[0].add(1)
+
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], sub_block_size, 4),
+                           dtype=jnp.float32)
+        return logits, kv_caches.at[1].add(1)
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, positions, active_rows, forward_context
+        logits = jnp.zeros((canvas.shape[0], 4), dtype=jnp.float32)
+        return logits, kv_caches.at[2].add(1)
+
+    initial_canvas = jnp.array(
+        [[0, mask_token_id, mask_token_id, mask_token_id]], dtype=jnp.int32)
+    output = denoise_block_dual_cache(
+        full_forward,
+        partial_forward,
+        final_forward,
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        initial_canvas == mask_token_id,
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.zeros((3, ), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1, value=0.9),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SHIFTED,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=mask_token_id,
+        sub_block_size=sub_block_size,
+    )
+
+    np.testing.assert_array_equal(output.canvas, [[0, 0, 0, 0]])
+    np.testing.assert_array_equal(output.kv_caches, [3, 0, 1])
+    assert int(output.q32_forward_calls) == 4
+    assert int(output.q8_forward_calls) == 0
+
+
 def test_dual_cache_partial_forward_receives_only_rows_with_work():
 
     def full_forward(model_state, canvas, positions, kv_caches, active_rows,
@@ -415,8 +470,8 @@ def test_dual_cache_partial_forward_receives_only_rows_with_work():
         logits = jnp.zeros((canvas.shape[0], 4, 4), dtype=jnp.float32)
         return logits, kv_caches.at[0].add(jnp.sum(active_rows))
 
-    def partial_forward(model_state, canvas, positions, kv_caches,
-                        active_rows, forward_context, start):
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
         del model_state, positions, forward_context, start
         logits = jnp.zeros((canvas.shape[0], 4, 4), dtype=jnp.float32)
         return logits, kv_caches.at[1].add(jnp.sum(active_rows))
@@ -433,8 +488,7 @@ def test_dual_cache_partial_forward_receives_only_rows_with_work():
         low_confidence_commit,
         None,
         jnp.array([[0, 3, 2, 1], [0, 3, 3, 3]], dtype=jnp.int32),
-        jnp.array([[False, True, False, False],
-                   [False, True, True, True]]),
+        jnp.array([[False, True, False, False], [False, True, True, True]]),
         jnp.tile(jnp.arange(4, dtype=jnp.int32), (2, 1)),
         jnp.zeros((2, ), dtype=jnp.int32),
         jnp.array([True, True]),

--- a/tests/runner/test_diffusion_algorithm.py
+++ b/tests/runner/test_diffusion_algorithm.py
@@ -305,6 +305,51 @@ def test_final_forward_refreshes_committed_kv_and_next_anchor():
     assert int(output.next_anchor[0]) == int(output.canvas.sum() % vocab_size)
 
 
+def test_terminal_block_skips_non_dual_cache_final_forward():
+    def forward(model_state, canvas, positions, kv_caches, active_rows,
+                forward_context):
+        del model_state, positions, active_rows, forward_context
+        logits = jnp.zeros((*canvas.shape, 4), dtype=jnp.float32)
+        return logits, kv_caches + 1
+
+    initial_canvas = jnp.array([[0, 3, 3, 3]], dtype=jnp.int32)
+    common_args = (
+        forward,
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        initial_canvas == 3,
+        jnp.arange(4, dtype=jnp.int32)[None, :],
+        jnp.array(0, dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1, value=1.0),
+        _temperatures(1),
+        None,
+    )
+    nonterminal = denoise_block(
+        *common_args,
+        logit_alignment=LogitAlignment.SHIFTED,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=3,
+        sub_block_size=4,
+        needs_final_forward=jnp.array([True]),
+    )
+    terminal = denoise_block(
+        *common_args,
+        logit_alignment=LogitAlignment.SHIFTED,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=3,
+        sub_block_size=4,
+        needs_final_forward=jnp.array([False]),
+    )
+
+    np.testing.assert_array_equal(terminal.canvas, nonterminal.canvas)
+    np.testing.assert_array_equal(terminal.denoise_steps,
+                                  nonterminal.denoise_steps)
+    assert int(terminal.kv_caches) + 1 == int(nonterminal.kv_caches)
+    np.testing.assert_array_equal(terminal.next_anchor, [0])
+
+
 def test_step_cap_force_fills_and_final_forward_refreshes_kv():
 
     initial_canvas = jnp.array([[4, 7, 7, 7]], dtype=jnp.int32)
@@ -403,8 +448,128 @@ def test_dual_cache_uses_q32_once_then_q8_for_each_sub_block():
     np.testing.assert_array_equal(output.denoise_steps, [31])
     assert int(output.q32_forward_calls) == 5
     assert int(output.q8_forward_calls) == 27
+    assert int(output.final_q32_forward_calls) == 1
     assert int(output.q32_forward_calls) * block_size + int(
         output.q8_forward_calls) * sub_block_size == 376
+
+
+def test_dual_cache_terminal_block_skips_final_q32():
+    mask_token_id = 3
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], 4, 4), dtype=jnp.float32)
+        return logits, kv_caches.at[0].add(1)
+
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], 4, 4), dtype=jnp.float32)
+        return logits, kv_caches.at[1].add(1)
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, canvas, positions, forward_context
+        target = jnp.where(active_rows, 2, 1)
+        logits = jax.nn.one_hot(target, 4) * 20.0
+        return logits, kv_caches.at[2].add(1)
+
+    initial_canvas = jnp.array(
+        [[0, mask_token_id, mask_token_id, mask_token_id]], dtype=jnp.int32)
+
+    def run(needs_final_forward):
+        return denoise_block_dual_cache(
+            full_forward,
+            partial_forward,
+            final_forward,
+            low_confidence_commit,
+            None,
+            initial_canvas,
+            initial_canvas == mask_token_id,
+            jnp.arange(4, dtype=jnp.int32)[None, :],
+            jnp.zeros((3, ), dtype=jnp.int32),
+            jnp.array([True]),
+            _thresholds(1, value=1.0),
+            _temperatures(1),
+            None,
+            logit_alignment=LogitAlignment.SHIFTED,
+            next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+            mask_token_id=mask_token_id,
+            sub_block_size=4,
+            needs_final_forward=jnp.array([needs_final_forward]),
+        )
+
+    nonterminal = run(True)
+    terminal = run(False)
+
+    np.testing.assert_array_equal(terminal.canvas, nonterminal.canvas)
+    np.testing.assert_array_equal(terminal.denoise_steps,
+                                  nonterminal.denoise_steps)
+    np.testing.assert_array_equal(terminal.kv_caches, [1, 2, 0])
+    np.testing.assert_array_equal(nonterminal.kv_caches, [1, 2, 1])
+    np.testing.assert_array_equal(terminal.next_anchor, [0])
+    np.testing.assert_array_equal(nonterminal.next_anchor, [2])
+    assert int(terminal.q32_forward_calls) + 1 == int(
+        nonterminal.q32_forward_calls)
+    assert int(terminal.q8_forward_calls) == int(nonterminal.q8_forward_calls)
+    assert int(terminal.final_q32_forward_calls) == 0
+    assert int(nonterminal.final_q32_forward_calls) == 1
+
+
+def test_dual_cache_mixed_terminal_rows_run_one_batch_final_q32():
+    mask_token_id = 3
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], 4, 4), dtype=jnp.float32)
+        return logits, kv_caches.at[0].add(1)
+
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], 4, 4), dtype=jnp.float32)
+        return logits, kv_caches.at[1].add(1)
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, canvas, positions, forward_context
+        target = jnp.where(active_rows, 2, 1)
+        logits = jax.nn.one_hot(target, 4) * 20.0
+        return logits, kv_caches.at[2].add(1)
+
+    initial_canvas = jnp.array(
+        [[0, mask_token_id, mask_token_id, mask_token_id],
+         [0, mask_token_id, mask_token_id, mask_token_id]],
+        dtype=jnp.int32)
+    output = denoise_block_dual_cache(
+        full_forward,
+        partial_forward,
+        final_forward,
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        initial_canvas == mask_token_id,
+        jnp.tile(jnp.arange(4, dtype=jnp.int32), (2, 1)),
+        jnp.zeros((3, ), dtype=jnp.int32),
+        jnp.array([True, True]),
+        _thresholds(2, value=1.0),
+        _temperatures(2),
+        None,
+        logit_alignment=LogitAlignment.SHIFTED,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=mask_token_id,
+        sub_block_size=4,
+        needs_final_forward=jnp.array([False, True]),
+    )
+
+    np.testing.assert_array_equal(output.canvas, np.zeros((2, 4)))
+    np.testing.assert_array_equal(output.next_anchor, [0, 2])
+    np.testing.assert_array_equal(output.kv_caches, [1, 2, 1])
+    assert int(output.q32_forward_calls) == 2
+    assert int(output.q8_forward_calls) == 2
+    assert int(output.final_q32_forward_calls) == 1
 
 
 def test_dual_cache_keeps_q32_until_shifted_sub_block_anchor_is_committed():

--- a/tests/runner/test_diffusion_algorithm.py
+++ b/tests/runner/test_diffusion_algorithm.py
@@ -57,6 +57,9 @@ _PROGRAM = _MODULES["tpu_inference.runner.diffusion.program"]
 LogitAlignment = _CONFIG.LogitAlignment
 NextBlockPolicy = _CONFIG.NextBlockPolicy
 low_confidence_commit = _ALGORITHM.low_confidence_commit
+low_confidence_diagnostics = _ALGORITHM.low_confidence_diagnostics
+confidence_threshold_with_log_bias = (
+    _ALGORITHM.confidence_threshold_with_log_bias)
 denoise_block = _PROGRAM.denoise_block
 denoise_block_dual_cache = _PROGRAM.denoise_block_dual_cache
 select_aligned_hidden_states = _PROGRAM.select_aligned_hidden_states
@@ -68,6 +71,46 @@ def _thresholds(batch_size, value=0.9):
 
 def _temperatures(batch_size):
     return jnp.zeros((batch_size, ), dtype=jnp.float32)
+
+
+def _official_gpu_reference_commit(logits, eligible_mask, active_rows,
+                                   confidence_threshold):
+    probabilities = jax.nn.softmax(logits, axis=-1)
+    token_ids = jnp.argmax(probabilities, axis=-1).astype(jnp.int32)
+    selected_probabilities = jnp.take_along_axis(probabilities,
+                                                 token_ids[..., None],
+                                                 axis=-1)[..., 0]
+    thresholds = jnp.asarray(confidence_threshold, dtype=probabilities.dtype)
+    eligible = jnp.asarray(eligible_mask, dtype=bool) & active_rows[:, None]
+    commit = eligible & (selected_probabilities > thresholds[:, None])
+
+    masked_probabilities = jnp.where(eligible, selected_probabilities,
+                                     -jnp.inf)
+    forced_indices = jnp.argmax(masked_probabilities, axis=-1)
+    forced = jax.nn.one_hot(forced_indices, logits.shape[1], dtype=bool)
+    forced &= jnp.any(eligible, axis=-1)[:, None]
+    commit |= forced
+    return token_ids, eligible & ~commit
+
+
+def test_log_confidence_bias_preserves_zero_and_lowers_threshold():
+    thresholds = _thresholds(2, value=0.9)
+
+    unchanged = confidence_threshold_with_log_bias(thresholds, 0.0)
+    biased = confidence_threshold_with_log_bias(thresholds, 0.05)
+
+    assert unchanged is thresholds
+    np.testing.assert_array_equal(unchanged, thresholds)
+    np.testing.assert_allclose(
+        biased,
+        np.asarray(thresholds) * np.exp(-0.05),
+        rtol=1e-6,
+    )
+    boundary_thresholds = jnp.array([0.0, 1.0], dtype=jnp.float32)
+    np.testing.assert_array_equal(
+        confidence_threshold_with_log_bias(boundary_thresholds, 0.5),
+        boundary_thresholds,
+    )
 
 
 def test_low_confidence_commit_threshold_and_forced_progress():
@@ -89,6 +132,185 @@ def test_low_confidence_commit_threshold_and_forced_progress():
     np.testing.assert_array_equal(tokens, [[0, 0, 1], [0, 1, 0]])
     assert remaining[0].sum() == 2
     assert remaining[1].sum() == 2
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.bfloat16],
+                         ids=["float32", "bfloat16"])
+def test_low_confidence_commit_matches_official_gpu_reference(dtype):
+    logits = jnp.array([
+        [[5.0, 0.0, -4.0, -20.0], [2.5, 0.0, -4.0, -20.0],
+         [0.25, 0.0, -4.0, -20.0]],
+        [[0.2, 0.0, -4.0, -20.0], [0.4, 0.0, -4.0, -20.0],
+         [0.3, 0.0, -4.0, -20.0]],
+    ],
+                       dtype=dtype)
+    eligible = jnp.ones((2, 3), dtype=bool)
+    active_rows = jnp.array([True, True])
+    thresholds = _thresholds(2)
+
+    actual_tokens, actual_remaining = low_confidence_commit(
+        logits,
+        eligible,
+        active_rows,
+        thresholds,
+        _temperatures(2),
+        3,
+    )
+    expected_tokens, expected_remaining = _official_gpu_reference_commit(
+        logits,
+        eligible,
+        active_rows,
+        thresholds,
+    )
+
+    np.testing.assert_array_equal(actual_tokens, expected_tokens)
+    np.testing.assert_array_equal(actual_remaining, expected_remaining)
+
+
+def test_float32_probability_boundary_documents_log_space_rounding_contract():
+    threshold = jnp.asarray(0.9, dtype=jnp.float32)
+    boundary_gap = jnp.log(jnp.asarray(9.0, dtype=jnp.float32))
+    position_logits = jnp.array([
+        [8.0, 0.0, -jnp.inf],
+        [boundary_gap, 0.0, -jnp.inf],
+        [0.0, 0.0, -jnp.inf],
+    ],
+                                dtype=jnp.float32)
+    boundary_probability = jax.nn.softmax(position_logits[1])[0]
+    np.testing.assert_array_equal(boundary_probability, threshold)
+    thresholds = jnp.array([
+        jnp.nextafter(boundary_probability, -jnp.inf),
+        boundary_probability,
+        jnp.nextafter(boundary_probability, jnp.inf),
+    ])
+    logits = jnp.broadcast_to(position_logits, (3, 3, 3))
+    eligible = jnp.ones((3, 3), dtype=bool)
+    active_rows = jnp.ones((3, ), dtype=bool)
+
+    _, official_remaining = _official_gpu_reference_commit(
+        logits,
+        eligible,
+        active_rows,
+        thresholds,
+    )
+    _, current_remaining = low_confidence_commit(
+        logits,
+        eligible,
+        active_rows,
+        thresholds,
+        _temperatures(3),
+        2,
+    )
+
+    np.testing.assert_array_equal(
+        official_remaining,
+        [[False, False, True], [False, True, True], [False, True, True]],
+    )
+    # At the exactly-equal boundary, the current FP32 log-space comparison
+    # rounds differently from the official probability-space comparison.
+    np.testing.assert_array_equal(
+        current_remaining,
+        [[False, False, True], [False, False, True], [False, True, True]],
+    )
+
+
+def test_bfloat16_probability_boundary_matches_official_gpu_reference():
+    boundary_gap = jnp.log(jnp.asarray(9.0, dtype=jnp.float32))
+    position_logits = jnp.array([
+        [8.0, 0.0, -jnp.inf],
+        [boundary_gap, 0.0, -jnp.inf],
+        [0.0, 0.0, -jnp.inf],
+    ],
+                                dtype=jnp.bfloat16)
+    boundary_probability = jax.nn.softmax(position_logits[1])[0]
+    thresholds = jnp.array([
+        jnp.nextafter(boundary_probability, -jnp.inf),
+        boundary_probability,
+        jnp.nextafter(boundary_probability, jnp.inf),
+    ],
+                           dtype=jnp.bfloat16)
+    logits = jnp.broadcast_to(position_logits, (3, 3, 3))
+    eligible = jnp.ones((3, 3), dtype=bool)
+    active_rows = jnp.ones((3, ), dtype=bool)
+
+    _, official_remaining = _official_gpu_reference_commit(
+        logits,
+        eligible,
+        active_rows,
+        thresholds,
+    )
+    _, current_remaining = low_confidence_commit(
+        logits,
+        eligible,
+        active_rows,
+        thresholds,
+        _temperatures(3),
+        2,
+    )
+
+    np.testing.assert_array_equal(
+        official_remaining,
+        [[False, False, True], [False, True, True], [False, True, True]],
+    )
+    np.testing.assert_array_equal(current_remaining, official_remaining)
+
+
+@pytest.mark.parametrize("dtype", [jnp.float32, jnp.bfloat16],
+                         ids=["float32", "bfloat16"])
+def test_threshold_one_commits_exactly_one_forced_position(dtype):
+    logits = jnp.array([
+        [[8.0, 0.0, -4.0, -20.0], [2.0, 0.0, -4.0, -20.0],
+         [1.0, 0.0, -4.0, -20.0]],
+        [[0.2, 0.0, -4.0, -20.0], [0.4, 0.0, -4.0, -20.0],
+         [0.3, 0.0, -4.0, -20.0]],
+    ],
+                       dtype=dtype)
+    eligible = jnp.ones((2, 3), dtype=bool)
+    active_rows = jnp.ones((2, ), dtype=bool)
+    thresholds = _thresholds(2, value=1.0)
+
+    actual_tokens, actual_remaining = low_confidence_commit(
+        logits,
+        eligible,
+        active_rows,
+        thresholds,
+        _temperatures(2),
+        3,
+    )
+    expected_tokens, expected_remaining = _official_gpu_reference_commit(
+        logits,
+        eligible,
+        active_rows,
+        thresholds,
+    )
+
+    np.testing.assert_array_equal(actual_tokens, expected_tokens)
+    np.testing.assert_array_equal(actual_remaining, expected_remaining)
+    committed = np.asarray(eligible & ~actual_remaining)
+    np.testing.assert_array_equal(committed.sum(axis=-1), [1, 1])
+    np.testing.assert_array_equal(np.argmax(committed, axis=-1), [0, 1])
+
+
+def test_low_confidence_diagnostics_report_selected_log_probability_margin():
+    logits = jnp.array([[[2.0, 0.0, -10.0]]], dtype=jnp.float32)
+
+    diagnostics = low_confidence_diagnostics(
+        logits,
+        _thresholds(1, value=0.5),
+        _temperatures(1),
+        2,
+    )
+
+    selected_probability = np.exp(
+        float(diagnostics.selected_log_confidence[0, 0]))
+    np.testing.assert_allclose(selected_probability,
+                               np.exp(2.0) / (np.exp(2.0) + 1.0),
+                               rtol=1e-6)
+    np.testing.assert_allclose(
+        diagnostics.threshold_margin[0, 0],
+        diagnostics.selected_log_confidence[0, 0] - np.log(0.5),
+        rtol=1e-6,
+    )
 
 
 def test_dual_cache_hidden_selection_matches_reference_shift_rules():
@@ -473,7 +695,211 @@ def test_step_cap_force_fills_and_final_forward_refreshes_kv():
     np.testing.assert_array_equal(next_block_token(initial_canvas), [1])
 
 
-def test_dual_cache_uses_q32_once_then_q8_for_each_sub_block():
+def test_dual_cache_acceptance_trace_is_opt_in_and_semantics_preserving():
+    mask_token_id = 3
+    sub_block_size = 2
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], sub_block_size, 4),
+                           dtype=jnp.float32)
+        return logits, kv_caches.at[0].add(1)
+
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], sub_block_size, 4),
+                           dtype=jnp.float32)
+        return logits, kv_caches.at[1].add(1)
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, canvas, positions, active_rows, forward_context
+        return jnp.zeros((1, 4), dtype=jnp.float32), kv_caches.at[2].add(1)
+
+    def run(trace_acceptance_steps):
+        return denoise_block_dual_cache(
+            full_forward,
+            partial_forward,
+            final_forward,
+            low_confidence_commit,
+            None,
+            jnp.array([[0, mask_token_id, mask_token_id, mask_token_id]],
+                      dtype=jnp.int32),
+            jnp.array([[False, True, True, True]]),
+            jnp.arange(40, 44, dtype=jnp.int32)[None, :],
+            jnp.zeros((3, ), dtype=jnp.int32),
+            jnp.array([True]),
+            _thresholds(1, value=1.0),
+            _temperatures(1),
+            None,
+            logit_alignment=LogitAlignment.SHIFTED,
+            next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+            mask_token_id=mask_token_id,
+            sub_block_size=sub_block_size,
+            commit_diagnostics_fn=low_confidence_diagnostics,
+            trace_acceptance_steps=trace_acceptance_steps,
+        )
+
+    untraced = run(False)
+    traced = run(True)
+
+    assert untraced.acceptance_trace is None
+    np.testing.assert_array_equal(traced.canvas, untraced.canvas)
+    np.testing.assert_array_equal(traced.next_anchor, untraced.next_anchor)
+    np.testing.assert_array_equal(traced.denoise_steps, untraced.denoise_steps)
+    np.testing.assert_array_equal(traced.kv_caches, untraced.kv_caches)
+    assert int(traced.q32_forward_calls) == int(untraced.q32_forward_calls)
+    assert int(traced.q8_forward_calls) == int(untraced.q8_forward_calls)
+
+    trace = traced.acceptance_trace
+    assert trace is not None
+    count = int(trace.count)
+    assert count == 3
+    assert int(trace.block_start) == 40
+    np.testing.assert_array_equal(trace.sub_block_starts[:count], [40, 42, 42])
+    np.testing.assert_array_equal(trace.iterations[:count], [0, 0, 1])
+    np.testing.assert_array_equal(trace.forward_kinds[:count], [0, 0, 1])
+    np.testing.assert_array_equal(
+        trace.row0_eligible[:count],
+        [[False, True], [True, True], [False, True]],
+    )
+    np.testing.assert_array_equal(
+        trace.row0_commit[:count],
+        [[False, True], [True, False], [False, True]],
+    )
+    np.testing.assert_array_equal(
+        trace.row0_remaining[:count],
+        [[False, False], [False, True], [False, False]],
+    )
+    assert np.all(np.isfinite(trace.row0_selected_log_confidence[:count]))
+    assert np.all(trace.row0_threshold_margin[:count] < 0.0)
+
+
+def test_dual_cache_acceptance_trace_requires_diagnostics_function():
+    with pytest.raises(ValueError, match="requires commit_diagnostics_fn"):
+        denoise_block_dual_cache(
+            lambda *args: (jnp.zeros((1, 2, 4)), args[3]),
+            lambda *args: (jnp.zeros((1, 2, 4)), args[3]),
+            lambda *args: (jnp.zeros((1, 4)), args[3]),
+            low_confidence_commit,
+            None,
+            jnp.array([[0, 3]], dtype=jnp.int32),
+            jnp.array([[False, True]]),
+            jnp.array([[0, 1]], dtype=jnp.int32),
+            jnp.zeros((1, ), dtype=jnp.int32),
+            jnp.array([True]),
+            _thresholds(1),
+            _temperatures(1),
+            None,
+            logit_alignment=LogitAlignment.SHIFTED,
+            next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+            mask_token_id=3,
+            sub_block_size=2,
+            trace_acceptance_steps=True,
+        )
+
+
+def test_q8_log_confidence_bias_changes_only_partial_commit_threshold():
+    mask_token_id = 3
+    threshold = 0.9
+
+    def logits_for_probability(probability):
+        gap = np.log(probability / (1.0 - probability))
+        return jnp.array([gap, 0.0, -20.0, -20.0], dtype=jnp.float32)
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], 4, 4), dtype=jnp.float32)
+        return logits, kv_caches.at[0].add(1)
+
+    partial_logits = jnp.stack([
+        logits_for_probability(0.5),
+        logits_for_probability(0.88),
+        logits_for_probability(0.87),
+        logits_for_probability(0.5),
+    ])[None, ...]
+
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
+        del model_state, canvas, positions, active_rows, forward_context, start
+        return partial_logits, kv_caches.at[1].add(1)
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, canvas, positions, active_rows, forward_context
+        return jnp.zeros((1, 4), dtype=jnp.float32), kv_caches.at[2].add(1)
+
+    def run(q8_log_confidence_bias=0.0):
+        return denoise_block_dual_cache(
+            full_forward,
+            partial_forward,
+            final_forward,
+            low_confidence_commit,
+            None,
+            jnp.full((1, 4), mask_token_id, dtype=jnp.int32),
+            jnp.ones((1, 4), dtype=bool),
+            jnp.arange(4, dtype=jnp.int32)[None, :],
+            jnp.zeros((3, ), dtype=jnp.int32),
+            jnp.array([True]),
+            _thresholds(1, value=threshold),
+            _temperatures(1),
+            None,
+            logit_alignment=LogitAlignment.SAME_POSITION,
+            next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+            mask_token_id=mask_token_id,
+            sub_block_size=4,
+            needs_final_forward=jnp.array([False]),
+            commit_diagnostics_fn=low_confidence_diagnostics,
+            trace_acceptance_steps=True,
+            q8_log_confidence_bias=q8_log_confidence_bias,
+        )
+
+    default = run()
+    explicit_zero = run(0.0)
+    biased = run(0.05)
+
+    assert jax.tree_util.tree_structure(
+        default) == jax.tree_util.tree_structure(explicit_zero)
+    for default_value, explicit_value in zip(
+            jax.tree_util.tree_leaves(default),
+            jax.tree_util.tree_leaves(explicit_zero),
+            strict=True):
+        np.testing.assert_array_equal(default_value, explicit_value)
+
+    assert int(default.q32_forward_calls) == 1
+    assert int(biased.q32_forward_calls) == 1
+    assert int(default.final_q32_forward_calls) == 0
+    assert int(biased.final_q32_forward_calls) == 0
+    assert int(default.q8_forward_calls) == 3
+    assert int(biased.q8_forward_calls) == 2
+
+    trace = biased.acceptance_trace
+    assert trace is not None
+    trace_count = int(trace.count)
+    q32_steps = np.asarray(trace.forward_kinds[:trace_count]) == 0
+    q8_steps = ~q32_steps
+    assert np.all(
+        np.asarray(trace.row0_threshold_margin[:trace_count])[q32_steps] < 0.0)
+    first_q8_log_confidence = np.asarray(
+        trace.row0_selected_log_confidence[:trace_count])[q8_steps][0]
+    np.testing.assert_allclose(
+        first_q8_log_confidence[1:3],
+        np.log([0.88, 0.87]),
+        atol=1e-6,
+    )
+    first_q8_margins = np.asarray(
+        trace.row0_threshold_margin[:trace_count])[q8_steps][0]
+    assert first_q8_margins[1] > 0.0
+    assert first_q8_margins[2] > 0.0
+    assert first_q8_margins[3] < 0.0
+
+
+@pytest.mark.parametrize("q8_log_confidence_bias", [0.0, 0.5])
+def test_threshold_one_uses_q32_once_then_q8_for_each_sub_block(
+        q8_log_confidence_bias):
     block_size = 32
     sub_block_size = 8
     mask_token_id = 3
@@ -519,6 +945,7 @@ def test_dual_cache_uses_q32_once_then_q8_for_each_sub_block():
         next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
         mask_token_id=mask_token_id,
         sub_block_size=sub_block_size,
+        q8_log_confidence_bias=q8_log_confidence_bias,
     )
 
     np.testing.assert_array_equal(output.canvas, np.zeros((1, block_size)))
@@ -907,13 +1334,14 @@ def test_dual_cache_three_row_bucket_matches_four_row_padding():
             jnp.tile(jnp.arange(4, dtype=jnp.int32), (batch_size, 1)),
             jnp.zeros((3, ), dtype=jnp.int32),
             active_rows,
-            _thresholds(batch_size, value=1.0),
+            _thresholds(batch_size, value=0.9),
             _temperatures(batch_size),
             None,
             logit_alignment=LogitAlignment.SHIFTED,
             next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
             mask_token_id=3,
             sub_block_size=4,
+            q8_log_confidence_bias=0.05,
         )
 
     exact = run(False)

--- a/tests/runner/test_diffusion_algorithm.py
+++ b/tests/runner/test_diffusion_algorithm.py
@@ -863,6 +863,71 @@ def test_dual_cache_partial_forward_receives_only_rows_with_work():
     assert int(output.q8_forward_calls) == 2
 
 
+def test_dual_cache_three_row_bucket_matches_four_row_padding():
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], 4, 4), dtype=jnp.float32)
+        return logits, kv_caches.at[0].add(1)
+
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], 4, 4), dtype=jnp.float32)
+        return logits, kv_caches.at[1].add(1)
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, canvas, positions, forward_context
+        targets = jnp.where(active_rows, 2, 1)
+        return jax.nn.one_hot(targets, 4) * 20.0, kv_caches.at[2].add(1)
+
+    active_canvas = jnp.array([[0, 3, 3, 3], [0, 3, 2, 1], [0, 3, 3, 2]],
+                              dtype=jnp.int32)
+
+    def run(pad_to_four):
+        if pad_to_four:
+            canvas = jnp.concatenate(
+                [active_canvas,
+                 jnp.array([[9, 8, 7, 6]], dtype=jnp.int32)])
+            active_rows = jnp.array([True, True, True, False])
+        else:
+            canvas = active_canvas
+            active_rows = jnp.ones((3, ), dtype=bool)
+        batch_size = canvas.shape[0]
+        return denoise_block_dual_cache(
+            full_forward,
+            partial_forward,
+            final_forward,
+            low_confidence_commit,
+            None,
+            canvas,
+            canvas == 3,
+            jnp.tile(jnp.arange(4, dtype=jnp.int32), (batch_size, 1)),
+            jnp.zeros((3, ), dtype=jnp.int32),
+            active_rows,
+            _thresholds(batch_size, value=1.0),
+            _temperatures(batch_size),
+            None,
+            logit_alignment=LogitAlignment.SHIFTED,
+            next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+            mask_token_id=3,
+            sub_block_size=4,
+        )
+
+    exact = run(False)
+    padded = run(True)
+
+    np.testing.assert_array_equal(exact.canvas, padded.canvas[:3])
+    np.testing.assert_array_equal(exact.next_anchor, padded.next_anchor[:3])
+    np.testing.assert_array_equal(exact.denoise_steps,
+                                  padded.denoise_steps[:3])
+    np.testing.assert_array_equal(exact.kv_caches, padded.kv_caches)
+    assert int(exact.q32_forward_calls) == int(padded.q32_forward_calls)
+    assert int(exact.q8_forward_calls) == int(padded.q8_forward_calls)
+
+
 def test_heterogeneous_rows_preserve_inactive_kv():
 
     def active_aware_forward(model_state, canvas, positions, kv_caches,

--- a/tests/runner/test_diffusion_algorithm.py
+++ b/tests/runner/test_diffusion_algorithm.py
@@ -1244,6 +1244,210 @@ def test_dual_cache_keeps_q32_until_shifted_sub_block_anchor_is_committed():
     np.testing.assert_array_equal(output.kv_caches, [3, 0, 1])
     assert int(output.q32_forward_calls) == 4
     assert int(output.q8_forward_calls) == 0
+    assert int(output.forced_q32_anchor_commits) == 0
+
+
+def test_forced_q32_anchor_commit_transitions_to_q8_after_initial_refresh():
+    mask_token_id = 5
+    sub_block_size = 4
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], sub_block_size, 6),
+                           dtype=jnp.float32)
+        logits = logits.at[:, 1, 2].set(20.0)
+        return logits, kv_caches.at[0].add(1)
+
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], sub_block_size, 6),
+                           dtype=jnp.float32)
+        return logits, kv_caches.at[1].add(1)
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, canvas, positions, active_rows, forward_context
+        return jnp.zeros((2, 6), dtype=jnp.float32), kv_caches.at[2].add(1)
+
+    initial_canvas = jnp.array([[
+        1, 2, 3, 4, mask_token_id, mask_token_id, mask_token_id, mask_token_id
+    ], [4, 4, 4, 4, 4, 4, 4, 4]],
+                               dtype=jnp.int32)
+    initial_mask = jnp.array(
+        [[False, False, False, False, True, True, True, True],
+         [False, False, False, False, False, False, False, False]])
+
+    def run(force_q32_anchor_commit=None,
+            confidence_threshold=0.9,
+            q8_log_confidence_bias=0.0,
+            needs_final_forward=False):
+        force_kwargs = ({} if force_q32_anchor_commit is None else {
+            "force_q32_anchor_commit": force_q32_anchor_commit
+        })
+        return denoise_block_dual_cache(
+            full_forward,
+            partial_forward,
+            final_forward,
+            low_confidence_commit,
+            None,
+            initial_canvas,
+            initial_mask,
+            jnp.tile(jnp.arange(8, dtype=jnp.int32), (2, 1)),
+            jnp.zeros((3, ), dtype=jnp.int32),
+            jnp.array([True, False]),
+            _thresholds(2, value=confidence_threshold),
+            _temperatures(2),
+            None,
+            logit_alignment=LogitAlignment.SHIFTED,
+            next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+            mask_token_id=mask_token_id,
+            sub_block_size=sub_block_size,
+            needs_final_forward=jnp.array([needs_final_forward, False]),
+            commit_diagnostics_fn=low_confidence_diagnostics,
+            trace_acceptance_steps=True,
+            q8_log_confidence_bias=q8_log_confidence_bias,
+            **force_kwargs,
+        )
+
+    implicit_default = run()
+    default = run(False)
+    forced = run(True)
+
+    assert jax.tree_util.tree_structure(
+        implicit_default) == jax.tree_util.tree_structure(default)
+    for implicit_value, explicit_value in zip(
+            jax.tree_util.tree_leaves(implicit_default),
+            jax.tree_util.tree_leaves(default),
+            strict=True):
+        np.testing.assert_array_equal(implicit_value, explicit_value)
+    np.testing.assert_array_equal(default.canvas, forced.canvas)
+    np.testing.assert_array_equal(forced.canvas[1], initial_canvas[1])
+    assert int(default.q32_forward_calls) == 2
+    assert int(forced.q32_forward_calls) == 1
+    assert int(default.q8_forward_calls) == int(forced.q8_forward_calls) == 2
+    assert int(default.final_q32_forward_calls) == 0
+    assert int(forced.final_q32_forward_calls) == 0
+    assert int(default.forced_q32_anchor_commits) == 0
+    assert int(forced.forced_q32_anchor_commits) == 1
+
+    trace = forced.acceptance_trace
+    assert trace is not None
+    np.testing.assert_array_equal(trace.row0_commit[0],
+                                  [True, True, False, False])
+    np.testing.assert_array_equal(trace.row0_remaining[0],
+                                  [False, False, True, True])
+    assert bool(trace.row0_forced_anchor[0])
+    assert not np.any(trace.row0_forced_anchor[1:int(trace.count)])
+
+    nonterminal = run(True, needs_final_forward=True)
+    assert int(nonterminal.q32_forward_calls) == 2
+    assert int(nonterminal.final_q32_forward_calls) == 1
+    assert int(nonterminal.forced_q32_anchor_commits) == 1
+
+    threshold_one = run(True, confidence_threshold=1.0)
+    threshold_one_biased = run(
+        True,
+        confidence_threshold=1.0,
+        q8_log_confidence_bias=0.5,
+    )
+    np.testing.assert_array_equal(threshold_one.canvas,
+                                  threshold_one_biased.canvas)
+    np.testing.assert_array_equal(threshold_one.denoise_steps,
+                                  threshold_one_biased.denoise_steps)
+    assert int(threshold_one.q32_forward_calls) == int(
+        threshold_one_biased.q32_forward_calls)
+    assert int(threshold_one.q8_forward_calls) == int(
+        threshold_one_biased.q8_forward_calls)
+    assert int(threshold_one.forced_q32_anchor_commits) == int(
+        threshold_one_biased.forced_q32_anchor_commits) == 1
+
+
+def test_forced_q32_anchor_commit_requires_shifted_alignment():
+    with pytest.raises(ValueError, match="requires shifted logit alignment"):
+        denoise_block_dual_cache(
+            lambda *args: (jnp.zeros((1, 2, 4)), args[3]),
+            lambda *args: (jnp.zeros((1, 2, 4)), args[3]),
+            lambda *args: (jnp.zeros((1, 4)), args[3]),
+            low_confidence_commit,
+            None,
+            jnp.full((1, 2), 3, dtype=jnp.int32),
+            jnp.ones((1, 2), dtype=bool),
+            jnp.arange(2, dtype=jnp.int32)[None, :],
+            jnp.zeros((1, ), dtype=jnp.int32),
+            jnp.array([True]),
+            _thresholds(1),
+            _temperatures(1),
+            None,
+            logit_alignment=LogitAlignment.SAME_POSITION,
+            next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+            mask_token_id=3,
+            sub_block_size=2,
+            force_q32_anchor_commit=True,
+        )
+
+
+def test_forced_q32_anchor_commit_honors_row_local_eos_stop():
+    mask_token_id = 5
+    eos_token_id = 2
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], 4, 6), dtype=jnp.float32)
+        logits = logits.at[:, 0, eos_token_id].set(0.1)
+        logits = logits.at[:, 1, 1].set(20.0)
+        return logits, kv_caches.at[0].add(1)
+
+    def partial_forward(model_state, canvas, positions, kv_caches, active_rows,
+                        forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        return jnp.zeros((1, 4, 6), dtype=jnp.float32), kv_caches.at[1].add(1)
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, canvas, positions, active_rows, forward_context
+        return jnp.zeros((1, 6), dtype=jnp.float32), kv_caches.at[2].add(1)
+
+    output = denoise_block_dual_cache(
+        full_forward,
+        partial_forward,
+        final_forward,
+        low_confidence_commit,
+        None,
+        jnp.array([[
+            1, 1, 1, 1, mask_token_id, mask_token_id, mask_token_id,
+            mask_token_id
+        ]],
+                  dtype=jnp.int32),
+        jnp.array([[False, False, False, False, True, True, True, True]]),
+        jnp.arange(8, dtype=jnp.int32)[None, :],
+        jnp.zeros((3, ), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1, value=0.9),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SHIFTED,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=mask_token_id,
+        sub_block_size=4,
+        needs_final_forward=jnp.array([True]),
+        stop_on_eos_rows=jnp.array([True]),
+        eos_token_ids=(eos_token_id, ),
+        force_q32_anchor_commit=True,
+    )
+
+    np.testing.assert_array_equal(
+        output.canvas,
+        [[1, 1, 1, 1, eos_token_id, 1, mask_token_id, mask_token_id]],
+    )
+    np.testing.assert_array_equal(output.stopped_rows, [True])
+    np.testing.assert_array_equal(output.denoise_steps, [1])
+    assert int(output.q32_forward_calls) == 1
+    assert int(output.q8_forward_calls) == 0
+    assert int(output.final_q32_forward_calls) == 0
+    assert int(output.forced_q32_anchor_commits) == 1
 
 
 def test_dual_cache_partial_forward_receives_only_rows_with_work():

--- a/tests/runner/test_diffusion_algorithm.py
+++ b/tests/runner/test_diffusion_algorithm.py
@@ -58,6 +58,8 @@ LogitAlignment = _CONFIG.LogitAlignment
 NextBlockPolicy = _CONFIG.NextBlockPolicy
 low_confidence_commit = _ALGORITHM.low_confidence_commit
 denoise_block = _PROGRAM.denoise_block
+denoise_block_dual_cache = _PROGRAM.denoise_block_dual_cache
+select_aligned_hidden_states = _PROGRAM.select_aligned_hidden_states
 
 
 def _thresholds(batch_size, value=0.9):
@@ -87,6 +89,32 @@ def test_low_confidence_commit_threshold_and_forced_progress():
     np.testing.assert_array_equal(tokens, [[0, 0, 1], [0, 1, 0]])
     assert remaining[0].sum() == 2
     assert remaining[1].sum() == 2
+
+
+def test_dual_cache_hidden_selection_matches_reference_shift_rules():
+    hidden = jnp.arange(32, dtype=jnp.float32).reshape(1, 32, 1)
+
+    full = select_aligned_hidden_states(
+        hidden,
+        1,
+        32,
+        jnp.array(8, dtype=jnp.int32),
+        8,
+        LogitAlignment.SHIFTED,
+        local_alignment=False,
+    )
+    partial = select_aligned_hidden_states(
+        hidden[:, :8],
+        1,
+        8,
+        jnp.array(0, dtype=jnp.int32),
+        8,
+        LogitAlignment.SHIFTED,
+        local_alignment=True,
+    )
+
+    np.testing.assert_array_equal(full[:, 0], np.arange(7, 15))
+    np.testing.assert_array_equal(partial[:, 0], [0, 0, 1, 2, 3, 4, 5, 6])
 
 
 def test_low_confidence_commit_keeps_inactive_rows_unchanged():
@@ -320,6 +348,108 @@ def test_step_cap_force_fills_and_final_forward_refreshes_kv():
     # the next block prediction; the final forward exposes the committed tokens.
     np.testing.assert_array_equal(next_block_token(output.kv_caches), [4])
     np.testing.assert_array_equal(next_block_token(initial_canvas), [1])
+
+
+def test_dual_cache_uses_q32_once_then_q8_for_each_sub_block():
+    block_size = 32
+    sub_block_size = 8
+    mask_token_id = 3
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], sub_block_size, 4),
+                           dtype=jnp.float32)
+        return logits, kv_caches.at[0].add(1)
+
+    def partial_forward(model_state, canvas, positions, kv_caches,
+                        active_rows, forward_context, start):
+        del model_state, positions, active_rows, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], sub_block_size, 4),
+                           dtype=jnp.float32)
+        return logits, kv_caches.at[1].add(1)
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, positions, active_rows, forward_context
+        logits = jnp.zeros((canvas.shape[0], 4), dtype=jnp.float32)
+        return logits, kv_caches.at[2].add(1)
+
+    initial_canvas = jnp.array(
+        [[0] + [mask_token_id] * (block_size - 1)], dtype=jnp.int32)
+    initial_mask = initial_canvas == mask_token_id
+    output = denoise_block_dual_cache(
+        full_forward,
+        partial_forward,
+        final_forward,
+        low_confidence_commit,
+        None,
+        initial_canvas,
+        initial_mask,
+        jnp.arange(block_size, dtype=jnp.int32)[None, :],
+        jnp.zeros((3, ), dtype=jnp.int32),
+        jnp.array([True]),
+        _thresholds(1, value=1.0),
+        _temperatures(1),
+        None,
+        logit_alignment=LogitAlignment.SHIFTED,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=mask_token_id,
+        sub_block_size=sub_block_size,
+    )
+
+    np.testing.assert_array_equal(output.canvas, np.zeros((1, block_size)))
+    np.testing.assert_array_equal(output.kv_caches, [4, 27, 1])
+    np.testing.assert_array_equal(output.denoise_steps, [31])
+    assert int(output.q32_forward_calls) == 5
+    assert int(output.q8_forward_calls) == 27
+    assert int(output.q32_forward_calls) * block_size + int(
+        output.q8_forward_calls) * sub_block_size == 376
+
+
+def test_dual_cache_partial_forward_receives_only_rows_with_work():
+
+    def full_forward(model_state, canvas, positions, kv_caches, active_rows,
+                     forward_context, start):
+        del model_state, positions, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], 4, 4), dtype=jnp.float32)
+        return logits, kv_caches.at[0].add(jnp.sum(active_rows))
+
+    def partial_forward(model_state, canvas, positions, kv_caches,
+                        active_rows, forward_context, start):
+        del model_state, positions, forward_context, start
+        logits = jnp.zeros((canvas.shape[0], 4, 4), dtype=jnp.float32)
+        return logits, kv_caches.at[1].add(jnp.sum(active_rows))
+
+    def final_forward(model_state, canvas, positions, kv_caches, active_rows,
+                      forward_context):
+        del model_state, canvas, positions, active_rows, forward_context
+        return jnp.zeros((2, 4), dtype=jnp.float32), kv_caches
+
+    output = denoise_block_dual_cache(
+        full_forward,
+        partial_forward,
+        final_forward,
+        low_confidence_commit,
+        None,
+        jnp.array([[0, 3, 2, 1], [0, 3, 3, 3]], dtype=jnp.int32),
+        jnp.array([[False, True, False, False],
+                   [False, True, True, True]]),
+        jnp.tile(jnp.arange(4, dtype=jnp.int32), (2, 1)),
+        jnp.zeros((2, ), dtype=jnp.int32),
+        jnp.array([True, True]),
+        _thresholds(2, value=1.0),
+        _temperatures(2),
+        None,
+        logit_alignment=LogitAlignment.SHIFTED,
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        mask_token_id=3,
+        sub_block_size=4,
+    )
+
+    np.testing.assert_array_equal(output.kv_caches, [2, 2])
+    np.testing.assert_array_equal(output.denoise_steps, [1, 3])
+    assert int(output.q8_forward_calls) == 2
 
 
 def test_heterogeneous_rows_preserve_inactive_kv():

--- a/tests/runner/test_diffusion_batch.py
+++ b/tests/runner/test_diffusion_batch.py
@@ -1,0 +1,67 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+
+
+def _load_batch_module():
+    path = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+            "runner" / "diffusion" / "batch.py")
+    spec = importlib.util.spec_from_file_location("diffusion_batch_under_test",
+                                                  path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+batch = _load_batch_module()
+
+
+def test_aligned_prompt_is_split_into_complete_blocks():
+    plan = batch.plan_seeded_prompt(list(range(8)), 4, 99)
+
+    assert plan.full_blocks == ((0, 1, 2, 3), (4, 5, 6, 7))
+    assert plan.partial_canvas is None
+    assert plan.remainder_size == 0
+
+
+def test_prompt_remainder_is_preserved_in_first_canvas():
+    plan = batch.plan_seeded_prompt(list(range(6)), 4, 99)
+
+    assert plan.full_blocks == ((0, 1, 2, 3), )
+    assert plan.partial_canvas == (4, 5, 99, 99)
+    assert plan.partial_mask == (False, False, True, True)
+    assert plan.remainder_size == 2
+
+
+def test_partial_block_is_flushed_at_the_next_scheduler_boundary():
+    first, pending = batch.start_partial_block_output([4, 5, 6, 7], 2, 8)
+
+    assert first == [6]
+    assert batch.flush_partial_block_output(pending) == [7, 8]
+
+
+def test_seeded_decode_emits_new_canvas_tokens_and_uncached_anchor():
+    emitted = batch.complete_seeded_decode_block([10, 11, 12, 13], 14)
+
+    assert emitted == [11, 12, 13, 14]
+
+
+def test_cache_capacity_accounts_for_the_uncached_final_anchor():
+    assert batch.required_cache_end(32, 32, 32) == 64
+    assert batch.required_cache_end(33, 32, 32) == 64
+    assert batch.required_cache_end(33, 33, 32) == 96

--- a/tests/runner/test_diffusion_batch.py
+++ b/tests/runner/test_diffusion_batch.py
@@ -68,6 +68,44 @@ def test_block_anchor_rejects_negative_output_budget():
         batch.needs_block_anchor([False, True], -1)
 
 
+@pytest.mark.parametrize(
+    "tokens_remaining,expected",
+    [
+        (0, [False, False, False, False]),
+        (1, [False, False, True, False]),
+        (2, [False, False, True, True]),
+        (3, [False, False, True, True]),
+    ],
+)
+def test_generation_mask_is_trimmed_to_remaining_output(
+        tokens_remaining, expected):
+    mask = [False, False, True, True]
+
+    assert batch.trim_generation_mask(mask, tokens_remaining) == expected
+    assert mask == [False, False, True, True]
+
+
+def test_generation_mask_preserves_noncontiguous_order():
+    assert batch.trim_generation_mask(
+        [False, True, False, True, True], 2) == [False, True, False, True, False]
+
+
+def test_generation_mask_rejects_negative_output_budget():
+    with pytest.raises(ValueError, match="tokens_remaining"):
+        batch.trim_generation_mask([False, True], -1)
+
+
+@pytest.mark.parametrize("tokens_remaining", [0, 1, 13, 31, 32, 33])
+def test_trimmed_seeded_block_has_exact_candidate_budget(tokens_remaining):
+    mask = batch.trim_generation_mask(
+        [False] + [True] * 31,
+        tokens_remaining,
+    )
+    candidates = sum(mask) + batch.needs_block_anchor(mask, tokens_remaining)
+
+    assert candidates == min(tokens_remaining, 32)
+
+
 def test_aligned_prompt_is_split_into_complete_blocks():
     plan = batch.plan_seeded_prompt(list(range(8)), 4, 99)
 

--- a/tests/runner/test_diffusion_batch.py
+++ b/tests/runner/test_diffusion_batch.py
@@ -16,6 +16,8 @@ import importlib.util
 import pathlib
 import sys
 
+import pytest
+
 
 def _load_batch_module():
     path = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
@@ -43,6 +45,20 @@ def test_diffusion_batch_size_uses_smallest_fitting_bucket():
 def test_diffusion_batch_size_supports_non_power_of_two_capacity():
     assert batch.select_diffusion_batch_size(3, 3) == 3
     assert batch.diffusion_batch_sizes(3) == (1, 2, 3)
+
+
+def test_block_anchor_is_skipped_when_it_cannot_reach_the_response():
+    mask = [False, True, True, True]
+
+    assert batch.needs_block_anchor(mask, 0) is False
+    assert batch.needs_block_anchor(mask, 2) is False
+    assert batch.needs_block_anchor(mask, 3) is False
+    assert batch.needs_block_anchor(mask, 4) is True
+
+
+def test_block_anchor_rejects_negative_output_budget():
+    with pytest.raises(ValueError, match="tokens_remaining"):
+        batch.needs_block_anchor([False, True], -1)
 
 
 def test_aligned_prompt_is_split_into_complete_blocks():

--- a/tests/runner/test_diffusion_batch.py
+++ b/tests/runner/test_diffusion_batch.py
@@ -31,6 +31,20 @@ def _load_batch_module():
 batch = _load_batch_module()
 
 
+def test_diffusion_batch_size_uses_smallest_fitting_bucket():
+    assert batch.select_diffusion_batch_size(0, 4) == 1
+    assert batch.select_diffusion_batch_size(1, 4) == 1
+    assert batch.select_diffusion_batch_size(2, 4) == 2
+    assert batch.select_diffusion_batch_size(3, 4) == 4
+    assert batch.select_diffusion_batch_size(4, 4) == 4
+    assert batch.diffusion_batch_sizes(4) == (1, 2, 4)
+
+
+def test_diffusion_batch_size_supports_non_power_of_two_capacity():
+    assert batch.select_diffusion_batch_size(3, 3) == 3
+    assert batch.diffusion_batch_sizes(3) == (1, 2, 3)
+
+
 def test_aligned_prompt_is_split_into_complete_blocks():
     plan = batch.plan_seeded_prompt(list(range(8)), 4, 99)
 

--- a/tests/runner/test_diffusion_batch.py
+++ b/tests/runner/test_diffusion_batch.py
@@ -37,9 +37,16 @@ def test_diffusion_batch_size_uses_smallest_fitting_bucket():
     assert batch.select_diffusion_batch_size(0, 4) == 1
     assert batch.select_diffusion_batch_size(1, 4) == 1
     assert batch.select_diffusion_batch_size(2, 4) == 2
-    assert batch.select_diffusion_batch_size(3, 4) == 4
+    assert batch.select_diffusion_batch_size(3, 4) == 3
     assert batch.select_diffusion_batch_size(4, 4) == 4
-    assert batch.diffusion_batch_sizes(4) == (1, 2, 4)
+    assert batch.diffusion_batch_sizes(4) == (1, 2, 3, 4)
+
+
+def test_diffusion_batch_size_limits_exact_shape_compilation():
+    assert batch.select_diffusion_batch_size(3, 8) == 3
+    assert batch.select_diffusion_batch_size(4, 8) == 4
+    assert batch.select_diffusion_batch_size(5, 8) == 8
+    assert batch.diffusion_batch_sizes(8) == (1, 2, 3, 4, 8)
 
 
 def test_diffusion_batch_size_supports_non_power_of_two_capacity():

--- a/tests/runner/test_diffusion_config.py
+++ b/tests/runner/test_diffusion_config.py
@@ -100,6 +100,7 @@ def test_resolves_seeded_shifted_semantics_from_hf_config():
     assert resolved.diffusion.runtime.cohort_max_wait_ms == 0.0
     assert resolved.diffusion.runtime.cohort_quiet_wait_ms == 0.0
     assert resolved.diffusion.runtime.cohort_strict_waves is False
+    assert resolved.diffusion.runtime.cohort_round_robin_dp is False
 
 
 def test_runtime_and_model_overrides_are_separate():
@@ -115,9 +116,10 @@ def test_runtime_and_model_overrides_are_separate():
                 "temperature": 0.2,
                 "max_denoise_steps": 12,
                 "use_dual_cache": True,
-                "cohort_max_wait_ms": 7.5,
+                "cohort_max_wait_ms": 5000.0,
                 "cohort_quiet_wait_ms": 1.5,
                 "cohort_strict_waves": True,
+                "cohort_round_robin_dp": True,
             },
         }))
 
@@ -133,9 +135,10 @@ def test_runtime_and_model_overrides_are_separate():
     assert resolved.diffusion.runtime.q8_log_confidence_bias == 0.0
     assert resolved.diffusion.runtime.force_q32_anchor_commit is False
     assert resolved.diffusion.runtime.trim_final_block_candidates is False
-    assert resolved.diffusion.runtime.cohort_max_wait_ms == 7.5
+    assert resolved.diffusion.runtime.cohort_max_wait_ms == 5000.0
     assert resolved.diffusion.runtime.cohort_quiet_wait_ms == 1.5
     assert resolved.diffusion.runtime.cohort_strict_waves is True
+    assert resolved.diffusion.runtime.cohort_round_robin_dp is True
 
 
 def test_resolves_opt_in_dual_cache_acceptance_trace():
@@ -350,9 +353,9 @@ def test_new_model_adapter_does_not_change_strategy_resolution():
             "generation_strategy": "block_diffusion",
             "diffusion": {
                 "model_adapter": "seeded_shifted",
-                "cohort_max_wait_ms": 100.01,
+                "cohort_max_wait_ms": 5000.01,
             },
-        }, "cohort_max_wait_ms must not exceed 100"),
+        }, "cohort_max_wait_ms must not exceed 5000"),
         ({
             "generation_strategy": "block_diffusion",
             "diffusion": {

--- a/tests/runner/test_diffusion_config.py
+++ b/tests/runner/test_diffusion_config.py
@@ -21,10 +21,10 @@ import pytest
 
 try:
     from tpu_inference.runner.diffusion.config import (
-        AttentionPolicy, CanvasPolicy, DiffusionAlgorithm, DiffusionModelSpec,
-        GenerationStrategy, LogitAlignment, NextBlockPolicy,
-        PromptRemainderPolicy, register_diffusion_model_adapter,
-        resolve_generation_strategy)
+        AttentionPolicy, CanvasPolicy, DiffusionAlgorithm, DiffusionConfig,
+        DiffusionModelSpec, DiffusionRuntimeConfig, GenerationStrategy,
+        LogitAlignment, NextBlockPolicy, PromptRemainderPolicy,
+        register_diffusion_model_adapter, resolve_generation_strategy)
 except ModuleNotFoundError:
     config_path = (pathlib.Path(__file__).resolve().parents[2] /
                    "tpu_inference" / "runner" / "diffusion" / "config.py")
@@ -36,7 +36,9 @@ except ModuleNotFoundError:
     AttentionPolicy = module.AttentionPolicy
     CanvasPolicy = module.CanvasPolicy
     DiffusionAlgorithm = module.DiffusionAlgorithm
+    DiffusionConfig = module.DiffusionConfig
     DiffusionModelSpec = module.DiffusionModelSpec
+    DiffusionRuntimeConfig = module.DiffusionRuntimeConfig
     GenerationStrategy = module.GenerationStrategy
     LogitAlignment = module.LogitAlignment
     NextBlockPolicy = module.NextBlockPolicy
@@ -127,6 +129,7 @@ def test_runtime_and_model_overrides_are_separate():
     assert resolved.diffusion.runtime.trace_acceptance_steps is False
     assert resolved.diffusion.runtime.fp32_partial_rpa is False
     assert resolved.diffusion.runtime.q8_log_confidence_bias == 0.0
+    assert resolved.diffusion.runtime.force_q32_anchor_commit is False
     assert resolved.diffusion.runtime.cohort_max_wait_ms == 7.5
     assert resolved.diffusion.runtime.cohort_quiet_wait_ms == 1.5
 
@@ -184,6 +187,24 @@ def test_resolves_opt_in_q8_log_confidence_bias():
 
     assert resolved.diffusion is not None
     assert resolved.diffusion.runtime.q8_log_confidence_bias == 0.05
+
+
+def test_resolves_opt_in_forced_q32_anchor_commit():
+    resolved = resolve_generation_strategy(
+        _vllm_config({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "block_size": 16,
+                "mask_token_id": 99,
+                "sub_block_size": 4,
+                "use_dual_cache": True,
+                "force_q32_anchor_commit": True,
+            },
+        }))
+
+    assert resolved.diffusion is not None
+    assert resolved.diffusion.runtime.force_q32_anchor_commit is True
 
 
 def test_new_model_adapter_does_not_change_strategy_resolution():
@@ -260,6 +281,13 @@ def test_new_model_adapter_does_not_change_strategy_resolution():
                 "q8_log_confidence_bias": 0.05,
             },
         }, "q8_log_confidence_bias requires use_dual_cache"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "force_q32_anchor_commit": True,
+            },
+        }, "force_q32_anchor_commit requires use_dual_cache"),
         ({
             "generation_strategy": "block_diffusion",
             "diffusion": {
@@ -352,6 +380,28 @@ def test_model_spec_rejects_incompatible_sub_block_size():
             sub_block_size=4,
             supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
         )
+
+
+def test_forced_q32_anchor_commit_rejects_same_position_alignment():
+    model = DiffusionModelSpec(
+        name="same-position",
+        block_size=4,
+        mask_token_id=7,
+        attention_policy=AttentionPolicy.BLOCK_CAUSAL,
+        logit_alignment=LogitAlignment.SAME_POSITION,
+        canvas_policy=CanvasPolicy.ALL_MASKED,
+        prompt_remainder_policy=(PromptRemainderPolicy.REQUIRE_BLOCK_ALIGNED),
+        next_block_policy=NextBlockPolicy.ALL_MASKED,
+        sub_block_size=4,
+        supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
+    )
+    runtime = DiffusionRuntimeConfig(
+        use_dual_cache=True,
+        force_q32_anchor_commit=True,
+    )
+
+    with pytest.raises(ValueError, match="requires shifted logit alignment"):
+        DiffusionConfig(model=model, runtime=runtime)
 
 
 def test_model_spec_rejects_shifted_all_masked_canvas():

--- a/tests/runner/test_diffusion_config.py
+++ b/tests/runner/test_diffusion_config.py
@@ -96,6 +96,7 @@ def test_resolves_seeded_shifted_semantics_from_hf_config():
         supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
     )
     assert resolved.diffusion.runtime.cohort_max_wait_ms == 0.0
+    assert resolved.diffusion.runtime.cohort_quiet_wait_ms == 0.0
 
 
 def test_runtime_and_model_overrides_are_separate():
@@ -112,6 +113,7 @@ def test_runtime_and_model_overrides_are_separate():
                 "max_denoise_steps": 12,
                 "use_dual_cache": True,
                 "cohort_max_wait_ms": 7.5,
+                "cohort_quiet_wait_ms": 1.5,
             },
         }))
 
@@ -126,6 +128,7 @@ def test_runtime_and_model_overrides_are_separate():
     assert resolved.diffusion.runtime.fp32_partial_rpa is False
     assert resolved.diffusion.runtime.q8_log_confidence_bias == 0.0
     assert resolved.diffusion.runtime.cohort_max_wait_ms == 7.5
+    assert resolved.diffusion.runtime.cohort_quiet_wait_ms == 1.5
 
 
 def test_resolves_opt_in_dual_cache_acceptance_trace():
@@ -302,6 +305,29 @@ def test_new_model_adapter_does_not_change_strategy_resolution():
                 "cohort_max_wait_ms": 100.01,
             },
         }, "cohort_max_wait_ms must not exceed 100"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "cohort_max_wait_ms": 20.0,
+                "cohort_quiet_wait_ms": -0.01,
+            },
+        }, "cohort_quiet_wait_ms must be finite and non-negative"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "cohort_quiet_wait_ms": 2.0,
+            },
+        }, "cohort_quiet_wait_ms requires positive cohort_max_wait_ms"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "cohort_max_wait_ms": 2.0,
+                "cohort_quiet_wait_ms": 2.01,
+            },
+        }, "cohort_quiet_wait_ms must not exceed cohort_max_wait_ms"),
     ],
 )
 def test_invalid_configuration_fails_at_resolution(additional_config, match):

--- a/tests/runner/test_diffusion_config.py
+++ b/tests/runner/test_diffusion_config.py
@@ -95,6 +95,7 @@ def test_resolves_seeded_shifted_semantics_from_hf_config():
         sub_block_size=8,
         supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
     )
+    assert resolved.diffusion.runtime.cohort_max_wait_ms == 0.0
 
 
 def test_runtime_and_model_overrides_are_separate():
@@ -110,6 +111,7 @@ def test_runtime_and_model_overrides_are_separate():
                 "temperature": 0.2,
                 "max_denoise_steps": 12,
                 "use_dual_cache": True,
+                "cohort_max_wait_ms": 7.5,
             },
         }))
 
@@ -123,6 +125,7 @@ def test_runtime_and_model_overrides_are_separate():
     assert resolved.diffusion.runtime.trace_acceptance_steps is False
     assert resolved.diffusion.runtime.fp32_partial_rpa is False
     assert resolved.diffusion.runtime.q8_log_confidence_bias == 0.0
+    assert resolved.diffusion.runtime.cohort_max_wait_ms == 7.5
 
 
 def test_resolves_opt_in_dual_cache_acceptance_trace():
@@ -278,6 +281,27 @@ def test_new_model_adapter_does_not_change_strategy_resolution():
                 "q8_log_confidence_bias": float("inf"),
             },
         }, "finite and non-negative"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "cohort_max_wait_ms": -0.01,
+            },
+        }, "cohort_max_wait_ms must be finite and non-negative"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "cohort_max_wait_ms": float("inf"),
+            },
+        }, "cohort_max_wait_ms must be finite and non-negative"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "cohort_max_wait_ms": 100.01,
+            },
+        }, "cohort_max_wait_ms must not exceed 100"),
     ],
 )
 def test_invalid_configuration_fails_at_resolution(additional_config, match):

--- a/tests/runner/test_diffusion_config.py
+++ b/tests/runner/test_diffusion_config.py
@@ -130,6 +130,7 @@ def test_runtime_and_model_overrides_are_separate():
     assert resolved.diffusion.runtime.fp32_partial_rpa is False
     assert resolved.diffusion.runtime.q8_log_confidence_bias == 0.0
     assert resolved.diffusion.runtime.force_q32_anchor_commit is False
+    assert resolved.diffusion.runtime.trim_final_block_candidates is False
     assert resolved.diffusion.runtime.cohort_max_wait_ms == 7.5
     assert resolved.diffusion.runtime.cohort_quiet_wait_ms == 1.5
 
@@ -205,6 +206,22 @@ def test_resolves_opt_in_forced_q32_anchor_commit():
 
     assert resolved.diffusion is not None
     assert resolved.diffusion.runtime.force_q32_anchor_commit is True
+
+
+def test_resolves_opt_in_final_block_candidate_trimming():
+    resolved = resolve_generation_strategy(
+        _vllm_config({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "block_size": 16,
+                "mask_token_id": 99,
+                "trim_final_block_candidates": True,
+            },
+        }))
+
+    assert resolved.diffusion is not None
+    assert resolved.diffusion.runtime.trim_final_block_candidates is True
 
 
 def test_new_model_adapter_does_not_change_strategy_resolution():

--- a/tests/runner/test_diffusion_config.py
+++ b/tests/runner/test_diffusion_config.py
@@ -109,6 +109,7 @@ def test_runtime_and_model_overrides_are_separate():
                 "confidence_threshold": 0.75,
                 "temperature": 0.2,
                 "max_denoise_steps": 12,
+                "use_dual_cache": True,
             },
         }))
 
@@ -118,6 +119,7 @@ def test_runtime_and_model_overrides_are_separate():
     assert resolved.diffusion.runtime.confidence_threshold == 0.75
     assert resolved.diffusion.runtime.temperature == 0.2
     assert resolved.diffusion.runtime.max_denoise_steps == 12
+    assert resolved.diffusion.runtime.use_dual_cache is True
 
 
 def test_new_model_adapter_does_not_change_strategy_resolution():

--- a/tests/runner/test_diffusion_config.py
+++ b/tests/runner/test_diffusion_config.py
@@ -99,6 +99,7 @@ def test_resolves_seeded_shifted_semantics_from_hf_config():
     )
     assert resolved.diffusion.runtime.cohort_max_wait_ms == 0.0
     assert resolved.diffusion.runtime.cohort_quiet_wait_ms == 0.0
+    assert resolved.diffusion.runtime.cohort_strict_waves is False
 
 
 def test_runtime_and_model_overrides_are_separate():
@@ -116,6 +117,7 @@ def test_runtime_and_model_overrides_are_separate():
                 "use_dual_cache": True,
                 "cohort_max_wait_ms": 7.5,
                 "cohort_quiet_wait_ms": 1.5,
+                "cohort_strict_waves": True,
             },
         }))
 
@@ -133,6 +135,7 @@ def test_runtime_and_model_overrides_are_separate():
     assert resolved.diffusion.runtime.trim_final_block_candidates is False
     assert resolved.diffusion.runtime.cohort_max_wait_ms == 7.5
     assert resolved.diffusion.runtime.cohort_quiet_wait_ms == 1.5
+    assert resolved.diffusion.runtime.cohort_strict_waves is True
 
 
 def test_resolves_opt_in_dual_cache_acceptance_trace():
@@ -373,6 +376,13 @@ def test_new_model_adapter_does_not_change_strategy_resolution():
                 "cohort_quiet_wait_ms": 2.01,
             },
         }, "cohort_quiet_wait_ms must not exceed cohort_max_wait_ms"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "cohort_strict_waves": True,
+            },
+        }, "cohort_strict_waves requires positive cohort_max_wait_ms"),
     ],
 )
 def test_invalid_configuration_fails_at_resolution(additional_config, match):

--- a/tests/runner/test_diffusion_config.py
+++ b/tests/runner/test_diffusion_config.py
@@ -1,0 +1,199 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+try:
+    from tpu_inference.runner.diffusion.config import (
+        AttentionPolicy, CanvasPolicy, DiffusionAlgorithm, DiffusionModelSpec,
+        GenerationStrategy, LogitAlignment, NextBlockPolicy,
+        PromptRemainderPolicy, register_diffusion_model_adapter,
+        resolve_generation_strategy)
+except ModuleNotFoundError:
+    config_path = (pathlib.Path(__file__).resolve().parents[2] /
+                   "tpu_inference" / "runner" / "diffusion" / "config.py")
+    spec = importlib.util.spec_from_file_location(
+        "diffusion_config_under_test", config_path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    AttentionPolicy = module.AttentionPolicy
+    CanvasPolicy = module.CanvasPolicy
+    DiffusionAlgorithm = module.DiffusionAlgorithm
+    DiffusionModelSpec = module.DiffusionModelSpec
+    GenerationStrategy = module.GenerationStrategy
+    LogitAlignment = module.LogitAlignment
+    NextBlockPolicy = module.NextBlockPolicy
+    PromptRemainderPolicy = module.PromptRemainderPolicy
+    register_diffusion_model_adapter = module.register_diffusion_model_adapter
+    resolve_generation_strategy = module.resolve_generation_strategy
+
+
+def _vllm_config(additional_config=None, **hf_values):
+    return SimpleNamespace(
+        additional_config=additional_config or {},
+        model_config=SimpleNamespace(hf_config=SimpleNamespace(**hf_values)),
+    )
+
+
+def test_autoregressive_is_the_default_and_has_no_diffusion_config():
+    resolved = resolve_generation_strategy(_vllm_config())
+
+    assert resolved.strategy is GenerationStrategy.AUTOREGRESSIVE
+    assert resolved.diffusion is None
+
+
+def test_strategy_enum_is_accepted_without_string_coercion():
+    resolved = resolve_generation_strategy(
+        _vllm_config(
+            {"generation_strategy": GenerationStrategy.AUTOREGRESSIVE}))
+
+    assert resolved.strategy is GenerationStrategy.AUTOREGRESSIVE
+
+
+def test_resolves_seeded_shifted_semantics_from_hf_config():
+    resolved = resolve_generation_strategy(
+        _vllm_config(
+            {
+                "generation_strategy": "block_diffusion",
+                "diffusion": {
+                    "model_adapter": "seeded_shifted"
+                },
+            },
+            bd_size=32,
+            mask_id=151669,
+        ))
+
+    assert resolved.strategy is GenerationStrategy.BLOCK_DIFFUSION
+    assert resolved.diffusion is not None
+    assert resolved.diffusion.model == DiffusionModelSpec(
+        name="seeded_shifted",
+        block_size=32,
+        mask_token_id=151669,
+        attention_policy=AttentionPolicy.BLOCK_CAUSAL,
+        logit_alignment=LogitAlignment.SHIFTED,
+        canvas_policy=CanvasPolicy.SEED_AND_MASK,
+        prompt_remainder_policy=(
+            PromptRemainderPolicy.INCLUDE_IN_FIRST_CANVAS),
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        sub_block_size=8,
+        supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
+    )
+
+
+def test_runtime_and_model_overrides_are_separate():
+    resolved = resolve_generation_strategy(
+        _vllm_config({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "block_size": 16,
+                "mask_token_id": 99,
+                "sub_block_size": 4,
+                "confidence_threshold": 0.75,
+                "temperature": 0.2,
+                "max_denoise_steps": 12,
+            },
+        }))
+
+    assert resolved.diffusion is not None
+    assert resolved.diffusion.model.block_size == 16
+    assert resolved.diffusion.model.sub_block_size == 4
+    assert resolved.diffusion.runtime.confidence_threshold == 0.75
+    assert resolved.diffusion.runtime.temperature == 0.2
+    assert resolved.diffusion.runtime.max_denoise_steps == 12
+
+
+def test_new_model_adapter_does_not_change_strategy_resolution():
+
+    def adapter(_hf_config, _values):
+        return DiffusionModelSpec(
+            name="test-model",
+            block_size=4,
+            mask_token_id=7,
+            attention_policy=AttentionPolicy.BLOCK_CAUSAL,
+            logit_alignment=LogitAlignment.SAME_POSITION,
+            canvas_policy=CanvasPolicy.ALL_MASKED,
+            prompt_remainder_policy=(
+                PromptRemainderPolicy.REQUIRE_BLOCK_ALIGNED),
+            next_block_policy=NextBlockPolicy.ALL_MASKED,
+            sub_block_size=4,
+            supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
+        )
+
+    register_diffusion_model_adapter("test-model", adapter)
+    resolved = resolve_generation_strategy(
+        _vllm_config({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "test-model"
+            },
+        }))
+
+    assert resolved.diffusion is not None
+    assert resolved.diffusion.model.name == "test-model"
+    assert resolved.diffusion.model.logit_alignment is LogitAlignment.SAME_POSITION
+
+
+@pytest.mark.parametrize(
+    "additional_config,match",
+    [
+        ({
+            "generation_strategy": "unknown"
+        }, "Unsupported generation_strategy"),
+        ({
+            "generation_strategy": "block_diffusion"
+        }, "model_adapter"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "missing"
+            },
+        }, "Unknown diffusion model_adapter"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "confidence_threshold": 2.0,
+            },
+        }, "confidence_threshold"),
+    ],
+)
+def test_invalid_configuration_fails_at_resolution(additional_config, match):
+    config = _vllm_config(additional_config, bd_size=32, mask_id=151669)
+
+    with pytest.raises(ValueError, match=match):
+        resolve_generation_strategy(config)
+
+
+def test_model_spec_rejects_incompatible_sub_block_size():
+    with pytest.raises(ValueError, match="divide block_size"):
+        DiffusionModelSpec(
+            name="invalid",
+            block_size=10,
+            mask_token_id=1,
+            attention_policy=AttentionPolicy.BLOCK_CAUSAL,
+            logit_alignment=LogitAlignment.SAME_POSITION,
+            canvas_policy=CanvasPolicy.ALL_MASKED,
+            prompt_remainder_policy=(
+                PromptRemainderPolicy.REQUIRE_BLOCK_ALIGNED),
+            next_block_policy=NextBlockPolicy.ALL_MASKED,
+            sub_block_size=4,
+            supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
+        )

--- a/tests/runner/test_diffusion_config.py
+++ b/tests/runner/test_diffusion_config.py
@@ -120,6 +120,64 @@ def test_runtime_and_model_overrides_are_separate():
     assert resolved.diffusion.runtime.temperature == 0.2
     assert resolved.diffusion.runtime.max_denoise_steps == 12
     assert resolved.diffusion.runtime.use_dual_cache is True
+    assert resolved.diffusion.runtime.trace_acceptance_steps is False
+    assert resolved.diffusion.runtime.fp32_partial_rpa is False
+    assert resolved.diffusion.runtime.q8_log_confidence_bias == 0.0
+
+
+def test_resolves_opt_in_dual_cache_acceptance_trace():
+    resolved = resolve_generation_strategy(
+        _vllm_config({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "block_size": 16,
+                "mask_token_id": 99,
+                "sub_block_size": 4,
+                "use_dual_cache": True,
+                "trace_acceptance_steps": True,
+            },
+        }))
+
+    assert resolved.diffusion is not None
+    assert resolved.diffusion.runtime.trace_acceptance_steps is True
+
+
+def test_resolves_opt_in_fp32_partial_rpa():
+    resolved = resolve_generation_strategy(
+        _vllm_config({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "block_size": 16,
+                "mask_token_id": 99,
+                "sub_block_size": 4,
+                "use_dual_cache": True,
+                "fp32_partial_rpa": True,
+            },
+        }))
+
+    assert resolved.diffusion is not None
+    assert resolved.diffusion.runtime.fp32_partial_rpa is True
+
+
+def test_resolves_opt_in_q8_log_confidence_bias():
+    resolved = resolve_generation_strategy(
+        _vllm_config({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "block_size": 16,
+                "mask_token_id": 99,
+                "sub_block_size": 4,
+                "confidence_threshold": 0.9,
+                "use_dual_cache": True,
+                "q8_log_confidence_bias": 0.05,
+            },
+        }))
+
+    assert resolved.diffusion is not None
+    assert resolved.diffusion.runtime.q8_log_confidence_bias == 0.05
 
 
 def test_new_model_adapter_does_not_change_strategy_resolution():
@@ -175,6 +233,51 @@ def test_new_model_adapter_does_not_change_strategy_resolution():
                 "confidence_threshold": 2.0,
             },
         }, "confidence_threshold"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "trace_acceptance_steps": True,
+            },
+        }, "requires use_dual_cache"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "fp32_partial_rpa": True,
+            },
+        }, "fp32_partial_rpa requires use_dual_cache"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "q8_log_confidence_bias": 0.05,
+            },
+        }, "q8_log_confidence_bias requires use_dual_cache"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "use_dual_cache": True,
+                "q8_log_confidence_bias": 0.51,
+            },
+        }, "must not exceed 0.5"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "use_dual_cache": True,
+                "q8_log_confidence_bias": -0.01,
+            },
+        }, "finite and non-negative"),
+        ({
+            "generation_strategy": "block_diffusion",
+            "diffusion": {
+                "model_adapter": "seeded_shifted",
+                "use_dual_cache": True,
+                "q8_log_confidence_bias": float("inf"),
+            },
+        }, "finite and non-negative"),
     ],
 )
 def test_invalid_configuration_fails_at_resolution(additional_config, match):

--- a/tests/runner/test_diffusion_config.py
+++ b/tests/runner/test_diffusion_config.py
@@ -197,3 +197,20 @@ def test_model_spec_rejects_incompatible_sub_block_size():
             sub_block_size=4,
             supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
         )
+
+
+def test_model_spec_rejects_shifted_all_masked_canvas():
+    with pytest.raises(ValueError, match="requires seed_and_mask"):
+        DiffusionModelSpec(
+            name="invalid",
+            block_size=4,
+            mask_token_id=7,
+            attention_policy=AttentionPolicy.BLOCK_CAUSAL,
+            logit_alignment=LogitAlignment.SHIFTED,
+            canvas_policy=CanvasPolicy.ALL_MASKED,
+            prompt_remainder_policy=(
+                PromptRemainderPolicy.REQUIRE_BLOCK_ALIGNED),
+            next_block_policy=NextBlockPolicy.ALL_MASKED,
+            sub_block_size=4,
+            supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
+        )

--- a/tests/runner/test_diffusion_kv_cache_replace.py
+++ b/tests/runner/test_diffusion_kv_cache_replace.py
@@ -1,0 +1,82 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+def _load_module():
+    path = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+            "layers" / "common" / "kv_cache_replace.py")
+    spec = importlib.util.spec_from_file_location("kv_cache_replace_under_test",
+                                                  path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+kv_cache_replace = _load_module()
+
+
+def test_replace_cached_kv_overwrites_only_requested_active_positions():
+    cache = jnp.zeros((4, 4, 2, 1, 2), dtype=jnp.float32)
+    keys = jnp.array([
+        [[1.0, 2.0]],
+        [[3.0, 4.0]],
+        [[50.0, 60.0]],
+        [[70.0, 80.0]],
+    ])
+    values = keys + 10.0
+
+    replace = jax.jit(kv_cache_replace.replace_cached_kv)
+    updated = replace(
+        cache,
+        keys,
+        values,
+        jnp.array([5, 6, 1, 2], dtype=jnp.int32),
+        jnp.array([[2, 1], [3, 0]], dtype=jnp.int32),
+        jnp.array([True, False]),
+    )
+
+    np.testing.assert_array_equal(updated[1, 1, 0, 0], [1.0, 2.0])
+    np.testing.assert_array_equal(updated[1, 1, 1, 0], [11.0, 12.0])
+    np.testing.assert_array_equal(updated[1, 2, 0, 0], [3.0, 4.0])
+    np.testing.assert_array_equal(updated[1, 2, 1, 0], [13.0, 14.0])
+    assert np.count_nonzero(np.asarray(updated[0])) == 0
+    assert np.count_nonzero(np.asarray(updated[2])) == 0
+    assert np.count_nonzero(np.asarray(updated[3])) == 0
+
+
+def test_replace_cached_kv_matches_bfloat16_head_packing():
+    cache = jnp.zeros((1, 4, 2, 2, 2), dtype=jnp.bfloat16)
+    keys = jnp.array([[[1, 2], [3, 4]]], dtype=jnp.bfloat16)
+    values = jnp.array([[[11, 12], [13, 14]]], dtype=jnp.bfloat16)
+
+    updated = kv_cache_replace.replace_cached_kv(
+        cache,
+        keys,
+        values,
+        jnp.array([2], dtype=jnp.int32),
+        jnp.array([[0]], dtype=jnp.int32),
+        jnp.array([True]),
+    )
+
+    np.testing.assert_array_equal(
+        updated[0, 2],
+        np.array([[[1, 2], [11, 12]], [[3, 4], [13, 14]]]),
+    )

--- a/tests/runner/test_diffusion_request_validation.py
+++ b/tests/runner/test_diffusion_request_validation.py
@@ -1,0 +1,81 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import pathlib
+import sys
+import types
+from types import SimpleNamespace
+
+import pytest
+
+
+def _load_validation_with_fake_vllm(monkeypatch):
+
+    class InputProcessor:
+
+        def __init__(self, additional_config):
+            self.vllm_config = SimpleNamespace(
+                additional_config=additional_config)
+
+        def process_inputs(self, *args, **kwargs):
+            return args, kwargs
+
+    modules = {
+        "vllm":
+        types.ModuleType("vllm"),
+        "vllm.v1":
+        types.ModuleType("vllm.v1"),
+        "vllm.v1.engine":
+        types.ModuleType("vllm.v1.engine"),
+        "vllm.v1.engine.input_processor":
+        types.ModuleType("vllm.v1.engine.input_processor"),
+    }
+    modules["vllm.v1.engine.input_processor"].InputProcessor = InputProcessor
+    for name, module in modules.items():
+        monkeypatch.setitem(sys.modules, name, module)
+
+    path = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+            "runner" / "diffusion" / "request_validation.py")
+    spec = importlib.util.spec_from_file_location(
+        "diffusion_request_validation_under_test", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module, InputProcessor
+
+
+def test_resumable_request_is_rejected_only_for_block_diffusion(monkeypatch):
+    validation, InputProcessor = _load_validation_with_fake_vllm(monkeypatch)
+    validation.patch_vllm_input_processor_for_block_diffusion()
+
+    autoregressive = InputProcessor({})
+    assert autoregressive.process_inputs(
+        resumable=True)[1]["resumable"] is True
+
+    diffusion = InputProcessor({"generation_strategy": "block_diffusion"})
+    assert diffusion.process_inputs(resumable=False)[1]["resumable"] is False
+    with pytest.raises(ValueError, match="resumable or streaming-input"):
+        diffusion.process_inputs(resumable=True)
+
+
+def test_resumable_positional_argument_and_patch_idempotence(monkeypatch):
+    validation, InputProcessor = _load_validation_with_fake_vllm(monkeypatch)
+    validation.patch_vllm_input_processor_for_block_diffusion()
+    validation.patch_vllm_input_processor_for_block_diffusion()
+    diffusion = InputProcessor({"generation_strategy": "block_diffusion"})
+
+    positional = tuple(range(10)) + (True, )
+    with pytest.raises(ValueError, match="resumable or streaming-input"):
+        diffusion.process_inputs(*positional)

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -1,0 +1,83 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import ast
+import pathlib
+
+RUNNER = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+          "runner" / "tpu_runner.py")
+STRATEGY = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
+            "runner" / "diffusion" / "strategy.py")
+
+
+def _method(name):
+    module = ast.parse(RUNNER.read_text())
+    runner_class = next(
+        node for node in module.body
+        if isinstance(node, ast.ClassDef) and node.name == "TPUModelRunner")
+    for node in runner_class.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"Method {name!r} not found")
+
+
+def _strategy_method(name):
+    module = ast.parse(STRATEGY.read_text())
+    strategy_class = next(node for node in module.body
+                          if isinstance(node, ast.ClassDef)
+                          and node.name == "BlockDiffusionStrategy")
+    for node in strategy_class.body:
+        if isinstance(node, ast.FunctionDef) and node.name == name:
+            return node
+    raise AssertionError(f"Strategy method {name!r} not found")
+
+
+def test_runner_resolves_generation_strategy_once_at_startup():
+    init_source = ast.unparse(_method("__init__"))
+
+    assert "resolve_generation_strategy(vllm_config)" in init_source
+    assert "BlockDiffusionStrategy" in init_source
+
+
+def test_diffusion_dispatch_precedes_autoregressive_phase_dispatch():
+    execute_source = ast.unparse(_method("_execute_model"))
+    diffusion_dispatch = execute_source.index(
+        "self.block_diffusion_strategy.execute(scheduler_output)")
+    autoregressive_dispatch = execute_source.index(
+        "self.enable_continue_decode")
+
+    assert diffusion_dispatch < autoregressive_dispatch
+
+
+def test_finished_requests_are_cleaned_before_empty_cycle_return():
+    execute_source = ast.unparse(_method("_execute_model"))
+    cleanup = execute_source.index("on_scheduler_update")
+    empty_cycle = execute_source.index(
+        "if not scheduler_output.total_num_scheduled_tokens")
+
+    assert cleanup < empty_cycle
+
+
+def test_diffusion_precompile_uses_the_runtime_mesh_context():
+    capture_source = ast.unparse(_method("capture_model"))
+
+    assert "with jax.set_mesh(self.mesh)" in capture_source
+    assert "self.block_diffusion_strategy.precompile()" in capture_source
+
+
+def test_diffusion_forward_uses_nested_jit_safe_model_callable():
+    forward_source = ast.unparse(_strategy_method("_model_forward"))
+
+    assert "runner.model_fn_no_options" in forward_source
+    assert "runner.model_fn(" not in forward_source

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -113,3 +113,14 @@ def test_diffusion_rejects_cache_reuse_and_transfer():
 
     assert "enable_prefix_caching" in validation_source
     assert "kv_transfer_config" in validation_source
+
+
+def test_diffusion_passes_request_eos_policy_into_denoising():
+    prefill_source = ast.unparse(_strategy_method("_process_prefill"))
+    decode_source = ast.unparse(_strategy_method("_process_decode"))
+    denoise_source = ast.unparse(_strategy_method("_denoise_blocks"))
+
+    assert "sampling_params.ignore_eos" in prefill_source
+    assert "sampling_params.ignore_eos" in decode_source
+    assert "stop_on_eos_rows" in denoise_source
+    assert "eos_token_ids" in denoise_source

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -104,3 +104,11 @@ def test_diffusion_uses_configured_capacity_and_partial_cache_metadata():
     assert "replace_cached_kv=True" in build_source
     assert "partial_query_start_loc" in build_source
     assert "diffusion_batch_sizes(self.batch_size)" in precompile_source
+
+
+def test_diffusion_rejects_cache_reuse_and_transfer():
+    validation_source = ast.unparse(
+        _strategy_method("_validate_runner_capabilities"))
+
+    assert "enable_prefix_caching" in validation_source
+    assert "kv_transfer_config" in validation_source

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -97,8 +97,10 @@ def test_dual_cache_has_distinct_full_partial_and_final_forwards():
 
 def test_diffusion_uses_configured_capacity_and_partial_cache_metadata():
     build_source = ast.unparse(_strategy_method("_build_batch"))
+    precompile_source = ast.unparse(_strategy_method("precompile"))
 
-    assert "batch_size = self.batch_size" in build_source
+    assert "select_diffusion_batch_size(num_active, capacity)" in build_source
     assert "batch_size = runner.max_num_reqs" not in build_source
     assert "replace_cached_kv=True" in build_source
     assert "partial_query_start_loc" in build_source
+    assert "diffusion_batch_sizes(self.batch_size)" in precompile_source

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -77,7 +77,28 @@ def test_diffusion_precompile_uses_the_runtime_mesh_context():
 
 
 def test_diffusion_forward_uses_nested_jit_safe_model_callable():
-    forward_source = ast.unparse(_strategy_method("_model_forward"))
+    forward_source = ast.unparse(_strategy_method("_run_model"))
 
     assert "runner.model_fn_no_options" in forward_source
     assert "runner.model_fn(" not in forward_source
+
+
+def test_dual_cache_has_distinct_full_partial_and_final_forwards():
+    denoise_source = ast.unparse(_strategy_method("_denoise_blocks"))
+    partial_source = ast.unparse(
+        _strategy_method("_model_forward_partial_subblock"))
+    final_source = ast.unparse(_strategy_method("_model_forward_final"))
+
+    assert "denoise_block_dual_cache" in denoise_source
+    assert "dynamic_slice" in partial_source
+    assert "sub_block_size" in partial_source
+    assert "[:, -1, :]" in final_source
+
+
+def test_diffusion_uses_configured_capacity_and_partial_cache_metadata():
+    build_source = ast.unparse(_strategy_method("_build_batch"))
+
+    assert "batch_size = self.batch_size" in build_source
+    assert "batch_size = runner.max_num_reqs" not in build_source
+    assert "replace_cached_kv=True" in build_source
+    assert "partial_query_start_loc" in build_source

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -95,6 +95,13 @@ def test_dual_cache_has_distinct_full_partial_and_final_forwards():
     assert "[:, -1, :]" in final_source
 
 
+def test_dual_cache_trace_separates_padding_and_straggler_waste():
+    denoise_source = ast.unparse(_strategy_method("_denoise_blocks"))
+
+    assert "padding_row_iterations" in denoise_source
+    assert "straggler_row_iterations" in denoise_source
+
+
 def test_diffusion_uses_configured_capacity_and_partial_cache_metadata():
     build_source = ast.unparse(_strategy_method("_build_batch"))
     precompile_source = ast.unparse(_strategy_method("precompile"))

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -103,6 +103,9 @@ def test_diffusion_uses_configured_capacity_and_partial_cache_metadata():
     assert "batch_size = runner.max_num_reqs" not in build_source
     assert "replace_cached_kv=True" in build_source
     assert "partial_query_start_loc" in build_source
+    assert "[0, num_active, num_active]" in build_source
+    assert "rpa_static_query_len=block_size" in build_source
+    assert "rpa_static_query_len=sub_block_size" in build_source
     assert "diffusion_batch_sizes(self.batch_size)" in precompile_source
 
 

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -103,9 +103,7 @@ def test_diffusion_uses_configured_capacity_and_partial_cache_metadata():
     assert "batch_size = runner.max_num_reqs" not in build_source
     assert "replace_cached_kv=True" in build_source
     assert "partial_query_start_loc" in build_source
-    assert "[0, num_active, num_active]" in build_source
-    assert "rpa_static_query_len=block_size" in build_source
-    assert "rpa_static_query_len=sub_block_size" in build_source
+    assert "[0, 0, num_active]" in build_source
     assert "diffusion_batch_sizes(self.batch_size)" in precompile_source
 
 

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -43,6 +43,12 @@ def _strategy_method(name):
     raise AssertionError(f"Strategy method {name!r} not found")
 
 
+def _module_function(name):
+    module = ast.parse(STRATEGY.read_text())
+    return next(node for node in module.body
+                if isinstance(node, ast.FunctionDef) and node.name == name)
+
+
 def test_runner_resolves_generation_strategy_once_at_startup():
     init_source = ast.unparse(_method("__init__"))
 
@@ -102,6 +108,31 @@ def test_dual_cache_trace_separates_padding_and_straggler_waste():
     assert "straggler_row_iterations" in denoise_source
 
 
+def test_dual_cache_acceptance_trace_is_opt_in_and_host_formatted():
+    init_source = ast.unparse(_strategy_method("__init__"))
+    denoise_source = ast.unparse(_strategy_method("_denoise_blocks"))
+    precompile_source = ast.unparse(_strategy_method("precompile"))
+    log_source = ast.unparse(
+        _module_function("_log_dual_cache_acceptance_trace"))
+    program_source = (STRATEGY.parent / "program.py").read_text()
+
+    assert "get_commit_diagnostics_algorithm" in init_source
+    assert "trace_acceptance_steps=self.config.runtime.trace_acceptance_steps" \
+        in denoise_source
+    assert "if self.config.runtime.trace_acceptance_steps" in denoise_source
+    assert "device_outputs += (output.acceptance_trace,)" in denoise_source
+    assert "trace_acceptance_steps=self.config.runtime.trace_acceptance_steps" \
+        in precompile_source
+    assert "q8_log_confidence_bias=self.config.runtime.q8_log_confidence_bias" \
+        in denoise_source
+    assert "q8_log_confidence_bias=self.config.runtime.q8_log_confidence_bias" \
+        in precompile_source
+    assert "row0_selected_log_confidence" in log_source
+    assert "row0_threshold_margin" in log_source
+    assert "json.dumps" in log_source
+    assert "debug.callback" not in program_source
+
+
 def test_diffusion_uses_configured_capacity_and_partial_cache_metadata():
     build_source = ast.unparse(_strategy_method("_build_batch"))
     precompile_source = ast.unparse(_strategy_method("precompile"))
@@ -109,6 +140,9 @@ def test_diffusion_uses_configured_capacity_and_partial_cache_metadata():
     assert "select_diffusion_batch_size(num_active, capacity)" in build_source
     assert "batch_size = runner.max_num_reqs" not in build_source
     assert "replace_cached_kv=True" in build_source
+    assert build_source.count("fp32_rpa_accumulator") == 1
+    assert "fp32_rpa_accumulator=self.config.runtime.fp32_partial_rpa" \
+        in build_source
     assert "partial_query_start_loc" in build_source
     assert "[0, 0, num_active]" in build_source
     assert "diffusion_batch_sizes(self.batch_size)" in precompile_source

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -19,6 +19,7 @@ RUNNER = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
           "runner" / "tpu_runner.py")
 STRATEGY = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
             "runner" / "diffusion" / "strategy.py")
+PROGRAM = STRATEGY.parent / "program.py"
 
 
 def _method(name):
@@ -47,6 +48,35 @@ def _module_function(name):
     module = ast.parse(STRATEGY.read_text())
     return next(node for node in module.body
                 if isinstance(node, ast.FunctionDef) and node.name == name)
+
+
+def _program_function(name):
+    module = ast.parse(PROGRAM.read_text())
+    return next(node for node in module.body
+                if isinstance(node, ast.FunctionDef) and node.name == name)
+
+
+def _calls(node, name):
+    return any(
+        isinstance(child, ast.Call) and isinstance(child.func, ast.Name)
+        and child.func.id == name for child in ast.walk(node))
+
+
+def _assert_donated_cache_is_immediately_replaced(method):
+    for node in ast.walk(method):
+        for _, value in ast.iter_fields(node):
+            if not isinstance(value, list):
+                continue
+            for index, statement in enumerate(value[:-1]):
+                if not isinstance(statement, ast.If) or not _calls(
+                        statement, "denoise_block_dual_cache"):
+                    continue
+                assert _calls(statement.body[-1], "denoise_block_dual_cache")
+                replacement = value[index + 1]
+                assert ast.unparse(
+                    replacement) == "self.runner.kv_caches = output.kv_caches"
+                return
+    raise AssertionError("dual-cache branch not found")
 
 
 def test_runner_resolves_generation_strategy_once_at_startup():
@@ -99,6 +129,27 @@ def test_dual_cache_has_distinct_full_partial_and_final_forwards():
     assert "dynamic_slice" in partial_source
     assert "sub_block_size" in partial_source
     assert "[:, -1, :]" in final_source
+
+
+def test_dual_cache_jit_donates_the_kv_cache_argument():
+    function = _program_function("_denoise_block_dual_cache_jit")
+    positional_args = [argument.arg for argument in function.args.args]
+    assert positional_args[9] == "kv_caches"
+
+    jit_decorator = next(
+        decorator for decorator in function.decorator_list
+        if isinstance(decorator, ast.Call) and ast.unparse(decorator.func) ==
+        "functools.partial" and ast.unparse(decorator.args[0]) == "jax.jit")
+    donate_argnums = next(keyword.value for keyword in jit_decorator.keywords
+                          if keyword.arg == "donate_argnums")
+    assert ast.literal_eval(donate_argnums) == (9, )
+
+
+def test_runtime_and_precompile_immediately_replace_donated_kv_cache():
+    _assert_donated_cache_is_immediately_replaced(
+        _strategy_method("_denoise_blocks"))
+    _assert_donated_cache_is_immediately_replaced(
+        _strategy_method("precompile"))
 
 
 def test_dual_cache_trace_separates_padding_and_straggler_waste():

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -127,6 +127,12 @@ def test_dual_cache_acceptance_trace_is_opt_in_and_host_formatted():
         in denoise_source
     assert "q8_log_confidence_bias=self.config.runtime.q8_log_confidence_bias" \
         in precompile_source
+    assert "force_q32_anchor_commit=self.config.runtime.force_q32_anchor_commit" \
+        in denoise_source
+    assert "force_q32_anchor_commit=self.config.runtime.force_q32_anchor_commit" \
+        in precompile_source
+    assert "forced_q32_anchor_commits" in denoise_source
+    assert "row0_forced_anchor" in log_source
     assert "row0_selected_log_confidence" in log_source
     assert "row0_threshold_margin" in log_source
     assert "json.dumps" in log_source

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -173,6 +173,20 @@ def test_diffusion_passes_request_eos_policy_into_denoising():
     assert "eos_token_ids" in denoise_source
 
 
+def test_final_block_candidate_trimming_is_opt_in_and_host_side():
+    prefill_source = ast.unparse(_strategy_method("_process_prefill"))
+    decode_source = ast.unparse(_strategy_method("_process_decode"))
+    denoise_source = ast.unparse(_strategy_method("_denoise_blocks"))
+    precompile_source = ast.unparse(_strategy_method("precompile"))
+
+    assert "self.config.runtime.trim_final_block_candidates" in prefill_source
+    assert "trim_generation_mask" in prefill_source
+    assert "self.config.runtime.trim_final_block_candidates" in decode_source
+    assert "trim_generation_mask" in decode_source
+    assert "trim_final_block_candidates" in denoise_source
+    assert "trim_generation_mask" not in precompile_source
+
+
 def test_prompt_prefill_is_one_block_causal_forward_per_length_group():
     build_source = ast.unparse(_strategy_method("_build_prompt_batch"))
     prefill_source = ast.unparse(_strategy_method("_process_prefill"))

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -20,6 +20,7 @@ RUNNER = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
 STRATEGY = (pathlib.Path(__file__).resolve().parents[2] / "tpu_inference" /
             "runner" / "diffusion" / "strategy.py")
 PROGRAM = STRATEGY.parent / "program.py"
+DECODE_LOOP = STRATEGY.parent.parent / "decode_loop.py"
 
 
 def _method(name):
@@ -54,6 +55,15 @@ def _program_function(name):
     module = ast.parse(PROGRAM.read_text())
     return next(node for node in module.body
                 if isinstance(node, ast.FunctionDef) and node.name == name)
+
+
+def _decorator_keyword(function, name):
+    jit_decorator = next(
+        decorator for decorator in function.decorator_list
+        if isinstance(decorator, ast.Call) and ast.unparse(decorator.func) ==
+        "functools.partial" and ast.unparse(decorator.args[0]) == "jax.jit")
+    return next(keyword.value for keyword in jit_decorator.keywords
+                if keyword.arg == name)
 
 
 def _calls(node, name):
@@ -136,13 +146,30 @@ def test_dual_cache_jit_donates_the_kv_cache_argument():
     positional_args = [argument.arg for argument in function.args.args]
     assert positional_args[9] == "kv_caches"
 
-    jit_decorator = next(
-        decorator for decorator in function.decorator_list
-        if isinstance(decorator, ast.Call) and ast.unparse(decorator.func) ==
-        "functools.partial" and ast.unparse(decorator.args[0]) == "jax.jit")
-    donate_argnums = next(keyword.value for keyword in jit_decorator.keywords
-                          if keyword.arg == "donate_argnums")
+    donate_argnums = _decorator_keyword(function, "donate_argnums")
     assert ast.literal_eval(donate_argnums) == (9, )
+
+
+def test_dual_cache_jit_uses_ar_collective_matmul_compiler_options():
+    function = _program_function("_denoise_block_dual_cache_jit")
+    compiler_options = ast.literal_eval(
+        _decorator_keyword(function, "compiler_options"))
+
+    decode_module = ast.parse(DECODE_LOOP.read_text())
+    decode_core = next(
+        node for node in decode_module.body
+        if isinstance(node, ast.FunctionDef) and node.name == "_decode_core")
+    ar_compiler_options = ast.literal_eval(
+        _decorator_keyword(decode_core, "compiler_options"))
+
+    expected_options = {
+        "xla_tpu_all_gather_collective_matmul_mode": "post_spmd_conservative",
+        "xla_tpu_reduce_scatter_collective_matmul_mode":
+        "post_spmd_conservative",
+        "xla_tpu_use_minor_sharding_for_major_trivial_input": "true",
+    }
+    assert compiler_options == expected_options
+    assert compiler_options == ar_compiler_options
 
 
 def test_runtime_and_precompile_immediately_replace_donated_kv_cache():

--- a/tests/runner/test_diffusion_strategy_wiring.py
+++ b/tests/runner/test_diffusion_strategy_wiring.py
@@ -124,3 +124,15 @@ def test_diffusion_passes_request_eos_policy_into_denoising():
     assert "sampling_params.ignore_eos" in decode_source
     assert "stop_on_eos_rows" in denoise_source
     assert "eos_token_ids" in denoise_source
+
+
+def test_prompt_prefill_is_one_block_causal_forward_per_length_group():
+    build_source = ast.unparse(_strategy_method("_build_prompt_batch"))
+    prefill_source = ast.unparse(_strategy_method("_process_prefill"))
+
+    assert "AttentionMaskKind.BLOCK_CAUSAL" in build_source
+    assert "rpa_static_query_len=sequence_length" in build_source
+    assert "request_distribution = np.array([0, num_active, num_active]" in \
+        build_source
+    assert "_forward_prompt_blocks(group, prompts)" in prefill_source
+    assert "for block_index in range" not in prefill_source

--- a/tpu_inference/core/diffusion_dp_router.py
+++ b/tpu_inference/core/diffusion_dp_router.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import annotations
+
+import inspect
+from typing import Any
+
+from tpu_inference.runner.diffusion.config import (GenerationStrategy,
+                                                   resolve_generation_strategy)
+
+_PATCH_MARKER = "_tpu_diffusion_round_robin_dp"
+_EXPECTED_CLIENT_INIT_PARAMETERS = (
+    "self",
+    "vllm_config",
+    "executor_class",
+    "log_stats",
+    "client_addresses",
+    "client_count",
+    "client_index",
+)
+_EXPECTED_ROUTER_PARAMETERS = ("self", "request")
+_EXPECTED_FACTORY_PARAMETERS = (
+    "vllm_config",
+    "executor_class",
+    "log_stats",
+    "client_addresses",
+    "client_count",
+    "client_index",
+)
+
+
+def _require_parameters(callable_obj: Any, expected: tuple[str, ...],
+                        name: str) -> None:
+    actual = tuple(inspect.signature(callable_obj).parameters)
+    if actual != expected:
+        raise RuntimeError(
+            f"Unsupported vLLM {name} signature: expected {expected}, got "
+            f"{actual}")
+
+
+def _round_robin_enabled(vllm_config: Any) -> bool:
+    generation_strategy = resolve_generation_strategy(vllm_config)
+    if generation_strategy.strategy is not GenerationStrategy.BLOCK_DIFFUSION:
+        return False
+    assert generation_strategy.diffusion is not None
+    return generation_strategy.diffusion.runtime.cohort_round_robin_dp
+
+
+def patch_vllm_dp_client_for_block_diffusion_round_robin() -> None:
+    """Patch vLLM's DP client with opt-in cohort-block round robin."""
+    from vllm.v1.engine import core_client
+    from vllm.v1.pool.late_interaction import \
+        get_late_interaction_engine_index
+
+    original_client = core_client.DPLBAsyncMPClient
+    if getattr(original_client, _PATCH_MARKER, False):
+        return
+
+    _require_parameters(original_client.__init__,
+                        _EXPECTED_CLIENT_INIT_PARAMETERS,
+                        "DPLBAsyncMPClient.__init__")
+    _require_parameters(original_client.get_core_engine_for_request,
+                        _EXPECTED_ROUTER_PARAMETERS,
+                        "DPLBAsyncMPClient.get_core_engine_for_request")
+    factory = core_client.EngineCoreClient.make_async_mp_client
+    _require_parameters(factory, _EXPECTED_FACTORY_PARAMETERS,
+                        "EngineCoreClient.make_async_mp_client")
+    factory_impl = inspect.unwrap(factory)
+    if factory_impl.__globals__.get(
+            "DPLBAsyncMPClient") is not original_client:
+        raise RuntimeError(
+            "Unsupported vLLM DP client factory: DPLBAsyncMPClient is not "
+            "resolved from the core_client module")
+
+    class CohortRoundRobinDPLBAsyncMPClient(original_client):
+        _tpu_diffusion_round_robin_dp = True
+
+        def __init__(
+            self,
+            vllm_config: Any,
+            executor_class: Any,
+            log_stats: bool,
+            client_addresses: dict[str, str] | None = None,
+            client_count: int = 1,
+            client_index: int = 0,
+        ) -> None:
+            round_robin_enabled = _round_robin_enabled(vllm_config)
+            if round_robin_enabled and client_count != 1:
+                raise ValueError(
+                    "diffusion cohort_round_robin_dp requires client_count=1")
+            cohort_size = 0
+            if round_robin_enabled:
+                cohort_size = vllm_config.scheduler_config.max_num_seqs
+                if type(cohort_size) is not int or cohort_size < 1:
+                    raise ValueError(
+                        "diffusion cohort_round_robin_dp requires positive "
+                        "scheduler_config.max_num_seqs")
+            super().__init__(
+                vllm_config,
+                executor_class,
+                log_stats,
+                client_addresses,
+                client_count,
+                client_index,
+            )
+            self._cohort_round_robin_dp_enabled = round_robin_enabled
+            self._cohort_round_robin_dp_cohort_size = cohort_size
+            self._cohort_round_robin_dp_next_engine_index = \
+                self.eng_start_index
+            self._cohort_round_robin_dp_active_engine_index = None
+            self._cohort_round_robin_dp_requests_in_cohort = 0
+
+        def _start_next_cohort(self) -> int:
+            num_engines = len(self.core_engines)
+            start_index = (self._cohort_round_robin_dp_next_engine_index %
+                           num_engines)
+            engine_indexes = {
+                engine: index
+                for index, engine in enumerate(self.core_engines)
+            }
+            in_flight_counts = [0] * num_engines
+            for engine in self.reqs_in_flight.values():
+                engine_index = engine_indexes.get(engine)
+                if engine_index is not None:
+                    in_flight_counts[engine_index] += 1
+            engine_index = min(
+                ((start_index + offset) % num_engines
+                 for offset in range(num_engines)),
+                key=lambda index: (in_flight_counts[index],
+                                   (index - start_index) % num_engines),
+            )
+            self._cohort_round_robin_dp_active_engine_index = engine_index
+            self._cohort_round_robin_dp_next_engine_index = (engine_index +
+                                                             1) % num_engines
+            return engine_index
+
+        def get_core_engine_for_request(self, request: Any) -> Any:
+            if not self._cohort_round_robin_dp_enabled:
+                return super().get_core_engine_for_request(request)
+            if request.data_parallel_rank is not None:
+                return super().get_core_engine_for_request(request)
+            if get_late_interaction_engine_index(
+                    request.pooling_params,
+                    len(self.core_engines)) is not None:
+                return super().get_core_engine_for_request(request)
+            existing_engine = self.reqs_in_flight.get(request.request_id)
+            if existing_engine is not None:
+                return existing_engine
+
+            if self._cohort_round_robin_dp_requests_in_cohort == 0:
+                engine_index = self._start_next_cohort()
+            else:
+                engine_index = self._cohort_round_robin_dp_active_engine_index
+                assert engine_index is not None
+            self._cohort_round_robin_dp_requests_in_cohort += 1
+            if (self._cohort_round_robin_dp_requests_in_cohort
+                    >= self._cohort_round_robin_dp_cohort_size):
+                self._cohort_round_robin_dp_requests_in_cohort = 0
+                self._cohort_round_robin_dp_active_engine_index = None
+            self.lb_engines[engine_index][0] += 1
+            chosen_engine = self.core_engines[engine_index]
+            self.reqs_in_flight[request.request_id] = chosen_engine
+            return chosen_engine
+
+    core_client.DPLBAsyncMPClient = CohortRoundRobinDPLBAsyncMPClient

--- a/tpu_inference/core/diffusion_dp_router.py
+++ b/tpu_inference/core/diffusion_dp_router.py
@@ -31,6 +31,8 @@ _EXPECTED_CLIENT_INIT_PARAMETERS = (
     "client_index",
 )
 _EXPECTED_ROUTER_PARAMETERS = ("self", "request")
+_EXPECTED_OUTPUT_HANDLER_PARAMETERS = ("self", "outputs")
+_EXPECTED_ABORT_PARAMETERS = ("self", "request_ids")
 _EXPECTED_FACTORY_PARAMETERS = (
     "vllm_config",
     "executor_class",
@@ -74,6 +76,12 @@ def patch_vllm_dp_client_for_block_diffusion_round_robin() -> None:
     _require_parameters(original_client.get_core_engine_for_request,
                         _EXPECTED_ROUTER_PARAMETERS,
                         "DPLBAsyncMPClient.get_core_engine_for_request")
+    _require_parameters(original_client.process_engine_outputs,
+                        _EXPECTED_OUTPUT_HANDLER_PARAMETERS,
+                        "DPLBAsyncMPClient.process_engine_outputs")
+    _require_parameters(original_client.abort_requests_async,
+                        _EXPECTED_ABORT_PARAMETERS,
+                        "DPLBAsyncMPClient.abort_requests_async")
     factory = core_client.EngineCoreClient.make_async_mp_client
     _require_parameters(factory, _EXPECTED_FACTORY_PARAMETERS,
                         "EngineCoreClient.make_async_mp_client")
@@ -107,6 +115,12 @@ def patch_vllm_dp_client_for_block_diffusion_round_robin() -> None:
                     raise ValueError(
                         "diffusion cohort_round_robin_dp requires positive "
                         "scheduler_config.max_num_seqs")
+            self._cohort_round_robin_dp_enabled = round_robin_enabled
+            self._cohort_round_robin_dp_cohort_size = cohort_size
+            self._cohort_round_robin_dp_active_engine_index = None
+            self._cohort_round_robin_dp_requests_in_cohort = 0
+            self._cohort_round_robin_dp_active_request_ids: set[str] = set()
+            self._cohort_round_robin_dp_epoch = 0
             super().__init__(
                 vllm_config,
                 executor_class,
@@ -115,14 +129,24 @@ def patch_vllm_dp_client_for_block_diffusion_round_robin() -> None:
                 client_count,
                 client_index,
             )
-            self._cohort_round_robin_dp_enabled = round_robin_enabled
-            self._cohort_round_robin_dp_cohort_size = cohort_size
             self._cohort_round_robin_dp_next_engine_index = \
                 self.eng_start_index
-            self._cohort_round_robin_dp_active_engine_index = None
-            self._cohort_round_robin_dp_requests_in_cohort = 0
+
+        def _finish_partial_cohort_requests(
+            self,
+            request_ids: tuple[str, ...],
+        ) -> None:
+            if (not self._cohort_round_robin_dp_enabled
+                    or not self._cohort_round_robin_dp_active_request_ids):
+                return
+            self._cohort_round_robin_dp_active_request_ids.difference_update(
+                request_ids)
+            if not self._cohort_round_robin_dp_active_request_ids:
+                self._cohort_round_robin_dp_requests_in_cohort = 0
+                self._cohort_round_robin_dp_active_engine_index = None
 
         def _start_next_cohort(self) -> int:
+            self._cohort_round_robin_dp_epoch += 1
             num_engines = len(self.core_engines)
             start_index = (self._cohort_round_robin_dp_next_engine_index %
                            num_engines)
@@ -165,13 +189,38 @@ def patch_vllm_dp_client_for_block_diffusion_round_robin() -> None:
                 engine_index = self._cohort_round_robin_dp_active_engine_index
                 assert engine_index is not None
             self._cohort_round_robin_dp_requests_in_cohort += 1
+            self._cohort_round_robin_dp_active_request_ids.add(
+                request.request_id)
             if (self._cohort_round_robin_dp_requests_in_cohort
                     >= self._cohort_round_robin_dp_cohort_size):
                 self._cohort_round_robin_dp_requests_in_cohort = 0
                 self._cohort_round_robin_dp_active_engine_index = None
+                self._cohort_round_robin_dp_active_request_ids.clear()
             self.lb_engines[engine_index][0] += 1
             chosen_engine = self.core_engines[engine_index]
             self.reqs_in_flight[request.request_id] = chosen_engine
             return chosen_engine
+
+        @staticmethod
+        async def process_engine_outputs(self: Any, outputs: Any) -> None:
+            cohort_epoch = self._cohort_round_robin_dp_epoch
+            finished_request_ids = tuple(outputs.finished_requests or ())
+            await original_client.process_engine_outputs(self, outputs)
+            if (self._cohort_round_robin_dp_enabled
+                    and self._cohort_round_robin_dp_epoch == cohort_epoch):
+                self._finish_partial_cohort_requests(finished_request_ids)
+
+        async def abort_requests_async(self, request_ids: list[str]) -> None:
+            if not self._cohort_round_robin_dp_enabled:
+                await super().abort_requests_async(request_ids)
+                return
+            cohort_epoch = self._cohort_round_robin_dp_epoch
+            tracked_request_ids = tuple(
+                request_id for request_id in request_ids
+                if request_id in self.reqs_in_flight and request_id in
+                self._cohort_round_robin_dp_active_request_ids)
+            await super().abort_requests_async(request_ids)
+            if self._cohort_round_robin_dp_epoch == cohort_epoch:
+                self._finish_partial_cohort_requests(tracked_request_ids)
 
     core_client.DPLBAsyncMPClient = CohortRoundRobinDPLBAsyncMPClient

--- a/tpu_inference/core/sched/diffusion_cohort_scheduler.py
+++ b/tpu_inference/core/sched/diffusion_cohort_scheduler.py
@@ -131,6 +131,8 @@ class BlockDiffusionCohortScheduler(Scheduler):
         max_wait_ms = generation_strategy.diffusion.runtime.cohort_max_wait_ms
         quiet_wait_ms = (
             generation_strategy.diffusion.runtime.cohort_quiet_wait_ms)
+        self._strict_waves = (
+            generation_strategy.diffusion.runtime.cohort_strict_waves)
         if max_wait_ms <= 0.0:
             raise ValueError(
                 "BlockDiffusionCohortScheduler requires positive cohort_max_wait_ms"
@@ -143,6 +145,9 @@ class BlockDiffusionCohortScheduler(Scheduler):
         self._cohort_request_ids: set[str] = set()
 
     def add_request(self, request: Request) -> None:
+        if request.request_id in self.requests:
+            super().add_request(request)
+            return
         if request.request_id in self._cohort_request_ids:
             raise ValueError(
                 f"Request {request.request_id!r} is already awaiting admission"
@@ -151,16 +156,18 @@ class BlockDiffusionCohortScheduler(Scheduler):
         self._cohort_request_ids.add(request.request_id)
 
     def schedule(self, *args: Any, **kwargs: Any) -> SchedulerOutput:
-        for request in self._cohort.drain_ready():
-            self._cohort_request_ids.remove(request.request_id)
-            super().add_request(request)
+        base_is_idle = super().get_num_unfinished_requests() == 0
+        if not self._strict_waves or base_is_idle:
+            for request in self._cohort.drain_ready():
+                self._cohort_request_ids.remove(request.request_id)
+                super().add_request(request)
         return super().schedule(*args, **kwargs)
 
     def finish_requests(
         self,
         request_ids: str | Iterable[str] | None,
         finished_status: RequestStatus,
-    ) -> None:
+    ) -> list[tuple[str, int]]:
         if request_ids is None:
             normalized_ids = list(self._cohort_request_ids)
             normalized_ids.extend(self.requests)
@@ -172,15 +179,23 @@ class BlockDiffusionCohortScheduler(Scheduler):
             lambda request: request.request_id in request_id_set)
         discarded_ids = {request.request_id for request in discarded}
         self._cohort_request_ids.difference_update(discarded_ids)
+        finished_requests = [(request.request_id, request.client_index)
+                             for request in discarded]
         admitted_ids = [
             request_id for request_id in normalized_ids
             if request_id not in discarded_ids
         ]
         if admitted_ids:
-            super().finish_requests(admitted_ids, finished_status)
+            finished_requests.extend(super().finish_requests(
+                admitted_ids, finished_status))
+        return finished_requests
 
     def get_num_unfinished_requests(self) -> int:
         return super().get_num_unfinished_requests() + len(self._cohort)
+
+    def get_request_counts(self) -> tuple[int, int]:
+        running, waiting = super().get_request_counts()
+        return running, waiting + len(self._cohort)
 
     def has_unfinished_requests(self) -> bool:
         return bool(self._cohort) or super().has_unfinished_requests()

--- a/tpu_inference/core/sched/diffusion_cohort_scheduler.py
+++ b/tpu_inference/core/sched/diffusion_cohort_scheduler.py
@@ -21,6 +21,7 @@ from typing import Any, Generic, TypeVar
 
 from vllm.config import VllmConfig
 from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
+from vllm.v1.core.sched.interface import PauseState
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.core.sched.scheduler import Scheduler
 from vllm.v1.kv_cache_interface import KVCacheConfig
@@ -186,10 +187,11 @@ class BlockDiffusionCohortScheduler(Scheduler):
         self._cohort_request_ids.add(request.request_id)
 
     def schedule(self, *args: Any, **kwargs: Any) -> SchedulerOutput:
-        base_is_idle = super().get_num_unfinished_requests() == 0
-        if self._strict_waves:
+        base_is_idle = super().get_request_counts() == (0, 0)
+        is_unpaused = self.pause_state == PauseState.UNPAUSED
+        if self._strict_waves and is_unpaused:
             self._update_full_refill_window(base_is_idle, self._clock())
-        if not self._strict_waves or base_is_idle:
+        if is_unpaused and (not self._strict_waves or base_is_idle):
             wait_for_full_refill = (self._strict_waves
                                     and self._last_admitted_cohort_was_full)
             cohort = self._cohort.drain_ready(
@@ -205,9 +207,9 @@ class BlockDiffusionCohortScheduler(Scheduler):
 
     def update_from_output(self, *args: Any, **kwargs: Any) -> Any:
         outputs = super().update_from_output(*args, **kwargs)
-        if self._strict_waves:
+        if self._strict_waves and self.pause_state == PauseState.UNPAUSED:
             self._update_full_refill_window(
-                super().get_num_unfinished_requests() == 0, self._clock())
+                super().get_request_counts() == (0, 0), self._clock())
         return outputs
 
     def finish_requests(
@@ -215,6 +217,8 @@ class BlockDiffusionCohortScheduler(Scheduler):
         request_ids: str | Iterable[str] | None,
         finished_status: RequestStatus,
     ) -> list[tuple[str, int]]:
+        assert RequestStatus.is_finished(finished_status)
+        publish_finished = request_ids is not None
         if request_ids is None:
             normalized_ids = list(self._cohort_request_ids)
             normalized_ids.extend(self.requests)
@@ -226,8 +230,18 @@ class BlockDiffusionCohortScheduler(Scheduler):
             lambda request: request.request_id in request_id_set)
         discarded_ids = {request.request_id for request in discarded}
         self._cohort_request_ids.difference_update(discarded_ids)
-        finished_requests = [(request.request_id, request.client_index)
-                             for request in discarded]
+        finished_requests = []
+        for request in discarded:
+            if request.is_finished():
+                continue
+            request.status = finished_status
+            finished_requests.append(
+                (request.request_id, request.client_index))
+            if publish_finished:
+                self.finished_req_ids.add(request.request_id)
+                if self.finished_req_ids_dict is not None:
+                    self.finished_req_ids_dict[request.client_index].add(
+                        request.request_id)
         admitted_ids = [
             request_id for request_id in normalized_ids
             if request_id not in discarded_ids
@@ -238,17 +252,25 @@ class BlockDiffusionCohortScheduler(Scheduler):
         if request_ids is None:
             self._last_admitted_cohort_was_full = False
             self._full_refill_deadline = None
-        elif self._strict_waves:
+        elif (self._strict_waves and self.pause_state == PauseState.UNPAUSED):
             self._update_full_refill_window(
-                super().get_num_unfinished_requests() == 0, self._clock())
+                super().get_request_counts() == (0, 0), self._clock())
         return finished_requests
 
     def get_num_unfinished_requests(self) -> int:
-        return super().get_num_unfinished_requests() + len(self._cohort)
+        base_unfinished = super().get_num_unfinished_requests()
+        if self.pause_state == PauseState.UNPAUSED:
+            return base_unfinished + len(self._cohort)
+        return base_unfinished
 
     def get_request_counts(self) -> tuple[int, int]:
         running, waiting = super().get_request_counts()
         return running, waiting + len(self._cohort)
 
     def has_unfinished_requests(self) -> bool:
-        return bool(self._cohort) or super().has_unfinished_requests()
+        return self.get_num_unfinished_requests() > 0
+
+    def set_pause_state(self, pause_state: PauseState) -> None:
+        if pause_state != PauseState.UNPAUSED:
+            self._full_refill_deadline = None
+        super().set_pause_state(pause_state)

--- a/tpu_inference/core/sched/diffusion_cohort_scheduler.py
+++ b/tpu_inference/core/sched/diffusion_cohort_scheduler.py
@@ -1,0 +1,171 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import inspect
+import math
+from collections import deque
+from collections.abc import Callable, Iterable
+from time import monotonic
+from typing import Any, Generic, TypeVar
+
+from vllm.config import VllmConfig
+from vllm.multimodal import MULTIMODAL_REGISTRY, MultiModalRegistry
+from vllm.v1.core.sched.output import SchedulerOutput
+from vllm.v1.core.sched.scheduler import Scheduler
+from vllm.v1.kv_cache_interface import KVCacheConfig
+from vllm.v1.request import Request, RequestStatus
+from vllm.v1.structured_output import StructuredOutputManager
+
+from tpu_inference.runner.diffusion.config import resolve_generation_strategy
+
+_ItemT = TypeVar("_ItemT")
+
+
+class CohortAdmissionQueue(Generic[_ItemT]):
+
+    def __init__(
+        self,
+        max_size: int,
+        max_wait_ms: float,
+        clock: Callable[[], float] | None = None,
+    ) -> None:
+        if max_size < 1:
+            raise ValueError("Cohort max_size must be positive")
+        if not math.isfinite(max_wait_ms) or max_wait_ms <= 0.0:
+            raise ValueError("Cohort max_wait_ms must be finite and positive")
+        self.max_size = max_size
+        self.max_wait_seconds = max_wait_ms / 1000.0
+        self._clock = monotonic if clock is None else clock
+        self._pending: deque[tuple[_ItemT, float]] = deque()
+
+    def __len__(self) -> int:
+        return len(self._pending)
+
+    @property
+    def deadline(self) -> float | None:
+        if not self._pending:
+            return None
+        return self._pending[0][1] + self.max_wait_seconds
+
+    def add(self, item: _ItemT) -> None:
+        self._pending.append((item, self._clock()))
+
+    def is_ready(self, now: float | None = None) -> bool:
+        if not self._pending:
+            return False
+        if len(self._pending) >= self.max_size:
+            return True
+        deadline = self.deadline
+        assert deadline is not None
+        return (self._clock() if now is None else now) >= deadline
+
+    def drain_ready(self, now: float | None = None) -> list[_ItemT]:
+        if not self.is_ready(now):
+            return []
+        cohort_size = min(len(self._pending), self.max_size)
+        return [self._pending.popleft()[0] for _ in range(cohort_size)]
+
+    def discard(self, predicate: Callable[[_ItemT], bool]) -> list[_ItemT]:
+        retained: deque[tuple[_ItemT, float]] = deque()
+        discarded = []
+        while self._pending:
+            item = self._pending.popleft()
+            if predicate(item[0]):
+                discarded.append(item[0])
+            else:
+                retained.append(item)
+        self._pending = retained
+        return discarded
+
+
+class BlockDiffusionCohortScheduler(Scheduler):
+
+    def __init__(
+        self,
+        vllm_config: VllmConfig,
+        kv_cache_config: KVCacheConfig,
+        structured_output_manager: StructuredOutputManager,
+        block_size: int,
+        hash_block_size: int | None = None,
+        mm_registry: MultiModalRegistry = MULTIMODAL_REGISTRY,
+        include_finished_set: bool = False,
+        log_stats: bool = False,
+    ) -> None:
+        scheduler_kwargs = dict(
+            vllm_config=vllm_config,
+            kv_cache_config=kv_cache_config,
+            structured_output_manager=structured_output_manager,
+            block_size=block_size,
+            mm_registry=mm_registry,
+            include_finished_set=include_finished_set,
+            log_stats=log_stats,
+        )
+        if "hash_block_size" in inspect.signature(Scheduler).parameters:
+            scheduler_kwargs["hash_block_size"] = hash_block_size
+        super().__init__(**scheduler_kwargs)
+        generation_strategy = resolve_generation_strategy(vllm_config)
+        assert generation_strategy.diffusion is not None
+        max_wait_ms = generation_strategy.diffusion.runtime.cohort_max_wait_ms
+        if max_wait_ms <= 0.0:
+            raise ValueError(
+                "BlockDiffusionCohortScheduler requires positive cohort_max_wait_ms"
+            )
+        self._cohort = CohortAdmissionQueue[Request](
+            max_size=vllm_config.scheduler_config.max_num_seqs,
+            max_wait_ms=max_wait_ms,
+        )
+        self._cohort_request_ids: set[str] = set()
+
+    def add_request(self, request: Request) -> None:
+        if request.request_id in self._cohort_request_ids:
+            raise ValueError(
+                f"Request {request.request_id!r} is already awaiting admission"
+            )
+        self._cohort.add(request)
+        self._cohort_request_ids.add(request.request_id)
+
+    def schedule(self, *args: Any, **kwargs: Any) -> SchedulerOutput:
+        for request in self._cohort.drain_ready():
+            self._cohort_request_ids.remove(request.request_id)
+            super().add_request(request)
+        return super().schedule(*args, **kwargs)
+
+    def finish_requests(
+        self,
+        request_ids: str | Iterable[str] | None,
+        finished_status: RequestStatus,
+    ) -> None:
+        if request_ids is None:
+            normalized_ids = list(self._cohort_request_ids)
+            normalized_ids.extend(self.requests)
+        else:
+            normalized_ids = ([request_ids] if isinstance(request_ids, str)
+                              else list(request_ids))
+        request_id_set = set(normalized_ids)
+        discarded = self._cohort.discard(
+            lambda request: request.request_id in request_id_set)
+        discarded_ids = {request.request_id for request in discarded}
+        self._cohort_request_ids.difference_update(discarded_ids)
+        admitted_ids = [
+            request_id for request_id in normalized_ids
+            if request_id not in discarded_ids
+        ]
+        if admitted_ids:
+            super().finish_requests(admitted_ids, finished_status)
+
+    def get_num_unfinished_requests(self) -> int:
+        return super().get_num_unfinished_requests() + len(self._cohort)
+
+    def has_unfinished_requests(self) -> bool:
+        return bool(self._cohort) or super().has_unfinished_requests()

--- a/tpu_inference/core/sched/diffusion_cohort_scheduler.py
+++ b/tpu_inference/core/sched/diffusion_cohort_scheduler.py
@@ -61,10 +61,16 @@ class CohortAdmissionQueue(Generic[_ItemT]):
         return len(self._pending)
 
     @property
-    def deadline(self) -> float | None:
+    def hard_deadline(self) -> float | None:
         if not self._pending:
             return None
-        deadline = self._pending[0][1] + self.max_wait_seconds
+        return self._pending[0][1] + self.max_wait_seconds
+
+    @property
+    def deadline(self) -> float | None:
+        deadline = self.hard_deadline
+        if deadline is None:
+            return None
         if self.quiet_wait_seconds:
             deadline = min(deadline,
                            self._pending[-1][1] + self.quiet_wait_seconds)
@@ -73,17 +79,27 @@ class CohortAdmissionQueue(Generic[_ItemT]):
     def add(self, item: _ItemT) -> None:
         self._pending.append((item, self._clock()))
 
-    def is_ready(self, now: float | None = None) -> bool:
+    def is_ready(
+        self,
+        now: float | None = None,
+        *,
+        ignore_quiet_wait: bool = False,
+    ) -> bool:
         if not self._pending:
             return False
         if len(self._pending) >= self.max_size:
             return True
-        deadline = self.deadline
+        deadline = self.hard_deadline if ignore_quiet_wait else self.deadline
         assert deadline is not None
         return (self._clock() if now is None else now) >= deadline
 
-    def drain_ready(self, now: float | None = None) -> list[_ItemT]:
-        if not self.is_ready(now):
+    def drain_ready(
+        self,
+        now: float | None = None,
+        *,
+        ignore_quiet_wait: bool = False,
+    ) -> list[_ItemT]:
+        if not self.is_ready(now, ignore_quiet_wait=ignore_quiet_wait):
             return []
         cohort_size = min(len(self._pending), self.max_size)
         return [self._pending.popleft()[0] for _ in range(cohort_size)]
@@ -143,6 +159,20 @@ class BlockDiffusionCohortScheduler(Scheduler):
             quiet_wait_ms=quiet_wait_ms,
         )
         self._cohort_request_ids: set[str] = set()
+        self._last_admitted_cohort_was_full = False
+        self._full_refill_deadline: float | None = None
+        self._clock = monotonic
+
+    def _update_full_refill_window(self, base_is_idle: bool,
+                                   now: float) -> None:
+        if (not self._strict_waves or not self._last_admitted_cohort_was_full
+                or not base_is_idle):
+            return
+        if self._full_refill_deadline is None:
+            self._full_refill_deadline = (now + self._cohort.max_wait_seconds)
+        elif now >= self._full_refill_deadline:
+            self._last_admitted_cohort_was_full = False
+            self._full_refill_deadline = None
 
     def add_request(self, request: Request) -> None:
         if request.request_id in self.requests:
@@ -157,11 +187,28 @@ class BlockDiffusionCohortScheduler(Scheduler):
 
     def schedule(self, *args: Any, **kwargs: Any) -> SchedulerOutput:
         base_is_idle = super().get_num_unfinished_requests() == 0
+        if self._strict_waves:
+            self._update_full_refill_window(base_is_idle, self._clock())
         if not self._strict_waves or base_is_idle:
-            for request in self._cohort.drain_ready():
+            wait_for_full_refill = (self._strict_waves
+                                    and self._last_admitted_cohort_was_full)
+            cohort = self._cohort.drain_ready(
+                ignore_quiet_wait=wait_for_full_refill)
+            if cohort:
+                self._last_admitted_cohort_was_full = (
+                    len(cohort) == self._cohort.max_size)
+                self._full_refill_deadline = None
+            for request in cohort:
                 self._cohort_request_ids.remove(request.request_id)
                 super().add_request(request)
         return super().schedule(*args, **kwargs)
+
+    def update_from_output(self, *args: Any, **kwargs: Any) -> Any:
+        outputs = super().update_from_output(*args, **kwargs)
+        if self._strict_waves:
+            self._update_full_refill_window(
+                super().get_num_unfinished_requests() == 0, self._clock())
+        return outputs
 
     def finish_requests(
         self,
@@ -188,6 +235,12 @@ class BlockDiffusionCohortScheduler(Scheduler):
         if admitted_ids:
             finished_requests.extend(super().finish_requests(
                 admitted_ids, finished_status))
+        if request_ids is None:
+            self._last_admitted_cohort_was_full = False
+            self._full_refill_deadline = None
+        elif self._strict_waves:
+            self._update_full_refill_window(
+                super().get_num_unfinished_requests() == 0, self._clock())
         return finished_requests
 
     def get_num_unfinished_requests(self) -> int:

--- a/tpu_inference/core/sched/diffusion_cohort_scheduler.py
+++ b/tpu_inference/core/sched/diffusion_cohort_scheduler.py
@@ -38,14 +38,22 @@ class CohortAdmissionQueue(Generic[_ItemT]):
         self,
         max_size: int,
         max_wait_ms: float,
+        quiet_wait_ms: float = 0.0,
         clock: Callable[[], float] | None = None,
     ) -> None:
         if max_size < 1:
             raise ValueError("Cohort max_size must be positive")
         if not math.isfinite(max_wait_ms) or max_wait_ms <= 0.0:
             raise ValueError("Cohort max_wait_ms must be finite and positive")
+        if not math.isfinite(quiet_wait_ms) or quiet_wait_ms < 0.0:
+            raise ValueError(
+                "Cohort quiet_wait_ms must be finite and non-negative")
+        if quiet_wait_ms > max_wait_ms:
+            raise ValueError(
+                "Cohort quiet_wait_ms must not exceed max_wait_ms")
         self.max_size = max_size
         self.max_wait_seconds = max_wait_ms / 1000.0
+        self.quiet_wait_seconds = quiet_wait_ms / 1000.0
         self._clock = monotonic if clock is None else clock
         self._pending: deque[tuple[_ItemT, float]] = deque()
 
@@ -56,7 +64,11 @@ class CohortAdmissionQueue(Generic[_ItemT]):
     def deadline(self) -> float | None:
         if not self._pending:
             return None
-        return self._pending[0][1] + self.max_wait_seconds
+        deadline = self._pending[0][1] + self.max_wait_seconds
+        if self.quiet_wait_seconds:
+            deadline = min(deadline,
+                           self._pending[-1][1] + self.quiet_wait_seconds)
+        return deadline
 
     def add(self, item: _ItemT) -> None:
         self._pending.append((item, self._clock()))
@@ -117,6 +129,8 @@ class BlockDiffusionCohortScheduler(Scheduler):
         generation_strategy = resolve_generation_strategy(vllm_config)
         assert generation_strategy.diffusion is not None
         max_wait_ms = generation_strategy.diffusion.runtime.cohort_max_wait_ms
+        quiet_wait_ms = (
+            generation_strategy.diffusion.runtime.cohort_quiet_wait_ms)
         if max_wait_ms <= 0.0:
             raise ValueError(
                 "BlockDiffusionCohortScheduler requires positive cohort_max_wait_ms"
@@ -124,6 +138,7 @@ class BlockDiffusionCohortScheduler(Scheduler):
         self._cohort = CohortAdmissionQueue[Request](
             max_size=vllm_config.scheduler_config.max_num_seqs,
             max_wait_ms=max_wait_ms,
+            quiet_wait_ms=quiet_wait_ms,
         )
         self._cohort_request_ids: set[str] = set()
 

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -269,9 +269,7 @@ def _scheduler_worker_process(
                     _send_result(result)
 
                 case SchedulerCommand.GET_REQUEST_COUNTS:
-                    running = len(scheduler.running)
-                    waiting = len(scheduler.waiting)
-                    _send_result((running, waiting))
+                    _send_result(scheduler.get_request_counts())
 
                 case SchedulerCommand.GET_TOKEN_COUNT:
                     # Calculate total tokens across running and waiting requests

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -206,7 +206,12 @@ def _scheduler_worker_process(
                     request_ids, finished_status = data
                     result = scheduler.finish_requests(request_ids,
                                                        finished_status)
-                    _send_result(result)
+                    retained_request_ids = set(scheduler.requests)
+                    retained_request_ids.update(scheduler.finished_req_ids)
+                    for cached_output in _cached_scheduler_outputs:
+                        retained_request_ids.update(
+                            cached_output.finished_req_ids)
+                    _send_result((result, retained_request_ids))
 
                 case SchedulerCommand.UPDATE_DRAFT_TOKEN_IDS:
                     draft_token_ids = data
@@ -1367,16 +1372,20 @@ class DPScheduler(SchedulerInterface):
 
         # Forward to each scheduler
         for rank, req_ids in rank_request_ids.items():
+            worker_request_ids = None if request_ids is None else req_ids
             self._send_command(rank, SchedulerCommand.FINISH_REQUESTS,
-                               (req_ids, finished_status))
+                               (worker_request_ids, finished_status))
+        reusable_assigned_ids = set()
         for rank in rank_request_ids:
-            finished_requests = self._get_result(
+            finished_requests, retained_request_ids = self._get_result(
                 rank, SchedulerCommand.FINISH_REQUESTS)
             for req_id, client_index in finished_requests:
                 if req_id in seen_ids:
                     finished_by_id.setdefault(req_id, (req_id, client_index))
+            reusable_assigned_ids.update(
+                set(rank_request_ids[rank]) - retained_request_ids)
 
-        self._cleanup_finished_requests(set(finished_by_id))
+        self._cleanup_finished_requests(reusable_assigned_ids)
         return [
             finished_by_id[req_id] for req_id in normalized_ids
             if req_id in finished_by_id

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -20,6 +20,7 @@ import multiprocessing.reduction
 import os
 import signal
 from collections import defaultdict, deque
+from collections.abc import Iterable
 from dataclasses import dataclass
 from enum import Enum
 from multiprocessing import Process
@@ -42,7 +43,7 @@ from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.metrics.stats import PrefixCacheStats, SchedulerStats
 from vllm.v1.outputs import (DraftTokenIds, LogprobsLists, ModelRunnerOutput,
                              RoutedExpertsLists)
-from vllm.v1.request import Request
+from vllm.v1.request import Request, RequestStatus
 from vllm.v1.spec_decode.metrics import SpecDecodingStats
 from vllm.v1.structured_output import StructuredOutputManager
 
@@ -203,8 +204,9 @@ def _scheduler_worker_process(
 
                 case SchedulerCommand.FINISH_REQUESTS:
                     request_ids, finished_status = data
-                    scheduler.finish_requests(request_ids, finished_status)
-                    _send_result(None)  # Signal completion
+                    result = scheduler.finish_requests(request_ids,
+                                                       finished_status)
+                    _send_result(result)
 
                 case SchedulerCommand.UPDATE_DRAFT_TOKEN_IDS:
                     draft_token_ids = data
@@ -1319,26 +1321,45 @@ class DPScheduler(SchedulerInterface):
         for req_id in finished_req_ids:
             self.assigned_dp_rank.pop(req_id, None)
 
-    def finish_requests(self, request_ids, finished_status) -> None:
+    def finish_requests(
+        self,
+        request_ids: str | Iterable[str] | None,
+        finished_status: RequestStatus,
+    ) -> list[tuple[str, int]]:
         """Forward request finish signals to the appropriate DP rank schedulers."""
         if isinstance(request_ids, str):
-            request_ids = [request_ids]
+            requested_ids = [request_ids]
         elif request_ids is None:
-            request_ids = list(self.assigned_dp_rank.keys()) + [
+            requested_ids = list(self.assigned_dp_rank.keys()) + [
                 r.request_id for r in self._pending_new_requests
             ]
+        else:
+            requested_ids = list(request_ids)
+
+        normalized_ids = []
+        seen_ids = set()
+        for request_id in requested_ids:
+            if request_id not in seen_ids:
+                normalized_ids.append(request_id)
+                seen_ids.add(request_id)
 
         # If any request is still held in the pending queue, drop it.
+        finished_by_id = {}
         if self._pending_new_requests:
-            request_id_set = set(request_ids)
-            self._pending_new_requests = [
-                r for r in self._pending_new_requests
-                if r.request_id not in request_id_set
-            ]
+            remaining_requests = []
+            for request in self._pending_new_requests:
+                if request.request_id in seen_ids:
+                    finished_by_id.setdefault(
+                        request.request_id,
+                        (request.request_id, request.client_index),
+                    )
+                else:
+                    remaining_requests.append(request)
+            self._pending_new_requests = remaining_requests
 
         # Route finish signals to appropriate schedulers
         rank_request_ids = defaultdict(list)
-        for req_id in request_ids:
+        for req_id in normalized_ids:
             if req_id not in self.assigned_dp_rank:
                 continue
             rank = self.assigned_dp_rank[req_id]
@@ -1348,7 +1369,18 @@ class DPScheduler(SchedulerInterface):
         for rank, req_ids in rank_request_ids.items():
             self._send_command(rank, SchedulerCommand.FINISH_REQUESTS,
                                (req_ids, finished_status))
-            self._get_result(rank, SchedulerCommand.FINISH_REQUESTS)
+        for rank in rank_request_ids:
+            finished_requests = self._get_result(
+                rank, SchedulerCommand.FINISH_REQUESTS)
+            for req_id, client_index in finished_requests:
+                if req_id in seen_ids:
+                    finished_by_id.setdefault(req_id, (req_id, client_index))
+
+        self._cleanup_finished_requests(set(finished_by_id))
+        return [
+            finished_by_id[req_id] for req_id in normalized_ids
+            if req_id in finished_by_id
+        ]
 
     def get_num_unfinished_requests(self) -> int:
         """Get total number of unfinished requests across all DP ranks.

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -13,17 +13,41 @@
 # limitations under the License.
 
 DEFAULT_MAX_DECODE_STEPS = 10
+MULTI_TOKEN_LOOKAHEAD_CONFIG = "multi_token_decode_lookahead"
 
 
-def patch_vllm_scheduler_for_continue_decode():
-    """Monkeypatches vLLM's Scheduler and AsyncScheduler for Continue Decode.
+def _get_multi_token_lookahead(vllm_config) -> int:
+    additional_config = getattr(vllm_config, "additional_config", {}) or {}
+    if MULTI_TOKEN_LOOKAHEAD_CONFIG in additional_config:
+        lookahead = int(additional_config[MULTI_TOKEN_LOOKAHEAD_CONFIG])
+        if lookahead < 0:
+            raise ValueError(
+                f"{MULTI_TOKEN_LOOKAHEAD_CONFIG} must be non-negative")
+        return lookahead
+    if additional_config.get("enable_continue_decode", False):
+        max_decode_steps = int(
+            additional_config.get("max_decode_steps",
+                                  DEFAULT_MAX_DECODE_STEPS))
+        return max(0, max_decode_steps - 1)
+    return 0
 
-    In Continue Decode, the host schedules 1 step while the TPU runner executes
-    up to max_decode_steps (N) decode iterations on-device in a single step.
+
+def _is_multi_token_decode_enabled(vllm_config) -> bool:
+    additional_config = getattr(vllm_config, "additional_config", {}) or {}
+    return (MULTI_TOKEN_LOOKAHEAD_CONFIG in additional_config
+            or bool(additional_config.get("enable_continue_decode", False)))
+
+
+def patch_vllm_scheduler_for_multi_token_decode() -> None:
+    """Patch vLLM scheduler accounting for multi-token model outputs.
+
+    The host schedules one decode position while the model runner may return N
+    tokens. The patch reserves a configured lookahead and reconciles the N - 1
+    additional tokens after stop-token processing.
 
     This function applies three patches:
-    1. patched_init: Forces KVCacheManager to reserve enough KV cache blocks for
-       all N tokens during schedule() (num_lookahead_tokens = max_decode_steps - 1).
+    1. patched_init: Forces KVCacheManager to reserve the configured lookahead
+       during schedule().
     2. patched_update_base: Reconciles request.num_computed_tokens on host by
        adding the extra (N - 1) tokens generated on-device once model output returns.
     3. patched_async_update_request_with_output: Pre-compensates in-flight
@@ -32,20 +56,17 @@ def patch_vllm_scheduler_for_continue_decode():
     """
     from vllm.v1.core.sched.scheduler import Scheduler
 
-    # Avoid patching multiple times
-    if not getattr(Scheduler, "_continue_decode_patched", False):
+    if not getattr(Scheduler, "_multi_token_decode_patched", False):
         original_update_base = Scheduler._update_request_with_output
 
         def patched_update_base(scheduler_self, request, new_token_ids):
-            # Original update appends new_token_ids to request output and trims on stop token.
             res_token_ids, stopped = original_update_base(
                 scheduler_self, request, new_token_ids)
 
-            # schedule() only incremented num_computed_tokens by 1. Advance by the remaining
-            # (N - 1) tokens generated on-device so host-side num_computed_tokens is accurate.
-            diff = len(res_token_ids) - 1
-            if diff > 0:
-                request.num_computed_tokens += diff
+            if getattr(scheduler_self, "_multi_token_decode_enabled", False):
+                diff = len(res_token_ids) - 1
+                if diff > 0:
+                    request.num_computed_tokens += diff
 
             return res_token_ids, stopped
 
@@ -56,33 +77,36 @@ def patch_vllm_scheduler_for_continue_decode():
         def patched_init(scheduler_self, vllm_config, *args, **kwargs):
             original_init(scheduler_self, vllm_config, *args, **kwargs)
 
-            additional_config = getattr(vllm_config, "additional_config", {})
-            max_decode_steps = additional_config.get("max_decode_steps",
-                                                     DEFAULT_MAX_DECODE_STEPS)
-            # Reserve max_decode_steps - 1 lookahead tokens so KVCacheManager allocates
-            # sufficient blocks for up to max_decode_steps tokens before execution on TPU.
+            scheduler_self._multi_token_decode_enabled = \
+                _is_multi_token_decode_enabled(vllm_config)
             scheduler_self.num_lookahead_tokens = max(
-                scheduler_self.num_lookahead_tokens, max_decode_steps - 1)
+                scheduler_self.num_lookahead_tokens,
+                _get_multi_token_lookahead(vllm_config),
+            )
 
         Scheduler.__init__ = patched_init
 
     from vllm.v1.core.sched.async_scheduler import AsyncScheduler
 
-    if not getattr(AsyncScheduler, "_continue_decode_patched", False):
+    if not getattr(AsyncScheduler, "_multi_token_decode_patched", False):
         original_async_update_req = AsyncScheduler._update_request_with_output
 
         def patched_async_update_request_with_output(scheduler_self, request,
                                                      new_token_ids):
-            if len(new_token_ids) > 1:
-                # In AsyncScheduler, _update_after_schedule() added 1 in-flight placeholder token.
-                # When N tokens return, original_async_update_req will subtract N from
-                # num_output_placeholders. Pre-compensate by adding (N - 1) first so that
-                # num_output_placeholders cleanly decrements by 1 without underflowing < 0.
+            if (getattr(scheduler_self, "_multi_token_decode_enabled", False)
+                    and len(new_token_ids) > 1):
                 request.num_output_placeholders += (len(new_token_ids) - 1)
             return original_async_update_req(scheduler_self, request,
                                              new_token_ids)
 
         AsyncScheduler._update_request_with_output = patched_async_update_request_with_output
+        AsyncScheduler._multi_token_decode_patched = True
         AsyncScheduler._continue_decode_patched = True
 
+    Scheduler._multi_token_decode_patched = True
     Scheduler._continue_decode_patched = True
+
+
+def patch_vllm_scheduler_for_continue_decode() -> None:
+    """Compatibility alias for existing continue-decode callers."""
+    patch_vllm_scheduler_for_multi_token_decode()

--- a/tpu_inference/core/sched/utils.py
+++ b/tpu_inference/core/sched/utils.py
@@ -59,9 +59,10 @@ def patch_vllm_scheduler_for_multi_token_decode() -> None:
     if not getattr(Scheduler, "_multi_token_decode_patched", False):
         original_update_base = Scheduler._update_request_with_output
 
-        def patched_update_base(scheduler_self, request, new_token_ids):
+        def patched_update_base(scheduler_self, request, new_token_ids, *args,
+                                **kwargs):
             res_token_ids, stopped = original_update_base(
-                scheduler_self, request, new_token_ids)
+                scheduler_self, request, new_token_ids, *args, **kwargs)
 
             if getattr(scheduler_self, "_multi_token_decode_enabled", False):
                 diff = len(res_token_ids) - 1
@@ -92,12 +93,13 @@ def patch_vllm_scheduler_for_multi_token_decode() -> None:
         original_async_update_req = AsyncScheduler._update_request_with_output
 
         def patched_async_update_request_with_output(scheduler_self, request,
-                                                     new_token_ids):
+                                                     new_token_ids, *args,
+                                                     **kwargs):
             if (getattr(scheduler_self, "_multi_token_decode_enabled", False)
                     and len(new_token_ids) > 1):
                 request.num_output_placeholders += (len(new_token_ids) - 1)
             return original_async_update_req(scheduler_self, request,
-                                             new_token_ids)
+                                             new_token_ids, *args, **kwargs)
 
         AsyncScheduler._update_request_with_output = patched_async_update_request_with_output
         AsyncScheduler._multi_token_decode_patched = True

--- a/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
+++ b/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
@@ -189,6 +189,7 @@ def get_kv_cache_shape(
         "debug_mode",
         "out_dtype",
         "use_causal_mask",
+        "block_causal_size",
         "update_kv_cache",
         "kv_layout",
     ),
@@ -224,6 +225,7 @@ def ragged_paged_attention(
     debug_mode: bool = False,
     out_dtype: jnp.dtype | None = None,
     use_causal_mask: bool = True,
+    block_causal_size: int | None = None,
     update_kv_cache: bool = True,
     kv_layout: configs.KVLayout | None = None,
 ) -> tuple[jax.Array, jax.Array]:
@@ -278,6 +280,8 @@ def ragged_paged_attention(
 
     if not use_causal_mask:
         raise ValueError("Only causal attention is supported.")
+    if block_causal_size is not None:
+        raise ValueError("Block-causal attention is not supported.")
     if chunk_prefill_size is not None:
         raise ValueError("Specifying chunk prefill size is not supported.")
     if debug_mode:

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -77,6 +77,7 @@ def ref_ragged_paged_attention(
     distribution: jax.Array,  # i32[3]
     *,
     use_causal_mask: bool = True,
+    block_causal_size: int | None = None,
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
@@ -103,6 +104,7 @@ def ref_ragged_paged_attention(
         cu_q_lens,
         distribution,
         use_causal_mask=use_causal_mask,
+        block_causal_size=block_causal_size,
         skip_kv_mask=skip_kv_mask,
         sm_scale=sm_scale,
         sliding_window=sliding_window,
@@ -185,11 +187,15 @@ def ref_ragged_paged_attention(
         if soft_cap is not None:
             attn = soft_cap * jnp.tanh(attn / soft_cap)
 
-        if use_causal_mask:
+        if use_causal_mask or block_causal_size is not None:
             q_span = (kv_len - q_len) + jax.lax.broadcasted_iota(
                 jnp.int32, attn.shape, 1)
             kv_span = jax.lax.broadcasted_iota(jnp.int32, attn.shape, 2)
-            mask = q_span >= kv_span
+            if block_causal_size is None:
+                mask = q_span >= kv_span
+            else:
+                mask = (q_span // block_causal_size
+                        >= kv_span // block_causal_size)
             if sliding_window is not None:
                 mask = jnp.logical_and(mask, q_span < kv_span + sliding_window)
             attn = jnp.where(mask, attn, mask_value)
@@ -317,6 +323,7 @@ def _ragged_paged_attention_kernel_loop(
     acc_ref,  # [actual_num_kv_heads, bq_sz * num_q_heads_per_kv_head, head_dim],
     *,
     use_causal_mask: bool = True,
+    block_causal_size: int | None = None,
     update_kv_cache: bool = True,  # KV-share: False = skip cache writes
     skip_kv_mask: bool = False,
     sm_scale: float,
@@ -485,6 +492,12 @@ def _ragged_paged_attention_kernel_loop(
         if use_causal_mask:
             assert not skip_kv_mask
             mask = mask_and(mask, q_span >= k_span)
+        elif block_causal_size is not None:
+            assert not skip_kv_mask
+            mask = mask_and(
+                mask,
+                q_span // block_causal_size >= k_span // block_causal_size,
+            )
 
         if not skip_kv_mask:
             mask = mask_and(mask, k_span < effective_kv_len_int)
@@ -943,6 +956,11 @@ def _ragged_paged_attention_kernel_loop(
             if use_causal_mask:
                 effective_kv_len = jnp.minimum(kv_len,
                                                processed_q_len + actual_bq_sz)
+            elif block_causal_size is not None:
+                last_q_block_end = (
+                    cdiv(processed_q_len + actual_bq_sz, block_causal_size) *
+                    block_causal_size)
+                effective_kv_len = jnp.minimum(kv_len, last_q_block_end)
             else:
                 effective_kv_len = kv_len
             end_bkv_idx = cdiv(effective_kv_len, bkv_sz)
@@ -1237,6 +1255,7 @@ def dynamic_validate_inputs(
     distribution: jax.Array,  # i32[3]
     *,
     use_causal_mask: bool = True,
+    block_causal_size: int | None = None,
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
@@ -1265,6 +1284,7 @@ def dynamic_validate_inputs(
         cu_q_lens,
         distribution,
         use_causal_mask=use_causal_mask,
+        block_causal_size=block_causal_size,
         skip_kv_mask=skip_kv_mask,
         sm_scale=sm_scale,
         sliding_window=sliding_window,
@@ -1332,6 +1352,7 @@ def static_validate_inputs(
     distribution: jax.Array,  # i32[3]
     *,
     use_causal_mask: bool = True,
+    block_causal_size: int | None = None,
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
     sliding_window: int | None = None,
@@ -1350,9 +1371,13 @@ def static_validate_inputs(
     vmem_limit_bytes: int | None = None,
 ):
     """Validate inputs to the RPA kernel statically."""
-    if use_causal_mask:
-        if skip_kv_mask:
-            raise ValueError("Can not skip kv mask when using causal mask.")
+    if block_causal_size is not None and block_causal_size <= 0:
+        raise ValueError("block_causal_size must be positive")
+    if use_causal_mask and block_causal_size is not None:
+        raise ValueError(
+            "Token-causal and block-causal masks are mutually exclusive")
+    if (use_causal_mask or block_causal_size is not None) and skip_kv_mask:
+        raise ValueError("Can not skip kv mask when using an attention mask.")
 
     q, k, v = queries, keys, values
     if not (len(q.shape) == len(k.shape) == len(v.shape) == 3):
@@ -1563,6 +1588,7 @@ def get_default_block_sizes(
 @jax.jit(
     static_argnames=(
         "use_causal_mask",
+        "block_causal_size",
         "update_kv_cache",
         "skip_kv_mask",
         "sm_scale",
@@ -1598,6 +1624,7 @@ def ragged_paged_attention(
     distribution: jax.Array,  # i32[3]
     *,
     use_causal_mask: bool = True,
+    block_causal_size: int | None = None,
     update_kv_cache: bool = True,
     skip_kv_mask: bool = False,
     sm_scale: float = 1.0,
@@ -1640,6 +1667,8 @@ def ragged_paged_attention(
       sequences[i:j] are chunked-prefill-only, and sequences[j:k] are mixed. The
       k is also the total number of sequences.
     use_causal_mask: if true, use causal mask.
+    block_causal_size: if set, allow each query to attend to its own fixed-size
+      block and all earlier blocks.
     skip_kv_mask: only set to true if use_causal_mask=False and each dynamic
       kv_len % bkv_csz == 0. Set to true can improve performance.
     sm_scale: the softmax scale which will be applied to the Q@K^T.
@@ -1690,6 +1719,7 @@ def ragged_paged_attention(
         cu_q_lens,
         distribution,
         use_causal_mask=use_causal_mask,
+        block_causal_size=block_causal_size,
         skip_kv_mask=skip_kv_mask,
         sm_scale=sm_scale,
         sliding_window=sliding_window,
@@ -1807,12 +1837,15 @@ def ragged_paged_attention(
         )
 
         scope_name = f"RPA{case.symbol}-p_{page_size}-bq_{bq_sz}_{bq_csz}-bkv_{bkv_sz}_{bkv_csz}"
+        if block_causal_size is not None:
+            scope_name += f"-bc_{block_causal_size}"
         if sliding_window is not None:
             scope_name += f"-sw_{sliding_window}"
         kernel = pl.pallas_call(
             functools.partial(
                 _ragged_paged_attention_kernel,
                 use_causal_mask=use_causal_mask,
+                block_causal_size=block_causal_size,
                 update_kv_cache=update_kv_cache,
                 skip_kv_mask=skip_kv_mask,
                 sm_scale=sm_scale,

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -194,8 +194,9 @@ def ref_ragged_paged_attention(
             if block_causal_size is None:
                 mask = q_span >= kv_span
             else:
-                mask = (q_span // block_causal_size
-                        >= kv_span // block_causal_size)
+                kv_block_start = kv_span - jnp.bitwise_and(
+                    kv_span, block_causal_size - 1)
+                mask = q_span >= kv_block_start
             if sliding_window is not None:
                 mask = jnp.logical_and(mask, q_span < kv_span + sliding_window)
             attn = jnp.where(mask, attn, mask_value)
@@ -494,9 +495,11 @@ def _ragged_paged_attention_kernel_loop(
             mask = mask_and(mask, q_span >= k_span)
         elif block_causal_size is not None:
             assert not skip_kv_mask
+            k_block_start = k_span - jnp.bitwise_and(k_span,
+                                                     block_causal_size - 1)
             mask = mask_and(
                 mask,
-                q_span // block_causal_size >= k_span // block_causal_size,
+                q_span >= k_block_start,
             )
 
         if not skip_kv_mask:
@@ -957,9 +960,10 @@ def _ragged_paged_attention_kernel_loop(
                 effective_kv_len = jnp.minimum(kv_len,
                                                processed_q_len + actual_bq_sz)
             elif block_causal_size is not None:
-                last_q_block_end = (
-                    cdiv(processed_q_len + actual_bq_sz, block_causal_size) *
-                    block_causal_size)
+                last_q_position = processed_q_len + actual_bq_sz - 1
+                last_q_block_start = last_q_position - jnp.bitwise_and(
+                    last_q_position, block_causal_size - 1)
+                last_q_block_end = last_q_block_start + block_causal_size
                 effective_kv_len = jnp.minimum(kv_len, last_q_block_end)
             else:
                 effective_kv_len = kv_len
@@ -1373,6 +1377,9 @@ def static_validate_inputs(
     """Validate inputs to the RPA kernel statically."""
     if block_causal_size is not None and block_causal_size <= 0:
         raise ValueError("block_causal_size must be positive")
+    if (block_causal_size is not None
+            and block_causal_size & (block_causal_size - 1)):
+        raise ValueError("block_causal_size must be a power of two")
     if use_causal_mask and block_causal_size is not None:
         raise ValueError(
             "Token-causal and block-causal masks are mutually exclusive")

--- a/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
+++ b/tpu_inference/kernels/ragged_paged_attention/v3/kernel.py
@@ -90,10 +90,12 @@ def ref_ragged_paged_attention(
 ):
     if out_dtype is None:
         out_dtype = jnp.float32 if queries.dtype == jnp.float32 else jnp.bfloat16
+    accumulator_dtype = out_dtype
+    output_dtype = queries.dtype
 
     if mask_value is None:
         # We do not set to -inf directly because (-inf) - (-inf) is nan.
-        mask_value = jnp.finfo(out_dtype).min
+        mask_value = jnp.finfo(accumulator_dtype).min
     dynamic_validate_inputs(
         queries,
         keys,
@@ -178,7 +180,8 @@ def ref_ragged_paged_attention(
         attn = jnp.einsum("qhd,khd->hqk",
                           q,
                           k,
-                          preferred_element_type=jnp.float32).astype(out_dtype)
+                          preferred_element_type=jnp.float32).astype(
+                              accumulator_dtype)
         attn *= sm_scale
         if k_scale is not None:
             attn *= k_scale
@@ -202,13 +205,14 @@ def ref_ragged_paged_attention(
             attn = jnp.where(mask, attn, mask_value)
         attn = jax.nn.softmax(attn, axis=-1).astype(v.dtype)
 
-        out = jnp.einsum("hqk,khd->qhd", attn, v).astype(out_dtype)
+        out = jnp.einsum("hqk,khd->qhd", attn, v).astype(
+            accumulator_dtype)
         if v_scale is not None:
             out *= v_scale
 
         outputs.append(out)
 
-    result = jnp.concatenate(outputs, axis=0)
+    result = jnp.concatenate(outputs, axis=0).astype(output_dtype)
     return result, kv_cache
 
 
@@ -348,7 +352,7 @@ def _ragged_paged_attention_kernel_loop(
     if case == RpaCase.DECODE:
         use_causal_mask = False
 
-    out_dtype = acc_ref.dtype
+    accumulator_dtype = acc_ref.dtype
     (
         actual_num_kv_heads,
         max_num_tokens,
@@ -375,8 +379,9 @@ def _ragged_paged_attention_kernel_loop(
     # num_kv_heads_x2 = num_kv_heads_x2_per_kv_packing * kv_packing
     num_q_heads_per_kv_head = num_q_heads_per_kv_head_per_packing * q_packing
     q_dtype = q_hbm_ref.dtype
+    output_dtype = o_hbm_ref.dtype
     kv_dtype = kv_cache_hbm_ref.dtype
-    assert o_hbm_ref.dtype == q_dtype
+    assert output_dtype == q_dtype
     assert get_dtype_packing(q_dtype) == q_packing
     assert get_dtype_packing(kv_dtype) == kv_packing
     assert head_dim % 128 == 0
@@ -515,13 +520,14 @@ def _ragged_paged_attention_kernel_loop(
         s_rowmax = jnp.max(s, axis=1, keepdims=True)
 
         # if converting the type too early, there will be accuracy issue.
-        s_rowmax = s_rowmax.astype(out_dtype)
+        s_rowmax = s_rowmax.astype(accumulator_dtype)
         m_prev = m_ref[...]
         m_curr = jnp.maximum(m_prev, s_rowmax)
         m_ref[...] = m_curr
         p = jnp.exp(s - broadcast_minor(m_curr, s.shape))
 
-        p_rowsum = jnp.sum(p, axis=1, keepdims=True, dtype=out_dtype)
+        p_rowsum = jnp.sum(
+            p, axis=1, keepdims=True, dtype=accumulator_dtype)
         exp_m_diff = jnp.exp(m_prev - m_curr)
         l_prev = l_ref[...]
         l_ref[...] = exp_m_diff * l_prev + p_rowsum
@@ -548,7 +554,7 @@ def _ragged_paged_attention_kernel_loop(
         if v_scale is not None:
             pv *= v_scale
         # if converting the type too early, there will be accuracy issue.
-        pv = pv.astype(out_dtype)
+        pv = pv.astype(accumulator_dtype)
         o_prev = o_ref[...]
         o_ref[...] = broadcast_minor(exp_m_diff, o_prev.shape) * o_prev + pv
 
@@ -1093,8 +1099,8 @@ def _ragged_paged_attention_kernel_loop(
             acc = acc_ref[...]
             l = broadcast_minor(l_ref[...], acc.shape)  # noqa
             out = (acc * pl.reciprocal(l, approx=True) if
-                   (l.dtype == jnp.float32 and out_dtype != jnp.float32) else
-                   lax.div(acc, l)).astype(out_dtype)
+                   (l.dtype == jnp.float32 and output_dtype != jnp.float32) else
+                   lax.div(acc, l)).astype(output_dtype)
 
             # Wait for previous bo to be fully sent before storing new bo.
             bo_sem_idx = sem_ids_ref[2]
@@ -1681,9 +1687,9 @@ def ragged_paged_attention(
     sm_scale: the softmax scale which will be applied to the Q@K^T.
     sliding_window: the sliding window size for the attention.
     soft_cap: the logit soft cap for the attention.
-    out_dtype: the dtype of the output and the accumulator for matmul. Set
-      lower for better performance, set higher for better accuracy. If None, it
-      uses q.dtype.
+    out_dtype: the dtype of the softmax and PV accumulators. The returned
+      output always uses the query dtype. Set lower for better performance and
+      higher for better accuracy. If None, it uses q.dtype.
     mask_value: mask value for causal mask.
     q_scale: the scale for the query.
     k_scale: the scale for the key.

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -386,6 +386,7 @@ def sharded_ragged_paged_attention(
     q_scale: float | None = None,
     k_scale: float | None = None,
     v_scale: float | None = None,
+    chunk_prefill_size: int | None = None,
     update_kv_cache: bool = True,
     use_causal_mask: bool = True,
 ):
@@ -445,6 +446,10 @@ def sharded_ragged_paged_attention(
         raise NotImplementedError(
             "Bidirectional attention is not supported on the head_dim==64 "
             "RPA kernel")
+    if use_hd64 and chunk_prefill_size is not None:
+        raise NotImplementedError(
+            "Static-query PREFILL RPA is not supported on the head_dim==64 "
+            "kernel")
 
     def _ragged_paged_attention(*args):
         kwargs = dict(
@@ -460,6 +465,7 @@ def sharded_ragged_paged_attention(
         if not use_hd64:
             kwargs["update_kv_cache"] = update_kv_cache
             kwargs["use_causal_mask"] = use_causal_mask
+            kwargs["chunk_prefill_size"] = chunk_prefill_size
         return func(*args, **kwargs)
 
     return jax.shard_map(
@@ -519,8 +525,8 @@ def attention(
             )
         active_rows = md.cache_update_active_rows
         if active_rows is None:
-            active_rows = (jnp.arange(md.seq_lens.shape[0]) <
-                           md.request_distribution[-1])
+            active_rows = (jnp.arange(md.seq_lens.shape[0])
+                           < md.request_distribution[-1])
         kv_cache = replace_cached_kv(
             kv_cache,
             k,
@@ -582,6 +588,7 @@ def attention(
         q_scale=q_scale,
         k_scale=k_scale,
         v_scale=v_scale,
+        chunk_prefill_size=md.rpa_static_query_len,
         update_kv_cache=update_kv_cache,
         use_causal_mask=use_causal_mask,
     )

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -37,6 +37,7 @@ from tpu_inference.kernels.mla.v2.tuned_params import (TuningKey,
 from tpu_inference.layers.common.attention_metadata import (
     AttentionMetadata, SharedAttentionMetadata, resolve_use_causal_mask)
 from tpu_inference.layers.common.cp_attention import dcp_forward, pcp_forward
+from tpu_inference.layers.common.kv_cache_replace import replace_cached_kv
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
 from tpu_inference.utils import get_megacore, get_mesh_shape_product
@@ -510,6 +511,25 @@ def attention(
     use_causal_mask = resolve_use_causal_mask(md, use_causal_mask)
     # shared_attention_metadata is None for flax models, and is used for vllm models to share the metadata across layers.
     shared_md = shared_attention_metadata if shared_attention_metadata is not None else md
+
+    if md.replace_cached_kv:
+        if not update_kv_cache:
+            raise ValueError(
+                "replace_cached_kv requires the attention layer to own its cache"
+            )
+        active_rows = md.cache_update_active_rows
+        if active_rows is None:
+            active_rows = (jnp.arange(md.seq_lens.shape[0]) <
+                           md.request_distribution[-1])
+        kv_cache = replace_cached_kv(
+            kv_cache,
+            k,
+            v,
+            md.input_positions,
+            md.block_tables,
+            active_rows,
+        )
+        update_kv_cache = False
 
     if 'dcp' in mesh.shape and mesh.shape['dcp'] > 1:
         if not use_causal_mask:

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -52,7 +52,8 @@ MAX_ALLOWED_PAGE_INDICES_N = (
 # NOTE: this kernel is experimental and not fully tested.  See
 # tpu-inference/tpu_inference/kernels/experimental/batched_rpa/wrapper.py
 # for details
-if envs.USE_BATCHED_RPA_KERNEL:
+_USE_BATCHED_RPA_KERNEL = envs.USE_BATCHED_RPA_KERNEL
+if _USE_BATCHED_RPA_KERNEL:
     import tpu_inference.kernels.experimental.batched_rpa.wrapper as rpa
     logger.info_once("Using experimental batched RPA kernel")
 else:
@@ -64,6 +65,24 @@ get_kv_cache_shape = rpa.get_kv_cache_shape
 
 ragged_paged_attention_hd64 = rpa_hd64.ragged_paged_attention_hd64
 get_kv_cache_shape_hd64 = rpa_hd64.get_kv_cache_shape
+
+
+def _rpa_v3_block_size_kwargs() -> dict[str, tuple[int, int, int, int]]:
+    block_size_kwargs = {}
+    for env_name, kwarg in (
+        ("RPA_V3_DECODE_BLOCK_SIZES", "d_block_sizes"),
+        ("RPA_V3_PREFILL_BLOCK_SIZES", "p_block_sizes"),
+        ("RPA_V3_MIXED_BLOCK_SIZES", "m_block_sizes"),
+    ):
+        block_sizes = getattr(envs, env_name)
+        if not block_sizes:
+            continue
+        if len(block_sizes) != 4:
+            raise ValueError(
+                f"{env_name} must contain exactly four comma-separated integers"
+            )
+        block_size_kwargs[kwarg] = tuple(block_sizes)
+    return block_size_kwargs
 
 
 def sharded_flash_attention(
@@ -428,6 +447,8 @@ def sharded_ragged_paged_attention(
 
     use_hd64 = q.shape[-1] == 64
     func = ragged_paged_attention_hd64 if use_hd64 else ragged_paged_attention
+    block_size_kwargs = (_rpa_v3_block_size_kwargs() if not use_hd64
+                         and not _USE_BATCHED_RPA_KERNEL else {})
 
     if attention_sink is not None:
         if not use_hd64:
@@ -479,6 +500,7 @@ def sharded_ragged_paged_attention(
             kwargs["block_causal_size"] = block_causal_size
             kwargs["chunk_prefill_size"] = chunk_prefill_size
             kwargs["out_dtype"] = out_dtype
+            kwargs.update(block_size_kwargs)
         return func(*args, **kwargs)
 
     return jax.shard_map(

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -35,7 +35,8 @@ from tpu_inference.kernels.mla.v2.kernel import mla_ragged_paged_attention
 from tpu_inference.kernels.mla.v2.tuned_params import (TuningKey,
                                                        get_tuned_params)
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, SharedAttentionMetadata, resolve_use_causal_mask)
+    AttentionMetadata, SharedAttentionMetadata, resolve_block_causal_size,
+    resolve_use_causal_mask)
 from tpu_inference.layers.common.cp_attention import dcp_forward, pcp_forward
 from tpu_inference.layers.common.kv_cache_replace import replace_cached_kv
 from tpu_inference.layers.common.sharding import ShardingAxisName
@@ -389,6 +390,7 @@ def sharded_ragged_paged_attention(
     chunk_prefill_size: int | None = None,
     update_kv_cache: bool = True,
     use_causal_mask: bool = True,
+    block_causal_size: int | None = None,
 ):
     """Shards along KV heads."""
     # Handle GQA/MQA where num_kv_heads < tp_size
@@ -442,9 +444,13 @@ def sharded_ragged_paged_attention(
             "update_kv_cache=False (KV-share) is not supported on the "
             "head_dim==64 RPA kernel.")
 
-    if use_hd64 and not use_causal_mask:
+    if use_causal_mask and block_causal_size is not None:
+        raise ValueError(
+            "Token-causal and block-causal masks are mutually exclusive")
+
+    if use_hd64 and (not use_causal_mask or block_causal_size is not None):
         raise NotImplementedError(
-            "Bidirectional attention is not supported on the head_dim==64 "
+            "Non-token-causal attention is not supported on the head_dim==64 "
             "RPA kernel")
     if use_hd64 and chunk_prefill_size is not None:
         raise NotImplementedError(
@@ -465,6 +471,7 @@ def sharded_ragged_paged_attention(
         if not use_hd64:
             kwargs["update_kv_cache"] = update_kv_cache
             kwargs["use_causal_mask"] = use_causal_mask
+            kwargs["block_causal_size"] = block_causal_size
             kwargs["chunk_prefill_size"] = chunk_prefill_size
         return func(*args, **kwargs)
 
@@ -514,6 +521,7 @@ def attention(
         sm_scale = head_dim_original**-0.5
 
     md = attention_metadata
+    block_causal_size = resolve_block_causal_size(md, use_causal_mask)
     use_causal_mask = resolve_use_causal_mask(md, use_causal_mask)
     # shared_attention_metadata is None for flax models, and is used for vllm models to share the metadata across layers.
     shared_md = shared_attention_metadata if shared_attention_metadata is not None else md
@@ -538,9 +546,9 @@ def attention(
         update_kv_cache = False
 
     if 'dcp' in mesh.shape and mesh.shape['dcp'] > 1:
-        if not use_causal_mask:
+        if not use_causal_mask or block_causal_size is not None:
             raise NotImplementedError(
-                "Bidirectional attention is not supported with DCP")
+                "Non-token-causal attention is not supported with DCP")
         return dcp_forward(
             mesh,
             q,
@@ -556,6 +564,9 @@ def attention(
             v_scale=v_scale,
         )
     if 'pcp' in mesh.shape and mesh.shape['pcp'] > 1:
+        if block_causal_size is not None:
+            raise NotImplementedError(
+                "Block-causal attention is not supported with PCP")
         return pcp_forward(
             mesh,
             q,
@@ -591,6 +602,7 @@ def attention(
         chunk_prefill_size=md.rpa_static_query_len,
         update_kv_cache=update_kv_cache,
         use_causal_mask=use_causal_mask,
+        block_causal_size=block_causal_size,
     )
 
     return kv_cache, output

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -35,7 +35,7 @@ from tpu_inference.kernels.mla.v2.kernel import mla_ragged_paged_attention
 from tpu_inference.kernels.mla.v2.tuned_params import (TuningKey,
                                                        get_tuned_params)
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, SharedAttentionMetadata)
+    AttentionMetadata, SharedAttentionMetadata, resolve_use_causal_mask)
 from tpu_inference.layers.common.cp_attention import dcp_forward, pcp_forward
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
@@ -440,6 +440,11 @@ def sharded_ragged_paged_attention(
             "update_kv_cache=False (KV-share) is not supported on the "
             "head_dim==64 RPA kernel.")
 
+    if use_hd64 and not use_causal_mask:
+        raise NotImplementedError(
+            "Bidirectional attention is not supported on the head_dim==64 "
+            "RPA kernel")
+
     def _ragged_paged_attention(*args):
         kwargs = dict(
             sm_scale=sm_scale,
@@ -480,7 +485,7 @@ def attention(
     v_scale: float | None = None,
     sinks: jax.Array | None = None,
     update_kv_cache: bool = True,
-    use_causal_mask: bool = True,
+    use_causal_mask: bool | None = None,
     shared_attention_metadata: SharedAttentionMetadata | None = None,
 ) -> Tuple[jax.Array, jax.Array]:
     # T: seq_len
@@ -502,10 +507,14 @@ def attention(
         sm_scale = head_dim_original**-0.5
 
     md = attention_metadata
+    use_causal_mask = resolve_use_causal_mask(md, use_causal_mask)
     # shared_attention_metadata is None for flax models, and is used for vllm models to share the metadata across layers.
     shared_md = shared_attention_metadata if shared_attention_metadata is not None else md
 
     if 'dcp' in mesh.shape and mesh.shape['dcp'] > 1:
+        if not use_causal_mask:
+            raise NotImplementedError(
+                "Bidirectional attention is not supported with DCP")
         return dcp_forward(
             mesh,
             q,

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -391,6 +391,7 @@ def sharded_ragged_paged_attention(
     update_kv_cache: bool = True,
     use_causal_mask: bool = True,
     block_causal_size: int | None = None,
+    out_dtype: Any = None,
 ):
     """Shards along KV heads."""
     # Handle GQA/MQA where num_kv_heads < tp_size
@@ -443,6 +444,10 @@ def sharded_ragged_paged_attention(
         raise NotImplementedError(
             "update_kv_cache=False (KV-share) is not supported on the "
             "head_dim==64 RPA kernel.")
+    if use_hd64 and out_dtype is not None:
+        raise NotImplementedError(
+            "Custom RPA accumulator dtype is not supported on the "
+            "head_dim==64 RPA kernel.")
 
     if use_causal_mask and block_causal_size is not None:
         raise ValueError(
@@ -473,6 +478,7 @@ def sharded_ragged_paged_attention(
             kwargs["use_causal_mask"] = use_causal_mask
             kwargs["block_causal_size"] = block_causal_size
             kwargs["chunk_prefill_size"] = chunk_prefill_size
+            kwargs["out_dtype"] = out_dtype
         return func(*args, **kwargs)
 
     return jax.shard_map(
@@ -523,6 +529,8 @@ def attention(
     md = attention_metadata
     block_causal_size = resolve_block_causal_size(md, use_causal_mask)
     use_causal_mask = resolve_use_causal_mask(md, use_causal_mask)
+    rpa_accumulator_dtype = (
+        jnp.float32 if md.fp32_rpa_accumulator else None)
     # shared_attention_metadata is None for flax models, and is used for vllm models to share the metadata across layers.
     shared_md = shared_attention_metadata if shared_attention_metadata is not None else md
 
@@ -546,6 +554,9 @@ def attention(
         update_kv_cache = False
 
     if 'dcp' in mesh.shape and mesh.shape['dcp'] > 1:
+        if rpa_accumulator_dtype is not None:
+            raise NotImplementedError(
+                "FP32 RPA accumulation is not supported with DCP")
         if not use_causal_mask or block_causal_size is not None:
             raise NotImplementedError(
                 "Non-token-causal attention is not supported with DCP")
@@ -564,6 +575,9 @@ def attention(
             v_scale=v_scale,
         )
     if 'pcp' in mesh.shape and mesh.shape['pcp'] > 1:
+        if rpa_accumulator_dtype is not None:
+            raise NotImplementedError(
+                "FP32 RPA accumulation is not supported with PCP")
         if block_causal_size is not None:
             raise NotImplementedError(
                 "Block-causal attention is not supported with PCP")
@@ -603,6 +617,7 @@ def attention(
         update_kv_cache=update_kv_cache,
         use_causal_mask=use_causal_mask,
         block_causal_size=block_causal_size,
+        out_dtype=rpa_accumulator_dtype,
     )
 
     return kv_cache, output

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -24,11 +24,22 @@ from vllm.utils.math_utils import cdiv
 class AttentionMaskKind(str, Enum):
     CAUSAL = "causal"
     BIDIRECTIONAL = "bidirectional"
+    BLOCK_CAUSAL = "block_causal"
 
 
 @dataclass(frozen=True)
 class AttentionMaskSpec:
     kind: AttentionMaskKind = AttentionMaskKind.CAUSAL
+    block_size: int | None = None
+
+    def __post_init__(self):
+        if self.kind is AttentionMaskKind.BLOCK_CAUSAL:
+            if self.block_size is None or self.block_size <= 0:
+                raise ValueError(
+                    "Block-causal attention requires a positive block_size")
+        elif self.block_size is not None:
+            raise ValueError(
+                "block_size is only valid for block-causal attention")
 
     @property
     def use_causal_mask(self) -> bool:
@@ -45,6 +56,18 @@ def resolve_use_causal_mask(
     if override is not None:
         return override
     return attention_metadata.attention_mask_spec.use_causal_mask
+
+
+def resolve_block_causal_size(
+    attention_metadata: "AttentionMetadata",
+    use_causal_mask_override: bool | None = None,
+) -> int | None:
+    if use_causal_mask_override is not None:
+        return None
+    spec = attention_metadata.attention_mask_spec
+    if spec.kind is AttentionMaskKind.BLOCK_CAUSAL:
+        return spec.block_size
+    return None
 
 
 @functools.partial(

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -90,6 +90,7 @@ class PCPMetadata:
         "pcp_cache_pages",
         "attention_mask_spec",
         "replace_cached_kv",
+        "rpa_static_query_len",
     ],
 )
 @dataclass
@@ -135,6 +136,9 @@ class AttentionMetadata(object):
     # Partial block-diffusion forwards replace K/V at existing logical token
     # positions, then attend to the complete cached block.
     replace_cached_kv: bool = False
+
+    # Selects the fixed-query PREFILL RPA path instead of dynamic MIXED RPA.
+    rpa_static_query_len: int | None = None
 
 
 @functools.partial(

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -82,12 +82,14 @@ class PCPMetadata:
         "query_start_loc",
         "request_distribution",
         "mamba_state_indices",
+        "cache_update_active_rows",
         "pcp",
     ],
     meta_fields=[
         "padded_num_reqs",
         "pcp_cache_pages",
         "attention_mask_spec",
+        "replace_cached_kv",
     ],
 )
 @dataclass
@@ -112,6 +114,9 @@ class AttentionMetadata(object):
     # use this field, only hybrid models exercise it today.
     mamba_state_indices: jax.Array | None = None
 
+    # Optional per-row write mask for block-diffusion cache replacement.
+    cache_update_active_rows: jax.Array | None = None
+
     # PCP-specific metadata. None when not running prefill context parallelism.
     pcp: PCPMetadata | None = None
 
@@ -126,6 +131,10 @@ class AttentionMetadata(object):
     pcp_cache_pages: int | None = None
 
     attention_mask_spec: AttentionMaskSpec = CAUSAL_ATTENTION_MASK
+
+    # Partial block-diffusion forwards replace K/V at existing logical token
+    # positions, then attend to the complete cached block.
+    replace_cached_kv: bool = False
 
 
 @functools.partial(

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -37,6 +37,10 @@ class AttentionMaskSpec:
             if self.block_size is None or self.block_size <= 0:
                 raise ValueError(
                     "Block-causal attention requires a positive block_size")
+            if self.block_size & (self.block_size - 1):
+                raise ValueError(
+                    "Block-causal attention requires a power-of-two block_size"
+                )
         elif self.block_size is not None:
             raise ValueError(
                 "block_size is only valid for block-causal attention")

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -118,6 +118,7 @@ class PCPMetadata:
         "attention_mask_spec",
         "replace_cached_kv",
         "rpa_static_query_len",
+        "fp32_rpa_accumulator",
     ],
 )
 @dataclass
@@ -166,6 +167,10 @@ class AttentionMetadata(object):
 
     # Selects the fixed-query PREFILL RPA path instead of dynamic MIXED RPA.
     rpa_static_query_len: int | None = None
+
+    # Runs RPA attention statistics and accumulation in float32, then restores
+    # the query dtype before the output projection.
+    fp32_rpa_accumulator: bool = False
 
 
 @functools.partial(

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -15,9 +15,36 @@
 import functools
 import math
 from dataclasses import dataclass
+from enum import Enum
 
 import jax
 from vllm.utils.math_utils import cdiv
+
+
+class AttentionMaskKind(str, Enum):
+    CAUSAL = "causal"
+    BIDIRECTIONAL = "bidirectional"
+
+
+@dataclass(frozen=True)
+class AttentionMaskSpec:
+    kind: AttentionMaskKind = AttentionMaskKind.CAUSAL
+
+    @property
+    def use_causal_mask(self) -> bool:
+        return self.kind is AttentionMaskKind.CAUSAL
+
+
+CAUSAL_ATTENTION_MASK = AttentionMaskSpec()
+
+
+def resolve_use_causal_mask(
+    attention_metadata: "AttentionMetadata",
+    override: bool | None = None,
+) -> bool:
+    if override is not None:
+        return override
+    return attention_metadata.attention_mask_spec.use_causal_mask
 
 
 @functools.partial(
@@ -57,7 +84,11 @@ class PCPMetadata:
         "mamba_state_indices",
         "pcp",
     ],
-    meta_fields=["padded_num_reqs", "pcp_cache_pages"],
+    meta_fields=[
+        "padded_num_reqs",
+        "pcp_cache_pages",
+        "attention_mask_spec",
+    ],
 )
 @dataclass
 class AttentionMetadata(object):
@@ -93,6 +124,8 @@ class AttentionMetadata(object):
 
     # PCP gather-KV only. Number of kv pages occupied by the current request.
     pcp_cache_pages: int | None = None
+
+    attention_mask_spec: AttentionMaskSpec = CAUSAL_ATTENTION_MASK
 
 
 @functools.partial(

--- a/tpu_inference/layers/common/kv_cache_replace.py
+++ b/tpu_inference/layers/common/kv_cache_replace.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax
+import jax.numpy as jnp
+
+
+def _pack_kv_for_cache(
+    keys: jax.Array,
+    values: jax.Array,
+    cache_shape: tuple[int, ...],
+) -> jax.Array:
+    if keys.shape != values.shape:
+        raise ValueError("keys and values must have identical shapes")
+    if keys.ndim != 3 or len(cache_shape) != 5:
+        raise ValueError("expected token-major K/V and a five-dimensional cache")
+
+    num_tokens, num_kv_heads, actual_head_dim = keys.shape
+    cache_head_groups, packing, cache_head_dim = cache_shape[-3:]
+    padded_kv_heads_x2 = cache_head_groups * packing
+    actual_kv_heads_x2 = num_kv_heads * 2
+    if actual_kv_heads_x2 > padded_kv_heads_x2:
+        raise ValueError("K/V heads do not fit the cache layout")
+    if actual_head_dim > cache_head_dim:
+        raise ValueError("K/V head dimension does not fit the cache layout")
+
+    merged = jnp.concatenate([keys, values], axis=-1).reshape(
+        num_tokens, actual_kv_heads_x2, actual_head_dim)
+    merged = jnp.pad(
+        merged,
+        (
+            (0, 0),
+            (0, padded_kv_heads_x2 - actual_kv_heads_x2),
+            (0, cache_head_dim - actual_head_dim),
+        ),
+    )
+    return merged.reshape(num_tokens, cache_head_groups, packing,
+                          cache_head_dim)
+
+
+def replace_cached_kv(
+    kv_cache: jax.Array,
+    keys: jax.Array,
+    values: jax.Array,
+    input_positions: jax.Array,
+    block_tables: jax.Array,
+    active_rows: jax.Array,
+) -> jax.Array:
+    """Overwrite arbitrary logical token positions in a paged K/V cache."""
+    if active_rows.ndim != 1:
+        raise ValueError("active_rows must be one-dimensional")
+    batch_size = active_rows.shape[0]
+    if keys.shape[0] % batch_size:
+        raise ValueError("K/V token count must be divisible by the batch size")
+    if input_positions.shape != (keys.shape[0], ):
+        raise ValueError("input_positions must contain one entry per K/V token")
+    if block_tables.size % batch_size:
+        raise ValueError("block_tables must contain equally sized request rows")
+
+    tokens_per_row = keys.shape[0] // batch_size
+    pages_per_row = block_tables.size // batch_size
+    page_size = kv_cache.shape[1]
+    logical_tables = block_tables.reshape(batch_size, pages_per_row)
+    row_indices = jnp.repeat(jnp.arange(batch_size), tokens_per_row)
+    logical_pages = input_positions // page_size
+    bounded_logical_pages = jnp.clip(logical_pages, 0, pages_per_row - 1)
+    physical_pages = logical_tables[row_indices, bounded_logical_pages]
+    token_is_active = jnp.repeat(active_rows.astype(bool), tokens_per_row)
+    token_is_valid = (
+        token_is_active
+        & (input_positions >= 0)
+        & (logical_pages >= 0)
+        & (logical_pages < pages_per_row)
+        & (physical_pages >= 0)
+        & (physical_pages < kv_cache.shape[0])
+    )
+    dropped_page = jnp.asarray(kv_cache.shape[0], dtype=physical_pages.dtype)
+    physical_pages = jnp.where(token_is_valid, physical_pages, dropped_page)
+    page_offsets = jnp.mod(input_positions, page_size)
+    packed_kv = _pack_kv_for_cache(keys, values, kv_cache.shape)
+    return kv_cache.at[physical_pages, page_offsets].set(packed_kv,
+                                                         mode="drop")

--- a/tpu_inference/layers/jax/__init__.py
+++ b/tpu_inference/layers/jax/__init__.py
@@ -28,7 +28,7 @@ class JaxModule(nnx.Module):
                          prefix: str = "",
                          recurse=True) -> Iterator[tuple[str, nnx.Param]]:
         """Yields the named parameters of the module.
-        
+
         Arguments:
             prefix: Prefix to add to the parameter names.
             recurse: If True, then yields parameters of this module and all submodules.
@@ -52,7 +52,7 @@ class JaxModule(nnx.Module):
     def named_children(
             self) -> Iterator[tuple[str, "JaxModule | JaxModuleList"]]:
         """Returns an iterator over immediate children modules.
-        
+
         Yields:
             (string, Module | list): Tuple containing a name and child module
         """
@@ -106,6 +106,15 @@ class JaxModule(nnx.Module):
             child_prefix = f"{prefix}.{name}" if prefix else name
             yield from child.named_modules(memo, child_prefix,
                                            remove_duplicate)
+
+    def modules(self) -> Iterator["JaxModule | JaxModuleList"]:
+        """Yields self and every descendant module.
+
+        Mirrors ``torch.nn.Module.modules`` so vLLM lifecycle code can inspect a
+        JAX model without assuming that it is a PyTorch module.
+        """
+        for _, module in self.named_modules():
+            yield module
 
 
 class JaxModuleList(nnx.List):
@@ -173,3 +182,8 @@ class JaxModuleList(nnx.List):
             module_prefix = f"{prefix}.{idx}" if prefix else str(idx)
             yield from module.named_modules(memo, module_prefix,
                                             remove_duplicate)
+
+    def modules(self) -> Iterator["JaxModule | JaxModuleList"]:
+        """Yields the container and every descendant module."""
+        for _, module in self.named_modules():
+            yield module

--- a/tpu_inference/layers/jax/attention/attention.py
+++ b/tpu_inference/layers/jax/attention/attention.py
@@ -26,7 +26,8 @@ from jax.sharding import PartitionSpec as P
 from tpu_inference import envs, utils
 from tpu_inference.kernels.ragged_paged_attention.v3.kernel import \
     ragged_paged_attention
-from tpu_inference.layers.common.attention_metadata import AttentionMetadata
+from tpu_inference.layers.common.attention_metadata import (
+    AttentionMetadata, resolve_use_causal_mask)
 from tpu_inference.layers.common.quantization import quantize_kv
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.base import create_param
@@ -272,6 +273,7 @@ class Attention(nnx.Module):
                 q_scale=q_scale,
                 k_scale=k_scale,
                 v_scale=v_scale,
+                use_causal_mask=resolve_use_causal_mask(attention_metadata),
                 **block_size_kwargs,
             )
 

--- a/tpu_inference/models/common/interface.py
+++ b/tpu_inference/models/common/interface.py
@@ -55,3 +55,6 @@ class ModelInterface:
     state_leaves: Any
     lora_manager: Callable
     model: Any
+    # Model forward callable safe to invoke from an enclosing JAX program. It
+    # omits compiler options that JAX only permits on a top-level jit.
+    model_fn_no_options: Callable | None = None

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -372,7 +372,27 @@ def get_flax_model(
     # costs ~17 ms/step on Gemma-4-31B decode at TP=2.
     _state_treedef = jax.tree_util.tree_structure(state)
 
-    @jax.jit(
+    def run_model_impl(state_leaves, *args):
+        state = jax.tree_util.tree_unflatten(_state_treedef, state_leaves)
+        model = nnx.merge(graphdef, state)
+        return model(*args)
+
+    run_model_no_options = jax.jit(
+        run_model_impl,
+        out_shardings=(
+            kv_cache_sharding,
+            hidden_states_sharding,
+            hidden_states_sharding,  # aux hidden states
+            None,  # expert ids
+        ),
+        donate_argnums=1,  # 0 is state_leaves, 1 is kv_cache
+        static_argnums=(
+            6, 9, 10
+        ),  # 6 is layer_name_to_kvcache_index, 9 is is_first_rank, 10 is is_last_rank
+    )
+
+    run_model = jax.jit(
+        run_model_impl,
         out_shardings=(
             kv_cache_sharding,
             hidden_states_sharding,
@@ -385,10 +405,6 @@ def get_flax_model(
         ),  # 6 is layer_name_to_kvcache_index, 9 is is_first_rank, 10 is is_last_rank
         compiler_options=get_step_fn_compiler_options(),
     )
-    def run_model(state_leaves, *args):
-        state = jax.tree_util.tree_unflatten(_state_treedef, state_leaves)
-        model = nnx.merge(graphdef, state)
-        return model(*args)
 
     @jax.jit(
         out_shardings=(
@@ -460,6 +476,8 @@ def get_flax_model(
     # `graphdef` and the state treedef are captured in each closure; the
     # runner passes pre-flattened `state_leaves` as the first positional arg.
     jitted_model_fn = run_draft_model if is_draft_model else run_model
+    model_fn_no_options = (run_draft_model
+                           if is_draft_model else run_model_no_options)
 
     model_supports_spec_step = supports_kw(model_class.__call__,
                                            "spec_step_idx")
@@ -469,6 +487,12 @@ def get_flax_model(
             kwargs.pop("spec_step_idx", None)
         kwargs.pop("shared_attention_metadata", None)
         return jitted_model_fn(*args, **kwargs)
+
+    def wrapped_model_fn_no_options(*args, **kwargs):
+        if not model_supports_spec_step:
+            kwargs.pop("spec_step_idx", None)
+        kwargs.pop("shared_attention_metadata", None)
+        return model_fn_no_options(*args, **kwargs)
 
     compute_logits_fn = run_compute_logits
     embed_input_ids_fn = run_embed_input_ids
@@ -553,6 +577,7 @@ def get_flax_model(
         state_leaves=state_leaves,
         lora_manager=lora_manager,
         model=jit_model,
+        model_fn_no_options=wrapped_model_fn_no_options,
     )
 
 
@@ -608,6 +633,7 @@ def get_vllm_model(
         state_leaves=params,
         lora_manager=lora_manager,
         model=model,
+        model_fn_no_options=getattr(model, "step_fn_no_options", jit_model),
     )
 
 

--- a/tpu_inference/models/jax/qwen2.py
+++ b/tpu_inference/models/jax/qwen2.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from itertools import islice
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
@@ -48,6 +48,10 @@ logger = init_logger(__name__)
 
 init_fn = nnx.initializers.uniform()
 modeling_flax_utils = FlaxUtils()
+
+
+def _get_language_config(hf_config: Any) -> Any:
+    return getattr(hf_config, "text_config", hf_config)
 
 
 class Qwen2MLP(JaxModule):
@@ -304,7 +308,7 @@ class Qwen2Model(JaxModule):
         model_config = vllm_config.model_config
         hf_config = model_config.hf_config
         # Since transformers v5, Qwen2_5_VLConfig nests language attrs under text_config
-        lang_config = getattr(hf_config, 'text_config', hf_config)
+        lang_config = _get_language_config(hf_config)
         vocab_size = model_config.get_vocab_size()
         dtype = model_config.dtype
         rms_norm_eps = lang_config.rms_norm_eps
@@ -396,9 +400,8 @@ class Qwen2ForCausalLM(JaxModule, LoadableWithIterator):
         model_config = vllm_config.model_config
         if not model_config.hf_config.tie_word_embeddings:
             vocab_size = model_config.get_vocab_size()
-            hidden_size = getattr(
-                model_config.hf_config, 'hidden_size',
-                model_config.hf_config.text_config.hidden_size)
+            hidden_size = _get_language_config(
+                model_config.hf_config).hidden_size
             self.lm_head = JaxLmHead(
                 hidden_size=hidden_size,
                 vocab_size=vocab_size,

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -9,6 +9,11 @@ import jax.numpy as jnp
 import numpy
 import torch
 import vllm.envs as vllm_envs
+from vllm.platforms.interface import Platform, PlatformEnum
+
+from tpu_inference import envs, tpu_info
+from tpu_inference.layers.common.sharding import ShardingConfigManager
+from tpu_inference.logger import init_logger
 
 # Monkeypatch torch.accelerator.empty_cache to ignore device_allocator error on TPU.
 if hasattr(torch, "accelerator") and hasattr(torch.accelerator, "empty_cache"):
@@ -24,11 +29,6 @@ if hasattr(torch, "accelerator") and hasattr(torch.accelerator, "empty_cache"):
                 raise e
 
     torch.accelerator.empty_cache = _patched_empty_cache
-from vllm.platforms.interface import Platform, PlatformEnum
-
-from tpu_inference import envs
-from tpu_inference.layers.common.sharding import ShardingConfigManager
-from tpu_inference.logger import init_logger
 
 # TODO(weiyulin): These dummy ops bypass vLLM's eager CUDA-specific imports during
 # Sequence Parallelism initialization. Our TPU SP implementation (see
@@ -158,15 +158,13 @@ class TpuPlatform(Platform):
             if vllm_envs.VLLM_TPU_USING_PATHWAYS:
                 # Causes mutliprocess accessing IFRT when calling jax.devices()
                 return "TPU v6 lite"
-            else:
-                # The tpu_info package, upon being imported, executes
-                # _initialize_libtpu_safely(), which attempts to start a new
-                # process (process.start()). Python's multiprocessing module
-                # forbids starting new processes, resulting in error.
-                # So import tpu_info here instead.
-                from tpu_info import device
-                chip_type, _ = device.get_local_chips()
-                return f"TPU {chip_type.name}"
+            accelerator_type = tpu_info.get_tpu_type()
+            chip_type = accelerator_type.split("-", maxsplit=1)[0].lower()
+            chip_type = {
+                "tpu7x": "v7x",
+                "v5litepod": "v5e",
+            }.get(chip_type, chip_type)
+            return f"TPU {chip_type}"
         except Exception as e:
             logger.warning(f"Error getting device name: {e}")
             return 'TPU'

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -403,6 +403,19 @@ class TpuPlatform(Platform):
         from tpu_inference.core.sched.dp_scheduler import \
             update_vllm_config_for_dp_scheduler
         update_vllm_config_for_dp_scheduler(vllm_config)
+        if (enable_block_diffusion
+                and generation_strategy.diffusion is not None
+                and generation_strategy.diffusion.runtime.cohort_max_wait_ms
+                > 0.0):
+            from tpu_inference.core.sched.diffusion_cohort_scheduler import \
+                BlockDiffusionCohortScheduler
+            scheduler_config.scheduler_cls = BlockDiffusionCohortScheduler
+            logger.info(
+                "Enabled block-diffusion cohort admission with max wait %.3f "
+                "ms and target size %d",
+                generation_strategy.diffusion.runtime.cohort_max_wait_ms,
+                scheduler_config.max_num_seqs,
+            )
 
         if enable_continue_decode or enable_block_diffusion:
             mode = ("continue_decode"

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -98,6 +98,9 @@ else:
 
 logger = init_logger(__name__)
 
+_DIFFUSION_ROUND_ROBIN_VALIDATED_DP_SIZE = \
+    "_tpu_diffusion_round_robin_validated_dp_size"
+
 
 class TpuPlatform(Platform):
     _enum = PlatformEnum.TPU
@@ -371,6 +374,7 @@ class TpuPlatform(Platform):
         generation_strategy = resolve_generation_strategy(vllm_config)
         enable_block_diffusion = (generation_strategy.strategy
                                   is GenerationStrategy.BLOCK_DIFFUSION)
+        install_diffusion_round_robin_dp = False
         if enable_continue_decode and enable_block_diffusion:
             raise ValueError(
                 "continue_decode and block_diffusion are mutually exclusive")
@@ -397,6 +401,41 @@ class TpuPlatform(Platform):
                 MULTI_TOKEN_LOOKAHEAD_CONFIG
             vllm_config.additional_config[
                 MULTI_TOKEN_LOOKAHEAD_CONFIG] = diffusion.model.block_size - 1
+            if diffusion.runtime.cohort_round_robin_dp:
+                data_parallel_index = getattr(parallel_config,
+                                              "data_parallel_index", None)
+                validated_dp_size = vllm_config.additional_config.get(
+                    _DIFFUSION_ROUND_ROBIN_VALIDATED_DP_SIZE)
+                is_validated_dp_child = (
+                    requested_data_parallel_size == 1
+                    and type(validated_dp_size) is int
+                    and validated_dp_size > 1
+                    and isinstance(data_parallel_index, int)
+                    and 0 <= data_parallel_index < validated_dp_size)
+                if not is_validated_dp_child:
+                    if (requested_data_parallel_size <= 1
+                            or not envs.TPU_MULTIPROCESS_DP):
+                        raise ValueError(
+                            "Diffusion cohort_round_robin_dp requires native "
+                            "multiprocess data parallelism with "
+                            "data_parallel_size greater than 1")
+                    if getattr(parallel_config, "data_parallel_external_lb",
+                               False):
+                        raise ValueError(
+                            "Diffusion cohort_round_robin_dp requires vLLM's "
+                            "internal data-parallel load balancer")
+                    if getattr(parallel_config, "data_parallel_hybrid_lb",
+                               False):
+                        raise ValueError(
+                            "Diffusion cohort_round_robin_dp does not support "
+                            "data-parallel hybrid load balancing")
+                    api_process_count = getattr(parallel_config,
+                                                "_api_process_count", None)
+                    if api_process_count != 1:
+                        raise ValueError(
+                            "Diffusion cohort_round_robin_dp requires "
+                            "--api-server-count=1")
+                    install_diffusion_round_robin_dp = True
         is_pooling_model = vllm_config.model_config.runner_type == "pooling"
 
         # Late initialization to avoid circular import.
@@ -478,6 +517,16 @@ class TpuPlatform(Platform):
                            False):
                     raise ValueError(
                         "block_diffusion is not supported with prefix caching")
+                if install_diffusion_round_robin_dp:
+                    from tpu_inference.core.diffusion_dp_router import \
+                        patch_vllm_dp_client_for_block_diffusion_round_robin
+                    patch_vllm_dp_client_for_block_diffusion_round_robin()
+                    vllm_config.additional_config[
+                        _DIFFUSION_ROUND_ROBIN_VALIDATED_DP_SIZE] = (
+                            requested_data_parallel_size)
+                    logger.info(
+                        "Enabled deterministic round-robin routing for "
+                        "block-diffusion DP cohorts")
 
             if enable_continue_decode:
                 from tpu_inference.core.sched.utils import \

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -266,6 +266,8 @@ class TpuPlatform(Platform):
     @classmethod
     def check_and_update_config(cls, vllm_config: VllmConfig) -> None:
 
+        requested_data_parallel_size = \
+            vllm_config.parallel_config.data_parallel_size
         cls._resolve_multiprocess_dp(vllm_config)
 
         if vllm_envs.VLLM_TPU_USING_PATHWAYS:
@@ -366,6 +368,37 @@ class TpuPlatform(Platform):
 
         enable_continue_decode = vllm_config.additional_config.get(
             "enable_continue_decode", False)
+        from tpu_inference.runner.diffusion.config import (
+            GenerationStrategy, resolve_generation_strategy)
+        generation_strategy = resolve_generation_strategy(vllm_config)
+        enable_block_diffusion = (generation_strategy.strategy
+                                  is GenerationStrategy.BLOCK_DIFFUSION)
+        if enable_continue_decode and enable_block_diffusion:
+            raise ValueError(
+                "continue_decode and block_diffusion are mutually exclusive")
+        if enable_block_diffusion:
+            assert generation_strategy.diffusion is not None
+            diffusion = generation_strategy.diffusion
+            from tpu_inference.runner.diffusion.request_validation import \
+                patch_vllm_input_processor_for_block_diffusion
+            patch_vllm_input_processor_for_block_diffusion()
+            from tpu_inference.runner.utils import MIN_NUM_SEQS
+            diffusion_batch_capacity = (
+                scheduler_config.max_num_batched_tokens //
+                diffusion.model.block_size)
+            if diffusion_batch_capacity < MIN_NUM_SEQS:
+                raise ValueError(
+                    "block_diffusion requires max_num_batched_tokens to fit "
+                    f"the minimum padded batch of {MIN_NUM_SEQS} diffusion "
+                    "blocks")
+            scheduler_config.max_num_seqs = min(
+                scheduler_config.max_num_seqs,
+                diffusion_batch_capacity,
+            )
+            from tpu_inference.core.sched.utils import \
+                MULTI_TOKEN_LOOKAHEAD_CONFIG
+            vllm_config.additional_config[
+                MULTI_TOKEN_LOOKAHEAD_CONFIG] = diffusion.model.block_size - 1
         is_pooling_model = vllm_config.model_config.runner_type == "pooling"
 
         # Late initialization to avoid circular import.
@@ -373,18 +406,73 @@ class TpuPlatform(Platform):
             update_vllm_config_for_dp_scheduler
         update_vllm_config_for_dp_scheduler(vllm_config)
 
-        if enable_continue_decode:
+        if enable_continue_decode or enable_block_diffusion:
+            mode = ("continue_decode"
+                    if enable_continue_decode else "block_diffusion")
             if parallel_config.pipeline_parallel_size > 1:
                 raise ValueError(
-                    "continue_decode is not supported with pipeline parallelism"
-                )
+                    f"{mode} is not supported with pipeline parallelism")
             if is_pooling_model:
-                raise ValueError(
-                    "continue_decode is not supported for pooling models")
+                raise ValueError(f"{mode} is not supported for pooling models")
 
-            from tpu_inference.core.sched.utils import \
-                patch_vllm_scheduler_for_continue_decode
-            patch_vllm_scheduler_for_continue_decode()
+            if enable_block_diffusion:
+                if kv_transfer_config is not None:
+                    raise ValueError(
+                        "block_diffusion does not support KV transfer")
+                if scheduler_config.async_scheduling:
+                    raise ValueError(
+                        "block_diffusion is not supported with async scheduling"
+                    )
+                if vllm_config.speculative_config is not None:
+                    raise ValueError(
+                        "block_diffusion is not supported with speculative decoding"
+                    )
+                if vllm_config.lora_config is not None:
+                    raise ValueError(
+                        "block_diffusion is not supported with LoRA")
+                if vllm_config.model_config.is_multimodal_model:
+                    raise ValueError(
+                        "block_diffusion is not supported for multimodal models"
+                    )
+                total_dp_size = getattr(vllm_config.sharding_config,
+                                        "total_dp_size", 1)
+                if (requested_data_parallel_size > 1 or
+                    (isinstance(total_dp_size, int) and total_dp_size > 1)):
+                    raise ValueError(
+                        "block_diffusion currently requires data_parallel_size=1"
+                    )
+                if getattr(scheduler_config, "enable_chunked_prefill", False):
+                    raise ValueError(
+                        "block_diffusion currently requires chunked prefill "
+                        "to be disabled")
+                if envs.USE_BATCHED_RPA_KERNEL:
+                    raise ValueError(
+                        "block_diffusion requires the default RPA kernel")
+                hf_config = vllm_config.model_config.hf_config
+                text_config = getattr(hf_config, "text_config", hf_config)
+                head_dim = getattr(text_config, "head_dim", None)
+                if head_dim is None:
+                    hidden_size = getattr(text_config, "hidden_size", None)
+                    num_heads = getattr(text_config, "num_attention_heads",
+                                        None)
+                    if hidden_size is not None and num_heads:
+                        head_dim = hidden_size // num_heads
+                if head_dim == 64:
+                    raise ValueError(
+                        "block_diffusion is not supported with head_dim=64")
+                if getattr(vllm_config.cache_config, "enable_prefix_caching",
+                           False):
+                    raise ValueError(
+                        "block_diffusion is not supported with prefix caching")
+
+            if enable_continue_decode:
+                from tpu_inference.core.sched.utils import \
+                    patch_vllm_scheduler_for_continue_decode
+                patch_vllm_scheduler_for_continue_decode()
+            else:
+                from tpu_inference.core.sched.utils import \
+                    patch_vllm_scheduler_for_multi_token_decode
+                patch_vllm_scheduler_for_multi_token_decode()
 
     @classmethod
     def update_block_size_for_backend(cls, vllm_config: VllmConfig) -> None:

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -448,11 +448,12 @@ class TpuPlatform(Platform):
                     )
                 total_dp_size = getattr(vllm_config.sharding_config,
                                         "total_dp_size", 1)
-                if (requested_data_parallel_size > 1 or
+                if ((requested_data_parallel_size > 1
+                     and not envs.TPU_MULTIPROCESS_DP) or
                     (isinstance(total_dp_size, int) and total_dp_size > 1)):
                     raise ValueError(
-                        "block_diffusion currently requires data_parallel_size=1"
-                    )
+                        "block_diffusion currently requires "
+                        "data_parallel_size=1 within each process")
                 if getattr(scheduler_config, "enable_chunked_prefill", False):
                     raise ValueError(
                         "block_diffusion currently requires chunked prefill "

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -412,9 +412,10 @@ class TpuPlatform(Platform):
             scheduler_config.scheduler_cls = BlockDiffusionCohortScheduler
             logger.info(
                 "Enabled block-diffusion cohort admission with max wait %.3f "
-                "ms, quiet wait %.3f ms, and target size %d",
+                "ms, quiet wait %.3f ms, strict waves %s, and target size %d",
                 generation_strategy.diffusion.runtime.cohort_max_wait_ms,
                 generation_strategy.diffusion.runtime.cohort_quiet_wait_ms,
+                generation_strategy.diffusion.runtime.cohort_strict_waves,
                 scheduler_config.max_num_seqs,
             )
 

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -412,8 +412,9 @@ class TpuPlatform(Platform):
             scheduler_config.scheduler_cls = BlockDiffusionCohortScheduler
             logger.info(
                 "Enabled block-diffusion cohort admission with max wait %.3f "
-                "ms and target size %d",
+                "ms, quiet wait %.3f ms, and target size %d",
                 generation_strategy.diffusion.runtime.cohort_max_wait_ms,
+                generation_strategy.diffusion.runtime.cohort_quiet_wait_ms,
                 scheduler_config.max_num_seqs,
             )
 

--- a/tpu_inference/runner/diffusion/__init__.py
+++ b/tpu_inference/runner/diffusion/__init__.py
@@ -1,0 +1,34 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from tpu_inference.runner.diffusion.config import (
+    AttentionPolicy, CanvasPolicy, DiffusionAlgorithm, DiffusionConfig,
+    DiffusionModelSpec, DiffusionRuntimeConfig, GenerationStrategy,
+    GenerationStrategyConfig, LogitAlignment, PromptRemainderPolicy,
+    register_diffusion_model_adapter, resolve_generation_strategy)
+
+__all__ = [
+    "AttentionPolicy",
+    "CanvasPolicy",
+    "DiffusionAlgorithm",
+    "DiffusionConfig",
+    "DiffusionModelSpec",
+    "DiffusionRuntimeConfig",
+    "GenerationStrategy",
+    "GenerationStrategyConfig",
+    "LogitAlignment",
+    "PromptRemainderPolicy",
+    "register_diffusion_model_adapter",
+    "resolve_generation_strategy",
+]

--- a/tpu_inference/runner/diffusion/__init__.py
+++ b/tpu_inference/runner/diffusion/__init__.py
@@ -21,9 +21,10 @@ from tpu_inference.runner.diffusion.config import (
     GenerationStrategyConfig, LogitAlignment, NextBlockPolicy,
     PromptRemainderPolicy, register_diffusion_model_adapter,
     resolve_generation_strategy)
-from tpu_inference.runner.diffusion.program import (BlockForwardFn,
-                                                    DenoiseBlockOutput,
-                                                    denoise_block)
+from tpu_inference.runner.diffusion.program import (
+    AlignedSubBlockForwardFn, BlockForwardFn, DenoiseBlockOutput,
+    DualCacheDenoiseBlockOutput, FinalBlockForwardFn, denoise_block,
+    denoise_block_dual_cache, select_aligned_hidden_states)
 
 from tpu_inference.runner.diffusion.batch import (  # isort: skip
     PendingBlockOutput, PromptBlockPlan, complete_seeded_decode_block,
@@ -33,16 +34,19 @@ from tpu_inference.runner.diffusion.batch import (  # isort: skip
 
 __all__ = [
     "AttentionPolicy",
+    "AlignedSubBlockForwardFn",
     "BlockForwardFn",
     "CanvasPolicy",
     "CommitFn",
     "DenoiseBlockOutput",
+    "DualCacheDenoiseBlockOutput",
     "DiffusionAlgorithm",
     "DiffusionConfig",
     "DiffusionModelSpec",
     "DiffusionRuntimeConfig",
     "GenerationStrategy",
     "GenerationStrategyConfig",
+    "FinalBlockForwardFn",
     "LogitAlignment",
     "NextBlockPolicy",
     "PendingBlockOutput",
@@ -50,6 +54,7 @@ __all__ = [
     "PromptRemainderPolicy",
     "complete_seeded_decode_block",
     "denoise_block",
+    "denoise_block_dual_cache",
     "flush_partial_block_output",
     "get_commit_algorithm",
     "low_confidence_commit",
@@ -57,5 +62,6 @@ __all__ = [
     "required_cache_end",
     "register_diffusion_model_adapter",
     "resolve_generation_strategy",
+    "select_aligned_hidden_states",
     "start_partial_block_output",
 ]

--- a/tpu_inference/runner/diffusion/__init__.py
+++ b/tpu_inference/runner/diffusion/__init__.py
@@ -12,15 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from tpu_inference.runner.diffusion.algorithm import (CommitFn,
+                                                      get_commit_algorithm,
+                                                      low_confidence_commit)
 from tpu_inference.runner.diffusion.config import (
     AttentionPolicy, CanvasPolicy, DiffusionAlgorithm, DiffusionConfig,
     DiffusionModelSpec, DiffusionRuntimeConfig, GenerationStrategy,
-    GenerationStrategyConfig, LogitAlignment, PromptRemainderPolicy,
-    register_diffusion_model_adapter, resolve_generation_strategy)
+    GenerationStrategyConfig, LogitAlignment, NextBlockPolicy,
+    PromptRemainderPolicy, register_diffusion_model_adapter,
+    resolve_generation_strategy)
+from tpu_inference.runner.diffusion.program import (BlockForwardFn,
+                                                    DenoiseBlockOutput,
+                                                    denoise_block)
 
 __all__ = [
     "AttentionPolicy",
+    "BlockForwardFn",
     "CanvasPolicy",
+    "CommitFn",
+    "DenoiseBlockOutput",
     "DiffusionAlgorithm",
     "DiffusionConfig",
     "DiffusionModelSpec",
@@ -28,7 +38,11 @@ __all__ = [
     "GenerationStrategy",
     "GenerationStrategyConfig",
     "LogitAlignment",
+    "NextBlockPolicy",
     "PromptRemainderPolicy",
+    "denoise_block",
+    "get_commit_algorithm",
+    "low_confidence_commit",
     "register_diffusion_model_adapter",
     "resolve_generation_strategy",
 ]

--- a/tpu_inference/runner/diffusion/__init__.py
+++ b/tpu_inference/runner/diffusion/__init__.py
@@ -25,6 +25,12 @@ from tpu_inference.runner.diffusion.program import (BlockForwardFn,
                                                     DenoiseBlockOutput,
                                                     denoise_block)
 
+from tpu_inference.runner.diffusion.batch import (  # isort: skip
+    PendingBlockOutput, PromptBlockPlan, complete_seeded_decode_block,
+    flush_partial_block_output, plan_seeded_prompt, required_cache_end,
+    start_partial_block_output,
+)
+
 __all__ = [
     "AttentionPolicy",
     "BlockForwardFn",
@@ -39,10 +45,17 @@ __all__ = [
     "GenerationStrategyConfig",
     "LogitAlignment",
     "NextBlockPolicy",
+    "PendingBlockOutput",
+    "PromptBlockPlan",
     "PromptRemainderPolicy",
+    "complete_seeded_decode_block",
     "denoise_block",
+    "flush_partial_block_output",
     "get_commit_algorithm",
     "low_confidence_commit",
+    "plan_seeded_prompt",
+    "required_cache_end",
     "register_diffusion_model_adapter",
     "resolve_generation_strategy",
+    "start_partial_block_output",
 ]

--- a/tpu_inference/runner/diffusion/algorithm.py
+++ b/tpu_inference/runner/diffusion/algorithm.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 from collections.abc import Callable
+from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -23,6 +24,31 @@ CommitFn = Callable[
     [jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, int],
     tuple[jax.Array, jax.Array],
 ]
+
+
+class CommitDiagnostics(NamedTuple):
+    selected_log_confidence: jax.Array
+    threshold_margin: jax.Array
+
+
+CommitDiagnosticsFn = Callable[
+    [jax.Array, jax.Array, jax.Array, int],
+    CommitDiagnostics,
+]
+
+
+def confidence_threshold_with_log_bias(
+    confidence_threshold: jax.Array,
+    log_confidence_bias: float,
+) -> jax.Array:
+    """Lower a probability threshold by an additive log-confidence bias."""
+    if log_confidence_bias == 0.0:
+        return confidence_threshold
+    threshold = jnp.asarray(confidence_threshold, dtype=jnp.float32)
+    bias = jnp.asarray(log_confidence_bias, dtype=jnp.float32)
+    biased_threshold = threshold * jnp.exp(-bias)
+    return jnp.where((threshold > 0.0) & (threshold < 1.0), biased_threshold,
+                     threshold)
 
 
 def _exclude_mask_token(
@@ -53,6 +79,45 @@ def _exclude_mask_token(
     return candidate_logits.at[..., fallback_token_id].set(fallback_logits)
 
 
+def _low_confidence_scores(
+    logits: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    mask_token_id: int,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    confidence_threshold = jnp.asarray(confidence_threshold, dtype=jnp.float32)
+    temperature = jnp.asarray(temperature, dtype=jnp.float32)
+    safe_temperature = jnp.where(temperature > 0.0, temperature, 1.0)
+    scaled_logits = logits.astype(jnp.float32) / safe_temperature[:, None,
+                                                                  None]
+    scaled_logits = _exclude_mask_token(scaled_logits, mask_token_id)
+
+    token_ids = jnp.argmax(scaled_logits, axis=-1).astype(jnp.int32)
+    max_logits = jnp.max(scaled_logits, axis=-1)
+    log_confidence = max_logits - jax.nn.logsumexp(scaled_logits, axis=-1)
+    log_threshold = jnp.log(jnp.clip(confidence_threshold, min=0.0,
+                                     max=1.0))[:, None]
+    return token_ids, log_confidence, log_threshold
+
+
+def low_confidence_diagnostics(
+    logits: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    mask_token_id: int,
+) -> CommitDiagnostics:
+    _, log_confidence, log_threshold = _low_confidence_scores(
+        logits,
+        confidence_threshold,
+        temperature,
+        mask_token_id,
+    )
+    return CommitDiagnostics(
+        selected_log_confidence=log_confidence,
+        threshold_margin=log_confidence - log_threshold,
+    )
+
+
 def low_confidence_commit(
     logits: jax.Array,
     eligible_mask: jax.Array,
@@ -71,18 +136,12 @@ def low_confidence_commit(
         raise ValueError("eligible_mask must match logits [batch, length]")
 
     active_rows = jnp.asarray(active_rows, dtype=bool)
-    confidence_threshold = jnp.asarray(confidence_threshold, dtype=jnp.float32)
-    temperature = jnp.asarray(temperature, dtype=jnp.float32)
-    safe_temperature = jnp.where(temperature > 0.0, temperature, 1.0)
-    scaled_logits = logits.astype(jnp.float32) / safe_temperature[:, None,
-                                                                  None]
-    scaled_logits = _exclude_mask_token(scaled_logits, mask_token_id)
-
-    token_ids = jnp.argmax(scaled_logits, axis=-1).astype(jnp.int32)
-    max_logits = jnp.max(scaled_logits, axis=-1)
-    log_confidence = max_logits - jax.nn.logsumexp(scaled_logits, axis=-1)
-    log_threshold = jnp.log(jnp.clip(confidence_threshold, min=0.0,
-                                     max=1.0))[:, None]
+    token_ids, log_confidence, log_threshold = _low_confidence_scores(
+        logits,
+        confidence_threshold,
+        temperature,
+        mask_token_id,
+    )
 
     eligible = jnp.asarray(eligible_mask, dtype=bool) & active_rows[:, None]
     commit = eligible & (log_confidence > log_threshold)
@@ -101,6 +160,10 @@ _COMMIT_ALGORITHMS: dict[DiffusionAlgorithm, CommitFn] = {
     DiffusionAlgorithm.LOW_CONFIDENCE: low_confidence_commit,
 }
 
+_COMMIT_DIAGNOSTICS: dict[DiffusionAlgorithm, CommitDiagnosticsFn] = {
+    DiffusionAlgorithm.LOW_CONFIDENCE: low_confidence_diagnostics,
+}
+
 
 def get_commit_algorithm(algorithm: DiffusionAlgorithm) -> CommitFn:
     try:
@@ -109,3 +172,13 @@ def get_commit_algorithm(algorithm: DiffusionAlgorithm) -> CommitFn:
         raise ValueError(
             f"No commit implementation is registered for {algorithm.value!r}"
         ) from exc
+
+
+def get_commit_diagnostics_algorithm(
+        algorithm: DiffusionAlgorithm) -> CommitDiagnosticsFn:
+    try:
+        return _COMMIT_DIAGNOSTICS[algorithm]
+    except KeyError as exc:
+        raise ValueError(
+            "No commit diagnostics implementation is registered for "
+            f"{algorithm.value!r}") from exc

--- a/tpu_inference/runner/diffusion/algorithm.py
+++ b/tpu_inference/runner/diffusion/algorithm.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable
+
+import jax
+import jax.numpy as jnp
+
+from tpu_inference.runner.diffusion.config import DiffusionAlgorithm
+
+CommitFn = Callable[
+    [jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, int],
+    tuple[jax.Array, jax.Array],
+]
+
+
+def _exclude_mask_token(
+    logits: jax.Array,
+    mask_token_id: int,
+) -> jax.Array:
+    """Remove the diffusion MASK token from the candidate distribution."""
+    if logits.ndim != 3:
+        raise ValueError("logits must have shape [batch, length, vocab]")
+    vocab_size = logits.shape[-1]
+    if vocab_size < 2:
+        raise ValueError("logits must contain at least two vocabulary entries")
+    if not 0 <= mask_token_id < vocab_size:
+        raise ValueError("mask_token_id must be within the logits vocabulary")
+
+    candidate_logits = logits.astype(jnp.float32)
+    candidate_logits = candidate_logits.at[..., mask_token_id].set(-jnp.inf)
+
+    # Keep one non-MASK candidate finite so argmax cannot select MASK even when
+    # every model logit is -inf.
+    fallback_token_id = 1 if mask_token_id == 0 else 0
+    fallback_logits = candidate_logits[..., fallback_token_id]
+    fallback_logits = jnp.where(
+        jnp.isneginf(fallback_logits) | jnp.isnan(fallback_logits),
+        jnp.finfo(jnp.float32).min,
+        fallback_logits,
+    )
+    return candidate_logits.at[..., fallback_token_id].set(fallback_logits)
+
+
+def low_confidence_commit(
+    logits: jax.Array,
+    eligible_mask: jax.Array,
+    active_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    mask_token_id: int,
+) -> tuple[jax.Array, jax.Array]:
+    """Select greedy tokens and retain positions that need more denoising.
+
+    Temperature rescales confidence and can therefore change which positions
+    cross the commit threshold. Token selection remains deterministic argmax:
+    this algorithm has no RNG and temperature does not sample alternate tokens.
+    """
+    if eligible_mask.shape != logits.shape[:2]:
+        raise ValueError("eligible_mask must match logits [batch, length]")
+
+    active_rows = jnp.asarray(active_rows, dtype=bool)
+    confidence_threshold = jnp.asarray(confidence_threshold, dtype=jnp.float32)
+    temperature = jnp.asarray(temperature, dtype=jnp.float32)
+    safe_temperature = jnp.where(temperature > 0.0, temperature, 1.0)
+    scaled_logits = logits.astype(jnp.float32) / safe_temperature[:, None,
+                                                                  None]
+    scaled_logits = _exclude_mask_token(scaled_logits, mask_token_id)
+
+    token_ids = jnp.argmax(scaled_logits, axis=-1).astype(jnp.int32)
+    max_logits = jnp.max(scaled_logits, axis=-1)
+    log_confidence = max_logits - jax.nn.logsumexp(scaled_logits, axis=-1)
+    log_threshold = jnp.log(jnp.clip(confidence_threshold, min=0.0,
+                                     max=1.0))[:, None]
+
+    eligible = jnp.asarray(eligible_mask, dtype=bool) & active_rows[:, None]
+    commit = eligible & (log_confidence > log_threshold)
+
+    masked_confidence = jnp.where(eligible, log_confidence, -jnp.inf)
+    forced_indices = jnp.argmax(masked_confidence, axis=-1)
+    forced = jax.nn.one_hot(forced_indices, logits.shape[1], dtype=bool)
+    forced &= jnp.any(eligible, axis=-1)[:, None]
+    commit |= forced
+
+    remaining = eligible & ~commit
+    return token_ids, remaining
+
+
+_COMMIT_ALGORITHMS: dict[DiffusionAlgorithm, CommitFn] = {
+    DiffusionAlgorithm.LOW_CONFIDENCE: low_confidence_commit,
+}
+
+
+def get_commit_algorithm(algorithm: DiffusionAlgorithm) -> CommitFn:
+    try:
+        return _COMMIT_ALGORITHMS[algorithm]
+    except KeyError as exc:
+        raise ValueError(
+            f"No commit implementation is registered for {algorithm.value!r}"
+        ) from exc

--- a/tpu_inference/runner/diffusion/batch.py
+++ b/tpu_inference/runner/diffusion/batch.py
@@ -1,0 +1,102 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class PromptBlockPlan:
+    full_blocks: tuple[tuple[int, ...], ...]
+    partial_canvas: tuple[int, ...] | None
+    partial_mask: tuple[bool, ...] | None
+    remainder_size: int
+
+
+@dataclass
+class PendingBlockOutput:
+    tokens: list[int]
+    next_anchor: int
+
+
+def required_cache_end(
+    prompt_length: int,
+    max_new_tokens: int,
+    block_size: int,
+) -> int:
+    if prompt_length < 0 or max_new_tokens < 0 or block_size < 1:
+        raise ValueError(
+            "Lengths must be non-negative and block_size positive")
+    num_cached_tokens = prompt_length + max(0, max_new_tokens - 1)
+    return ((num_cached_tokens + block_size - 1) // block_size * block_size)
+
+
+def plan_seeded_prompt(
+    prompt_token_ids: list[int],
+    block_size: int,
+    mask_token_id: int,
+) -> PromptBlockPlan:
+    if not prompt_token_ids:
+        raise ValueError("Block diffusion requires a non-empty prompt")
+    if block_size < 1:
+        raise ValueError("block_size must be positive")
+
+    num_full_blocks, remainder_size = divmod(len(prompt_token_ids), block_size)
+    full_blocks = tuple(
+        tuple(prompt_token_ids[index * block_size:(index + 1) * block_size])
+        for index in range(num_full_blocks))
+    if remainder_size == 0:
+        return PromptBlockPlan(
+            full_blocks=full_blocks,
+            partial_canvas=None,
+            partial_mask=None,
+            remainder_size=0,
+        )
+
+    remainder = prompt_token_ids[num_full_blocks * block_size:]
+    partial_canvas = tuple(remainder) + (mask_token_id, ) * (block_size -
+                                                             remainder_size)
+    partial_mask = (False, ) * remainder_size + (True, ) * (block_size -
+                                                            remainder_size)
+    return PromptBlockPlan(
+        full_blocks=full_blocks,
+        partial_canvas=partial_canvas,
+        partial_mask=partial_mask,
+        remainder_size=remainder_size,
+    )
+
+
+def start_partial_block_output(
+    committed_canvas: list[int],
+    remainder_size: int,
+    next_anchor: int,
+) -> tuple[list[int], PendingBlockOutput]:
+    generated = committed_canvas[remainder_size:]
+    if not generated:
+        raise ValueError(
+            "A partial prompt block must generate at least one token")
+    pending = PendingBlockOutput(tokens=generated[1:], next_anchor=next_anchor)
+    return [generated[0]], pending
+
+
+def flush_partial_block_output(state: PendingBlockOutput) -> list[int]:
+    return [*state.tokens, state.next_anchor]
+
+
+def complete_seeded_decode_block(
+    committed_canvas: list[int],
+    next_anchor: int,
+) -> list[int]:
+    if not committed_canvas:
+        raise ValueError("committed_canvas must not be empty")
+    return [*committed_canvas[1:], next_anchor]

--- a/tpu_inference/runner/diffusion/batch.py
+++ b/tpu_inference/runner/diffusion/batch.py
@@ -50,6 +50,13 @@ def diffusion_batch_sizes(capacity: int) -> tuple[int, ...]:
             for num_active in range(capacity + 1)))
 
 
+def needs_block_anchor(mask: list[bool], tokens_remaining: int) -> bool:
+    """Return whether the uncached next-block anchor can reach the response."""
+    if tokens_remaining < 0:
+        raise ValueError("tokens_remaining must be non-negative")
+    return tokens_remaining > sum(mask)
+
+
 def required_cache_end(
     prompt_length: int,
     max_new_tokens: int,

--- a/tpu_inference/runner/diffusion/batch.py
+++ b/tpu_inference/runner/diffusion/batch.py
@@ -14,6 +14,8 @@
 
 from dataclasses import dataclass
 
+_EXACT_BATCH_BUCKET_LIMIT = 4
+
 
 @dataclass(frozen=True)
 class PromptBlockPlan:
@@ -30,13 +32,13 @@ class PendingBlockOutput:
 
 
 def select_diffusion_batch_size(num_active: int, capacity: int) -> int:
-    """Choose the smallest power-of-two request bucket that fits the batch."""
+    """Choose a compact request bucket without compiling every large shape."""
     if capacity < 1:
         raise ValueError("capacity must be positive")
     if not 0 <= num_active <= capacity:
         raise ValueError("num_active must be within the configured capacity")
-    if num_active <= 1:
-        return 1
+    if num_active <= min(capacity, _EXACT_BATCH_BUCKET_LIMIT):
+        return max(1, num_active)
     return min(1 << (num_active - 1).bit_length(), capacity)
 
 

--- a/tpu_inference/runner/diffusion/batch.py
+++ b/tpu_inference/runner/diffusion/batch.py
@@ -29,6 +29,27 @@ class PendingBlockOutput:
     next_anchor: int
 
 
+def select_diffusion_batch_size(num_active: int, capacity: int) -> int:
+    """Choose the smallest power-of-two request bucket that fits the batch."""
+    if capacity < 1:
+        raise ValueError("capacity must be positive")
+    if not 0 <= num_active <= capacity:
+        raise ValueError("num_active must be within the configured capacity")
+    if num_active <= 1:
+        return 1
+    return min(1 << (num_active - 1).bit_length(), capacity)
+
+
+def diffusion_batch_sizes(capacity: int) -> tuple[int, ...]:
+    """Return every request bucket that must be compiled for a capacity."""
+    if capacity < 1:
+        raise ValueError("capacity must be positive")
+    return tuple(
+        dict.fromkeys(
+            select_diffusion_batch_size(num_active, capacity)
+            for num_active in range(capacity + 1)))
+
+
 def required_cache_end(
     prompt_length: int,
     max_new_tokens: int,

--- a/tpu_inference/runner/diffusion/batch.py
+++ b/tpu_inference/runner/diffusion/batch.py
@@ -59,6 +59,18 @@ def needs_block_anchor(mask: list[bool], tokens_remaining: int) -> bool:
     return tokens_remaining > sum(mask)
 
 
+def trim_generation_mask(mask: list[bool], tokens_remaining: int) -> list[bool]:
+    if tokens_remaining < 0:
+        raise ValueError("tokens_remaining must be non-negative")
+    remaining = tokens_remaining
+    trimmed = []
+    for eligible in mask:
+        keep = eligible and remaining > 0
+        trimmed.append(keep)
+        remaining -= int(keep)
+    return trimmed
+
+
 def required_cache_end(
     prompt_length: int,
     max_new_tokens: int,

--- a/tpu_inference/runner/diffusion/config.py
+++ b/tpu_inference/runner/diffusion/config.py
@@ -99,6 +99,7 @@ class DiffusionRuntimeConfig:
     trace_acceptance_steps: bool = False
     fp32_partial_rpa: bool = False
     q8_log_confidence_bias: float = 0.0
+    force_q32_anchor_commit: bool = False
     cohort_max_wait_ms: float = 0.0
     cohort_quiet_wait_ms: float = 0.0
 
@@ -128,6 +129,9 @@ class DiffusionRuntimeConfig:
         if self.q8_log_confidence_bias and not self.use_dual_cache:
             raise ValueError(
                 "Diffusion q8_log_confidence_bias requires use_dual_cache")
+        if self.force_q32_anchor_commit and not self.use_dual_cache:
+            raise ValueError(
+                "Diffusion force_q32_anchor_commit requires use_dual_cache")
         if (not math.isfinite(self.cohort_max_wait_ms)
                 or self.cohort_max_wait_ms < 0.0):
             raise ValueError(
@@ -159,6 +163,11 @@ class DiffusionConfig:
             raise ValueError(
                 f"Diffusion algorithm {self.runtime.algorithm.value!r} is not "
                 f"supported by model adapter {self.model.name!r}")
+        if (self.runtime.force_q32_anchor_commit
+                and self.model.logit_alignment is not LogitAlignment.SHIFTED):
+            raise ValueError(
+                "Diffusion force_q32_anchor_commit requires shifted logit "
+                "alignment")
 
 
 @dataclass(frozen=True)
@@ -297,6 +306,8 @@ def resolve_generation_strategy(vllm_config: Any) -> GenerationStrategyConfig:
         fp32_partial_rpa=bool(diffusion_values.get("fp32_partial_rpa", False)),
         q8_log_confidence_bias=float(
             diffusion_values.get("q8_log_confidence_bias", 0.0)),
+        force_q32_anchor_commit=bool(
+            diffusion_values.get("force_q32_anchor_commit", False)),
         cohort_max_wait_ms=float(
             diffusion_values.get("cohort_max_wait_ms", 0.0)),
         cohort_quiet_wait_ms=float(

--- a/tpu_inference/runner/diffusion/config.py
+++ b/tpu_inference/runner/diffusion/config.py
@@ -100,6 +100,7 @@ class DiffusionRuntimeConfig:
     fp32_partial_rpa: bool = False
     q8_log_confidence_bias: float = 0.0
     cohort_max_wait_ms: float = 0.0
+    cohort_quiet_wait_ms: float = 0.0
 
     def __post_init__(self) -> None:
         if not 0.0 <= self.confidence_threshold <= 1.0:
@@ -134,6 +135,18 @@ class DiffusionRuntimeConfig:
         if self.cohort_max_wait_ms > MAX_COHORT_WAIT_MS:
             raise ValueError("Diffusion cohort_max_wait_ms must not exceed "
                              f"{MAX_COHORT_WAIT_MS:g}")
+        if (not math.isfinite(self.cohort_quiet_wait_ms)
+                or self.cohort_quiet_wait_ms < 0.0):
+            raise ValueError(
+                "Diffusion cohort_quiet_wait_ms must be finite and "
+                "non-negative")
+        if self.cohort_quiet_wait_ms and self.cohort_max_wait_ms <= 0.0:
+            raise ValueError(
+                "Diffusion cohort_quiet_wait_ms requires positive "
+                "cohort_max_wait_ms")
+        if self.cohort_quiet_wait_ms > self.cohort_max_wait_ms:
+            raise ValueError("Diffusion cohort_quiet_wait_ms must not exceed "
+                             "cohort_max_wait_ms")
 
 
 @dataclass(frozen=True)
@@ -286,6 +299,8 @@ def resolve_generation_strategy(vllm_config: Any) -> GenerationStrategyConfig:
             diffusion_values.get("q8_log_confidence_bias", 0.0)),
         cohort_max_wait_ms=float(
             diffusion_values.get("cohort_max_wait_ms", 0.0)),
+        cohort_quiet_wait_ms=float(
+            diffusion_values.get("cohort_quiet_wait_ms", 0.0)),
     )
     return GenerationStrategyConfig(
         strategy=strategy,

--- a/tpu_inference/runner/diffusion/config.py
+++ b/tpu_inference/runner/diffusion/config.py
@@ -100,6 +100,7 @@ class DiffusionRuntimeConfig:
     fp32_partial_rpa: bool = False
     q8_log_confidence_bias: float = 0.0
     force_q32_anchor_commit: bool = False
+    trim_final_block_candidates: bool = False
     cohort_max_wait_ms: float = 0.0
     cohort_quiet_wait_ms: float = 0.0
 
@@ -308,6 +309,8 @@ def resolve_generation_strategy(vllm_config: Any) -> GenerationStrategyConfig:
             diffusion_values.get("q8_log_confidence_bias", 0.0)),
         force_q32_anchor_commit=bool(
             diffusion_values.get("force_q32_anchor_commit", False)),
+        trim_final_block_candidates=bool(
+            diffusion_values.get("trim_final_block_candidates", False)),
         cohort_max_wait_ms=float(
             diffusion_values.get("cohort_max_wait_ms", 0.0)),
         cohort_quiet_wait_ms=float(

--- a/tpu_inference/runner/diffusion/config.py
+++ b/tpu_inference/runner/diffusion/config.py
@@ -76,6 +76,11 @@ class DiffusionModelSpec:
         if self.block_size % self.sub_block_size:
             raise ValueError(
                 "Diffusion sub_block_size must divide block_size exactly")
+        if (self.logit_alignment is LogitAlignment.SHIFTED
+                and self.canvas_policy is not CanvasPolicy.SEED_AND_MASK):
+            raise ValueError(
+                "Shifted logit alignment requires seed_and_mask canvas semantics"
+            )
         if not self.supported_algorithms:
             raise ValueError(
                 "Diffusion model spec must support at least one algorithm")

--- a/tpu_inference/runner/diffusion/config.py
+++ b/tpu_inference/runner/diffusion/config.py
@@ -18,7 +18,7 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
-MAX_COHORT_WAIT_MS = 100.0
+MAX_COHORT_WAIT_MS = 5000.0
 
 
 class GenerationStrategy(str, Enum):
@@ -104,6 +104,7 @@ class DiffusionRuntimeConfig:
     cohort_max_wait_ms: float = 0.0
     cohort_quiet_wait_ms: float = 0.0
     cohort_strict_waves: bool = False
+    cohort_round_robin_dp: bool = False
 
     def __post_init__(self) -> None:
         if not 0.0 <= self.confidence_threshold <= 1.0:
@@ -321,6 +322,8 @@ def resolve_generation_strategy(vllm_config: Any) -> GenerationStrategyConfig:
             diffusion_values.get("cohort_quiet_wait_ms", 0.0)),
         cohort_strict_waves=bool(
             diffusion_values.get("cohort_strict_waves", False)),
+        cohort_round_robin_dp=bool(
+            diffusion_values.get("cohort_round_robin_dp", False)),
     )
     return GenerationStrategyConfig(
         strategy=strategy,

--- a/tpu_inference/runner/diffusion/config.py
+++ b/tpu_inference/runner/diffusion/config.py
@@ -92,6 +92,7 @@ class DiffusionRuntimeConfig:
     confidence_threshold: float = 0.9
     temperature: float = 0.0
     max_denoise_steps: int = 0
+    use_dual_cache: bool = False
 
     def __post_init__(self) -> None:
         if not 0.0 <= self.confidence_threshold <= 1.0:
@@ -246,6 +247,7 @@ def resolve_generation_strategy(vllm_config: Any) -> GenerationStrategyConfig:
             diffusion_values.get("confidence_threshold", 0.9)),
         temperature=float(diffusion_values.get("temperature", 0.0)),
         max_denoise_steps=int(diffusion_values.get("max_denoise_steps", 0)),
+        use_dual_cache=bool(diffusion_values.get("use_dual_cache", False)),
     )
     return GenerationStrategyConfig(
         strategy=strategy,

--- a/tpu_inference/runner/diffusion/config.py
+++ b/tpu_inference/runner/diffusion/config.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from enum import Enum
@@ -93,6 +94,9 @@ class DiffusionRuntimeConfig:
     temperature: float = 0.0
     max_denoise_steps: int = 0
     use_dual_cache: bool = False
+    trace_acceptance_steps: bool = False
+    fp32_partial_rpa: bool = False
+    q8_log_confidence_bias: float = 0.0
 
     def __post_init__(self) -> None:
         if not 0.0 <= self.confidence_threshold <= 1.0:
@@ -103,6 +107,23 @@ class DiffusionRuntimeConfig:
         if self.max_denoise_steps < 0:
             raise ValueError(
                 "Diffusion max_denoise_steps must be non-negative")
+        if self.trace_acceptance_steps and not self.use_dual_cache:
+            raise ValueError(
+                "Diffusion trace_acceptance_steps requires use_dual_cache")
+        if self.fp32_partial_rpa and not self.use_dual_cache:
+            raise ValueError(
+                "Diffusion fp32_partial_rpa requires use_dual_cache")
+        if (not math.isfinite(self.q8_log_confidence_bias)
+                or self.q8_log_confidence_bias < 0.0):
+            raise ValueError(
+                "Diffusion q8_log_confidence_bias must be finite and "
+                "non-negative")
+        if self.q8_log_confidence_bias > 0.5:
+            raise ValueError(
+                "Diffusion q8_log_confidence_bias must not exceed 0.5")
+        if self.q8_log_confidence_bias and not self.use_dual_cache:
+            raise ValueError(
+                "Diffusion q8_log_confidence_bias requires use_dual_cache")
 
 
 @dataclass(frozen=True)
@@ -248,6 +269,11 @@ def resolve_generation_strategy(vllm_config: Any) -> GenerationStrategyConfig:
         temperature=float(diffusion_values.get("temperature", 0.0)),
         max_denoise_steps=int(diffusion_values.get("max_denoise_steps", 0)),
         use_dual_cache=bool(diffusion_values.get("use_dual_cache", False)),
+        trace_acceptance_steps=bool(
+            diffusion_values.get("trace_acceptance_steps", False)),
+        fp32_partial_rpa=bool(diffusion_values.get("fp32_partial_rpa", False)),
+        q8_log_confidence_bias=float(
+            diffusion_values.get("q8_log_confidence_bias", 0.0)),
     )
     return GenerationStrategyConfig(
         strategy=strategy,

--- a/tpu_inference/runner/diffusion/config.py
+++ b/tpu_inference/runner/diffusion/config.py
@@ -1,0 +1,251 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from collections.abc import Callable, Mapping
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any
+
+
+class GenerationStrategy(str, Enum):
+    AUTOREGRESSIVE = "autoregressive"
+    BLOCK_DIFFUSION = "block_diffusion"
+
+
+class AttentionPolicy(str, Enum):
+    BLOCK_CAUSAL = "block_causal"
+
+
+class LogitAlignment(str, Enum):
+    SAME_POSITION = "same_position"
+    SHIFTED = "shifted"
+
+
+class CanvasPolicy(str, Enum):
+    ALL_MASKED = "all_masked"
+    SEED_AND_MASK = "seed_and_mask"
+
+
+class PromptRemainderPolicy(str, Enum):
+    INCLUDE_IN_FIRST_CANVAS = "include_in_first_canvas"
+    REQUIRE_BLOCK_ALIGNED = "require_block_aligned"
+
+
+class NextBlockPolicy(str, Enum):
+    LAST_LOGIT_ANCHOR = "last_logit_anchor"
+    ALL_MASKED = "all_masked"
+
+
+class DiffusionAlgorithm(str, Enum):
+    LOW_CONFIDENCE = "low_confidence"
+
+
+@dataclass(frozen=True)
+class DiffusionModelSpec:
+    name: str
+    block_size: int
+    mask_token_id: int
+    attention_policy: AttentionPolicy
+    logit_alignment: LogitAlignment
+    canvas_policy: CanvasPolicy
+    prompt_remainder_policy: PromptRemainderPolicy
+    next_block_policy: NextBlockPolicy
+    sub_block_size: int
+    supported_algorithms: tuple[DiffusionAlgorithm, ...]
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("Diffusion model spec name must not be empty")
+        if self.block_size < 1:
+            raise ValueError("Diffusion block_size must be positive")
+        if self.mask_token_id < 0:
+            raise ValueError("Diffusion mask_token_id must be non-negative")
+        if self.sub_block_size < 1:
+            raise ValueError("Diffusion sub_block_size must be positive")
+        if self.block_size % self.sub_block_size:
+            raise ValueError(
+                "Diffusion sub_block_size must divide block_size exactly")
+        if not self.supported_algorithms:
+            raise ValueError(
+                "Diffusion model spec must support at least one algorithm")
+
+
+@dataclass(frozen=True)
+class DiffusionRuntimeConfig:
+    algorithm: DiffusionAlgorithm = DiffusionAlgorithm.LOW_CONFIDENCE
+    confidence_threshold: float = 0.9
+    temperature: float = 0.0
+    max_denoise_steps: int = 0
+
+    def __post_init__(self) -> None:
+        if not 0.0 <= self.confidence_threshold <= 1.0:
+            raise ValueError(
+                "Diffusion confidence_threshold must be between 0 and 1")
+        if self.temperature < 0.0:
+            raise ValueError("Diffusion temperature must be non-negative")
+        if self.max_denoise_steps < 0:
+            raise ValueError(
+                "Diffusion max_denoise_steps must be non-negative")
+
+
+@dataclass(frozen=True)
+class DiffusionConfig:
+    model: DiffusionModelSpec
+    runtime: DiffusionRuntimeConfig
+
+    def __post_init__(self) -> None:
+        if self.runtime.algorithm not in self.model.supported_algorithms:
+            raise ValueError(
+                f"Diffusion algorithm {self.runtime.algorithm.value!r} is not "
+                f"supported by model adapter {self.model.name!r}")
+
+
+@dataclass(frozen=True)
+class GenerationStrategyConfig:
+    strategy: GenerationStrategy
+    diffusion: DiffusionConfig | None = None
+
+    def __post_init__(self) -> None:
+        has_diffusion = self.diffusion is not None
+        expects_diffusion = self.strategy is GenerationStrategy.BLOCK_DIFFUSION
+        if has_diffusion != expects_diffusion:
+            raise ValueError(
+                "A diffusion config is required only for block_diffusion")
+
+
+DiffusionModelAdapter = Callable[[Any, Mapping[str, Any]], DiffusionModelSpec]
+_MODEL_ADAPTERS: dict[str, DiffusionModelAdapter] = {}
+
+
+def register_diffusion_model_adapter(
+    name: str,
+    adapter: DiffusionModelAdapter,
+) -> None:
+    normalized = name.strip().lower()
+    if not normalized:
+        raise ValueError("Diffusion model adapter name must not be empty")
+    if normalized in _MODEL_ADAPTERS:
+        raise ValueError(
+            f"Diffusion model adapter {normalized!r} is already registered")
+    _MODEL_ADAPTERS[normalized] = adapter
+
+
+def _read_int(
+    config: Mapping[str, Any],
+    key: str,
+    hf_config: Any,
+    hf_keys: tuple[str, ...],
+    *,
+    default: int | None = None,
+) -> int:
+    value = config.get(key)
+    if value is None:
+        for hf_key in hf_keys:
+            value = getattr(hf_config, hf_key, None)
+            if value is not None:
+                break
+    if value is None:
+        value = default
+    if value is None:
+        raise ValueError(
+            f"Diffusion config {key!r} is required by the model adapter")
+    return int(value)
+
+
+def _seeded_shifted_adapter(
+    hf_config: Any,
+    config: Mapping[str, Any],
+) -> DiffusionModelSpec:
+    block_size = _read_int(config, "block_size", hf_config,
+                           ("block_size", "bd_size"))
+    mask_token_id = _read_int(config, "mask_token_id", hf_config,
+                              ("mask_token_id", "mask_id"))
+    sub_block_size = _read_int(config,
+                               "sub_block_size",
+                               hf_config, ("sub_block_size", ),
+                               default=min(8, block_size))
+    return DiffusionModelSpec(
+        name="seeded_shifted",
+        block_size=block_size,
+        mask_token_id=mask_token_id,
+        attention_policy=AttentionPolicy.BLOCK_CAUSAL,
+        logit_alignment=LogitAlignment.SHIFTED,
+        canvas_policy=CanvasPolicy.SEED_AND_MASK,
+        prompt_remainder_policy=(
+            PromptRemainderPolicy.INCLUDE_IN_FIRST_CANVAS),
+        next_block_policy=NextBlockPolicy.LAST_LOGIT_ANCHOR,
+        sub_block_size=sub_block_size,
+        supported_algorithms=(DiffusionAlgorithm.LOW_CONFIDENCE, ),
+    )
+
+
+def _as_mapping(value: Any, name: str) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if not isinstance(value, Mapping):
+        raise ValueError(f"{name} must be a mapping")
+    return value
+
+
+def resolve_generation_strategy(vllm_config: Any) -> GenerationStrategyConfig:
+    additional_config = _as_mapping(
+        getattr(vllm_config, "additional_config", None),
+        "additional_config",
+    )
+    raw_strategy = additional_config.get(
+        "generation_strategy", GenerationStrategy.AUTOREGRESSIVE.value)
+    try:
+        strategy = GenerationStrategy(raw_strategy)
+    except ValueError as exc:
+        supported = ", ".join(item.value for item in GenerationStrategy)
+        raise ValueError(
+            f"Unsupported generation_strategy {raw_strategy!r}; expected one "
+            f"of: {supported}") from exc
+
+    if strategy is GenerationStrategy.AUTOREGRESSIVE:
+        return GenerationStrategyConfig(strategy=strategy)
+
+    diffusion_values = _as_mapping(additional_config.get("diffusion"),
+                                   "additional_config['diffusion']")
+    adapter_name = str(diffusion_values.get("model_adapter",
+                                            "")).strip().lower()
+    if not adapter_name:
+        raise ValueError("block_diffusion requires diffusion.model_adapter")
+    try:
+        adapter = _MODEL_ADAPTERS[adapter_name]
+    except KeyError as exc:
+        supported = ", ".join(sorted(_MODEL_ADAPTERS)) or "<none>"
+        raise ValueError(
+            f"Unknown diffusion model_adapter {adapter_name!r}; registered "
+            f"adapters: {supported}") from exc
+
+    hf_config = getattr(getattr(vllm_config, "model_config", None),
+                        "hf_config", None)
+    model_spec = adapter(hf_config, diffusion_values)
+    runtime = DiffusionRuntimeConfig(
+        algorithm=DiffusionAlgorithm(
+            diffusion_values.get("algorithm",
+                                 DiffusionAlgorithm.LOW_CONFIDENCE.value)),
+        confidence_threshold=float(
+            diffusion_values.get("confidence_threshold", 0.9)),
+        temperature=float(diffusion_values.get("temperature", 0.0)),
+        max_denoise_steps=int(diffusion_values.get("max_denoise_steps", 0)),
+    )
+    return GenerationStrategyConfig(
+        strategy=strategy,
+        diffusion=DiffusionConfig(model=model_spec, runtime=runtime),
+    )
+
+
+register_diffusion_model_adapter("seeded_shifted", _seeded_shifted_adapter)

--- a/tpu_inference/runner/diffusion/config.py
+++ b/tpu_inference/runner/diffusion/config.py
@@ -18,6 +18,8 @@ from dataclasses import dataclass
 from enum import Enum
 from typing import Any
 
+MAX_COHORT_WAIT_MS = 100.0
+
 
 class GenerationStrategy(str, Enum):
     AUTOREGRESSIVE = "autoregressive"
@@ -97,6 +99,7 @@ class DiffusionRuntimeConfig:
     trace_acceptance_steps: bool = False
     fp32_partial_rpa: bool = False
     q8_log_confidence_bias: float = 0.0
+    cohort_max_wait_ms: float = 0.0
 
     def __post_init__(self) -> None:
         if not 0.0 <= self.confidence_threshold <= 1.0:
@@ -124,6 +127,13 @@ class DiffusionRuntimeConfig:
         if self.q8_log_confidence_bias and not self.use_dual_cache:
             raise ValueError(
                 "Diffusion q8_log_confidence_bias requires use_dual_cache")
+        if (not math.isfinite(self.cohort_max_wait_ms)
+                or self.cohort_max_wait_ms < 0.0):
+            raise ValueError(
+                "Diffusion cohort_max_wait_ms must be finite and non-negative")
+        if self.cohort_max_wait_ms > MAX_COHORT_WAIT_MS:
+            raise ValueError("Diffusion cohort_max_wait_ms must not exceed "
+                             f"{MAX_COHORT_WAIT_MS:g}")
 
 
 @dataclass(frozen=True)
@@ -274,6 +284,8 @@ def resolve_generation_strategy(vllm_config: Any) -> GenerationStrategyConfig:
         fp32_partial_rpa=bool(diffusion_values.get("fp32_partial_rpa", False)),
         q8_log_confidence_bias=float(
             diffusion_values.get("q8_log_confidence_bias", 0.0)),
+        cohort_max_wait_ms=float(
+            diffusion_values.get("cohort_max_wait_ms", 0.0)),
     )
     return GenerationStrategyConfig(
         strategy=strategy,

--- a/tpu_inference/runner/diffusion/config.py
+++ b/tpu_inference/runner/diffusion/config.py
@@ -103,6 +103,7 @@ class DiffusionRuntimeConfig:
     trim_final_block_candidates: bool = False
     cohort_max_wait_ms: float = 0.0
     cohort_quiet_wait_ms: float = 0.0
+    cohort_strict_waves: bool = False
 
     def __post_init__(self) -> None:
         if not 0.0 <= self.confidence_threshold <= 1.0:
@@ -151,6 +152,9 @@ class DiffusionRuntimeConfig:
                 "cohort_max_wait_ms")
         if self.cohort_quiet_wait_ms > self.cohort_max_wait_ms:
             raise ValueError("Diffusion cohort_quiet_wait_ms must not exceed "
+                             "cohort_max_wait_ms")
+        if self.cohort_strict_waves and self.cohort_max_wait_ms <= 0.0:
+            raise ValueError("Diffusion cohort_strict_waves requires positive "
                              "cohort_max_wait_ms")
 
 
@@ -315,6 +319,8 @@ def resolve_generation_strategy(vllm_config: Any) -> GenerationStrategyConfig:
             diffusion_values.get("cohort_max_wait_ms", 0.0)),
         cohort_quiet_wait_ms=float(
             diffusion_values.get("cohort_quiet_wait_ms", 0.0)),
+        cohort_strict_waves=bool(
+            diffusion_values.get("cohort_strict_waves", False)),
     )
     return GenerationStrategyConfig(
         strategy=strategy,

--- a/tpu_inference/runner/diffusion/program.py
+++ b/tpu_inference/runner/diffusion/program.py
@@ -20,8 +20,11 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from tpu_inference.runner.diffusion.algorithm import (CommitFn,
-                                                      _exclude_mask_token)
+from tpu_inference.runner.diffusion.algorithm import (CommitDiagnostics,
+                                                      CommitDiagnosticsFn,
+                                                      CommitFn,
+                                                      _exclude_mask_token,
+                                                      confidence_threshold_with_log_bias)
 from tpu_inference.runner.diffusion.config import (LogitAlignment,
                                                    NextBlockPolicy)
 
@@ -40,6 +43,9 @@ FinalBlockForwardFn = Callable[
     tuple[jax.Array, Any],
 ]
 
+DUAL_CACHE_Q32 = 0
+DUAL_CACHE_Q8 = 1
+
 
 class DenoiseBlockOutput(NamedTuple):
     canvas: jax.Array
@@ -47,6 +53,20 @@ class DenoiseBlockOutput(NamedTuple):
     denoise_steps: jax.Array
     kv_caches: Any
     stopped_rows: jax.Array
+
+
+class DualCacheAcceptanceTrace(NamedTuple):
+    count: jax.Array
+    block_start: jax.Array
+    sub_block_starts: jax.Array
+    iterations: jax.Array
+    forward_kinds: jax.Array
+    row0_token_ids: jax.Array
+    row0_eligible: jax.Array
+    row0_commit: jax.Array
+    row0_remaining: jax.Array
+    row0_selected_log_confidence: jax.Array
+    row0_threshold_margin: jax.Array
 
 
 class DualCacheDenoiseBlockOutput(NamedTuple):
@@ -58,6 +78,59 @@ class DualCacheDenoiseBlockOutput(NamedTuple):
     q8_forward_calls: jax.Array
     final_q32_forward_calls: jax.Array
     stopped_rows: jax.Array
+    acceptance_trace: DualCacheAcceptanceTrace | None
+
+
+def _empty_dual_cache_acceptance_trace(
+    positions: jax.Array,
+    max_steps: int,
+    sub_block_size: int,
+) -> DualCacheAcceptanceTrace:
+    step_shape = (max_steps, )
+    row_shape = (max_steps, sub_block_size)
+    return DualCacheAcceptanceTrace(
+        count=jnp.array(0, dtype=jnp.int32),
+        block_start=positions[0, 0].astype(jnp.int32),
+        sub_block_starts=jnp.zeros(step_shape, dtype=jnp.int32),
+        iterations=jnp.zeros(step_shape, dtype=jnp.int32),
+        forward_kinds=jnp.zeros(step_shape, dtype=jnp.int8),
+        row0_token_ids=jnp.zeros(row_shape, dtype=jnp.int32),
+        row0_eligible=jnp.zeros(row_shape, dtype=bool),
+        row0_commit=jnp.zeros(row_shape, dtype=bool),
+        row0_remaining=jnp.zeros(row_shape, dtype=bool),
+        row0_selected_log_confidence=jnp.zeros(row_shape, dtype=jnp.float32),
+        row0_threshold_margin=jnp.zeros(row_shape, dtype=jnp.float32),
+    )
+
+
+def _record_dual_cache_acceptance_step(
+    trace: DualCacheAcceptanceTrace,
+    sub_block_start: jax.Array,
+    iteration: jax.Array,
+    forward_kind: int,
+    token_ids: jax.Array,
+    eligible: jax.Array,
+    remaining: jax.Array,
+    diagnostics: CommitDiagnostics,
+) -> DualCacheAcceptanceTrace:
+    index = trace.count
+    committed = eligible & ~remaining
+    return DualCacheAcceptanceTrace(
+        count=index + 1,
+        block_start=trace.block_start,
+        sub_block_starts=trace.sub_block_starts.at[index].set(sub_block_start),
+        iterations=trace.iterations.at[index].set(iteration),
+        forward_kinds=trace.forward_kinds.at[index].set(forward_kind),
+        row0_token_ids=trace.row0_token_ids.at[index].set(token_ids[0]),
+        row0_eligible=trace.row0_eligible.at[index].set(eligible[0]),
+        row0_commit=trace.row0_commit.at[index].set(committed[0]),
+        row0_remaining=trace.row0_remaining.at[index].set(remaining[0]),
+        row0_selected_log_confidence=(
+            trace.row0_selected_log_confidence.at[index].set(
+                diagnostics.selected_log_confidence[0])),
+        row0_threshold_margin=trace.row0_threshold_margin.at[index].set(
+            diagnostics.threshold_margin[0]),
+    )
 
 
 def _resolved_eos_rows(
@@ -381,35 +454,41 @@ def denoise_block(
         "partial_forward_fn",
         "final_forward_fn",
         "commit_fn",
+        "commit_diagnostics_fn",
         "next_block_policy",
         "mask_token_id",
         "sub_block_size",
         "max_denoise_steps",
         "eos_token_ids",
+        "trace_acceptance_steps",
+        "q8_log_confidence_bias",
     ),
 )
 def _denoise_block_dual_cache_jit(
-        full_forward_fn: AlignedSubBlockForwardFn,
-        partial_forward_fn: AlignedSubBlockForwardFn,
-        final_forward_fn: FinalBlockForwardFn,
-        commit_fn: CommitFn,
-        model_state: Any,
-        initial_canvas: jax.Array,
-        initial_mask: jax.Array,
-        positions: jax.Array,
-        kv_caches: Any,
-        active_rows: jax.Array,
-        needs_final_forward: jax.Array,
-        stop_on_eos_rows: jax.Array,
-        confidence_threshold: jax.Array,
-        temperature: jax.Array,
-        forward_context: Any,
-        *,
-        next_block_policy: NextBlockPolicy,
-        mask_token_id: int,
-        sub_block_size: int,
-        max_denoise_steps: int = 0,
-        eos_token_ids: tuple[int, ...] = (),
+    full_forward_fn: AlignedSubBlockForwardFn,
+    partial_forward_fn: AlignedSubBlockForwardFn,
+    final_forward_fn: FinalBlockForwardFn,
+    commit_fn: CommitFn,
+    commit_diagnostics_fn: CommitDiagnosticsFn | None,
+    model_state: Any,
+    initial_canvas: jax.Array,
+    initial_mask: jax.Array,
+    positions: jax.Array,
+    kv_caches: Any,
+    active_rows: jax.Array,
+    needs_final_forward: jax.Array,
+    stop_on_eos_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    forward_context: Any,
+    *,
+    next_block_policy: NextBlockPolicy,
+    mask_token_id: int,
+    sub_block_size: int,
+    max_denoise_steps: int = 0,
+    eos_token_ids: tuple[int, ...] = (),
+    trace_acceptance_steps: bool = False,
+    q8_log_confidence_bias: float = 0.0,
 ) -> DualCacheDenoiseBlockOutput:
     batch_size, block_size = initial_canvas.shape
     active_rows = jnp.asarray(active_rows, dtype=bool)
@@ -422,10 +501,48 @@ def _denoise_block_dual_cache_jit(
     steps_per_sub_block = (sub_block_size
                            if max_denoise_steps <= 0 else max_denoise_steps)
     num_sub_blocks = block_size // sub_block_size
+    q8_confidence_threshold = confidence_threshold_with_log_bias(
+        confidence_threshold, q8_log_confidence_bias)
+    acceptance_trace = (_empty_dual_cache_acceptance_trace(
+        positions,
+        num_sub_blocks * steps_per_sub_block,
+        sub_block_size,
+    ) if trace_acceptance_steps else None)
+
+    def record_acceptance_step(
+        trace,
+        start,
+        iteration,
+        forward_kind,
+        logits,
+        token_ids,
+        eligible,
+        remaining,
+        step_confidence_threshold,
+    ):
+        if not trace_acceptance_steps:
+            return trace
+        assert commit_diagnostics_fn is not None
+        diagnostics = commit_diagnostics_fn(
+            logits,
+            step_confidence_threshold,
+            temperature,
+            mask_token_id,
+        )
+        return _record_dual_cache_acceptance_step(
+            trace,
+            positions[0, 0] + start,
+            iteration,
+            forward_kind,
+            token_ids,
+            eligible,
+            remaining,
+            diagnostics,
+        )
 
     def denoise_sub_block(sub_block_index, carry):
-        (canvas, mask, denoise_steps, kv, q32_calls, q8_calls,
-         stopped_rows) = carry
+        (canvas, mask, denoise_steps, kv, q32_calls, q8_calls, stopped_rows,
+         acceptance_trace) = carry
         start = sub_block_index * sub_block_size
         sub_canvas = jax.lax.dynamic_slice(canvas, (0, start),
                                            (batch_size, sub_block_size))
@@ -434,7 +551,7 @@ def _denoise_block_dual_cache_jit(
 
         def no_work(_):
             return (canvas, mask, denoise_steps, kv, q32_calls, q8_calls,
-                    stopped_rows)
+                    stopped_rows, acceptance_trace)
 
         def work(_):
 
@@ -476,6 +593,17 @@ def _denoise_block_dual_cache_jit(
                 temperature,
                 mask_token_id,
             )
+            next_acceptance_trace = record_acceptance_step(
+                acceptance_trace,
+                start,
+                jnp.array(0, dtype=jnp.int32),
+                DUAL_CACHE_Q32,
+                logits,
+                token_ids,
+                eligible,
+                remaining,
+                confidence_threshold,
+            )
             committed = eligible & ~remaining
             next_sub_canvas = jnp.where(committed, token_ids, sub_canvas)
             next_sub_mask = eligible & ~committed
@@ -496,17 +624,19 @@ def _denoise_block_dual_cache_jit(
                 q32_calls + 1,
                 q8_calls,
                 next_stopped_rows,
+                next_acceptance_trace,
             )
 
             def needs_full_refresh(state):
-                _, _, _, _, remaining, _, iteration, _, _, _ = state
+                _, _, _, _, remaining, _, iteration, _, _, _, _ = state
                 return ((iteration < steps_per_sub_block)
                         & jnp.any(remaining[:, 0]))
 
             def full_refresh_step(state):
                 (current_sub_canvas, current_sub_mask, current_steps,
                  current_kv, remaining, _, iteration, current_q32_calls,
-                 current_q8_calls, current_stopped_rows) = state
+                 current_q8_calls, current_stopped_rows,
+                 current_acceptance_trace) = state
                 current_canvas = jax.lax.dynamic_update_slice(
                     canvas, current_sub_canvas, (0, start))
                 row_has_work = jnp.any(remaining, axis=-1)
@@ -528,6 +658,17 @@ def _denoise_block_dual_cache_jit(
                     temperature,
                     mask_token_id,
                 )
+                current_acceptance_trace = record_acceptance_step(
+                    current_acceptance_trace,
+                    start,
+                    iteration,
+                    DUAL_CACHE_Q32,
+                    logits,
+                    token_ids,
+                    remaining,
+                    next_remaining,
+                    confidence_threshold,
+                )
                 committed = remaining & ~next_remaining
                 current_sub_canvas = jnp.where(committed, token_ids,
                                                current_sub_canvas)
@@ -548,19 +689,21 @@ def _denoise_block_dual_cache_jit(
                     current_q32_calls + 1,
                     current_q8_calls,
                     current_stopped_rows,
+                    current_acceptance_trace,
                 )
 
             state = jax.lax.while_loop(needs_full_refresh, full_refresh_step,
                                        state)
 
             def has_work(state):
-                _, _, _, _, remaining, _, iteration, _, _, _ = state
+                _, _, _, _, remaining, _, iteration, _, _, _, _ = state
                 return ((iteration < steps_per_sub_block) & jnp.any(remaining))
 
             def denoise_step(state):
                 (current_sub_canvas, current_sub_mask, current_steps,
                  current_kv, remaining, _, iteration, current_q32_calls,
-                 current_q8_calls, current_stopped_rows) = state
+                 current_q8_calls, current_stopped_rows,
+                 current_acceptance_trace) = state
                 current_canvas = jax.lax.dynamic_update_slice(
                     canvas, current_sub_canvas, (0, start))
                 row_has_work = jnp.any(remaining, axis=-1)
@@ -578,9 +721,20 @@ def _denoise_block_dual_cache_jit(
                     logits,
                     remaining,
                     row_has_work,
-                    confidence_threshold,
+                    q8_confidence_threshold,
                     temperature,
                     mask_token_id,
+                )
+                current_acceptance_trace = record_acceptance_step(
+                    current_acceptance_trace,
+                    start,
+                    iteration,
+                    DUAL_CACHE_Q8,
+                    logits,
+                    token_ids,
+                    remaining,
+                    next_remaining,
+                    q8_confidence_threshold,
                 )
                 committed = remaining & ~next_remaining
                 current_sub_canvas = jnp.where(committed, token_ids,
@@ -602,12 +756,13 @@ def _denoise_block_dual_cache_jit(
                     current_q32_calls,
                     current_q8_calls + 1,
                     current_stopped_rows,
+                    current_acceptance_trace,
                 )
 
             state = jax.lax.while_loop(has_work, denoise_step, state)
             (next_sub_canvas, next_sub_mask, next_steps, next_kv, remaining,
-             last_tokens, _, next_q32_calls, next_q8_calls,
-             next_stopped_rows) = state
+             last_tokens, _, next_q32_calls, next_q8_calls, next_stopped_rows,
+             next_acceptance_trace) = state
             next_sub_canvas = jnp.where(remaining, last_tokens,
                                         next_sub_canvas)
             next_sub_mask &= ~remaining
@@ -623,12 +778,13 @@ def _denoise_block_dual_cache_jit(
             next_mask = jax.lax.dynamic_update_slice(mask, next_sub_mask,
                                                      (0, start))
             return (next_canvas, next_mask, next_steps, next_kv,
-                    next_q32_calls, next_q8_calls, next_stopped_rows)
+                    next_q32_calls, next_q8_calls, next_stopped_rows,
+                    next_acceptance_trace)
 
         return jax.lax.cond(jnp.any(eligible), work, no_work, operand=None)
 
     (canvas, mask, denoise_steps, kv_caches, q32_forward_calls,
-     q8_forward_calls, stopped_rows) = jax.lax.fori_loop(
+     q8_forward_calls, stopped_rows, acceptance_trace) = jax.lax.fori_loop(
          0,
          num_sub_blocks,
          denoise_sub_block,
@@ -640,6 +796,7 @@ def _denoise_block_dual_cache_jit(
              jnp.array(0, dtype=jnp.int32),
              jnp.array(0, dtype=jnp.int32),
              stopped_rows,
+             acceptance_trace,
          ),
      )
 
@@ -683,32 +840,36 @@ def _denoise_block_dual_cache_jit(
         q8_forward_calls=q8_forward_calls,
         final_q32_forward_calls=final_q32_forward_calls,
         stopped_rows=stopped_rows,
+        acceptance_trace=acceptance_trace,
     )
 
 
 def denoise_block_dual_cache(
-        full_forward_fn: AlignedSubBlockForwardFn,
-        partial_forward_fn: AlignedSubBlockForwardFn,
-        final_forward_fn: FinalBlockForwardFn,
-        commit_fn: CommitFn,
-        model_state: Any,
-        initial_canvas: jax.Array,
-        initial_mask: jax.Array,
-        positions: jax.Array,
-        kv_caches: Any,
-        active_rows: jax.Array,
-        confidence_threshold: jax.Array,
-        temperature: jax.Array,
-        forward_context: Any,
-        *,
-        logit_alignment: LogitAlignment,
-        next_block_policy: NextBlockPolicy,
-        mask_token_id: int,
-        sub_block_size: int,
-        max_denoise_steps: int = 0,
-        needs_final_forward: jax.Array | None = None,
-        stop_on_eos_rows: jax.Array | None = None,
-        eos_token_ids: tuple[int, ...] = (),
+    full_forward_fn: AlignedSubBlockForwardFn,
+    partial_forward_fn: AlignedSubBlockForwardFn,
+    final_forward_fn: FinalBlockForwardFn,
+    commit_fn: CommitFn,
+    model_state: Any,
+    initial_canvas: jax.Array,
+    initial_mask: jax.Array,
+    positions: jax.Array,
+    kv_caches: Any,
+    active_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    forward_context: Any,
+    *,
+    logit_alignment: LogitAlignment,
+    next_block_policy: NextBlockPolicy,
+    mask_token_id: int,
+    sub_block_size: int,
+    max_denoise_steps: int = 0,
+    needs_final_forward: jax.Array | None = None,
+    stop_on_eos_rows: jax.Array | None = None,
+    eos_token_ids: tuple[int, ...] = (),
+    commit_diagnostics_fn: CommitDiagnosticsFn | None = None,
+    trace_acceptance_steps: bool = False,
+    q8_log_confidence_bias: float = 0.0,
 ) -> DualCacheDenoiseBlockOutput:
     """Denoise with aligned q32 refreshes followed by q8 replacements."""
     if initial_canvas.ndim != 2:
@@ -729,6 +890,15 @@ def denoise_block_dual_cache(
         raise ValueError("stop_on_eos_rows must match active_rows")
     if sub_block_size < 1 or initial_canvas.shape[1] % sub_block_size:
         raise ValueError("sub_block_size must divide the model block size")
+    if trace_acceptance_steps and commit_diagnostics_fn is None:
+        raise ValueError(
+            "trace_acceptance_steps requires commit_diagnostics_fn")
+    if (not np.isfinite(q8_log_confidence_bias)
+            or q8_log_confidence_bias < 0.0):
+        raise ValueError(
+            "q8_log_confidence_bias must be finite and non-negative")
+    if q8_log_confidence_bias > 0.5:
+        raise ValueError("q8_log_confidence_bias must not exceed 0.5")
     if logit_alignment is LogitAlignment.SHIFTED:
         seed_mask, active = jax.device_get((initial_mask[:, 0], active_rows))
         if np.any(
@@ -743,6 +913,7 @@ def denoise_block_dual_cache(
         partial_forward_fn,
         final_forward_fn,
         commit_fn,
+        commit_diagnostics_fn,
         model_state,
         initial_canvas,
         initial_mask,
@@ -759,4 +930,6 @@ def denoise_block_dual_cache(
         sub_block_size=sub_block_size,
         max_denoise_steps=max_denoise_steps,
         eos_token_ids=eos_token_ids,
+        trace_acceptance_steps=trace_acceptance_steps,
+        q8_log_confidence_bias=q8_log_confidence_bias,
     )

--- a/tpu_inference/runner/diffusion/program.py
+++ b/tpu_inference/runner/diffusion/program.py
@@ -1,0 +1,252 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+from collections.abc import Callable
+from typing import Any, NamedTuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from tpu_inference.runner.diffusion.algorithm import (CommitFn,
+                                                      _exclude_mask_token)
+from tpu_inference.runner.diffusion.config import (LogitAlignment,
+                                                   NextBlockPolicy)
+
+BlockForwardFn = Callable[
+    [Any, jax.Array, jax.Array, Any, jax.Array, Any],
+    tuple[jax.Array, Any],
+]
+
+
+class DenoiseBlockOutput(NamedTuple):
+    canvas: jax.Array
+    next_anchor: jax.Array
+    denoise_steps: jax.Array
+    kv_caches: Any
+
+
+def _align_logits(
+    logits: jax.Array,
+    alignment: LogitAlignment,
+) -> jax.Array:
+    if alignment is LogitAlignment.SAME_POSITION:
+        return logits
+    if alignment is LogitAlignment.SHIFTED:
+        indices = jnp.maximum(
+            jnp.arange(logits.shape[1], dtype=jnp.int32) - 1, 0)
+        return logits[:, indices, :]
+    raise ValueError(f"Unsupported logit alignment: {alignment}")
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=(
+        "forward_fn",
+        "commit_fn",
+        "logit_alignment",
+        "next_block_policy",
+        "mask_token_id",
+        "sub_block_size",
+        "max_denoise_steps",
+    ),
+)
+def _denoise_block_jit(
+    forward_fn: BlockForwardFn,
+    commit_fn: CommitFn,
+    model_state: Any,
+    initial_canvas: jax.Array,
+    initial_mask: jax.Array,
+    positions: jax.Array,
+    kv_caches: Any,
+    active_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    forward_context: Any,
+    *,
+    logit_alignment: LogitAlignment,
+    next_block_policy: NextBlockPolicy,
+    mask_token_id: int,
+    sub_block_size: int,
+    max_denoise_steps: int = 0,
+) -> DenoiseBlockOutput:
+    """Jitted block denoising implementation.
+
+    ``forward_fn`` must leave cache entries for false ``active_rows`` unchanged.
+    The cache is opaque to this program, so inactive-row isolation belongs to
+    the forward implementation that maps logical rows to physical cache pages.
+
+    ``max_denoise_steps`` limits while-loop iterations for each sub-block, not
+    for the full model block. Zero uses ``sub_block_size`` iterations. The full
+    block can therefore run ``num_sub_blocks * steps_per_sub_block`` denoising
+    forwards, followed by one final forward that commits the completed KV state.
+    """
+    if initial_canvas.ndim != 2:
+        raise ValueError("initial_canvas must have shape [batch, block_size]")
+    if initial_mask.shape != initial_canvas.shape:
+        raise ValueError("initial_mask must match initial_canvas")
+    if positions.shape != initial_canvas.shape:
+        raise ValueError("positions must match initial_canvas")
+    if sub_block_size < 1 or initial_canvas.shape[1] % sub_block_size:
+        raise ValueError("sub_block_size must divide the model block size")
+
+    batch_size, block_size = initial_canvas.shape
+    del batch_size
+    active_rows = jnp.asarray(active_rows, dtype=bool)
+    canvas = initial_canvas.astype(jnp.int32)
+    mask = jnp.asarray(initial_mask, dtype=bool) & active_rows[:, None]
+    denoise_steps = jnp.zeros((canvas.shape[0], ), dtype=jnp.int32)
+    steps_per_sub_block = (sub_block_size
+                           if max_denoise_steps <= 0 else max_denoise_steps)
+    num_sub_blocks = block_size // sub_block_size
+
+    def denoise_sub_block(sub_block_index, carry):
+        canvas, mask, denoise_steps, kv = carry
+        start = sub_block_index * sub_block_size
+        sub_block_positions = (
+            (jnp.arange(block_size) >= start) &
+            (jnp.arange(block_size) < start + sub_block_size))
+        eligible = mask & sub_block_positions[None, :]
+        last_tokens = canvas
+
+        state = (
+            canvas,
+            mask,
+            denoise_steps,
+            kv,
+            eligible,
+            last_tokens,
+            jnp.array(0, dtype=jnp.int32),
+        )
+
+        def has_work(state):
+            _, _, _, _, eligible, _, iteration = state
+            return ((iteration < steps_per_sub_block) & jnp.any(eligible))
+
+        def denoise_step(state):
+            canvas, mask, steps, kv, eligible, _, iteration = state
+            row_has_work = jnp.any(eligible, axis=-1)
+            logits, kv = forward_fn(model_state, canvas, positions, kv,
+                                    active_rows, forward_context)
+            aligned_logits = _align_logits(logits, logit_alignment)
+            token_ids, remaining = commit_fn(
+                aligned_logits,
+                eligible,
+                active_rows,
+                confidence_threshold,
+                temperature,
+                mask_token_id,
+            )
+            committed = eligible & ~remaining
+            canvas = jnp.where(committed, token_ids, canvas)
+            mask &= ~committed
+            steps += row_has_work.astype(jnp.int32)
+            return (canvas, mask, steps, kv, remaining, token_ids,
+                    iteration + 1)
+
+        state = jax.lax.while_loop(has_work, denoise_step, state)
+        canvas, mask, denoise_steps, kv, remaining, last_tokens, _ = state
+
+        canvas = jnp.where(remaining, last_tokens, canvas)
+        mask &= ~remaining
+        return canvas, mask, denoise_steps, kv
+
+    canvas, mask, denoise_steps, kv_caches = jax.lax.fori_loop(
+        0,
+        num_sub_blocks,
+        denoise_sub_block,
+        (canvas, mask, denoise_steps, kv_caches),
+    )
+
+    final_logits, kv_caches = forward_fn(model_state, canvas, positions,
+                                         kv_caches, active_rows,
+                                         forward_context)
+    if next_block_policy is NextBlockPolicy.LAST_LOGIT_ANCHOR:
+        anchor_logits = _exclude_mask_token(final_logits[:, -1:, :],
+                                            mask_token_id)
+        next_anchor = jnp.argmax(anchor_logits[:, 0, :],
+                                 axis=-1).astype(jnp.int32)
+    elif next_block_policy is NextBlockPolicy.ALL_MASKED:
+        next_anchor = jnp.zeros((canvas.shape[0], ), dtype=jnp.int32)
+    else:
+        raise ValueError(f"Unsupported next block policy: {next_block_policy}")
+    next_anchor = jnp.where(active_rows, next_anchor, 0)
+    return DenoiseBlockOutput(
+        canvas=canvas,
+        next_anchor=next_anchor,
+        denoise_steps=denoise_steps,
+        kv_caches=kv_caches,
+    )
+
+
+def denoise_block(
+    forward_fn: BlockForwardFn,
+    commit_fn: CommitFn,
+    model_state: Any,
+    initial_canvas: jax.Array,
+    initial_mask: jax.Array,
+    positions: jax.Array,
+    kv_caches: Any,
+    active_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    forward_context: Any,
+    *,
+    logit_alignment: LogitAlignment,
+    next_block_policy: NextBlockPolicy,
+    mask_token_id: int,
+    sub_block_size: int,
+    max_denoise_steps: int = 0,
+) -> DenoiseBlockOutput:
+    """Validate and denoise one model block.
+
+    Shifted logits predict canvas position ``i + 1`` from logits position ``i``.
+    Position zero therefore has no aligned prediction and must be an immutable
+    seed for every active row. This host-side check fails before compilation or
+    token commitment instead of silently consuming the wrong logits.
+    """
+    if initial_canvas.ndim != 2:
+        raise ValueError("initial_canvas must have shape [batch, block_size]")
+    if initial_mask.shape != initial_canvas.shape:
+        raise ValueError("initial_mask must match initial_canvas")
+    if active_rows.shape != (initial_canvas.shape[0], ):
+        raise ValueError("active_rows must match the canvas batch size")
+    if logit_alignment is LogitAlignment.SHIFTED:
+        seed_mask, active = jax.device_get((initial_mask[:, 0], active_rows))
+        if np.any(
+                np.asarray(seed_mask, dtype=bool)
+                & np.asarray(active, dtype=bool)):
+            raise ValueError(
+                "Shifted logit alignment requires position 0 to be an "
+                "unmasked seed for every active row")
+
+    return _denoise_block_jit(
+        forward_fn,
+        commit_fn,
+        model_state,
+        initial_canvas,
+        initial_mask,
+        positions,
+        kv_caches,
+        active_rows,
+        confidence_threshold,
+        temperature,
+        forward_context,
+        logit_alignment=logit_alignment,
+        next_block_policy=next_block_policy,
+        mask_token_id=mask_token_id,
+        sub_block_size=sub_block_size,
+        max_denoise_steps=max_denoise_steps,
+    )

--- a/tpu_inference/runner/diffusion/program.py
+++ b/tpu_inference/runner/diffusion/program.py
@@ -46,6 +46,7 @@ class DenoiseBlockOutput(NamedTuple):
     next_anchor: jax.Array
     denoise_steps: jax.Array
     kv_caches: Any
+    stopped_rows: jax.Array
 
 
 class DualCacheDenoiseBlockOutput(NamedTuple):
@@ -56,6 +57,33 @@ class DualCacheDenoiseBlockOutput(NamedTuple):
     q32_forward_calls: jax.Array
     q8_forward_calls: jax.Array
     final_q32_forward_calls: jax.Array
+    stopped_rows: jax.Array
+
+
+def _resolved_eos_rows(
+    canvas: jax.Array,
+    mask: jax.Array,
+    generation_positions: jax.Array,
+    stop_on_eos_rows: jax.Array,
+    eos_token_ids: tuple[int, ...],
+) -> jax.Array:
+    if not eos_token_ids:
+        return jnp.zeros((canvas.shape[0], ), dtype=bool)
+
+    is_eos = jnp.zeros_like(mask)
+    for token_id in eos_token_ids:
+        is_eos |= canvas == token_id
+    is_eos &= generation_positions
+
+    has_eos = jnp.any(is_eos, axis=-1)
+    first_eos = jnp.argmax(is_eos, axis=-1)
+    positions = jnp.arange(canvas.shape[1], dtype=jnp.int32)
+    unresolved_before_eos = jnp.any(
+        mask & generation_positions &
+        (positions[None, :] < first_eos[:, None]),
+        axis=-1,
+    )
+    return stop_on_eos_rows & has_eos & ~unresolved_before_eos
 
 
 def select_aligned_hidden_states(
@@ -101,27 +129,30 @@ def _align_logits(
         "mask_token_id",
         "sub_block_size",
         "max_denoise_steps",
+        "eos_token_ids",
     ),
 )
 def _denoise_block_jit(
-    forward_fn: BlockForwardFn,
-    commit_fn: CommitFn,
-    model_state: Any,
-    initial_canvas: jax.Array,
-    initial_mask: jax.Array,
-    positions: jax.Array,
-    kv_caches: Any,
-    active_rows: jax.Array,
-    needs_final_forward: jax.Array,
-    confidence_threshold: jax.Array,
-    temperature: jax.Array,
-    forward_context: Any,
-    *,
-    logit_alignment: LogitAlignment,
-    next_block_policy: NextBlockPolicy,
-    mask_token_id: int,
-    sub_block_size: int,
-    max_denoise_steps: int = 0,
+        forward_fn: BlockForwardFn,
+        commit_fn: CommitFn,
+        model_state: Any,
+        initial_canvas: jax.Array,
+        initial_mask: jax.Array,
+        positions: jax.Array,
+        kv_caches: Any,
+        active_rows: jax.Array,
+        needs_final_forward: jax.Array,
+        stop_on_eos_rows: jax.Array,
+        confidence_threshold: jax.Array,
+        temperature: jax.Array,
+        forward_context: Any,
+        *,
+        logit_alignment: LogitAlignment,
+        next_block_policy: NextBlockPolicy,
+        mask_token_id: int,
+        sub_block_size: int,
+        max_denoise_steps: int = 0,
+        eos_token_ids: tuple[int, ...] = (),
 ) -> DenoiseBlockOutput:
     """Jitted block denoising implementation.
 
@@ -148,13 +179,16 @@ def _denoise_block_jit(
     active_rows = jnp.asarray(active_rows, dtype=bool)
     canvas = initial_canvas.astype(jnp.int32)
     mask = jnp.asarray(initial_mask, dtype=bool) & active_rows[:, None]
+    generation_positions = mask
+    stop_on_eos_rows = jnp.asarray(stop_on_eos_rows, dtype=bool) & active_rows
+    stopped_rows = jnp.zeros_like(active_rows)
     denoise_steps = jnp.zeros((canvas.shape[0], ), dtype=jnp.int32)
     steps_per_sub_block = (sub_block_size
                            if max_denoise_steps <= 0 else max_denoise_steps)
     num_sub_blocks = block_size // sub_block_size
 
     def denoise_sub_block(sub_block_index, carry):
-        canvas, mask, denoise_steps, kv = carry
+        canvas, mask, denoise_steps, kv, stopped_rows = carry
         start = sub_block_index * sub_block_size
         sub_block_positions = (
             (jnp.arange(block_size) >= start) &
@@ -170,17 +204,19 @@ def _denoise_block_jit(
             eligible,
             last_tokens,
             jnp.array(0, dtype=jnp.int32),
+            stopped_rows,
         )
 
         def has_work(state):
-            _, _, _, _, eligible, _, iteration = state
+            _, _, _, _, eligible, _, iteration, _ = state
             return ((iteration < steps_per_sub_block) & jnp.any(eligible))
 
         def denoise_step(state):
-            canvas, mask, steps, kv, eligible, _, iteration = state
+            (canvas, mask, steps, kv, eligible, _, iteration,
+             stopped_rows) = state
             row_has_work = jnp.any(eligible, axis=-1)
             logits, kv = forward_fn(model_state, canvas, positions, kv,
-                                    active_rows, forward_context)
+                                    row_has_work, forward_context)
             aligned_logits = _align_logits(logits, logit_alignment)
             token_ids, remaining = commit_fn(
                 aligned_logits,
@@ -193,25 +229,45 @@ def _denoise_block_jit(
             committed = eligible & ~remaining
             canvas = jnp.where(committed, token_ids, canvas)
             mask &= ~committed
+            newly_stopped = _resolved_eos_rows(
+                canvas,
+                mask,
+                generation_positions,
+                stop_on_eos_rows,
+                eos_token_ids,
+            )
+            stopped_rows |= newly_stopped
+            mask &= ~stopped_rows[:, None]
+            remaining &= ~stopped_rows[:, None]
             steps += row_has_work.astype(jnp.int32)
             return (canvas, mask, steps, kv, remaining, token_ids,
-                    iteration + 1)
+                    iteration + 1, stopped_rows)
 
         state = jax.lax.while_loop(has_work, denoise_step, state)
-        canvas, mask, denoise_steps, kv, remaining, last_tokens, _ = state
+        (canvas, mask, denoise_steps, kv, remaining, last_tokens, _,
+         stopped_rows) = state
 
         canvas = jnp.where(remaining, last_tokens, canvas)
         mask &= ~remaining
-        return canvas, mask, denoise_steps, kv
+        newly_stopped = _resolved_eos_rows(
+            canvas,
+            mask,
+            generation_positions,
+            stop_on_eos_rows,
+            eos_token_ids,
+        )
+        stopped_rows |= newly_stopped
+        mask &= ~stopped_rows[:, None]
+        return canvas, mask, denoise_steps, kv, stopped_rows
 
-    canvas, mask, denoise_steps, kv_caches = jax.lax.fori_loop(
+    canvas, mask, denoise_steps, kv_caches, stopped_rows = jax.lax.fori_loop(
         0,
         num_sub_blocks,
         denoise_sub_block,
-        (canvas, mask, denoise_steps, kv_caches),
+        (canvas, mask, denoise_steps, kv_caches, stopped_rows),
     )
 
-    final_rows = active_rows & needs_final_forward
+    final_rows = active_rows & needs_final_forward & ~stopped_rows
 
     def run_final_forward(kv):
         final_logits, next_kv = forward_fn(model_state, canvas, positions, kv,
@@ -239,28 +295,31 @@ def _denoise_block_jit(
         next_anchor=next_anchor,
         denoise_steps=denoise_steps,
         kv_caches=kv_caches,
+        stopped_rows=stopped_rows,
     )
 
 
 def denoise_block(
-    forward_fn: BlockForwardFn,
-    commit_fn: CommitFn,
-    model_state: Any,
-    initial_canvas: jax.Array,
-    initial_mask: jax.Array,
-    positions: jax.Array,
-    kv_caches: Any,
-    active_rows: jax.Array,
-    confidence_threshold: jax.Array,
-    temperature: jax.Array,
-    forward_context: Any,
-    *,
-    logit_alignment: LogitAlignment,
-    next_block_policy: NextBlockPolicy,
-    mask_token_id: int,
-    sub_block_size: int,
-    max_denoise_steps: int = 0,
-    needs_final_forward: jax.Array | None = None,
+        forward_fn: BlockForwardFn,
+        commit_fn: CommitFn,
+        model_state: Any,
+        initial_canvas: jax.Array,
+        initial_mask: jax.Array,
+        positions: jax.Array,
+        kv_caches: Any,
+        active_rows: jax.Array,
+        confidence_threshold: jax.Array,
+        temperature: jax.Array,
+        forward_context: Any,
+        *,
+        logit_alignment: LogitAlignment,
+        next_block_policy: NextBlockPolicy,
+        mask_token_id: int,
+        sub_block_size: int,
+        max_denoise_steps: int = 0,
+        needs_final_forward: jax.Array | None = None,
+        stop_on_eos_rows: jax.Array | None = None,
+        eos_token_ids: tuple[int, ...] = (),
 ) -> DenoiseBlockOutput:
     """Validate and denoise one model block.
 
@@ -279,6 +338,10 @@ def denoise_block(
         needs_final_forward = active_rows
     elif needs_final_forward.shape != active_rows.shape:
         raise ValueError("needs_final_forward must match active_rows")
+    if stop_on_eos_rows is None:
+        stop_on_eos_rows = jnp.zeros_like(active_rows, dtype=bool)
+    elif stop_on_eos_rows.shape != active_rows.shape:
+        raise ValueError("stop_on_eos_rows must match active_rows")
     if logit_alignment is LogitAlignment.SHIFTED:
         seed_mask, active = jax.device_get((initial_mask[:, 0], active_rows))
         if np.any(
@@ -298,6 +361,7 @@ def denoise_block(
         kv_caches,
         active_rows,
         needs_final_forward,
+        stop_on_eos_rows,
         confidence_threshold,
         temperature,
         forward_context,
@@ -306,6 +370,7 @@ def denoise_block(
         mask_token_id=mask_token_id,
         sub_block_size=sub_block_size,
         max_denoise_steps=max_denoise_steps,
+        eos_token_ids=eos_token_ids,
     )
 
 
@@ -320,40 +385,47 @@ def denoise_block(
         "mask_token_id",
         "sub_block_size",
         "max_denoise_steps",
+        "eos_token_ids",
     ),
 )
 def _denoise_block_dual_cache_jit(
-    full_forward_fn: AlignedSubBlockForwardFn,
-    partial_forward_fn: AlignedSubBlockForwardFn,
-    final_forward_fn: FinalBlockForwardFn,
-    commit_fn: CommitFn,
-    model_state: Any,
-    initial_canvas: jax.Array,
-    initial_mask: jax.Array,
-    positions: jax.Array,
-    kv_caches: Any,
-    active_rows: jax.Array,
-    needs_final_forward: jax.Array,
-    confidence_threshold: jax.Array,
-    temperature: jax.Array,
-    forward_context: Any,
-    *,
-    next_block_policy: NextBlockPolicy,
-    mask_token_id: int,
-    sub_block_size: int,
-    max_denoise_steps: int = 0,
+        full_forward_fn: AlignedSubBlockForwardFn,
+        partial_forward_fn: AlignedSubBlockForwardFn,
+        final_forward_fn: FinalBlockForwardFn,
+        commit_fn: CommitFn,
+        model_state: Any,
+        initial_canvas: jax.Array,
+        initial_mask: jax.Array,
+        positions: jax.Array,
+        kv_caches: Any,
+        active_rows: jax.Array,
+        needs_final_forward: jax.Array,
+        stop_on_eos_rows: jax.Array,
+        confidence_threshold: jax.Array,
+        temperature: jax.Array,
+        forward_context: Any,
+        *,
+        next_block_policy: NextBlockPolicy,
+        mask_token_id: int,
+        sub_block_size: int,
+        max_denoise_steps: int = 0,
+        eos_token_ids: tuple[int, ...] = (),
 ) -> DualCacheDenoiseBlockOutput:
     batch_size, block_size = initial_canvas.shape
     active_rows = jnp.asarray(active_rows, dtype=bool)
     canvas = initial_canvas.astype(jnp.int32)
     mask = jnp.asarray(initial_mask, dtype=bool) & active_rows[:, None]
+    generation_positions = mask
+    stop_on_eos_rows = jnp.asarray(stop_on_eos_rows, dtype=bool) & active_rows
+    stopped_rows = jnp.zeros_like(active_rows)
     denoise_steps = jnp.zeros((batch_size, ), dtype=jnp.int32)
     steps_per_sub_block = (sub_block_size
                            if max_denoise_steps <= 0 else max_denoise_steps)
     num_sub_blocks = block_size // sub_block_size
 
     def denoise_sub_block(sub_block_index, carry):
-        canvas, mask, denoise_steps, kv, q32_calls, q8_calls = carry
+        (canvas, mask, denoise_steps, kv, q32_calls, q8_calls,
+         stopped_rows) = carry
         start = sub_block_index * sub_block_size
         sub_canvas = jax.lax.dynamic_slice(canvas, (0, start),
                                            (batch_size, sub_block_size))
@@ -361,9 +433,30 @@ def _denoise_block_dual_cache_jit(
                                          (batch_size, sub_block_size))
 
         def no_work(_):
-            return canvas, mask, denoise_steps, kv, q32_calls, q8_calls
+            return (canvas, mask, denoise_steps, kv, q32_calls, q8_calls,
+                    stopped_rows)
 
         def work(_):
+
+            def apply_eos_stop(current_sub_canvas, current_sub_mask,
+                               current_remaining, current_stopped_rows):
+                current_canvas = jax.lax.dynamic_update_slice(
+                    canvas, current_sub_canvas, (0, start))
+                current_mask = jax.lax.dynamic_update_slice(
+                    mask, current_sub_mask, (0, start))
+                newly_stopped = _resolved_eos_rows(
+                    current_canvas,
+                    current_mask,
+                    generation_positions,
+                    stop_on_eos_rows,
+                    eos_token_ids,
+                )
+                current_stopped_rows |= newly_stopped
+                current_sub_mask &= ~current_stopped_rows[:, None]
+                current_remaining &= ~current_stopped_rows[:, None]
+                return (current_sub_canvas, current_sub_mask,
+                        current_remaining, current_stopped_rows)
+
             row_has_work = jnp.any(eligible, axis=-1)
             with jax.named_scope("diffusion_dual_cache_q32"):
                 logits, next_kv = full_forward_fn(
@@ -386,6 +479,10 @@ def _denoise_block_dual_cache_jit(
             committed = eligible & ~remaining
             next_sub_canvas = jnp.where(committed, token_ids, sub_canvas)
             next_sub_mask = eligible & ~committed
+            (next_sub_canvas, next_sub_mask, remaining,
+             next_stopped_rows) = apply_eos_stop(next_sub_canvas,
+                                                 next_sub_mask, remaining,
+                                                 stopped_rows)
             next_steps = denoise_steps + row_has_work.astype(jnp.int32)
 
             state = (
@@ -398,17 +495,18 @@ def _denoise_block_dual_cache_jit(
                 jnp.array(1, dtype=jnp.int32),
                 q32_calls + 1,
                 q8_calls,
+                next_stopped_rows,
             )
 
             def needs_full_refresh(state):
-                _, _, _, _, remaining, _, iteration, _, _ = state
+                _, _, _, _, remaining, _, iteration, _, _, _ = state
                 return ((iteration < steps_per_sub_block)
                         & jnp.any(remaining[:, 0]))
 
             def full_refresh_step(state):
                 (current_sub_canvas, current_sub_mask, current_steps,
                  current_kv, remaining, _, iteration, current_q32_calls,
-                 current_q8_calls) = state
+                 current_q8_calls, current_stopped_rows) = state
                 current_canvas = jax.lax.dynamic_update_slice(
                     canvas, current_sub_canvas, (0, start))
                 row_has_work = jnp.any(remaining, axis=-1)
@@ -434,6 +532,10 @@ def _denoise_block_dual_cache_jit(
                 current_sub_canvas = jnp.where(committed, token_ids,
                                                current_sub_canvas)
                 current_sub_mask &= ~committed
+                (current_sub_canvas, current_sub_mask, next_remaining,
+                 current_stopped_rows) = apply_eos_stop(
+                     current_sub_canvas, current_sub_mask, next_remaining,
+                     current_stopped_rows)
                 current_steps += row_has_work.astype(jnp.int32)
                 return (
                     current_sub_canvas,
@@ -445,19 +547,20 @@ def _denoise_block_dual_cache_jit(
                     iteration + 1,
                     current_q32_calls + 1,
                     current_q8_calls,
+                    current_stopped_rows,
                 )
 
             state = jax.lax.while_loop(needs_full_refresh, full_refresh_step,
                                        state)
 
             def has_work(state):
-                _, _, _, _, remaining, _, iteration, _, _ = state
+                _, _, _, _, remaining, _, iteration, _, _, _ = state
                 return ((iteration < steps_per_sub_block) & jnp.any(remaining))
 
             def denoise_step(state):
                 (current_sub_canvas, current_sub_mask, current_steps,
                  current_kv, remaining, _, iteration, current_q32_calls,
-                 current_q8_calls) = state
+                 current_q8_calls, current_stopped_rows) = state
                 current_canvas = jax.lax.dynamic_update_slice(
                     canvas, current_sub_canvas, (0, start))
                 row_has_work = jnp.any(remaining, axis=-1)
@@ -483,6 +586,10 @@ def _denoise_block_dual_cache_jit(
                 current_sub_canvas = jnp.where(committed, token_ids,
                                                current_sub_canvas)
                 current_sub_mask &= ~committed
+                (current_sub_canvas, current_sub_mask, next_remaining,
+                 current_stopped_rows) = apply_eos_stop(
+                     current_sub_canvas, current_sub_mask, next_remaining,
+                     current_stopped_rows)
                 current_steps += row_has_work.astype(jnp.int32)
                 return (
                     current_sub_canvas,
@@ -494,25 +601,34 @@ def _denoise_block_dual_cache_jit(
                     iteration + 1,
                     current_q32_calls,
                     current_q8_calls + 1,
+                    current_stopped_rows,
                 )
 
             state = jax.lax.while_loop(has_work, denoise_step, state)
             (next_sub_canvas, next_sub_mask, next_steps, next_kv, remaining,
-             last_tokens, _, next_q32_calls, next_q8_calls) = state
+             last_tokens, _, next_q32_calls, next_q8_calls,
+             next_stopped_rows) = state
             next_sub_canvas = jnp.where(remaining, last_tokens,
                                         next_sub_canvas)
             next_sub_mask &= ~remaining
+            (next_sub_canvas, next_sub_mask, _,
+             next_stopped_rows) = apply_eos_stop(
+                 next_sub_canvas,
+                 next_sub_mask,
+                 jnp.zeros_like(remaining),
+                 next_stopped_rows,
+             )
             next_canvas = jax.lax.dynamic_update_slice(canvas, next_sub_canvas,
                                                        (0, start))
             next_mask = jax.lax.dynamic_update_slice(mask, next_sub_mask,
                                                      (0, start))
             return (next_canvas, next_mask, next_steps, next_kv,
-                    next_q32_calls, next_q8_calls)
+                    next_q32_calls, next_q8_calls, next_stopped_rows)
 
         return jax.lax.cond(jnp.any(eligible), work, no_work, operand=None)
 
     (canvas, mask, denoise_steps, kv_caches, q32_forward_calls,
-     q8_forward_calls) = jax.lax.fori_loop(
+     q8_forward_calls, stopped_rows) = jax.lax.fori_loop(
          0,
          num_sub_blocks,
          denoise_sub_block,
@@ -523,10 +639,11 @@ def _denoise_block_dual_cache_jit(
              kv_caches,
              jnp.array(0, dtype=jnp.int32),
              jnp.array(0, dtype=jnp.int32),
+             stopped_rows,
          ),
      )
 
-    final_rows = active_rows & needs_final_forward
+    final_rows = active_rows & needs_final_forward & ~stopped_rows
 
     def run_final_forward(kv):
         with jax.named_scope("diffusion_dual_cache_final_q32"):
@@ -565,30 +682,33 @@ def _denoise_block_dual_cache_jit(
         q32_forward_calls=q32_forward_calls,
         q8_forward_calls=q8_forward_calls,
         final_q32_forward_calls=final_q32_forward_calls,
+        stopped_rows=stopped_rows,
     )
 
 
 def denoise_block_dual_cache(
-    full_forward_fn: AlignedSubBlockForwardFn,
-    partial_forward_fn: AlignedSubBlockForwardFn,
-    final_forward_fn: FinalBlockForwardFn,
-    commit_fn: CommitFn,
-    model_state: Any,
-    initial_canvas: jax.Array,
-    initial_mask: jax.Array,
-    positions: jax.Array,
-    kv_caches: Any,
-    active_rows: jax.Array,
-    confidence_threshold: jax.Array,
-    temperature: jax.Array,
-    forward_context: Any,
-    *,
-    logit_alignment: LogitAlignment,
-    next_block_policy: NextBlockPolicy,
-    mask_token_id: int,
-    sub_block_size: int,
-    max_denoise_steps: int = 0,
-    needs_final_forward: jax.Array | None = None,
+        full_forward_fn: AlignedSubBlockForwardFn,
+        partial_forward_fn: AlignedSubBlockForwardFn,
+        final_forward_fn: FinalBlockForwardFn,
+        commit_fn: CommitFn,
+        model_state: Any,
+        initial_canvas: jax.Array,
+        initial_mask: jax.Array,
+        positions: jax.Array,
+        kv_caches: Any,
+        active_rows: jax.Array,
+        confidence_threshold: jax.Array,
+        temperature: jax.Array,
+        forward_context: Any,
+        *,
+        logit_alignment: LogitAlignment,
+        next_block_policy: NextBlockPolicy,
+        mask_token_id: int,
+        sub_block_size: int,
+        max_denoise_steps: int = 0,
+        needs_final_forward: jax.Array | None = None,
+        stop_on_eos_rows: jax.Array | None = None,
+        eos_token_ids: tuple[int, ...] = (),
 ) -> DualCacheDenoiseBlockOutput:
     """Denoise with aligned q32 refreshes followed by q8 replacements."""
     if initial_canvas.ndim != 2:
@@ -603,6 +723,10 @@ def denoise_block_dual_cache(
         needs_final_forward = active_rows
     elif needs_final_forward.shape != active_rows.shape:
         raise ValueError("needs_final_forward must match active_rows")
+    if stop_on_eos_rows is None:
+        stop_on_eos_rows = jnp.zeros_like(active_rows, dtype=bool)
+    elif stop_on_eos_rows.shape != active_rows.shape:
+        raise ValueError("stop_on_eos_rows must match active_rows")
     if sub_block_size < 1 or initial_canvas.shape[1] % sub_block_size:
         raise ValueError("sub_block_size must divide the model block size")
     if logit_alignment is LogitAlignment.SHIFTED:
@@ -626,6 +750,7 @@ def denoise_block_dual_cache(
         kv_caches,
         active_rows,
         needs_final_forward,
+        stop_on_eos_rows,
         confidence_threshold,
         temperature,
         forward_context,
@@ -633,4 +758,5 @@ def denoise_block_dual_cache(
         mask_token_id=mask_token_id,
         sub_block_size=sub_block_size,
         max_denoise_steps=max_denoise_steps,
+        eos_token_ids=eos_token_ids,
     )

--- a/tpu_inference/runner/diffusion/program.py
+++ b/tpu_inference/runner/diffusion/program.py
@@ -377,17 +377,67 @@ def _denoise_block_dual_cache_jit(
                 remaining,
                 token_ids,
                 jnp.array(1, dtype=jnp.int32),
+                q32_calls + 1,
                 q8_calls,
             )
 
-            def has_work(state):
-                _, _, _, _, remaining, _, iteration, _ = state
+            def needs_full_refresh(state):
+                _, _, _, _, remaining, _, iteration, _, _ = state
                 return ((iteration < steps_per_sub_block)
-                        & jnp.any(remaining))
+                        & jnp.any(remaining[:, 0]))
+
+            def full_refresh_step(state):
+                (current_sub_canvas, current_sub_mask, current_steps,
+                 current_kv, remaining, _, iteration, current_q32_calls,
+                 current_q8_calls) = state
+                current_canvas = jax.lax.dynamic_update_slice(
+                    canvas, current_sub_canvas, (0, start))
+                row_has_work = jnp.any(remaining, axis=-1)
+                with jax.named_scope("diffusion_dual_cache_q32"):
+                    logits, current_kv = full_forward_fn(
+                        model_state,
+                        current_canvas,
+                        positions,
+                        current_kv,
+                        row_has_work,
+                        forward_context,
+                        start,
+                    )
+                token_ids, next_remaining = commit_fn(
+                    logits,
+                    remaining,
+                    row_has_work,
+                    confidence_threshold,
+                    temperature,
+                    mask_token_id,
+                )
+                committed = remaining & ~next_remaining
+                current_sub_canvas = jnp.where(committed, token_ids,
+                                               current_sub_canvas)
+                current_sub_mask &= ~committed
+                current_steps += row_has_work.astype(jnp.int32)
+                return (
+                    current_sub_canvas,
+                    current_sub_mask,
+                    current_steps,
+                    current_kv,
+                    next_remaining,
+                    token_ids,
+                    iteration + 1,
+                    current_q32_calls + 1,
+                    current_q8_calls,
+                )
+
+            state = jax.lax.while_loop(needs_full_refresh, full_refresh_step,
+                                       state)
+
+            def has_work(state):
+                _, _, _, _, remaining, _, iteration, _, _ = state
+                return ((iteration < steps_per_sub_block) & jnp.any(remaining))
 
             def denoise_step(state):
                 (current_sub_canvas, current_sub_mask, current_steps,
-                 current_kv, remaining, _, iteration,
+                 current_kv, remaining, _, iteration, current_q32_calls,
                  current_q8_calls) = state
                 current_canvas = jax.lax.dynamic_update_slice(
                     canvas, current_sub_canvas, (0, start))
@@ -423,21 +473,22 @@ def _denoise_block_dual_cache_jit(
                     next_remaining,
                     token_ids,
                     iteration + 1,
+                    current_q32_calls,
                     current_q8_calls + 1,
                 )
 
             state = jax.lax.while_loop(has_work, denoise_step, state)
             (next_sub_canvas, next_sub_mask, next_steps, next_kv, remaining,
-             last_tokens, _, next_q8_calls) = state
+             last_tokens, _, next_q32_calls, next_q8_calls) = state
             next_sub_canvas = jnp.where(remaining, last_tokens,
                                         next_sub_canvas)
             next_sub_mask &= ~remaining
-            next_canvas = jax.lax.dynamic_update_slice(
-                canvas, next_sub_canvas, (0, start))
+            next_canvas = jax.lax.dynamic_update_slice(canvas, next_sub_canvas,
+                                                       (0, start))
             next_mask = jax.lax.dynamic_update_slice(mask, next_sub_mask,
                                                      (0, start))
             return (next_canvas, next_mask, next_steps, next_kv,
-                    q32_calls + 1, next_q8_calls)
+                    next_q32_calls, next_q8_calls)
 
         return jax.lax.cond(jnp.any(eligible), work, no_work, operand=None)
 
@@ -506,7 +557,7 @@ def denoise_block_dual_cache(
     sub_block_size: int,
     max_denoise_steps: int = 0,
 ) -> DualCacheDenoiseBlockOutput:
-    """Denoise with one q32 refresh followed by cached q8 replacements."""
+    """Denoise with aligned q32 refreshes followed by q8 replacements."""
     if initial_canvas.ndim != 2:
         raise ValueError("initial_canvas must have shape [batch, block_size]")
     if initial_mask.shape != initial_canvas.shape:

--- a/tpu_inference/runner/diffusion/program.py
+++ b/tpu_inference/runner/diffusion/program.py
@@ -55,6 +55,7 @@ class DualCacheDenoiseBlockOutput(NamedTuple):
     kv_caches: Any
     q32_forward_calls: jax.Array
     q8_forward_calls: jax.Array
+    final_q32_forward_calls: jax.Array
 
 
 def select_aligned_hidden_states(
@@ -111,6 +112,7 @@ def _denoise_block_jit(
     positions: jax.Array,
     kv_caches: Any,
     active_rows: jax.Array,
+    needs_final_forward: jax.Array,
     confidence_threshold: jax.Array,
     temperature: jax.Array,
     forward_context: Any,
@@ -209,19 +211,29 @@ def _denoise_block_jit(
         (canvas, mask, denoise_steps, kv_caches),
     )
 
-    final_logits, kv_caches = forward_fn(model_state, canvas, positions,
-                                         kv_caches, active_rows,
-                                         forward_context)
-    if next_block_policy is NextBlockPolicy.LAST_LOGIT_ANCHOR:
-        anchor_logits = _exclude_mask_token(final_logits[:, -1:, :],
-                                            mask_token_id)
-        next_anchor = jnp.argmax(anchor_logits[:, 0, :],
-                                 axis=-1).astype(jnp.int32)
-    elif next_block_policy is NextBlockPolicy.ALL_MASKED:
-        next_anchor = jnp.zeros((canvas.shape[0], ), dtype=jnp.int32)
-    else:
-        raise ValueError(f"Unsupported next block policy: {next_block_policy}")
-    next_anchor = jnp.where(active_rows, next_anchor, 0)
+    final_rows = active_rows & needs_final_forward
+
+    def run_final_forward(kv):
+        final_logits, next_kv = forward_fn(model_state, canvas, positions, kv,
+                                           final_rows, forward_context)
+        if next_block_policy is NextBlockPolicy.LAST_LOGIT_ANCHOR:
+            anchor_logits = _exclude_mask_token(final_logits[:, -1:, :],
+                                                mask_token_id)
+            next_anchor = jnp.argmax(anchor_logits[:, 0, :],
+                                     axis=-1).astype(jnp.int32)
+        elif next_block_policy is NextBlockPolicy.ALL_MASKED:
+            next_anchor = jnp.zeros((canvas.shape[0], ), dtype=jnp.int32)
+        else:
+            raise ValueError(
+                f"Unsupported next block policy: {next_block_policy}")
+        return jnp.where(final_rows, next_anchor, 0), next_kv
+
+    def skip_final_forward(kv):
+        return jnp.zeros((canvas.shape[0], ), dtype=jnp.int32), kv
+
+    next_anchor, kv_caches = jax.lax.cond(jnp.any(final_rows),
+                                          run_final_forward,
+                                          skip_final_forward, kv_caches)
     return DenoiseBlockOutput(
         canvas=canvas,
         next_anchor=next_anchor,
@@ -248,6 +260,7 @@ def denoise_block(
     mask_token_id: int,
     sub_block_size: int,
     max_denoise_steps: int = 0,
+    needs_final_forward: jax.Array | None = None,
 ) -> DenoiseBlockOutput:
     """Validate and denoise one model block.
 
@@ -262,6 +275,10 @@ def denoise_block(
         raise ValueError("initial_mask must match initial_canvas")
     if active_rows.shape != (initial_canvas.shape[0], ):
         raise ValueError("active_rows must match the canvas batch size")
+    if needs_final_forward is None:
+        needs_final_forward = active_rows
+    elif needs_final_forward.shape != active_rows.shape:
+        raise ValueError("needs_final_forward must match active_rows")
     if logit_alignment is LogitAlignment.SHIFTED:
         seed_mask, active = jax.device_get((initial_mask[:, 0], active_rows))
         if np.any(
@@ -280,6 +297,7 @@ def denoise_block(
         positions,
         kv_caches,
         active_rows,
+        needs_final_forward,
         confidence_threshold,
         temperature,
         forward_context,
@@ -315,6 +333,7 @@ def _denoise_block_dual_cache_jit(
     positions: jax.Array,
     kv_caches: Any,
     active_rows: jax.Array,
+    needs_final_forward: jax.Array,
     confidence_threshold: jax.Array,
     temperature: jax.Array,
     forward_context: Any,
@@ -507,25 +526,37 @@ def _denoise_block_dual_cache_jit(
          ),
      )
 
-    with jax.named_scope("diffusion_dual_cache_final_q32"):
-        anchor_logits, kv_caches = final_forward_fn(
-            model_state,
-            canvas,
-            positions,
-            kv_caches,
-            active_rows,
-            forward_context,
-        )
-    q32_forward_calls += 1
-    if next_block_policy is NextBlockPolicy.LAST_LOGIT_ANCHOR:
-        anchor_logits = _exclude_mask_token(anchor_logits[:, None, :],
-                                            mask_token_id)[:, 0, :]
-        next_anchor = jnp.argmax(anchor_logits, axis=-1).astype(jnp.int32)
-    elif next_block_policy is NextBlockPolicy.ALL_MASKED:
-        next_anchor = jnp.zeros((canvas.shape[0], ), dtype=jnp.int32)
-    else:
-        raise ValueError(f"Unsupported next block policy: {next_block_policy}")
-    next_anchor = jnp.where(active_rows, next_anchor, 0)
+    final_rows = active_rows & needs_final_forward
+
+    def run_final_forward(kv):
+        with jax.named_scope("diffusion_dual_cache_final_q32"):
+            anchor_logits, next_kv = final_forward_fn(
+                model_state,
+                canvas,
+                positions,
+                kv,
+                final_rows,
+                forward_context,
+            )
+        if next_block_policy is NextBlockPolicy.LAST_LOGIT_ANCHOR:
+            anchor_logits = _exclude_mask_token(anchor_logits[:, None, :],
+                                                mask_token_id)[:, 0, :]
+            next_anchor = jnp.argmax(anchor_logits, axis=-1).astype(jnp.int32)
+        elif next_block_policy is NextBlockPolicy.ALL_MASKED:
+            next_anchor = jnp.zeros((canvas.shape[0], ), dtype=jnp.int32)
+        else:
+            raise ValueError(
+                f"Unsupported next block policy: {next_block_policy}")
+        return (jnp.where(final_rows, next_anchor,
+                          0), next_kv, jnp.array(1, dtype=jnp.int32))
+
+    def skip_final_forward(kv):
+        return (jnp.zeros((canvas.shape[0], ),
+                          dtype=jnp.int32), kv, jnp.array(0, dtype=jnp.int32))
+
+    next_anchor, kv_caches, final_q32_forward_calls = jax.lax.cond(
+        jnp.any(final_rows), run_final_forward, skip_final_forward, kv_caches)
+    q32_forward_calls += final_q32_forward_calls
     return DualCacheDenoiseBlockOutput(
         canvas=canvas,
         next_anchor=next_anchor,
@@ -533,6 +564,7 @@ def _denoise_block_dual_cache_jit(
         kv_caches=kv_caches,
         q32_forward_calls=q32_forward_calls,
         q8_forward_calls=q8_forward_calls,
+        final_q32_forward_calls=final_q32_forward_calls,
     )
 
 
@@ -556,6 +588,7 @@ def denoise_block_dual_cache(
     mask_token_id: int,
     sub_block_size: int,
     max_denoise_steps: int = 0,
+    needs_final_forward: jax.Array | None = None,
 ) -> DualCacheDenoiseBlockOutput:
     """Denoise with aligned q32 refreshes followed by q8 replacements."""
     if initial_canvas.ndim != 2:
@@ -566,6 +599,10 @@ def denoise_block_dual_cache(
         raise ValueError("positions must match initial_canvas")
     if active_rows.shape != (initial_canvas.shape[0], ):
         raise ValueError("active_rows must match the canvas batch size")
+    if needs_final_forward is None:
+        needs_final_forward = active_rows
+    elif needs_final_forward.shape != active_rows.shape:
+        raise ValueError("needs_final_forward must match active_rows")
     if sub_block_size < 1 or initial_canvas.shape[1] % sub_block_size:
         raise ValueError("sub_block_size must divide the model block size")
     if logit_alignment is LogitAlignment.SHIFTED:
@@ -588,6 +625,7 @@ def denoise_block_dual_cache(
         positions,
         kv_caches,
         active_rows,
+        needs_final_forward,
         confidence_threshold,
         temperature,
         forward_context,

--- a/tpu_inference/runner/diffusion/program.py
+++ b/tpu_inference/runner/diffusion/program.py
@@ -453,6 +453,7 @@ def denoise_block(
 
 @functools.partial(
     jax.jit,
+    donate_argnums=(9, ),
     static_argnames=(
         "full_forward_fn",
         "partial_forward_fn",

--- a/tpu_inference/runner/diffusion/program.py
+++ b/tpu_inference/runner/diffusion/program.py
@@ -454,6 +454,14 @@ def denoise_block(
 @functools.partial(
     jax.jit,
     donate_argnums=(9, ),
+    # Model forwards are nested no-options JITs, so TPU compiler options must
+    # live on this top-level denoise-loop JIT.
+    compiler_options={
+        "xla_tpu_all_gather_collective_matmul_mode": "post_spmd_conservative",
+        "xla_tpu_reduce_scatter_collective_matmul_mode":
+        "post_spmd_conservative",
+        "xla_tpu_use_minor_sharding_for_major_trivial_input": "true",
+    },
     static_argnames=(
         "full_forward_fn",
         "partial_forward_fn",

--- a/tpu_inference/runner/diffusion/program.py
+++ b/tpu_inference/runner/diffusion/program.py
@@ -20,11 +20,9 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 
-from tpu_inference.runner.diffusion.algorithm import (CommitDiagnostics,
-                                                      CommitDiagnosticsFn,
-                                                      CommitFn,
-                                                      _exclude_mask_token,
-                                                      confidence_threshold_with_log_bias)
+from tpu_inference.runner.diffusion.algorithm import (
+    CommitDiagnostics, CommitDiagnosticsFn, CommitFn, _exclude_mask_token,
+    confidence_threshold_with_log_bias)
 from tpu_inference.runner.diffusion.config import (LogitAlignment,
                                                    NextBlockPolicy)
 
@@ -65,6 +63,7 @@ class DualCacheAcceptanceTrace(NamedTuple):
     row0_eligible: jax.Array
     row0_commit: jax.Array
     row0_remaining: jax.Array
+    row0_forced_anchor: jax.Array
     row0_selected_log_confidence: jax.Array
     row0_threshold_margin: jax.Array
 
@@ -77,6 +76,7 @@ class DualCacheDenoiseBlockOutput(NamedTuple):
     q32_forward_calls: jax.Array
     q8_forward_calls: jax.Array
     final_q32_forward_calls: jax.Array
+    forced_q32_anchor_commits: jax.Array
     stopped_rows: jax.Array
     acceptance_trace: DualCacheAcceptanceTrace | None
 
@@ -98,6 +98,7 @@ def _empty_dual_cache_acceptance_trace(
         row0_eligible=jnp.zeros(row_shape, dtype=bool),
         row0_commit=jnp.zeros(row_shape, dtype=bool),
         row0_remaining=jnp.zeros(row_shape, dtype=bool),
+        row0_forced_anchor=jnp.zeros(step_shape, dtype=bool),
         row0_selected_log_confidence=jnp.zeros(row_shape, dtype=jnp.float32),
         row0_threshold_margin=jnp.zeros(row_shape, dtype=jnp.float32),
     )
@@ -111,6 +112,7 @@ def _record_dual_cache_acceptance_step(
     token_ids: jax.Array,
     eligible: jax.Array,
     remaining: jax.Array,
+    forced_anchor_rows: jax.Array,
     diagnostics: CommitDiagnostics,
 ) -> DualCacheAcceptanceTrace:
     index = trace.count
@@ -125,6 +127,8 @@ def _record_dual_cache_acceptance_step(
         row0_eligible=trace.row0_eligible.at[index].set(eligible[0]),
         row0_commit=trace.row0_commit.at[index].set(committed[0]),
         row0_remaining=trace.row0_remaining.at[index].set(remaining[0]),
+        row0_forced_anchor=trace.row0_forced_anchor.at[index].set(
+            forced_anchor_rows[0]),
         row0_selected_log_confidence=(
             trace.row0_selected_log_confidence.at[index].set(
                 diagnostics.selected_log_confidence[0])),
@@ -462,6 +466,7 @@ def denoise_block(
         "eos_token_ids",
         "trace_acceptance_steps",
         "q8_log_confidence_bias",
+        "force_q32_anchor_commit",
     ),
 )
 def _denoise_block_dual_cache_jit(
@@ -489,6 +494,7 @@ def _denoise_block_dual_cache_jit(
     eos_token_ids: tuple[int, ...] = (),
     trace_acceptance_steps: bool = False,
     q8_log_confidence_bias: float = 0.0,
+    force_q32_anchor_commit: bool = False,
 ) -> DualCacheDenoiseBlockOutput:
     batch_size, block_size = initial_canvas.shape
     active_rows = jnp.asarray(active_rows, dtype=bool)
@@ -518,6 +524,7 @@ def _denoise_block_dual_cache_jit(
         token_ids,
         eligible,
         remaining,
+        forced_anchor_rows,
         step_confidence_threshold,
     ):
         if not trace_acceptance_steps:
@@ -537,12 +544,13 @@ def _denoise_block_dual_cache_jit(
             token_ids,
             eligible,
             remaining,
+            forced_anchor_rows,
             diagnostics,
         )
 
     def denoise_sub_block(sub_block_index, carry):
-        (canvas, mask, denoise_steps, kv, q32_calls, q8_calls, stopped_rows,
-         acceptance_trace) = carry
+        (canvas, mask, denoise_steps, kv, q32_calls, q8_calls,
+         forced_anchor_commits, stopped_rows, acceptance_trace) = carry
         start = sub_block_index * sub_block_size
         sub_canvas = jax.lax.dynamic_slice(canvas, (0, start),
                                            (batch_size, sub_block_size))
@@ -551,7 +559,7 @@ def _denoise_block_dual_cache_jit(
 
         def no_work(_):
             return (canvas, mask, denoise_steps, kv, q32_calls, q8_calls,
-                    stopped_rows, acceptance_trace)
+                    forced_anchor_commits, stopped_rows, acceptance_trace)
 
         def work(_):
 
@@ -593,6 +601,14 @@ def _denoise_block_dual_cache_jit(
                 temperature,
                 mask_token_id,
             )
+            if force_q32_anchor_commit:
+                forced_anchor_rows = remaining[:, 0]
+                remaining = remaining.at[:, 0].set(False)
+            else:
+                forced_anchor_rows = jnp.zeros_like(remaining[:, 0])
+            next_forced_anchor_commits = (
+                forced_anchor_commits +
+                jnp.sum(forced_anchor_rows.astype(jnp.int32)))
             next_acceptance_trace = record_acceptance_step(
                 acceptance_trace,
                 start,
@@ -602,6 +618,7 @@ def _denoise_block_dual_cache_jit(
                 token_ids,
                 eligible,
                 remaining,
+                forced_anchor_rows,
                 confidence_threshold,
             )
             committed = eligible & ~remaining
@@ -667,6 +684,7 @@ def _denoise_block_dual_cache_jit(
                     token_ids,
                     remaining,
                     next_remaining,
+                    jnp.zeros((batch_size, ), dtype=bool),
                     confidence_threshold,
                 )
                 committed = remaining & ~next_remaining
@@ -734,6 +752,7 @@ def _denoise_block_dual_cache_jit(
                     token_ids,
                     remaining,
                     next_remaining,
+                    jnp.zeros((batch_size, ), dtype=bool),
                     q8_confidence_threshold,
                 )
                 committed = remaining & ~next_remaining
@@ -778,13 +797,14 @@ def _denoise_block_dual_cache_jit(
             next_mask = jax.lax.dynamic_update_slice(mask, next_sub_mask,
                                                      (0, start))
             return (next_canvas, next_mask, next_steps, next_kv,
-                    next_q32_calls, next_q8_calls, next_stopped_rows,
-                    next_acceptance_trace)
+                    next_q32_calls, next_q8_calls, next_forced_anchor_commits,
+                    next_stopped_rows, next_acceptance_trace)
 
         return jax.lax.cond(jnp.any(eligible), work, no_work, operand=None)
 
     (canvas, mask, denoise_steps, kv_caches, q32_forward_calls,
-     q8_forward_calls, stopped_rows, acceptance_trace) = jax.lax.fori_loop(
+     q8_forward_calls, forced_q32_anchor_commits, stopped_rows,
+     acceptance_trace) = jax.lax.fori_loop(
          0,
          num_sub_blocks,
          denoise_sub_block,
@@ -793,6 +813,7 @@ def _denoise_block_dual_cache_jit(
              mask,
              denoise_steps,
              kv_caches,
+             jnp.array(0, dtype=jnp.int32),
              jnp.array(0, dtype=jnp.int32),
              jnp.array(0, dtype=jnp.int32),
              stopped_rows,
@@ -839,6 +860,7 @@ def _denoise_block_dual_cache_jit(
         q32_forward_calls=q32_forward_calls,
         q8_forward_calls=q8_forward_calls,
         final_q32_forward_calls=final_q32_forward_calls,
+        forced_q32_anchor_commits=forced_q32_anchor_commits,
         stopped_rows=stopped_rows,
         acceptance_trace=acceptance_trace,
     )
@@ -870,6 +892,7 @@ def denoise_block_dual_cache(
     commit_diagnostics_fn: CommitDiagnosticsFn | None = None,
     trace_acceptance_steps: bool = False,
     q8_log_confidence_bias: float = 0.0,
+    force_q32_anchor_commit: bool = False,
 ) -> DualCacheDenoiseBlockOutput:
     """Denoise with aligned q32 refreshes followed by q8 replacements."""
     if initial_canvas.ndim != 2:
@@ -899,6 +922,10 @@ def denoise_block_dual_cache(
             "q8_log_confidence_bias must be finite and non-negative")
     if q8_log_confidence_bias > 0.5:
         raise ValueError("q8_log_confidence_bias must not exceed 0.5")
+    if (force_q32_anchor_commit
+            and logit_alignment is not LogitAlignment.SHIFTED):
+        raise ValueError(
+            "force_q32_anchor_commit requires shifted logit alignment")
     if logit_alignment is LogitAlignment.SHIFTED:
         seed_mask, active = jax.device_get((initial_mask[:, 0], active_rows))
         if np.any(
@@ -932,4 +959,5 @@ def denoise_block_dual_cache(
         eos_token_ids=eos_token_ids,
         trace_acceptance_steps=trace_acceptance_steps,
         q8_log_confidence_bias=q8_log_confidence_bias,
+        force_q32_anchor_commit=force_q32_anchor_commit,
     )

--- a/tpu_inference/runner/diffusion/program.py
+++ b/tpu_inference/runner/diffusion/program.py
@@ -30,12 +30,51 @@ BlockForwardFn = Callable[
     tuple[jax.Array, Any],
 ]
 
+AlignedSubBlockForwardFn = Callable[
+    [Any, jax.Array, jax.Array, Any, jax.Array, Any, jax.Array],
+    tuple[jax.Array, Any],
+]
+
+FinalBlockForwardFn = Callable[
+    [Any, jax.Array, jax.Array, Any, jax.Array, Any],
+    tuple[jax.Array, Any],
+]
+
 
 class DenoiseBlockOutput(NamedTuple):
     canvas: jax.Array
     next_anchor: jax.Array
     denoise_steps: jax.Array
     kv_caches: Any
+
+
+class DualCacheDenoiseBlockOutput(NamedTuple):
+    canvas: jax.Array
+    next_anchor: jax.Array
+    denoise_steps: jax.Array
+    kv_caches: Any
+    q32_forward_calls: jax.Array
+    q8_forward_calls: jax.Array
+
+
+def select_aligned_hidden_states(
+    hidden_states: jax.Array,
+    batch_size: int,
+    query_length: int,
+    start: jax.Array,
+    sub_block_size: int,
+    alignment: LogitAlignment,
+    *,
+    local_alignment: bool,
+) -> jax.Array:
+    hidden_states = hidden_states.reshape(batch_size, query_length, -1)
+    indices = jnp.arange(sub_block_size, dtype=jnp.int32)
+    if not local_alignment:
+        indices += start
+    if alignment is LogitAlignment.SHIFTED:
+        indices = jnp.maximum(indices - 1, 0)
+    selected = jnp.take(hidden_states, indices, axis=1)
+    return selected.reshape(-1, hidden_states.shape[-1])
 
 
 def _align_logits(
@@ -245,6 +284,262 @@ def denoise_block(
         temperature,
         forward_context,
         logit_alignment=logit_alignment,
+        next_block_policy=next_block_policy,
+        mask_token_id=mask_token_id,
+        sub_block_size=sub_block_size,
+        max_denoise_steps=max_denoise_steps,
+    )
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=(
+        "full_forward_fn",
+        "partial_forward_fn",
+        "final_forward_fn",
+        "commit_fn",
+        "next_block_policy",
+        "mask_token_id",
+        "sub_block_size",
+        "max_denoise_steps",
+    ),
+)
+def _denoise_block_dual_cache_jit(
+    full_forward_fn: AlignedSubBlockForwardFn,
+    partial_forward_fn: AlignedSubBlockForwardFn,
+    final_forward_fn: FinalBlockForwardFn,
+    commit_fn: CommitFn,
+    model_state: Any,
+    initial_canvas: jax.Array,
+    initial_mask: jax.Array,
+    positions: jax.Array,
+    kv_caches: Any,
+    active_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    forward_context: Any,
+    *,
+    next_block_policy: NextBlockPolicy,
+    mask_token_id: int,
+    sub_block_size: int,
+    max_denoise_steps: int = 0,
+) -> DualCacheDenoiseBlockOutput:
+    batch_size, block_size = initial_canvas.shape
+    active_rows = jnp.asarray(active_rows, dtype=bool)
+    canvas = initial_canvas.astype(jnp.int32)
+    mask = jnp.asarray(initial_mask, dtype=bool) & active_rows[:, None]
+    denoise_steps = jnp.zeros((batch_size, ), dtype=jnp.int32)
+    steps_per_sub_block = (sub_block_size
+                           if max_denoise_steps <= 0 else max_denoise_steps)
+    num_sub_blocks = block_size // sub_block_size
+
+    def denoise_sub_block(sub_block_index, carry):
+        canvas, mask, denoise_steps, kv, q32_calls, q8_calls = carry
+        start = sub_block_index * sub_block_size
+        sub_canvas = jax.lax.dynamic_slice(canvas, (0, start),
+                                           (batch_size, sub_block_size))
+        eligible = jax.lax.dynamic_slice(mask, (0, start),
+                                         (batch_size, sub_block_size))
+
+        def no_work(_):
+            return canvas, mask, denoise_steps, kv, q32_calls, q8_calls
+
+        def work(_):
+            row_has_work = jnp.any(eligible, axis=-1)
+            with jax.named_scope("diffusion_dual_cache_q32"):
+                logits, next_kv = full_forward_fn(
+                    model_state,
+                    canvas,
+                    positions,
+                    kv,
+                    row_has_work,
+                    forward_context,
+                    start,
+                )
+            token_ids, remaining = commit_fn(
+                logits,
+                eligible,
+                row_has_work,
+                confidence_threshold,
+                temperature,
+                mask_token_id,
+            )
+            committed = eligible & ~remaining
+            next_sub_canvas = jnp.where(committed, token_ids, sub_canvas)
+            next_sub_mask = eligible & ~committed
+            next_steps = denoise_steps + row_has_work.astype(jnp.int32)
+
+            state = (
+                next_sub_canvas,
+                next_sub_mask,
+                next_steps,
+                next_kv,
+                remaining,
+                token_ids,
+                jnp.array(1, dtype=jnp.int32),
+                q8_calls,
+            )
+
+            def has_work(state):
+                _, _, _, _, remaining, _, iteration, _ = state
+                return ((iteration < steps_per_sub_block)
+                        & jnp.any(remaining))
+
+            def denoise_step(state):
+                (current_sub_canvas, current_sub_mask, current_steps,
+                 current_kv, remaining, _, iteration,
+                 current_q8_calls) = state
+                current_canvas = jax.lax.dynamic_update_slice(
+                    canvas, current_sub_canvas, (0, start))
+                row_has_work = jnp.any(remaining, axis=-1)
+                with jax.named_scope("diffusion_dual_cache_q8"):
+                    logits, current_kv = partial_forward_fn(
+                        model_state,
+                        current_canvas,
+                        positions,
+                        current_kv,
+                        row_has_work,
+                        forward_context,
+                        start,
+                    )
+                token_ids, next_remaining = commit_fn(
+                    logits,
+                    remaining,
+                    row_has_work,
+                    confidence_threshold,
+                    temperature,
+                    mask_token_id,
+                )
+                committed = remaining & ~next_remaining
+                current_sub_canvas = jnp.where(committed, token_ids,
+                                               current_sub_canvas)
+                current_sub_mask &= ~committed
+                current_steps += row_has_work.astype(jnp.int32)
+                return (
+                    current_sub_canvas,
+                    current_sub_mask,
+                    current_steps,
+                    current_kv,
+                    next_remaining,
+                    token_ids,
+                    iteration + 1,
+                    current_q8_calls + 1,
+                )
+
+            state = jax.lax.while_loop(has_work, denoise_step, state)
+            (next_sub_canvas, next_sub_mask, next_steps, next_kv, remaining,
+             last_tokens, _, next_q8_calls) = state
+            next_sub_canvas = jnp.where(remaining, last_tokens,
+                                        next_sub_canvas)
+            next_sub_mask &= ~remaining
+            next_canvas = jax.lax.dynamic_update_slice(
+                canvas, next_sub_canvas, (0, start))
+            next_mask = jax.lax.dynamic_update_slice(mask, next_sub_mask,
+                                                     (0, start))
+            return (next_canvas, next_mask, next_steps, next_kv,
+                    q32_calls + 1, next_q8_calls)
+
+        return jax.lax.cond(jnp.any(eligible), work, no_work, operand=None)
+
+    (canvas, mask, denoise_steps, kv_caches, q32_forward_calls,
+     q8_forward_calls) = jax.lax.fori_loop(
+         0,
+         num_sub_blocks,
+         denoise_sub_block,
+         (
+             canvas,
+             mask,
+             denoise_steps,
+             kv_caches,
+             jnp.array(0, dtype=jnp.int32),
+             jnp.array(0, dtype=jnp.int32),
+         ),
+     )
+
+    with jax.named_scope("diffusion_dual_cache_final_q32"):
+        anchor_logits, kv_caches = final_forward_fn(
+            model_state,
+            canvas,
+            positions,
+            kv_caches,
+            active_rows,
+            forward_context,
+        )
+    q32_forward_calls += 1
+    if next_block_policy is NextBlockPolicy.LAST_LOGIT_ANCHOR:
+        anchor_logits = _exclude_mask_token(anchor_logits[:, None, :],
+                                            mask_token_id)[:, 0, :]
+        next_anchor = jnp.argmax(anchor_logits, axis=-1).astype(jnp.int32)
+    elif next_block_policy is NextBlockPolicy.ALL_MASKED:
+        next_anchor = jnp.zeros((canvas.shape[0], ), dtype=jnp.int32)
+    else:
+        raise ValueError(f"Unsupported next block policy: {next_block_policy}")
+    next_anchor = jnp.where(active_rows, next_anchor, 0)
+    return DualCacheDenoiseBlockOutput(
+        canvas=canvas,
+        next_anchor=next_anchor,
+        denoise_steps=denoise_steps,
+        kv_caches=kv_caches,
+        q32_forward_calls=q32_forward_calls,
+        q8_forward_calls=q8_forward_calls,
+    )
+
+
+def denoise_block_dual_cache(
+    full_forward_fn: AlignedSubBlockForwardFn,
+    partial_forward_fn: AlignedSubBlockForwardFn,
+    final_forward_fn: FinalBlockForwardFn,
+    commit_fn: CommitFn,
+    model_state: Any,
+    initial_canvas: jax.Array,
+    initial_mask: jax.Array,
+    positions: jax.Array,
+    kv_caches: Any,
+    active_rows: jax.Array,
+    confidence_threshold: jax.Array,
+    temperature: jax.Array,
+    forward_context: Any,
+    *,
+    logit_alignment: LogitAlignment,
+    next_block_policy: NextBlockPolicy,
+    mask_token_id: int,
+    sub_block_size: int,
+    max_denoise_steps: int = 0,
+) -> DualCacheDenoiseBlockOutput:
+    """Denoise with one q32 refresh followed by cached q8 replacements."""
+    if initial_canvas.ndim != 2:
+        raise ValueError("initial_canvas must have shape [batch, block_size]")
+    if initial_mask.shape != initial_canvas.shape:
+        raise ValueError("initial_mask must match initial_canvas")
+    if positions.shape != initial_canvas.shape:
+        raise ValueError("positions must match initial_canvas")
+    if active_rows.shape != (initial_canvas.shape[0], ):
+        raise ValueError("active_rows must match the canvas batch size")
+    if sub_block_size < 1 or initial_canvas.shape[1] % sub_block_size:
+        raise ValueError("sub_block_size must divide the model block size")
+    if logit_alignment is LogitAlignment.SHIFTED:
+        seed_mask, active = jax.device_get((initial_mask[:, 0], active_rows))
+        if np.any(
+                np.asarray(seed_mask, dtype=bool)
+                & np.asarray(active, dtype=bool)):
+            raise ValueError(
+                "Shifted logit alignment requires position 0 to be an "
+                "unmasked seed for every active row")
+
+    return _denoise_block_dual_cache_jit(
+        full_forward_fn,
+        partial_forward_fn,
+        final_forward_fn,
+        commit_fn,
+        model_state,
+        initial_canvas,
+        initial_mask,
+        positions,
+        kv_caches,
+        active_rows,
+        confidence_threshold,
+        temperature,
+        forward_context,
         next_block_policy=next_block_policy,
         mask_token_id=mask_token_id,
         sub_block_size=sub_block_size,

--- a/tpu_inference/runner/diffusion/request_validation.py
+++ b/tpu_inference/runner/diffusion/request_validation.py
@@ -1,0 +1,45 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import functools
+
+
+def patch_vllm_input_processor_for_block_diffusion() -> None:
+    """Reject resumable requests before they reach the diffusion runner."""
+    from vllm.v1.engine.input_processor import InputProcessor
+
+    if getattr(InputProcessor, "_block_diffusion_validation_patched", False):
+        return
+
+    original_process_inputs = InputProcessor.process_inputs
+
+    @functools.wraps(original_process_inputs)
+    def patched_process_inputs(processor_self, *args, **kwargs):
+        if "resumable" in kwargs:
+            resumable = bool(kwargs["resumable"])
+        else:
+            # `resumable` is the eleventh positional argument after `self`.
+            resumable = len(args) > 10 and bool(args[10])
+        additional_config = getattr(processor_self.vllm_config,
+                                    "additional_config", {}) or {}
+        raw_strategy = additional_config.get("generation_strategy")
+        strategy = getattr(raw_strategy, "value", raw_strategy)
+        if resumable and strategy == "block_diffusion":
+            raise ValueError(
+                "block_diffusion does not support resumable or streaming-input "
+                "requests")
+        return original_process_inputs(processor_self, *args, **kwargs)
+
+    InputProcessor.process_inputs = patched_process_inputs
+    InputProcessor._block_diffusion_validation_patched = True

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -88,6 +88,8 @@ def _log_dual_cache_acceptance_trace(trace: DualCacheAcceptanceTrace) -> None:
             np.asarray(trace_host.row0_commit[index], dtype=bool).tolist(),
             "row0_remaining":
             np.asarray(trace_host.row0_remaining[index], dtype=bool).tolist(),
+            "row0_forced_anchor":
+            bool(trace_host.row0_forced_anchor[index]),
             "row0_selected_log_confidence":
             _eligible_finite_values(
                 np.asarray(trace_host.row0_selected_log_confidence[index]),
@@ -662,6 +664,8 @@ class BlockDiffusionStrategy:
                     self.config.runtime.trace_acceptance_steps),
                 q8_log_confidence_bias=(
                     self.config.runtime.q8_log_confidence_bias),
+                force_q32_anchor_commit=(
+                    self.config.runtime.force_q32_anchor_commit),
             )
         else:
             output = denoise_block(
@@ -695,14 +699,15 @@ class BlockDiffusionStrategy:
                 output.q32_forward_calls,
                 output.q8_forward_calls,
                 output.final_q32_forward_calls,
+                output.forced_q32_anchor_commits,
             )
             if self.config.runtime.trace_acceptance_steps:
                 assert output.acceptance_trace is not None
                 device_outputs += (output.acceptance_trace, )
             host_outputs = jax.device_get(device_outputs)
             (canvas_host, anchors_host, denoise_steps_host, stopped_rows_host,
-             q32_calls_host, q8_calls_host,
-             final_q32_calls_host) = host_outputs[:7]
+             q32_calls_host, q8_calls_host, final_q32_calls_host,
+             forced_q32_anchor_commits_host) = (host_outputs[:8])
             q32_calls = int(q32_calls_host)
             q8_calls = int(q8_calls_host)
             final_q32_calls = int(final_q32_calls_host)
@@ -727,6 +732,10 @@ class BlockDiffusionStrategy:
                 q8_calls,
                 "final_q32_forward_calls":
                 final_q32_calls,
+                "force_q32_anchor_commit":
+                self.config.runtime.force_q32_anchor_commit,
+                "forced_q32_anchor_commits":
+                int(forced_q32_anchor_commits_host),
                 "output_candidate_positions":
                 output_candidate_positions,
                 "confidence_threshold":
@@ -760,7 +769,7 @@ class BlockDiffusionStrategy:
             logger.info("Fast-dLLM DualCache trace: %s",
                         self._last_denoise_trace)
             if self.config.runtime.trace_acceptance_steps:
-                _log_dual_cache_acceptance_trace(host_outputs[7])
+                _log_dual_cache_acceptance_trace(host_outputs[8])
         else:
             canvas_host, anchors_host = jax.device_get((
                 output.canvas[:len(req_ids)],
@@ -1068,6 +1077,8 @@ class BlockDiffusionStrategy:
                         self.config.runtime.trace_acceptance_steps),
                     q8_log_confidence_bias=(
                         self.config.runtime.q8_log_confidence_bias),
+                    force_q32_anchor_commit=(
+                        self.config.runtime.force_q32_anchor_commit),
                 )
             else:
                 output = denoise_block(

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -28,8 +28,9 @@ from tpu_inference.logger import init_logger
 from tpu_inference.runner.diffusion.algorithm import get_commit_algorithm
 from tpu_inference.runner.diffusion.batch import (
     PendingBlockOutput, complete_seeded_decode_block, diffusion_batch_sizes,
-    flush_partial_block_output, plan_seeded_prompt, required_cache_end,
-    select_diffusion_batch_size, start_partial_block_output)
+    flush_partial_block_output, needs_block_anchor, plan_seeded_prompt,
+    required_cache_end, select_diffusion_batch_size,
+    start_partial_block_output)
 from tpu_inference.runner.diffusion.config import (CanvasPolicy,
                                                    DiffusionConfig,
                                                    NextBlockPolicy,
@@ -102,6 +103,11 @@ class BlockDiffusionStrategy:
         if runner.kv_cache_config.has_mamba_layers:
             raise ValueError(
                 "Block diffusion does not support hybrid or Mamba models")
+        if runner.cache_config.enable_prefix_caching:
+            raise ValueError("Block diffusion does not support prefix caching")
+        if getattr(runner.vllm_config, "kv_transfer_config", None) is not None:
+            raise ValueError(
+                "Block diffusion does not support KV transfer connectors")
 
     def _validate_requests(self, req_ids: list[str]) -> None:
         input_batch = self.runner.input_batch
@@ -432,10 +438,20 @@ class BlockDiffusionStrategy:
         block_starts: list[int],
         canvases: list[list[int]],
         masks: list[list[bool]],
+        needs_final_forward: list[bool] | None = None,
     ) -> tuple[np.ndarray, np.ndarray]:
         canvas, mask, positions, active_rows, metadata = self._build_batch(
             req_ids, block_starts, canvases, masks)
         batch_size = canvas.shape[0]
+        if needs_final_forward is None:
+            needs_final_forward = [True] * len(req_ids)
+        if len(needs_final_forward) != len(req_ids):
+            raise ValueError("needs_final_forward must match req_ids")
+        output_candidate_positions = sum(
+            sum(row_mask) for row_mask in masks) + sum(needs_final_forward)
+        final_rows = np.zeros((batch_size, ), dtype=np.bool_)
+        final_rows[:len(req_ids)] = needs_final_forward
+        final_rows = device_array(self.runner.mesh, final_rows)
         thresholds = jnp.full(
             (batch_size, ),
             self.config.runtime.confidence_threshold,
@@ -462,6 +478,7 @@ class BlockDiffusionStrategy:
                 next_block_policy=self.config.model.next_block_policy,
                 sub_block_size=self.config.model.sub_block_size,
                 max_denoise_steps=self.config.runtime.max_denoise_steps,
+                needs_final_forward=final_rows,
             )
         else:
             output = denoise_block(
@@ -481,26 +498,29 @@ class BlockDiffusionStrategy:
                 next_block_policy=self.config.model.next_block_policy,
                 sub_block_size=self.config.model.sub_block_size,
                 max_denoise_steps=self.config.runtime.max_denoise_steps,
+                needs_final_forward=final_rows,
             )
         self.runner.kv_caches = output.kv_caches
         if self.config.runtime.use_dual_cache:
             (canvas_host, anchors_host, denoise_steps_host, q32_calls_host,
-             q8_calls_host) = jax.device_get((
+             q8_calls_host, final_q32_calls_host) = jax.device_get((
                  output.canvas[:len(req_ids)],
                  output.next_anchor[:len(req_ids)],
                  output.denoise_steps[:len(req_ids)],
                  output.q32_forward_calls,
                  output.q8_forward_calls,
+                 output.final_q32_forward_calls,
              ))
             q32_calls = int(q32_calls_host)
             q8_calls = int(q8_calls_host)
+            final_q32_calls = int(final_q32_calls_host)
             static_transformer_positions = batch_size * (
                 q32_calls * self.block_size +
                 q8_calls * self.config.model.sub_block_size)
             static_lm_head_positions = batch_size * (
-                (q32_calls - 1 + q8_calls) * self.config.model.sub_block_size +
-                1)
-            denoise_iterations = q32_calls + q8_calls - 1
+                (q32_calls - final_q32_calls + q8_calls) *
+                self.config.model.sub_block_size + final_q32_calls)
+            denoise_iterations = q32_calls + q8_calls - final_q32_calls
             useful_row_iterations = int(np.asarray(denoise_steps_host).sum())
             static_row_iterations = batch_size * denoise_iterations
             self._last_denoise_trace = {
@@ -512,6 +532,10 @@ class BlockDiffusionStrategy:
                 q32_calls,
                 "q8_forward_calls":
                 q8_calls,
+                "final_q32_forward_calls":
+                final_q32_calls,
+                "output_candidate_positions":
+                output_candidate_positions,
                 "static_transformer_positions":
                 static_transformer_positions,
                 "static_lm_head_positions":
@@ -590,15 +614,29 @@ class BlockDiffusionStrategy:
             canvases = [
                 list(plans[req_id].partial_canvas) for req_id in partial_group
             ]
-            masks = [
-                list(plans[req_id].partial_mask) for req_id in partial_group
-            ]
+            masks = []
+            needs_final_forward = []
+            for req_id in partial_group:
+                plan = plans[req_id]
+                assert plan.partial_mask is not None
+                mask = list(plan.partial_mask)
+                masks.append(mask)
+                needs_final_forward.append(
+                    needs_block_anchor(
+                        mask,
+                        self._remaining_output_capacity(req_id),
+                    ))
             starts = [
                 len(plans[req_id].full_blocks) * self.block_size
                 for req_id in partial_group
             ]
-            committed, anchors = self._denoise_blocks(partial_group, starts,
-                                                      canvases, masks)
+            committed, anchors = self._denoise_blocks(
+                partial_group,
+                starts,
+                canvases,
+                masks,
+                needs_final_forward,
+            )
             for row, req_id in enumerate(partial_group):
                 output, pending = start_partial_block_output(
                     committed[row].tolist(),
@@ -624,6 +662,7 @@ class BlockDiffusionStrategy:
 
         canvases = []
         masks = []
+        needs_final_forward = []
         starts = []
         for req_id in denoise_group:
             request = self.runner.requests[req_id]
@@ -631,24 +670,39 @@ class BlockDiffusionStrategy:
             seed = request.get_token_id(block_start)
             canvases.append([seed] + [self.config.model.mask_token_id] *
                             (self.block_size - 1))
-            masks.append([False] + [True] * (self.block_size - 1))
+            mask = [False] + [True] * (self.block_size - 1)
+            masks.append(mask)
+            needs_final_forward.append(
+                needs_block_anchor(
+                    mask,
+                    self._remaining_output_capacity(req_id),
+                ))
             starts.append(block_start)
 
-        committed, anchors = self._denoise_blocks(denoise_group, starts,
-                                                  canvases, masks)
+        committed, anchors = self._denoise_blocks(
+            denoise_group,
+            starts,
+            canvases,
+            masks,
+            needs_final_forward,
+        )
         for row, req_id in enumerate(denoise_group):
             outputs[req_id] = complete_seeded_decode_block(
                 committed[row].tolist(), int(anchors[row]))
         return outputs
 
-    def _truncate_output(self, req_id: str, tokens: list[int]) -> list[int]:
+    def _remaining_output_capacity(self, req_id: str) -> int:
         request = self.runner.requests[req_id]
         assert request.sampling_params.max_tokens is not None
         max_tokens = int(request.sampling_params.max_tokens)
         output_remaining = max(0, max_tokens - len(request.output_token_ids))
         context_remaining = max(0,
                                 self.runner.max_model_len - request.num_tokens)
-        remaining = min(output_remaining, context_remaining)
+        return min(output_remaining, context_remaining)
+
+    def _truncate_output(self, req_id: str, tokens: list[int]) -> list[int]:
+        request = self.runner.requests[req_id]
+        remaining = self._remaining_output_capacity(req_id)
         tokens = tokens[:remaining]
 
         if not request.sampling_params.ignore_eos:

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -235,8 +235,7 @@ class BlockDiffusionStrategy:
             active_rows[row] = True
             block_tables[row] = source_block_tables[req_index]
 
-        request_distribution = np.array([0, num_active, num_active],
-                                        dtype=np.int32)
+        request_distribution = np.array([0, 0, num_active], dtype=np.int32)
         (canvas, mask, positions, seq_lens, active_rows, query_start_loc,
          partial_query_start_loc, request_distribution,
          block_tables) = device_array(self.runner.mesh, (
@@ -259,7 +258,6 @@ class BlockDiffusionStrategy:
             padded_num_reqs=batch_size,
             attention_mask_spec=AttentionMaskSpec(
                 AttentionMaskKind.BIDIRECTIONAL),
-            rpa_static_query_len=block_size,
         )
         partial_metadata = AttentionMetadata(
             input_positions=positions[:, :sub_block_size].reshape(-1),
@@ -271,7 +269,6 @@ class BlockDiffusionStrategy:
             attention_mask_spec=AttentionMaskSpec(
                 AttentionMaskKind.BIDIRECTIONAL),
             replace_cached_kv=True,
-            rpa_static_query_len=sub_block_size,
         )
         return (canvas, mask, positions, active_rows, (full_metadata,
                                                        partial_metadata))

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -235,7 +235,8 @@ class BlockDiffusionStrategy:
             active_rows[row] = True
             block_tables[row] = source_block_tables[req_index]
 
-        request_distribution = np.array([0, 0, num_active], dtype=np.int32)
+        request_distribution = np.array([0, num_active, num_active],
+                                        dtype=np.int32)
         (canvas, mask, positions, seq_lens, active_rows, query_start_loc,
          partial_query_start_loc, request_distribution,
          block_tables) = device_array(self.runner.mesh, (
@@ -258,6 +259,7 @@ class BlockDiffusionStrategy:
             padded_num_reqs=batch_size,
             attention_mask_spec=AttentionMaskSpec(
                 AttentionMaskKind.BIDIRECTIONAL),
+            rpa_static_query_len=block_size,
         )
         partial_metadata = AttentionMetadata(
             input_positions=positions[:, :sub_block_size].reshape(-1),
@@ -269,6 +271,7 @@ class BlockDiffusionStrategy:
             attention_mask_spec=AttentionMaskSpec(
                 AttentionMaskKind.BIDIRECTIONAL),
             replace_cached_kv=True,
+            rpa_static_query_len=sub_block_size,
         )
         return (canvas, mask, positions, active_rows, (full_metadata,
                                                        partial_metadata))

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -439,6 +439,7 @@ class BlockDiffusionStrategy:
         canvases: list[list[int]],
         masks: list[list[bool]],
         needs_final_forward: list[bool] | None = None,
+        stop_on_eos: list[bool] | None = None,
     ) -> tuple[np.ndarray, np.ndarray]:
         canvas, mask, positions, active_rows, metadata = self._build_batch(
             req_ids, block_starts, canvases, masks)
@@ -447,11 +448,21 @@ class BlockDiffusionStrategy:
             needs_final_forward = [True] * len(req_ids)
         if len(needs_final_forward) != len(req_ids):
             raise ValueError("needs_final_forward must match req_ids")
+        if stop_on_eos is None:
+            stop_on_eos = [False] * len(req_ids)
+        if len(stop_on_eos) != len(req_ids):
+            raise ValueError("stop_on_eos must match req_ids")
         output_candidate_positions = sum(
             sum(row_mask) for row_mask in masks) + sum(needs_final_forward)
         final_rows = np.zeros((batch_size, ), dtype=np.bool_)
         final_rows[:len(req_ids)] = needs_final_forward
         final_rows = device_array(self.runner.mesh, final_rows)
+        stop_rows = np.zeros((batch_size, ), dtype=np.bool_)
+        stop_rows[:len(req_ids)] = stop_on_eos
+        stop_rows = device_array(self.runner.mesh, stop_rows)
+        eos_token_ids = tuple(
+            int(token_id)
+            for token_id in np.atleast_1d(self.runner.eos_token_id))
         thresholds = jnp.full(
             (batch_size, ),
             self.config.runtime.confidence_threshold,
@@ -479,6 +490,8 @@ class BlockDiffusionStrategy:
                 sub_block_size=self.config.model.sub_block_size,
                 max_denoise_steps=self.config.runtime.max_denoise_steps,
                 needs_final_forward=final_rows,
+                stop_on_eos_rows=stop_rows,
+                eos_token_ids=eos_token_ids,
             )
         else:
             output = denoise_block(
@@ -499,14 +512,18 @@ class BlockDiffusionStrategy:
                 sub_block_size=self.config.model.sub_block_size,
                 max_denoise_steps=self.config.runtime.max_denoise_steps,
                 needs_final_forward=final_rows,
+                stop_on_eos_rows=stop_rows,
+                eos_token_ids=eos_token_ids,
             )
         self.runner.kv_caches = output.kv_caches
         if self.config.runtime.use_dual_cache:
-            (canvas_host, anchors_host, denoise_steps_host, q32_calls_host,
-             q8_calls_host, final_q32_calls_host) = jax.device_get((
+            (canvas_host, anchors_host, denoise_steps_host, stopped_rows_host,
+             q32_calls_host, q8_calls_host,
+             final_q32_calls_host) = jax.device_get((
                  output.canvas[:len(req_ids)],
                  output.next_anchor[:len(req_ids)],
                  output.denoise_steps[:len(req_ids)],
+                 output.stopped_rows[:len(req_ids)],
                  output.q32_forward_calls,
                  output.q8_forward_calls,
                  output.final_q32_forward_calls,
@@ -548,6 +565,8 @@ class BlockDiffusionStrategy:
                 (static_row_iterations - useful_row_iterations),
                 "denoise_steps":
                 np.asarray(denoise_steps_host).tolist(),
+                "eos_stopped_rows":
+                np.asarray(stopped_rows_host).tolist(),
             }
             logger.info("Fast-dLLM DualCache trace: %s",
                         self._last_denoise_trace)
@@ -616,6 +635,7 @@ class BlockDiffusionStrategy:
             ]
             masks = []
             needs_final_forward = []
+            stop_on_eos = []
             for req_id in partial_group:
                 plan = plans[req_id]
                 assert plan.partial_mask is not None
@@ -626,6 +646,8 @@ class BlockDiffusionStrategy:
                         mask,
                         self._remaining_output_capacity(req_id),
                     ))
+                stop_on_eos.append(not self.runner.requests[req_id].
+                                   sampling_params.ignore_eos)
             starts = [
                 len(plans[req_id].full_blocks) * self.block_size
                 for req_id in partial_group
@@ -636,6 +658,7 @@ class BlockDiffusionStrategy:
                 canvases,
                 masks,
                 needs_final_forward,
+                stop_on_eos,
             )
             for row, req_id in enumerate(partial_group):
                 output, pending = start_partial_block_output(
@@ -663,6 +686,7 @@ class BlockDiffusionStrategy:
         canvases = []
         masks = []
         needs_final_forward = []
+        stop_on_eos = []
         starts = []
         for req_id in denoise_group:
             request = self.runner.requests[req_id]
@@ -677,6 +701,7 @@ class BlockDiffusionStrategy:
                     mask,
                     self._remaining_output_capacity(req_id),
                 ))
+            stop_on_eos.append(not request.sampling_params.ignore_eos)
             starts.append(block_start)
 
         committed, anchors = self._denoise_blocks(
@@ -685,6 +710,7 @@ class BlockDiffusionStrategy:
             canvases,
             masks,
             needs_final_forward,
+            stop_on_eos,
         )
         for row, req_id in enumerate(denoise_group):
             outputs[req_id] = complete_seeded_decode_block(
@@ -786,6 +812,9 @@ class BlockDiffusionStrategy:
 
     def precompile(self) -> None:
         self._validate_runner_capabilities()
+        eos_token_ids = tuple(
+            int(token_id)
+            for token_id in np.atleast_1d(self.runner.eos_token_id))
         for batch_size in diffusion_batch_sizes(self.batch_size):
             canvas, mask, positions, active_rows, metadata = self._build_batch(
                 [], [], [], [], padded_batch_size=batch_size)
@@ -822,6 +851,8 @@ class BlockDiffusionStrategy:
                     next_block_policy=self.config.model.next_block_policy,
                     sub_block_size=self.config.model.sub_block_size,
                     max_denoise_steps=self.config.runtime.max_denoise_steps,
+                    stop_on_eos_rows=jnp.zeros_like(active_rows),
+                    eos_token_ids=eos_token_ids,
                 )
             else:
                 output = denoise_block(
@@ -841,6 +872,8 @@ class BlockDiffusionStrategy:
                     next_block_policy=self.config.model.next_block_policy,
                     sub_block_size=self.config.model.sub_block_size,
                     max_denoise_steps=self.config.runtime.max_denoise_steps,
+                    stop_on_eos_rows=jnp.zeros_like(active_rows),
+                    eos_token_ids=eos_token_ids,
                 )
             self.runner.kv_caches = output.kv_caches
             jax.block_until_ready((logits, output.canvas))

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -1,0 +1,547 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import replace
+from typing import TYPE_CHECKING, Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from vllm.forward_context import set_forward_context
+from vllm.v1.outputs import ModelRunnerOutput
+
+from tpu_inference.layers.common.attention_metadata import (AttentionMaskKind,
+                                                            AttentionMaskSpec,
+                                                            AttentionMetadata)
+from tpu_inference.runner.diffusion.algorithm import get_commit_algorithm
+from tpu_inference.runner.diffusion.batch import (PendingBlockOutput,
+                                                  complete_seeded_decode_block,
+                                                  flush_partial_block_output,
+                                                  plan_seeded_prompt,
+                                                  required_cache_end,
+                                                  start_partial_block_output)
+from tpu_inference.runner.diffusion.config import (CanvasPolicy,
+                                                   DiffusionConfig,
+                                                   NextBlockPolicy,
+                                                   PromptRemainderPolicy)
+from tpu_inference.runner.diffusion.program import denoise_block
+from tpu_inference.utils import device_array
+
+if TYPE_CHECKING:
+    from vllm.v1.core.sched.output import SchedulerOutput
+
+    from tpu_inference.runner.tpu_runner import TPUModelRunner
+
+
+class BlockDiffusionStrategy:
+
+    def __init__(self, runner: "TPUModelRunner",
+                 config: DiffusionConfig) -> None:
+        self.runner = runner
+        self.config = config
+        self._pending_outputs: dict[str, PendingBlockOutput] = {}
+        self._forward_fn = self._model_forward
+        self._commit_fn = get_commit_algorithm(config.runtime.algorithm)
+
+        model = config.model
+        if model.canvas_policy is not CanvasPolicy.SEED_AND_MASK:
+            raise ValueError(
+                "The TPU serving strategy currently requires seed_and_mask "
+                "canvas semantics")
+        if model.prompt_remainder_policy is not \
+                PromptRemainderPolicy.INCLUDE_IN_FIRST_CANVAS:
+            raise ValueError(
+                "The TPU serving strategy currently requires prompt "
+                "remainders in the first canvas")
+        if model.next_block_policy is not NextBlockPolicy.LAST_LOGIT_ANCHOR:
+            raise ValueError(
+                "The seed_and_mask serving strategy requires a last-logit "
+                "next-block anchor")
+        if config.runtime.temperature != 0.0:
+            raise ValueError(
+                "Stochastic diffusion sampling is not supported yet; set "
+                "diffusion.temperature to 0")
+
+    @property
+    def block_size(self) -> int:
+        return self.config.model.block_size
+
+    def _validate_runner_capabilities(self) -> None:
+        runner = self.runner
+        if runner.dp_size != 1:
+            raise ValueError(
+                "Block diffusion currently supports data_parallel_size=1")
+        if "dcp" in runner.mesh.shape and runner.mesh.shape["dcp"] > 1:
+            raise ValueError("Block diffusion does not support DCP")
+        if len(runner.kv_cache_config.kv_cache_groups) != 1:
+            raise ValueError(
+                "Block diffusion requires exactly one KV cache group")
+        if runner.kv_cache_config.has_mamba_layers:
+            raise ValueError(
+                "Block diffusion does not support hybrid or Mamba models")
+
+    def _validate_requests(self, req_ids: list[str]) -> None:
+        input_batch = self.runner.input_batch
+        for req_id in req_ids:
+            req_index = input_batch.req_id_to_index[req_id]
+            request = self.runner.requests[req_id]
+            sampling_params = request.sampling_params
+            if (req_id in input_batch.num_logprobs
+                    or req_id in input_batch.num_prompt_logprobs):
+                raise ValueError(
+                    "Block diffusion does not support token logprobs yet")
+            if req_id in input_batch.has_allowed_token_ids:
+                raise ValueError(
+                    "Block diffusion does not support allowed_token_ids")
+            if req_index in input_batch.bad_words_token_ids:
+                raise ValueError(
+                    "Block diffusion does not support bad_words filtering")
+            if input_batch.logit_bias[req_index]:
+                raise ValueError(
+                    "Block diffusion does not support per-request logit_bias")
+            if req_id in input_batch.random_reqs:
+                raise ValueError(
+                    "Block diffusion currently requires greedy sampling; set "
+                    "temperature=0")
+            if (sampling_params.presence_penalty != 0.0
+                    or sampling_params.frequency_penalty != 0.0
+                    or sampling_params.repetition_penalty != 1.0):
+                raise ValueError(
+                    "Block diffusion does not support sampling penalties")
+            if sampling_params.min_tokens != 0:
+                raise ValueError(
+                    "Block diffusion does not support min_tokens yet")
+
+            if sampling_params.max_tokens is None:
+                raise ValueError(
+                    "Block diffusion requires an explicit max_tokens limit")
+            max_tokens = int(sampling_params.max_tokens)
+            max_tokens = min(
+                max_tokens,
+                max(0, self.runner.max_model_len - request.num_prompt_tokens),
+            )
+            cache_end = required_cache_end(request.num_prompt_tokens,
+                                           max_tokens, self.block_size)
+            if cache_end > self.runner.max_model_len:
+                raise ValueError(
+                    f"Block diffusion request {req_id!r} requires cache "
+                    f"through position {cache_end}, beyond "
+                    f"max_model_len={self.runner.max_model_len}")
+
+    def _build_batch(
+        self,
+        req_ids: list[str],
+        block_starts: list[int],
+        canvases: list[list[int]],
+        masks: list[list[bool]] | None = None,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, AttentionMetadata]:
+        runner = self.runner
+        batch_size = runner.max_num_reqs
+        block_size = self.block_size
+        num_active = len(req_ids)
+        if num_active > batch_size:
+            raise ValueError("Diffusion batch exceeds max_num_reqs")
+
+        canvas = np.zeros((batch_size, block_size), dtype=np.int32)
+        mask = np.zeros((batch_size, block_size), dtype=np.bool_)
+        positions = np.zeros((batch_size, block_size), dtype=np.int32)
+        seq_lens = np.zeros((batch_size, ), dtype=np.int32)
+        active_rows = np.zeros((batch_size, ), dtype=np.bool_)
+        query_start_loc = np.full((batch_size + 1, ),
+                                  num_active * block_size,
+                                  dtype=np.int32)
+        query_start_loc[:num_active + 1] = np.arange(
+            num_active + 1, dtype=np.int32) * block_size
+
+        source_block_tables = runner.input_batch.block_table[0].get_cpu_tensor(
+        )
+        block_tables = np.zeros_like(source_block_tables)
+        offsets = np.arange(block_size, dtype=np.int32)
+        for row, (req_id, block_start,
+                  row_canvas) in enumerate(zip(req_ids, block_starts,
+                                               canvases)):
+            if len(row_canvas) != block_size:
+                raise ValueError("Every diffusion canvas must be one block")
+            req_index = runner.input_batch.req_id_to_index[req_id]
+            block_end = block_start + block_size
+            if block_end > runner.max_model_len:
+                raise ValueError(
+                    f"Diffusion block for request {req_id!r} ends at "
+                    f"{block_end}, beyond max_model_len={runner.max_model_len}"
+                )
+            cache_block_size = runner.block_size
+            required_cache_blocks = (block_end + cache_block_size -
+                                     1) // cache_block_size
+            allocated_cache_blocks = int(runner.input_batch.block_table[0].
+                                         num_blocks_per_row[req_index])
+            if required_cache_blocks > allocated_cache_blocks:
+                raise ValueError(
+                    f"Diffusion block for request {req_id!r} needs "
+                    f"{required_cache_blocks} KV blocks, but the scheduler "
+                    f"allocated {allocated_cache_blocks}")
+            canvas[row] = row_canvas
+            if masks is not None:
+                mask[row] = masks[row]
+            positions[row] = block_start + offsets
+            seq_lens[row] = block_start + block_size
+            active_rows[row] = True
+            block_tables[row] = source_block_tables[req_index]
+
+        request_distribution = np.array([0, 0, num_active], dtype=np.int32)
+        (canvas, mask, positions, seq_lens, active_rows, query_start_loc,
+         request_distribution,
+         block_tables) = device_array(self.runner.mesh, (
+             canvas,
+             mask,
+             positions,
+             seq_lens,
+             active_rows,
+             query_start_loc,
+             request_distribution,
+             block_tables.reshape(-1),
+         ))
+        metadata = AttentionMetadata(
+            input_positions=positions.reshape(-1),
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            query_start_loc=query_start_loc,
+            request_distribution=request_distribution,
+            padded_num_reqs=batch_size,
+            attention_mask_spec=AttentionMaskSpec(
+                AttentionMaskKind.BIDIRECTIONAL),
+        )
+        return canvas, mask, positions, active_rows, metadata
+
+    def _model_forward(
+        self,
+        state_leaves: Any,
+        canvas: jax.Array,
+        positions: jax.Array,
+        kv_caches: Any,
+        active_rows: jax.Array,
+        attention_metadata: AttentionMetadata,
+    ) -> tuple[jax.Array, Any]:
+        del active_rows
+        runner = self.runner
+        flat_canvas = canvas.reshape(-1)
+        flat_positions = positions.reshape(-1)
+        attention_metadata = replace(attention_metadata,
+                                     input_positions=flat_positions)
+        kv_caches, hidden_states, _, _ = runner.model_fn_no_options(
+            state_leaves,
+            kv_caches,
+            flat_canvas,
+            attention_metadata,
+            None,
+            flat_positions,
+            tuple(runner.layer_name_to_kvcache_index.items()),
+            None,
+            None,
+            runner.is_first_rank,
+            runner.is_last_rank,
+        )
+        logits = runner.compute_logits_fn(state_leaves, hidden_states, None)
+        return logits.reshape(canvas.shape[0], canvas.shape[1], -1), kv_caches
+
+    def _forward_blocks(
+        self,
+        req_ids: list[str],
+        block_starts: list[int],
+        canvases: list[list[int]],
+    ) -> np.ndarray:
+        canvas, _, positions, active_rows, metadata = self._build_batch(
+            req_ids, block_starts, canvases)
+        logits, self.runner.kv_caches = self._forward_fn(
+            self.runner.state_leaves,
+            canvas,
+            positions,
+            self.runner.kv_caches,
+            active_rows,
+            metadata,
+        )
+        return np.asarray(jax.device_get(logits[:len(req_ids)]))
+
+    def _denoise_blocks(
+        self,
+        req_ids: list[str],
+        block_starts: list[int],
+        canvases: list[list[int]],
+        masks: list[list[bool]],
+    ) -> tuple[np.ndarray, np.ndarray]:
+        canvas, mask, positions, active_rows, metadata = self._build_batch(
+            req_ids, block_starts, canvases, masks)
+        batch_size = self.runner.max_num_reqs
+        thresholds = jnp.full(
+            (batch_size, ),
+            self.config.runtime.confidence_threshold,
+            dtype=jnp.float32,
+        )
+        temperatures = jnp.zeros((batch_size, ), dtype=jnp.float32)
+        output = denoise_block(
+            self._forward_fn,
+            self._commit_fn,
+            self.runner.state_leaves,
+            canvas,
+            mask,
+            positions,
+            self.runner.kv_caches,
+            active_rows,
+            thresholds,
+            temperatures,
+            metadata,
+            mask_token_id=self.config.model.mask_token_id,
+            logit_alignment=self.config.model.logit_alignment,
+            next_block_policy=self.config.model.next_block_policy,
+            sub_block_size=self.config.model.sub_block_size,
+            max_denoise_steps=self.config.runtime.max_denoise_steps,
+        )
+        self.runner.kv_caches = output.kv_caches
+        canvas_host, anchors_host = jax.device_get(
+            (output.canvas[:len(req_ids)], output.next_anchor[:len(req_ids)]))
+        return np.asarray(canvas_host), np.asarray(anchors_host)
+
+    def _process_prefill(self, req_ids: list[str]) -> dict[str, list[int]]:
+        plans = {}
+        for req_id in req_ids:
+            request = self.runner.requests[req_id]
+            scheduled = self._scheduler_output.num_scheduled_tokens[req_id]
+            history_token_ids = [
+                *request.prompt_token_ids,
+                *request.output_token_ids,
+            ]
+            if request.num_computed_tokens != 0 or scheduled != len(
+                    history_token_ids):
+                raise ValueError(
+                    "Block diffusion requires a full unchunked prefill or "
+                    "recompute pass "
+                    f"for request {req_id!r}")
+            self._pending_outputs.pop(req_id, None)
+            plans[req_id] = plan_seeded_prompt(
+                history_token_ids,
+                self.block_size,
+                self.config.model.mask_token_id,
+            )
+
+        aligned_seeds: dict[str, int] = {}
+        max_full_blocks = max(
+            (len(plan.full_blocks) for plan in plans.values()), default=0)
+        for block_index in range(max_full_blocks):
+            group = [
+                req_id for req_id in req_ids
+                if block_index < len(plans[req_id].full_blocks)
+            ]
+            canvases = [
+                list(plans[req_id].full_blocks[block_index])
+                for req_id in group
+            ]
+            logits = self._forward_blocks(
+                group,
+                [block_index * self.block_size] * len(group),
+                canvases,
+            )
+            anchors = np.argmax(logits[:, -1, :], axis=-1)
+            for row, req_id in enumerate(group):
+                plan = plans[req_id]
+                if (plan.remainder_size == 0
+                        and block_index == len(plan.full_blocks) - 1):
+                    aligned_seeds[req_id] = int(anchors[row])
+
+        outputs = {req_id: [aligned_seeds[req_id]] for req_id in aligned_seeds}
+        partial_group = [
+            req_id for req_id in req_ids
+            if plans[req_id].partial_canvas is not None
+        ]
+        if partial_group:
+            canvases = [
+                list(plans[req_id].partial_canvas) for req_id in partial_group
+            ]
+            masks = [
+                list(plans[req_id].partial_mask) for req_id in partial_group
+            ]
+            starts = [
+                len(plans[req_id].full_blocks) * self.block_size
+                for req_id in partial_group
+            ]
+            committed, anchors = self._denoise_blocks(partial_group, starts,
+                                                      canvases, masks)
+            for row, req_id in enumerate(partial_group):
+                output, pending = start_partial_block_output(
+                    committed[row].tolist(),
+                    plans[req_id].remainder_size,
+                    int(anchors[row]),
+                )
+                outputs[req_id] = output
+                self._pending_outputs[req_id] = pending
+        return outputs
+
+    def _process_decode(self, req_ids: list[str]) -> dict[str, list[int]]:
+        outputs: dict[str, list[int]] = {}
+        denoise_group = []
+        for req_id in req_ids:
+            pending = self._pending_outputs.pop(req_id, None)
+            if pending is not None:
+                outputs[req_id] = flush_partial_block_output(pending)
+            else:
+                denoise_group.append(req_id)
+
+        if not denoise_group:
+            return outputs
+
+        canvases = []
+        masks = []
+        starts = []
+        for req_id in denoise_group:
+            request = self.runner.requests[req_id]
+            block_start = request.num_computed_tokens
+            seed = request.get_token_id(block_start)
+            canvases.append([seed] + [self.config.model.mask_token_id] *
+                            (self.block_size - 1))
+            masks.append([False] + [True] * (self.block_size - 1))
+            starts.append(block_start)
+
+        committed, anchors = self._denoise_blocks(denoise_group, starts,
+                                                  canvases, masks)
+        for row, req_id in enumerate(denoise_group):
+            outputs[req_id] = complete_seeded_decode_block(
+                committed[row].tolist(), int(anchors[row]))
+        return outputs
+
+    def _truncate_output(self, req_id: str, tokens: list[int]) -> list[int]:
+        request = self.runner.requests[req_id]
+        assert request.sampling_params.max_tokens is not None
+        max_tokens = int(request.sampling_params.max_tokens)
+        output_remaining = max(0, max_tokens - len(request.output_token_ids))
+        context_remaining = max(0,
+                                self.runner.max_model_len - request.num_tokens)
+        remaining = min(output_remaining, context_remaining)
+        tokens = tokens[:remaining]
+
+        if not request.sampling_params.ignore_eos:
+            eos_token_ids = np.atleast_1d(self.runner.eos_token_id)
+            for index, token in enumerate(tokens):
+                if token in eos_token_ids:
+                    tokens = tokens[:index + 1]
+                    self._pending_outputs.pop(req_id, None)
+                    break
+        if len(tokens) == remaining:
+            self._pending_outputs.pop(req_id, None)
+        return tokens
+
+    def _append_outputs(self, outputs: dict[str,
+                                            list[int]]) -> list[list[int]]:
+        runner = self.runner
+        sampled_token_ids = [[] for _ in range(runner.input_batch.num_reqs)]
+        for req_id, tokens in outputs.items():
+            tokens = self._truncate_output(req_id, tokens)
+            req_index = runner.input_batch.req_id_to_index[req_id]
+            sampled_token_ids[req_index] = tokens
+            if not tokens:
+                continue
+            start = runner.input_batch.num_tokens_no_spec[req_index]
+            end = start + len(tokens)
+            if end > runner.max_model_len:
+                raise ValueError(
+                    f"Diffusion output for request {req_id!r} exceeds "
+                    "max_model_len")
+            runner.input_batch.token_ids_cpu[req_index, start:end] = tokens
+            runner.input_batch.num_tokens_no_spec[req_index] = end
+            runner.input_batch.num_tokens[req_index] = end
+            runner.requests[req_id].output_token_ids.extend(tokens)
+        return sampled_token_ids
+
+    def execute(self, scheduler_output: "SchedulerOutput") -> None:
+        self._validate_runner_capabilities()
+        self._scheduler_output = scheduler_output
+
+        scheduled_req_ids = [
+            req_id for req_id in
+            self.runner.input_batch.req_ids[:self.runner.input_batch.num_reqs]
+            if req_id in scheduler_output.num_scheduled_tokens
+        ]
+        if getattr(scheduler_output, "has_structured_output_requests", False):
+            raise ValueError(
+                "Block diffusion does not support structured output")
+        self._validate_requests(scheduled_req_ids)
+        prefill_req_ids = [
+            req_id for req_id in scheduled_req_ids
+            if self.runner.requests[req_id].num_computed_tokens <
+            self.runner.requests[req_id].num_prompt_tokens
+        ]
+        decode_req_ids = [
+            req_id for req_id in scheduled_req_ids
+            if req_id not in set(prefill_req_ids)
+        ]
+
+        with self.runner.maybe_forbid_compile, \
+             set_forward_context(None, self.runner.vllm_config), \
+             self.runner.maybe_get_kv_connector_output(
+                 scheduler_output) as kv_connector_output:
+            outputs = self._process_prefill(prefill_req_ids)
+            outputs.update(self._process_decode(decode_req_ids))
+
+        sampled_token_ids = self._append_outputs(outputs)
+        num_reqs = self.runner.input_batch.num_reqs
+        self.runner._generation_strategy_output = ModelRunnerOutput(
+            req_ids=self.runner.input_batch.req_ids[:num_reqs],
+            req_id_to_index=self.runner.input_batch.req_id_to_index.copy(),
+            sampled_token_ids=sampled_token_ids,
+            logprobs=None,
+            prompt_logprobs_dict={},
+            pooler_output=[],
+            kv_connector_output=kv_connector_output,
+        )
+
+    def on_scheduler_update(self, finished_req_ids: set[str]) -> None:
+        for req_id in finished_req_ids:
+            self._pending_outputs.pop(req_id, None)
+
+    def precompile(self) -> None:
+        self._validate_runner_capabilities()
+        canvas, mask, positions, active_rows, metadata = self._build_batch([],
+                                                                           [],
+                                                                           [],
+                                                                           [])
+        logits, self.runner.kv_caches = self._forward_fn(
+            self.runner.state_leaves,
+            canvas,
+            positions,
+            self.runner.kv_caches,
+            active_rows,
+            metadata,
+        )
+        thresholds = jnp.full(
+            (self.runner.max_num_reqs, ),
+            self.config.runtime.confidence_threshold,
+            dtype=jnp.float32,
+        )
+        output = denoise_block(
+            self._forward_fn,
+            self._commit_fn,
+            self.runner.state_leaves,
+            canvas,
+            mask,
+            positions,
+            self.runner.kv_caches,
+            active_rows,
+            thresholds,
+            jnp.zeros_like(thresholds),
+            metadata,
+            mask_token_id=self.config.model.mask_token_id,
+            logit_alignment=self.config.model.logit_alignment,
+            next_block_policy=self.config.model.next_block_policy,
+            sub_block_size=self.config.model.sub_block_size,
+            max_denoise_steps=self.config.runtime.max_denoise_steps,
+        )
+        self.runner.kv_caches = output.kv_caches
+        jax.block_until_ready((logits, output.canvas))

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -118,7 +118,11 @@ class BlockDiffusionStrategy:
                     or sampling_params.frequency_penalty != 0.0
                     or sampling_params.repetition_penalty != 1.0):
                 raise ValueError(
-                    "Block diffusion does not support sampling penalties")
+                    "Block diffusion does not support sampling penalties: "
+                    f"presence_penalty={sampling_params.presence_penalty}, "
+                    f"frequency_penalty={sampling_params.frequency_penalty}, "
+                    f"repetition_penalty={sampling_params.repetition_penalty}"
+                )
             if sampling_params.min_tokens != 0:
                 raise ValueError(
                     "Block diffusion does not support min_tokens yet")

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -24,6 +24,7 @@ from vllm.v1.outputs import ModelRunnerOutput
 from tpu_inference.layers.common.attention_metadata import (AttentionMaskKind,
                                                             AttentionMaskSpec,
                                                             AttentionMetadata)
+from tpu_inference.logger import init_logger
 from tpu_inference.runner.diffusion.algorithm import get_commit_algorithm
 from tpu_inference.runner.diffusion.batch import (PendingBlockOutput,
                                                   complete_seeded_decode_block,
@@ -35,13 +36,18 @@ from tpu_inference.runner.diffusion.config import (CanvasPolicy,
                                                    DiffusionConfig,
                                                    NextBlockPolicy,
                                                    PromptRemainderPolicy)
-from tpu_inference.runner.diffusion.program import denoise_block
+from tpu_inference.runner.diffusion.program import (denoise_block,
+                                                    denoise_block_dual_cache,
+                                                    select_aligned_hidden_states)
 from tpu_inference.utils import device_array
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
 
     from tpu_inference.runner.tpu_runner import TPUModelRunner
+
+
+logger = init_logger(__name__)
 
 
 class BlockDiffusionStrategy:
@@ -51,7 +57,11 @@ class BlockDiffusionStrategy:
         self.runner = runner
         self.config = config
         self._pending_outputs: dict[str, PendingBlockOutput] = {}
+        self._last_denoise_trace: dict[str, Any] | None = None
         self._forward_fn = self._model_forward
+        self._full_subblock_forward_fn = self._model_forward_full_subblock
+        self._partial_subblock_forward_fn = self._model_forward_partial_subblock
+        self._final_forward_fn = self._model_forward_final
         self._commit_fn = get_commit_algorithm(config.runtime.algorithm)
 
         model = config.model
@@ -76,6 +86,12 @@ class BlockDiffusionStrategy:
     @property
     def block_size(self) -> int:
         return self.config.model.block_size
+
+    @property
+    def batch_size(self) -> int:
+        configured = (self.runner.dp_size *
+                      self.runner.scheduler_config.max_num_seqs)
+        return max(1, min(configured, self.runner.max_num_reqs))
 
     def _validate_runner_capabilities(self) -> None:
         runner = self.runner
@@ -149,10 +165,12 @@ class BlockDiffusionStrategy:
         block_starts: list[int],
         canvases: list[list[int]],
         masks: list[list[bool]] | None = None,
-    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, AttentionMetadata]:
+    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array,
+               tuple[AttentionMetadata, AttentionMetadata]]:
         runner = self.runner
-        batch_size = runner.max_num_reqs
+        batch_size = self.batch_size
         block_size = self.block_size
+        sub_block_size = self.config.model.sub_block_size
         num_active = len(req_ids)
         if num_active > batch_size:
             raise ValueError("Diffusion batch exceeds max_num_reqs")
@@ -167,10 +185,16 @@ class BlockDiffusionStrategy:
                                   dtype=np.int32)
         query_start_loc[:num_active + 1] = np.arange(
             num_active + 1, dtype=np.int32) * block_size
+        partial_query_start_loc = np.full((batch_size + 1, ),
+                                          num_active * sub_block_size,
+                                          dtype=np.int32)
+        partial_query_start_loc[:num_active + 1] = np.arange(
+            num_active + 1, dtype=np.int32) * sub_block_size
 
         source_block_tables = runner.input_batch.block_table[0].get_cpu_tensor(
         )
-        block_tables = np.zeros_like(source_block_tables)
+        block_tables = np.zeros((batch_size, source_block_tables.shape[1]),
+                                dtype=source_block_tables.dtype)
         offsets = np.arange(block_size, dtype=np.int32)
         for row, (req_id, block_start,
                   row_canvas) in enumerate(zip(req_ids, block_starts,
@@ -204,7 +228,7 @@ class BlockDiffusionStrategy:
 
         request_distribution = np.array([0, 0, num_active], dtype=np.int32)
         (canvas, mask, positions, seq_lens, active_rows, query_start_loc,
-         request_distribution,
+         partial_query_start_loc, request_distribution,
          block_tables) = device_array(self.runner.mesh, (
              canvas,
              mask,
@@ -212,10 +236,11 @@ class BlockDiffusionStrategy:
              seq_lens,
              active_rows,
              query_start_loc,
+             partial_query_start_loc,
              request_distribution,
              block_tables.reshape(-1),
          ))
-        metadata = AttentionMetadata(
+        full_metadata = AttentionMetadata(
             input_positions=positions.reshape(-1),
             block_tables=block_tables,
             seq_lens=seq_lens,
@@ -225,7 +250,19 @@ class BlockDiffusionStrategy:
             attention_mask_spec=AttentionMaskSpec(
                 AttentionMaskKind.BIDIRECTIONAL),
         )
-        return canvas, mask, positions, active_rows, metadata
+        partial_metadata = AttentionMetadata(
+            input_positions=positions[:, :sub_block_size].reshape(-1),
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            query_start_loc=partial_query_start_loc,
+            request_distribution=request_distribution,
+            padded_num_reqs=batch_size,
+            attention_mask_spec=AttentionMaskSpec(
+                AttentionMaskKind.BIDIRECTIONAL),
+            replace_cached_kv=True,
+        )
+        return (canvas, mask, positions, active_rows,
+                (full_metadata, partial_metadata))
 
     def _model_forward(
         self,
@@ -234,29 +271,139 @@ class BlockDiffusionStrategy:
         positions: jax.Array,
         kv_caches: Any,
         active_rows: jax.Array,
-        attention_metadata: AttentionMetadata,
+        forward_context: tuple[AttentionMetadata, AttentionMetadata],
     ) -> tuple[jax.Array, Any]:
         del active_rows
+        attention_metadata, _ = forward_context
+        kv_caches, hidden_states = self._run_model(
+            state_leaves,
+            kv_caches,
+            canvas.reshape(-1),
+            positions.reshape(-1),
+            attention_metadata,
+        )
+        logits = self.runner.compute_logits_fn(state_leaves, hidden_states,
+                                               None)
+        return logits.reshape(canvas.shape[0], canvas.shape[1], -1), kv_caches
+
+    def _run_model(
+        self,
+        state_leaves: Any,
+        kv_caches: Any,
+        input_ids: jax.Array,
+        input_positions: jax.Array,
+        attention_metadata: AttentionMetadata,
+    ) -> tuple[Any, jax.Array]:
         runner = self.runner
-        flat_canvas = canvas.reshape(-1)
-        flat_positions = positions.reshape(-1)
         attention_metadata = replace(attention_metadata,
-                                     input_positions=flat_positions)
+                                     input_positions=input_positions)
         kv_caches, hidden_states, _, _ = runner.model_fn_no_options(
             state_leaves,
             kv_caches,
-            flat_canvas,
+            input_ids,
             attention_metadata,
             None,
-            flat_positions,
+            input_positions,
             tuple(runner.layer_name_to_kvcache_index.items()),
             None,
             None,
             runner.is_first_rank,
             runner.is_last_rank,
         )
-        logits = runner.compute_logits_fn(state_leaves, hidden_states, None)
-        return logits.reshape(canvas.shape[0], canvas.shape[1], -1), kv_caches
+        return kv_caches, hidden_states
+
+    def _model_forward_full_subblock(
+        self,
+        state_leaves: Any,
+        canvas: jax.Array,
+        positions: jax.Array,
+        kv_caches: Any,
+        active_rows: jax.Array,
+        forward_context: tuple[AttentionMetadata, AttentionMetadata],
+        start: jax.Array,
+    ) -> tuple[jax.Array, Any]:
+        del active_rows
+        full_metadata, _ = forward_context
+        kv_caches, hidden_states = self._run_model(
+            state_leaves,
+            kv_caches,
+            canvas.reshape(-1),
+            positions.reshape(-1),
+            full_metadata,
+        )
+        selected = select_aligned_hidden_states(
+            hidden_states,
+            canvas.shape[0],
+            canvas.shape[1],
+            start,
+            self.config.model.sub_block_size,
+            self.config.model.logit_alignment,
+            local_alignment=False,
+        )
+        logits = self.runner.compute_logits_fn(state_leaves, selected, None)
+        return logits.reshape(canvas.shape[0],
+                              self.config.model.sub_block_size, -1), kv_caches
+
+    def _model_forward_partial_subblock(
+        self,
+        state_leaves: Any,
+        canvas: jax.Array,
+        positions: jax.Array,
+        kv_caches: Any,
+        active_rows: jax.Array,
+        forward_context: tuple[AttentionMetadata, AttentionMetadata],
+        start: jax.Array,
+    ) -> tuple[jax.Array, Any]:
+        _, partial_metadata = forward_context
+        sub_block_size = self.config.model.sub_block_size
+        partial_canvas = jax.lax.dynamic_slice(
+            canvas, (0, start), (canvas.shape[0], sub_block_size))
+        partial_positions = jax.lax.dynamic_slice(
+            positions, (0, start), (positions.shape[0], sub_block_size))
+        partial_metadata = replace(partial_metadata,
+                                   cache_update_active_rows=active_rows)
+        kv_caches, hidden_states = self._run_model(
+            state_leaves,
+            kv_caches,
+            partial_canvas.reshape(-1),
+            partial_positions.reshape(-1),
+            partial_metadata,
+        )
+        selected = select_aligned_hidden_states(
+            hidden_states,
+            canvas.shape[0],
+            sub_block_size,
+            jnp.array(0, dtype=jnp.int32),
+            sub_block_size,
+            self.config.model.logit_alignment,
+            local_alignment=True,
+        )
+        logits = self.runner.compute_logits_fn(state_leaves, selected, None)
+        return logits.reshape(canvas.shape[0], sub_block_size, -1), kv_caches
+
+    def _model_forward_final(
+        self,
+        state_leaves: Any,
+        canvas: jax.Array,
+        positions: jax.Array,
+        kv_caches: Any,
+        active_rows: jax.Array,
+        forward_context: tuple[AttentionMetadata, AttentionMetadata],
+    ) -> tuple[jax.Array, Any]:
+        del active_rows
+        full_metadata, _ = forward_context
+        kv_caches, hidden_states = self._run_model(
+            state_leaves,
+            kv_caches,
+            canvas.reshape(-1),
+            positions.reshape(-1),
+            full_metadata,
+        )
+        final_hidden = hidden_states.reshape(canvas.shape[0], canvas.shape[1],
+                                             -1)[:, -1, :]
+        logits = self.runner.compute_logits_fn(state_leaves, final_hidden,
+                                               None)
+        return logits, kv_caches
 
     def _forward_blocks(
         self,
@@ -266,7 +413,7 @@ class BlockDiffusionStrategy:
     ) -> np.ndarray:
         canvas, _, positions, active_rows, metadata = self._build_batch(
             req_ids, block_starts, canvases)
-        logits, self.runner.kv_caches = self._forward_fn(
+        logits, self.runner.kv_caches = self._final_forward_fn(
             self.runner.state_leaves,
             canvas,
             positions,
@@ -285,34 +432,88 @@ class BlockDiffusionStrategy:
     ) -> tuple[np.ndarray, np.ndarray]:
         canvas, mask, positions, active_rows, metadata = self._build_batch(
             req_ids, block_starts, canvases, masks)
-        batch_size = self.runner.max_num_reqs
+        batch_size = self.batch_size
         thresholds = jnp.full(
             (batch_size, ),
             self.config.runtime.confidence_threshold,
             dtype=jnp.float32,
         )
         temperatures = jnp.zeros((batch_size, ), dtype=jnp.float32)
-        output = denoise_block(
-            self._forward_fn,
-            self._commit_fn,
-            self.runner.state_leaves,
-            canvas,
-            mask,
-            positions,
-            self.runner.kv_caches,
-            active_rows,
-            thresholds,
-            temperatures,
-            metadata,
-            mask_token_id=self.config.model.mask_token_id,
-            logit_alignment=self.config.model.logit_alignment,
-            next_block_policy=self.config.model.next_block_policy,
-            sub_block_size=self.config.model.sub_block_size,
-            max_denoise_steps=self.config.runtime.max_denoise_steps,
-        )
+        if self.config.runtime.use_dual_cache:
+            output = denoise_block_dual_cache(
+                self._full_subblock_forward_fn,
+                self._partial_subblock_forward_fn,
+                self._final_forward_fn,
+                self._commit_fn,
+                self.runner.state_leaves,
+                canvas,
+                mask,
+                positions,
+                self.runner.kv_caches,
+                active_rows,
+                thresholds,
+                temperatures,
+                metadata,
+                mask_token_id=self.config.model.mask_token_id,
+                logit_alignment=self.config.model.logit_alignment,
+                next_block_policy=self.config.model.next_block_policy,
+                sub_block_size=self.config.model.sub_block_size,
+                max_denoise_steps=self.config.runtime.max_denoise_steps,
+            )
+        else:
+            output = denoise_block(
+                self._forward_fn,
+                self._commit_fn,
+                self.runner.state_leaves,
+                canvas,
+                mask,
+                positions,
+                self.runner.kv_caches,
+                active_rows,
+                thresholds,
+                temperatures,
+                metadata,
+                mask_token_id=self.config.model.mask_token_id,
+                logit_alignment=self.config.model.logit_alignment,
+                next_block_policy=self.config.model.next_block_policy,
+                sub_block_size=self.config.model.sub_block_size,
+                max_denoise_steps=self.config.runtime.max_denoise_steps,
+            )
         self.runner.kv_caches = output.kv_caches
-        canvas_host, anchors_host = jax.device_get(
-            (output.canvas[:len(req_ids)], output.next_anchor[:len(req_ids)]))
+        if self.config.runtime.use_dual_cache:
+            (canvas_host, anchors_host, denoise_steps_host, q32_calls_host,
+             q8_calls_host) = jax.device_get((
+                 output.canvas[:len(req_ids)],
+                 output.next_anchor[:len(req_ids)],
+                 output.denoise_steps[:len(req_ids)],
+                 output.q32_forward_calls,
+                 output.q8_forward_calls,
+             ))
+            q32_calls = int(q32_calls_host)
+            q8_calls = int(q8_calls_host)
+            static_transformer_positions = self.batch_size * (
+                q32_calls * self.block_size
+                + q8_calls * self.config.model.sub_block_size)
+            static_lm_head_positions = self.batch_size * (
+                (q32_calls - 1 + q8_calls) *
+                self.config.model.sub_block_size + 1)
+            self._last_denoise_trace = {
+                "active_requests": len(req_ids),
+                "static_batch_rows": self.batch_size,
+                "q32_forward_calls": q32_calls,
+                "q8_forward_calls": q8_calls,
+                "static_transformer_positions": static_transformer_positions,
+                "static_lm_head_positions": static_lm_head_positions,
+                "denoise_steps": np.asarray(denoise_steps_host).tolist(),
+            }
+            logger.info("Fast-dLLM DualCache trace: %s",
+                        self._last_denoise_trace)
+        else:
+            canvas_host, anchors_host = jax.device_get((
+                output.canvas[:len(req_ids)],
+                output.next_anchor[:len(req_ids)],
+            ))
+            self._last_denoise_trace = None
         return np.asarray(canvas_host), np.asarray(anchors_host)
 
     def _process_prefill(self, req_ids: list[str]) -> dict[str, list[int]]:
@@ -354,7 +555,7 @@ class BlockDiffusionStrategy:
                 [block_index * self.block_size] * len(group),
                 canvases,
             )
-            anchors = np.argmax(logits[:, -1, :], axis=-1)
+            anchors = np.argmax(logits, axis=-1)
             for row, req_id in enumerate(group):
                 plan = plans[req_id]
                 if (plan.remainder_size == 0
@@ -516,7 +717,7 @@ class BlockDiffusionStrategy:
                                                                            [],
                                                                            [],
                                                                            [])
-        logits, self.runner.kv_caches = self._forward_fn(
+        logits, self.runner.kv_caches = self._final_forward_fn(
             self.runner.state_leaves,
             canvas,
             positions,
@@ -525,27 +726,49 @@ class BlockDiffusionStrategy:
             metadata,
         )
         thresholds = jnp.full(
-            (self.runner.max_num_reqs, ),
+            (self.batch_size, ),
             self.config.runtime.confidence_threshold,
             dtype=jnp.float32,
         )
-        output = denoise_block(
-            self._forward_fn,
-            self._commit_fn,
-            self.runner.state_leaves,
-            canvas,
-            mask,
-            positions,
-            self.runner.kv_caches,
-            active_rows,
-            thresholds,
-            jnp.zeros_like(thresholds),
-            metadata,
-            mask_token_id=self.config.model.mask_token_id,
-            logit_alignment=self.config.model.logit_alignment,
-            next_block_policy=self.config.model.next_block_policy,
-            sub_block_size=self.config.model.sub_block_size,
-            max_denoise_steps=self.config.runtime.max_denoise_steps,
-        )
+        if self.config.runtime.use_dual_cache:
+            output = denoise_block_dual_cache(
+                self._full_subblock_forward_fn,
+                self._partial_subblock_forward_fn,
+                self._final_forward_fn,
+                self._commit_fn,
+                self.runner.state_leaves,
+                canvas,
+                mask,
+                positions,
+                self.runner.kv_caches,
+                active_rows,
+                thresholds,
+                jnp.zeros_like(thresholds),
+                metadata,
+                mask_token_id=self.config.model.mask_token_id,
+                logit_alignment=self.config.model.logit_alignment,
+                next_block_policy=self.config.model.next_block_policy,
+                sub_block_size=self.config.model.sub_block_size,
+                max_denoise_steps=self.config.runtime.max_denoise_steps,
+            )
+        else:
+            output = denoise_block(
+                self._forward_fn,
+                self._commit_fn,
+                self.runner.state_leaves,
+                canvas,
+                mask,
+                positions,
+                self.runner.kv_caches,
+                active_rows,
+                thresholds,
+                jnp.zeros_like(thresholds),
+                metadata,
+                mask_token_id=self.config.model.mask_token_id,
+                logit_alignment=self.config.model.logit_alignment,
+                next_block_policy=self.config.model.next_block_policy,
+                sub_block_size=self.config.model.sub_block_size,
+                max_denoise_steps=self.config.runtime.max_denoise_steps,
+            )
         self.runner.kv_caches = output.kv_caches
         jax.block_until_ready((logits, output.canvas))

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -32,7 +32,7 @@ from tpu_inference.runner.diffusion.batch import (
     PendingBlockOutput, complete_seeded_decode_block, diffusion_batch_sizes,
     flush_partial_block_output, needs_block_anchor, plan_seeded_prompt,
     required_cache_end, select_diffusion_batch_size,
-    start_partial_block_output)
+    start_partial_block_output, trim_generation_mask)
 from tpu_inference.runner.diffusion.config import (CanvasPolicy,
                                                    DiffusionConfig,
                                                    NextBlockPolicy,
@@ -738,6 +738,8 @@ class BlockDiffusionStrategy:
                 int(forced_q32_anchor_commits_host),
                 "output_candidate_positions":
                 output_candidate_positions,
+                "trim_final_block_candidates":
+                self.config.runtime.trim_final_block_candidates,
                 "confidence_threshold":
                 self.config.runtime.confidence_threshold,
                 "q8_log_confidence_bias":
@@ -859,6 +861,11 @@ class BlockDiffusionStrategy:
                 plan = plans[req_id]
                 assert plan.partial_mask is not None
                 mask = list(plan.partial_mask)
+                if self.config.runtime.trim_final_block_candidates:
+                    mask = trim_generation_mask(
+                        mask,
+                        self._remaining_output_capacity(req_id),
+                    )
                 masks.append(mask)
                 needs_final_forward.append(
                     needs_block_anchor(
@@ -914,6 +921,11 @@ class BlockDiffusionStrategy:
             canvases.append([seed] + [self.config.model.mask_token_id] *
                             (self.block_size - 1))
             mask = [False] + [True] * (self.block_size - 1)
+            if self.config.runtime.trim_final_block_candidates:
+                mask = trim_generation_mask(
+                    mask,
+                    self._remaining_output_capacity(req_id),
+                )
             masks.append(mask)
             needs_final_forward.append(
                 needs_block_anchor(

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -55,6 +55,7 @@ class BlockDiffusionStrategy:
         self.config = config
         self._pending_outputs: dict[str, PendingBlockOutput] = {}
         self._last_denoise_trace: dict[str, Any] | None = None
+        self._last_prefill_trace: dict[str, Any] | None = None
         self._forward_fn = self._model_forward
         self._full_subblock_forward_fn = self._model_forward_full_subblock
         self._partial_subblock_forward_fn = self._model_forward_partial_subblock
@@ -414,23 +415,122 @@ class BlockDiffusionStrategy:
                                                None)
         return logits, kv_caches
 
-    def _forward_blocks(
+    def _build_prompt_batch(
         self,
         req_ids: list[str],
-        block_starts: list[int],
-        canvases: list[list[int]],
-    ) -> np.ndarray:
-        canvas, _, positions, active_rows, metadata = self._build_batch(
-            req_ids, block_starts, canvases)
-        logits, self.runner.kv_caches = self._final_forward_fn(
+        prompt_tokens: list[list[int]],
+    ) -> tuple[jax.Array, jax.Array, jax.Array, AttentionMetadata]:
+        if not req_ids or len(req_ids) != len(prompt_tokens):
+            raise ValueError(
+                "Prompt prefill requires matching non-empty request and token lists"
+            )
+        sequence_length = len(prompt_tokens[0])
+        if sequence_length == 0 or sequence_length % self.block_size != 0:
+            raise ValueError(
+                "Block-causal prompt prefill requires complete diffusion blocks"
+            )
+        if any(len(tokens) != sequence_length for tokens in prompt_tokens):
+            raise ValueError(
+                "Requests in one prompt prefill batch must have equal lengths")
+
+        runner = self.runner
+        num_active = len(req_ids)
+        batch_size = select_diffusion_batch_size(num_active, self.batch_size)
+        total_tokens = num_active * sequence_length
+        padded_tokens = next(
+            (size
+             for size in runner.num_tokens_paddings if size >= total_tokens),
+            None)
+        if padded_tokens is None:
+            raise ValueError(
+                f"Prompt prefill needs {total_tokens} tokens, beyond the "
+                "configured TPU token buckets")
+
+        input_ids = np.full((padded_tokens, ),
+                            runner.pad_token_id,
+                            dtype=np.int32)
+        positions = np.zeros((padded_tokens, ), dtype=np.int32)
+        seq_lens = np.zeros((batch_size, ), dtype=np.int32)
+        query_start_loc = np.full((batch_size + 1, ),
+                                  total_tokens,
+                                  dtype=np.int32)
+        query_start_loc[:num_active + 1] = np.arange(
+            num_active + 1, dtype=np.int32) * sequence_length
+        final_hidden_indices = np.full((batch_size, ),
+                                       total_tokens - 1,
+                                       dtype=np.int32)
+
+        source_block_tables = runner.input_batch.block_table[0].get_cpu_tensor(
+        )
+        block_tables = np.zeros((batch_size, source_block_tables.shape[1]),
+                                dtype=source_block_tables.dtype)
+        token_positions = np.arange(sequence_length, dtype=np.int32)
+        for row, (req_id, tokens) in enumerate(zip(req_ids, prompt_tokens)):
+            req_index = runner.input_batch.req_id_to_index[req_id]
+            required_cache_blocks = (sequence_length + runner.block_size -
+                                     1) // runner.block_size
+            allocated_cache_blocks = int(runner.input_batch.block_table[0].
+                                         num_blocks_per_row[req_index])
+            if required_cache_blocks > allocated_cache_blocks:
+                raise ValueError(
+                    f"Prompt prefill for request {req_id!r} needs "
+                    f"{required_cache_blocks} KV blocks, but the scheduler "
+                    f"allocated {allocated_cache_blocks}")
+            start = row * sequence_length
+            end = start + sequence_length
+            input_ids[start:end] = tokens
+            positions[start:end] = token_positions
+            seq_lens[row] = sequence_length
+            final_hidden_indices[row] = end - 1
+            block_tables[row] = source_block_tables[req_index]
+
+        request_distribution = np.array([0, num_active, num_active],
+                                        dtype=np.int32)
+        (input_ids, positions, seq_lens, query_start_loc, final_hidden_indices,
+         request_distribution,
+         block_tables) = device_array(runner.mesh, (
+             input_ids,
+             positions,
+             seq_lens,
+             query_start_loc,
+             final_hidden_indices,
+             request_distribution,
+             block_tables.reshape(-1),
+         ))
+        metadata = AttentionMetadata(
+            input_positions=positions,
+            block_tables=block_tables,
+            seq_lens=seq_lens,
+            query_start_loc=query_start_loc,
+            request_distribution=request_distribution,
+            padded_num_reqs=batch_size,
+            attention_mask_spec=AttentionMaskSpec(
+                AttentionMaskKind.BLOCK_CAUSAL,
+                block_size=self.block_size,
+            ),
+            rpa_static_query_len=sequence_length,
+        )
+        return input_ids, positions, final_hidden_indices, metadata
+
+    def _forward_prompt_blocks(
+        self,
+        req_ids: list[str],
+        prompt_tokens: list[list[int]],
+    ) -> tuple[np.ndarray, int]:
+        input_ids, positions, final_hidden_indices, metadata = \
+            self._build_prompt_batch(req_ids, prompt_tokens)
+        self.runner.kv_caches, hidden_states = self._run_model(
             self.runner.state_leaves,
-            canvas,
-            positions,
             self.runner.kv_caches,
-            active_rows,
+            input_ids,
+            positions,
             metadata,
         )
-        return np.asarray(jax.device_get(logits[:len(req_ids)]))
+        final_hidden = hidden_states[final_hidden_indices]
+        logits = self.runner.compute_logits_fn(self.runner.state_leaves,
+                                               final_hidden, None)
+        logits = np.asarray(jax.device_get(logits[:len(req_ids)]))
+        return logits, input_ids.shape[0]
 
     def _denoise_blocks(
         self,
@@ -579,6 +679,8 @@ class BlockDiffusionStrategy:
         return np.asarray(canvas_host), np.asarray(anchors_host)
 
     def _process_prefill(self, req_ids: list[str]) -> dict[str, list[int]]:
+        if not req_ids:
+            return {}
         plans = {}
         for req_id in req_ids:
             request = self.runner.requests[req_id]
@@ -601,28 +703,45 @@ class BlockDiffusionStrategy:
             )
 
         aligned_seeds: dict[str, int] = {}
-        max_full_blocks = max(
-            (len(plan.full_blocks) for plan in plans.values()), default=0)
-        for block_index in range(max_full_blocks):
-            group = [
-                req_id for req_id in req_ids
-                if block_index < len(plans[req_id].full_blocks)
-            ]
-            canvases = [
-                list(plans[req_id].full_blocks[block_index])
-                for req_id in group
-            ]
-            logits = self._forward_blocks(
-                group,
-                [block_index * self.block_size] * len(group),
-                canvases,
-            )
+        full_block_groups: dict[int, list[str]] = {}
+        for req_id in req_ids:
+            block_count = len(plans[req_id].full_blocks)
+            if block_count:
+                full_block_groups.setdefault(block_count, []).append(req_id)
+
+        full_prompt_tokens = 0
+        padded_transformer_positions = 0
+        for block_count, group in full_block_groups.items():
+            prompts = [[
+                token for block in plans[req_id].full_blocks for token in block
+            ] for req_id in group]
+            logits, padded_tokens = self._forward_prompt_blocks(group, prompts)
+            full_prompt_tokens += len(group) * block_count * self.block_size
+            padded_transformer_positions += padded_tokens
             anchors = np.argmax(logits, axis=-1)
             for row, req_id in enumerate(group):
                 plan = plans[req_id]
-                if (plan.remainder_size == 0
-                        and block_index == len(plan.full_blocks) - 1):
+                if plan.remainder_size == 0:
                     aligned_seeds[req_id] = int(anchors[row])
+
+        self._last_prefill_trace = {
+            "active_requests":
+            len(req_ids),
+            "requests_with_full_blocks":
+            sum(len(group) for group in full_block_groups.values()),
+            "forward_calls":
+            len(full_block_groups),
+            "full_prompt_tokens":
+            full_prompt_tokens,
+            "padded_transformer_positions":
+            padded_transformer_positions,
+            "prompt_block_counts": {
+                block_count: len(group)
+                for block_count, group in full_block_groups.items()
+            },
+        }
+        logger.info("Fast-dLLM block-causal prefill trace: %s",
+                    self._last_prefill_trace)
 
         outputs = {req_id: [aligned_seeds[req_id]] for req_id in aligned_seeds}
         partial_group = [

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -639,6 +639,7 @@ class BlockDiffusionStrategy:
                 self.config.model.sub_block_size + final_q32_calls)
             denoise_iterations = q32_calls + q8_calls - final_q32_calls
             useful_row_iterations = int(np.asarray(denoise_steps_host).sum())
+            active_row_iterations = len(req_ids) * denoise_iterations
             static_row_iterations = batch_size * denoise_iterations
             self._last_denoise_trace = {
                 "active_requests":
@@ -661,6 +662,10 @@ class BlockDiffusionStrategy:
                 useful_row_iterations,
                 "static_row_iterations":
                 static_row_iterations,
+                "padding_row_iterations":
+                (static_row_iterations - active_row_iterations),
+                "straggler_row_iterations":
+                (active_row_iterations - useful_row_iterations),
                 "wasted_row_iterations":
                 (static_row_iterations - useful_row_iterations),
                 "denoise_steps":

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -26,26 +26,22 @@ from tpu_inference.layers.common.attention_metadata import (AttentionMaskKind,
                                                             AttentionMetadata)
 from tpu_inference.logger import init_logger
 from tpu_inference.runner.diffusion.algorithm import get_commit_algorithm
-from tpu_inference.runner.diffusion.batch import (PendingBlockOutput,
-                                                  complete_seeded_decode_block,
-                                                  flush_partial_block_output,
-                                                  plan_seeded_prompt,
-                                                  required_cache_end,
-                                                  start_partial_block_output)
+from tpu_inference.runner.diffusion.batch import (
+    PendingBlockOutput, complete_seeded_decode_block, diffusion_batch_sizes,
+    flush_partial_block_output, plan_seeded_prompt, required_cache_end,
+    select_diffusion_batch_size, start_partial_block_output)
 from tpu_inference.runner.diffusion.config import (CanvasPolicy,
                                                    DiffusionConfig,
                                                    NextBlockPolicy,
                                                    PromptRemainderPolicy)
-from tpu_inference.runner.diffusion.program import (denoise_block,
-                                                    denoise_block_dual_cache,
-                                                    select_aligned_hidden_states)
+from tpu_inference.runner.diffusion.program import (
+    denoise_block, denoise_block_dual_cache, select_aligned_hidden_states)
 from tpu_inference.utils import device_array
 
 if TYPE_CHECKING:
     from vllm.v1.core.sched.output import SchedulerOutput
 
     from tpu_inference.runner.tpu_runner import TPUModelRunner
-
 
 logger = init_logger(__name__)
 
@@ -137,8 +133,7 @@ class BlockDiffusionStrategy:
                     "Block diffusion does not support sampling penalties: "
                     f"presence_penalty={sampling_params.presence_penalty}, "
                     f"frequency_penalty={sampling_params.frequency_penalty}, "
-                    f"repetition_penalty={sampling_params.repetition_penalty}"
-                )
+                    f"repetition_penalty={sampling_params.repetition_penalty}")
             if sampling_params.min_tokens != 0:
                 raise ValueError(
                     "Block diffusion does not support min_tokens yet")
@@ -165,14 +160,22 @@ class BlockDiffusionStrategy:
         block_starts: list[int],
         canvases: list[list[int]],
         masks: list[list[bool]] | None = None,
-    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array,
-               tuple[AttentionMetadata, AttentionMetadata]]:
+        *,
+        padded_batch_size: int | None = None,
+    ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, tuple[
+            AttentionMetadata, AttentionMetadata]]:
         runner = self.runner
-        batch_size = self.batch_size
         block_size = self.block_size
         sub_block_size = self.config.model.sub_block_size
         num_active = len(req_ids)
-        if num_active > batch_size:
+        capacity = self.batch_size
+        batch_size = (select_diffusion_batch_size(num_active, capacity)
+                      if padded_batch_size is None else padded_batch_size)
+        if not max(1, num_active) <= batch_size <= capacity:
+            raise ValueError(
+                "Diffusion padded batch size must fit the active requests and "
+                "configured capacity")
+        if num_active > capacity:
             raise ValueError("Diffusion batch exceeds max_num_reqs")
 
         canvas = np.zeros((batch_size, block_size), dtype=np.int32)
@@ -261,8 +264,8 @@ class BlockDiffusionStrategy:
                 AttentionMaskKind.BIDIRECTIONAL),
             replace_cached_kv=True,
         )
-        return (canvas, mask, positions, active_rows,
-                (full_metadata, partial_metadata))
+        return (canvas, mask, positions, active_rows, (full_metadata,
+                                                       partial_metadata))
 
     def _model_forward(
         self,
@@ -432,7 +435,7 @@ class BlockDiffusionStrategy:
     ) -> tuple[np.ndarray, np.ndarray]:
         canvas, mask, positions, active_rows, metadata = self._build_batch(
             req_ids, block_starts, canvases, masks)
-        batch_size = self.batch_size
+        batch_size = canvas.shape[0]
         thresholds = jnp.full(
             (batch_size, ),
             self.config.runtime.confidence_threshold,
@@ -491,20 +494,36 @@ class BlockDiffusionStrategy:
              ))
             q32_calls = int(q32_calls_host)
             q8_calls = int(q8_calls_host)
-            static_transformer_positions = self.batch_size * (
-                q32_calls * self.block_size
-                + q8_calls * self.config.model.sub_block_size)
-            static_lm_head_positions = self.batch_size * (
-                (q32_calls - 1 + q8_calls) *
-                self.config.model.sub_block_size + 1)
+            static_transformer_positions = batch_size * (
+                q32_calls * self.block_size +
+                q8_calls * self.config.model.sub_block_size)
+            static_lm_head_positions = batch_size * (
+                (q32_calls - 1 + q8_calls) * self.config.model.sub_block_size +
+                1)
+            denoise_iterations = q32_calls + q8_calls - 1
+            useful_row_iterations = int(np.asarray(denoise_steps_host).sum())
+            static_row_iterations = batch_size * denoise_iterations
             self._last_denoise_trace = {
-                "active_requests": len(req_ids),
-                "static_batch_rows": self.batch_size,
-                "q32_forward_calls": q32_calls,
-                "q8_forward_calls": q8_calls,
-                "static_transformer_positions": static_transformer_positions,
-                "static_lm_head_positions": static_lm_head_positions,
-                "denoise_steps": np.asarray(denoise_steps_host).tolist(),
+                "active_requests":
+                len(req_ids),
+                "static_batch_rows":
+                batch_size,
+                "q32_forward_calls":
+                q32_calls,
+                "q8_forward_calls":
+                q8_calls,
+                "static_transformer_positions":
+                static_transformer_positions,
+                "static_lm_head_positions":
+                static_lm_head_positions,
+                "useful_row_iterations":
+                useful_row_iterations,
+                "static_row_iterations":
+                static_row_iterations,
+                "wasted_row_iterations":
+                (static_row_iterations - useful_row_iterations),
+                "denoise_steps":
+                np.asarray(denoise_steps_host).tolist(),
             }
             logger.info("Fast-dLLM DualCache trace: %s",
                         self._last_denoise_trace)
@@ -713,62 +732,61 @@ class BlockDiffusionStrategy:
 
     def precompile(self) -> None:
         self._validate_runner_capabilities()
-        canvas, mask, positions, active_rows, metadata = self._build_batch([],
-                                                                           [],
-                                                                           [],
-                                                                           [])
-        logits, self.runner.kv_caches = self._final_forward_fn(
-            self.runner.state_leaves,
-            canvas,
-            positions,
-            self.runner.kv_caches,
-            active_rows,
-            metadata,
-        )
-        thresholds = jnp.full(
-            (self.batch_size, ),
-            self.config.runtime.confidence_threshold,
-            dtype=jnp.float32,
-        )
-        if self.config.runtime.use_dual_cache:
-            output = denoise_block_dual_cache(
-                self._full_subblock_forward_fn,
-                self._partial_subblock_forward_fn,
-                self._final_forward_fn,
-                self._commit_fn,
+        for batch_size in diffusion_batch_sizes(self.batch_size):
+            canvas, mask, positions, active_rows, metadata = self._build_batch(
+                [], [], [], [], padded_batch_size=batch_size)
+            logits, self.runner.kv_caches = self._final_forward_fn(
                 self.runner.state_leaves,
                 canvas,
-                mask,
                 positions,
                 self.runner.kv_caches,
                 active_rows,
-                thresholds,
-                jnp.zeros_like(thresholds),
                 metadata,
-                mask_token_id=self.config.model.mask_token_id,
-                logit_alignment=self.config.model.logit_alignment,
-                next_block_policy=self.config.model.next_block_policy,
-                sub_block_size=self.config.model.sub_block_size,
-                max_denoise_steps=self.config.runtime.max_denoise_steps,
             )
-        else:
-            output = denoise_block(
-                self._forward_fn,
-                self._commit_fn,
-                self.runner.state_leaves,
-                canvas,
-                mask,
-                positions,
-                self.runner.kv_caches,
-                active_rows,
-                thresholds,
-                jnp.zeros_like(thresholds),
-                metadata,
-                mask_token_id=self.config.model.mask_token_id,
-                logit_alignment=self.config.model.logit_alignment,
-                next_block_policy=self.config.model.next_block_policy,
-                sub_block_size=self.config.model.sub_block_size,
-                max_denoise_steps=self.config.runtime.max_denoise_steps,
+            thresholds = jnp.full(
+                (batch_size, ),
+                self.config.runtime.confidence_threshold,
+                dtype=jnp.float32,
             )
-        self.runner.kv_caches = output.kv_caches
-        jax.block_until_ready((logits, output.canvas))
+            if self.config.runtime.use_dual_cache:
+                output = denoise_block_dual_cache(
+                    self._full_subblock_forward_fn,
+                    self._partial_subblock_forward_fn,
+                    self._final_forward_fn,
+                    self._commit_fn,
+                    self.runner.state_leaves,
+                    canvas,
+                    mask,
+                    positions,
+                    self.runner.kv_caches,
+                    active_rows,
+                    thresholds,
+                    jnp.zeros_like(thresholds),
+                    metadata,
+                    mask_token_id=self.config.model.mask_token_id,
+                    logit_alignment=self.config.model.logit_alignment,
+                    next_block_policy=self.config.model.next_block_policy,
+                    sub_block_size=self.config.model.sub_block_size,
+                    max_denoise_steps=self.config.runtime.max_denoise_steps,
+                )
+            else:
+                output = denoise_block(
+                    self._forward_fn,
+                    self._commit_fn,
+                    self.runner.state_leaves,
+                    canvas,
+                    mask,
+                    positions,
+                    self.runner.kv_caches,
+                    active_rows,
+                    thresholds,
+                    jnp.zeros_like(thresholds),
+                    metadata,
+                    mask_token_id=self.config.model.mask_token_id,
+                    logit_alignment=self.config.model.logit_alignment,
+                    next_block_policy=self.config.model.next_block_policy,
+                    sub_block_size=self.config.model.sub_block_size,
+                    max_denoise_steps=self.config.runtime.max_denoise_steps,
+                )
+            self.runner.kv_caches = output.kv_caches
+            jax.block_until_ready((logits, output.canvas))

--- a/tpu_inference/runner/diffusion/strategy.py
+++ b/tpu_inference/runner/diffusion/strategy.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import json
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
@@ -25,7 +26,8 @@ from tpu_inference.layers.common.attention_metadata import (AttentionMaskKind,
                                                             AttentionMaskSpec,
                                                             AttentionMetadata)
 from tpu_inference.logger import init_logger
-from tpu_inference.runner.diffusion.algorithm import get_commit_algorithm
+from tpu_inference.runner.diffusion.algorithm import (
+    get_commit_algorithm, get_commit_diagnostics_algorithm)
 from tpu_inference.runner.diffusion.batch import (
     PendingBlockOutput, complete_seeded_decode_block, diffusion_batch_sizes,
     flush_partial_block_output, needs_block_anchor, plan_seeded_prompt,
@@ -36,7 +38,8 @@ from tpu_inference.runner.diffusion.config import (CanvasPolicy,
                                                    NextBlockPolicy,
                                                    PromptRemainderPolicy)
 from tpu_inference.runner.diffusion.program import (
-    denoise_block, denoise_block_dual_cache, select_aligned_hidden_states)
+    DUAL_CACHE_Q32, DUAL_CACHE_Q8, DualCacheAcceptanceTrace, denoise_block,
+    denoise_block_dual_cache, select_aligned_hidden_states)
 from tpu_inference.utils import device_array
 
 if TYPE_CHECKING:
@@ -45,6 +48,65 @@ if TYPE_CHECKING:
     from tpu_inference.runner.tpu_runner import TPUModelRunner
 
 logger = init_logger(__name__)
+
+DUAL_CACHE_ACCEPTANCE_TRACE_PREFIX = \
+    "Fast-dLLM DualCache acceptance step: "
+
+
+def _eligible_finite_values(values: np.ndarray,
+                            eligible: np.ndarray) -> list[float | None]:
+    return [
+        float(value) if is_eligible and np.isfinite(value) else None
+        for value, is_eligible in zip(values, eligible, strict=True)
+    ]
+
+
+def _log_dual_cache_acceptance_trace(trace: DualCacheAcceptanceTrace) -> None:
+    trace_host = jax.device_get(trace)
+    count = int(trace_host.count)
+    block_start = int(trace_host.block_start)
+    forward_kinds = {
+        DUAL_CACHE_Q32: "q32",
+        DUAL_CACHE_Q8: "q8",
+    }
+    for index in range(count):
+        eligible = np.asarray(trace_host.row0_eligible[index], dtype=bool)
+        record = {
+            "block_start":
+            block_start,
+            "subblock_start":
+            int(trace_host.sub_block_starts[index]),
+            "iteration":
+            int(trace_host.iterations[index]),
+            "forward_kind":
+            forward_kinds[int(trace_host.forward_kinds[index])],
+            "row0_token_ids":
+            np.asarray(trace_host.row0_token_ids[index]).tolist(),
+            "row0_eligible":
+            eligible.tolist(),
+            "row0_commit":
+            np.asarray(trace_host.row0_commit[index], dtype=bool).tolist(),
+            "row0_remaining":
+            np.asarray(trace_host.row0_remaining[index], dtype=bool).tolist(),
+            "row0_selected_log_confidence":
+            _eligible_finite_values(
+                np.asarray(trace_host.row0_selected_log_confidence[index]),
+                eligible,
+            ),
+            "row0_threshold_margin":
+            _eligible_finite_values(
+                np.asarray(trace_host.row0_threshold_margin[index]),
+                eligible,
+            ),
+        }
+        logger.info(
+            "%s%s",
+            DUAL_CACHE_ACCEPTANCE_TRACE_PREFIX,
+            json.dumps(record,
+                       allow_nan=False,
+                       separators=(",", ":"),
+                       sort_keys=True),
+        )
 
 
 class BlockDiffusionStrategy:
@@ -61,6 +123,8 @@ class BlockDiffusionStrategy:
         self._partial_subblock_forward_fn = self._model_forward_partial_subblock
         self._final_forward_fn = self._model_forward_final
         self._commit_fn = get_commit_algorithm(config.runtime.algorithm)
+        self._commit_diagnostics_fn = get_commit_diagnostics_algorithm(
+            config.runtime.algorithm)
 
         model = config.model
         if model.canvas_policy is not CanvasPolicy.SEED_AND_MASK:
@@ -270,6 +334,7 @@ class BlockDiffusionStrategy:
             attention_mask_spec=AttentionMaskSpec(
                 AttentionMaskKind.BIDIRECTIONAL),
             replace_cached_kv=True,
+            fp32_rpa_accumulator=self.config.runtime.fp32_partial_rpa,
         )
         return (canvas, mask, positions, active_rows, (full_metadata,
                                                        partial_metadata))
@@ -592,6 +657,11 @@ class BlockDiffusionStrategy:
                 needs_final_forward=final_rows,
                 stop_on_eos_rows=stop_rows,
                 eos_token_ids=eos_token_ids,
+                commit_diagnostics_fn=self._commit_diagnostics_fn,
+                trace_acceptance_steps=(
+                    self.config.runtime.trace_acceptance_steps),
+                q8_log_confidence_bias=(
+                    self.config.runtime.q8_log_confidence_bias),
             )
         else:
             output = denoise_block(
@@ -617,17 +687,22 @@ class BlockDiffusionStrategy:
             )
         self.runner.kv_caches = output.kv_caches
         if self.config.runtime.use_dual_cache:
+            device_outputs = (
+                output.canvas[:len(req_ids)],
+                output.next_anchor[:len(req_ids)],
+                output.denoise_steps[:len(req_ids)],
+                output.stopped_rows[:len(req_ids)],
+                output.q32_forward_calls,
+                output.q8_forward_calls,
+                output.final_q32_forward_calls,
+            )
+            if self.config.runtime.trace_acceptance_steps:
+                assert output.acceptance_trace is not None
+                device_outputs += (output.acceptance_trace, )
+            host_outputs = jax.device_get(device_outputs)
             (canvas_host, anchors_host, denoise_steps_host, stopped_rows_host,
              q32_calls_host, q8_calls_host,
-             final_q32_calls_host) = jax.device_get((
-                 output.canvas[:len(req_ids)],
-                 output.next_anchor[:len(req_ids)],
-                 output.denoise_steps[:len(req_ids)],
-                 output.stopped_rows[:len(req_ids)],
-                 output.q32_forward_calls,
-                 output.q8_forward_calls,
-                 output.final_q32_forward_calls,
-             ))
+             final_q32_calls_host) = host_outputs[:7]
             q32_calls = int(q32_calls_host)
             q8_calls = int(q8_calls_host)
             final_q32_calls = int(final_q32_calls_host)
@@ -654,6 +729,15 @@ class BlockDiffusionStrategy:
                 final_q32_calls,
                 "output_candidate_positions":
                 output_candidate_positions,
+                "confidence_threshold":
+                self.config.runtime.confidence_threshold,
+                "q8_log_confidence_bias":
+                self.config.runtime.q8_log_confidence_bias,
+                "q8_effective_confidence_threshold":
+                (self.config.runtime.confidence_threshold *
+                 np.exp(-self.config.runtime.q8_log_confidence_bias)
+                 if 0.0 < self.config.runtime.confidence_threshold < 1.0 else
+                 self.config.runtime.confidence_threshold),
                 "static_transformer_positions":
                 static_transformer_positions,
                 "static_lm_head_positions":
@@ -675,6 +759,8 @@ class BlockDiffusionStrategy:
             }
             logger.info("Fast-dLLM DualCache trace: %s",
                         self._last_denoise_trace)
+            if self.config.runtime.trace_acceptance_steps:
+                _log_dual_cache_acceptance_trace(host_outputs[7])
         else:
             canvas_host, anchors_host = jax.device_get((
                 output.canvas[:len(req_ids)],
@@ -977,6 +1063,11 @@ class BlockDiffusionStrategy:
                     max_denoise_steps=self.config.runtime.max_denoise_steps,
                     stop_on_eos_rows=jnp.zeros_like(active_rows),
                     eos_token_ids=eos_token_ids,
+                    commit_diagnostics_fn=self._commit_diagnostics_fn,
+                    trace_acceptance_steps=(
+                        self.config.runtime.trace_acceptance_steps),
+                    q8_log_confidence_bias=(
+                        self.config.runtime.q8_log_confidence_bias),
                 )
             else:
                 output = denoise_block(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -73,6 +73,9 @@ from tpu_inference.models.jax.jax_intermediate_tensor import \
 from tpu_inference.runner import utils as runner_utils
 from tpu_inference.runner.compilation_manager import CompilationManager
 from tpu_inference.runner.decode_loop import TpuSamplingState, continue_decode
+from tpu_inference.runner.diffusion.config import (GenerationStrategy,
+                                                   resolve_generation_strategy)
+from tpu_inference.runner.diffusion.strategy import BlockDiffusionStrategy
 from tpu_inference.runner.input_batch import CachedRequestState, InputBatch
 from tpu_inference.runner.kv_cache_manager import KVCacheManager
 from tpu_inference.runner.lora_utils import LoraUtils
@@ -124,7 +127,7 @@ logging.getLogger("torchax.tensor").setLevel(logging.ERROR)
 
 INVALID_TOKEN_ID = -1
 # Smallest output size
-MIN_NUM_SEQS = 8
+MIN_NUM_SEQS = runner_utils.MIN_NUM_SEQS
 
 
 @functools.partial(jax.jit, static_argnames=["dp_size", "tokens_per_dp"])
@@ -805,6 +808,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.speculative_config = vllm_config.speculative_config
         self.observability_config = vllm_config.observability_config
         self.device_config = vllm_config.device_config
+        self.generation_strategy_config = resolve_generation_strategy(
+            vllm_config)
 
         self.devices = devices
         self.dtype = self.model_config.dtype
@@ -845,6 +850,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self._substitute_placeholder_token_fn = _substitute_placeholder_token
         self.execute_model_state: ExecuteModelState | None = None
         self._continue_decode_output = None
+        self._generation_strategy_output = None
         self.batch_counter = 0
 
         self.kv_caches: list[jax.Array] = []
@@ -865,6 +871,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             "max_decode_steps", DEFAULT_MAX_DECODE_STEPS)
         self.eos_token_id = runner_utils.get_eos_token_id(self.model_config)
         self.pad_token_id = runner_utils.get_pad_token_id(self.model_config)
+        self.block_diffusion_strategy = (
+            BlockDiffusionStrategy(self,
+                                   self.generation_strategy_config.diffusion)
+            if self.generation_strategy_config.strategy
+            is GenerationStrategy.BLOCK_DIFFUSION else None)
 
     def _init_random(self):
         if self.model_config.seed is None:
@@ -1213,6 +1224,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 self.drafter.load_model(self.state)
 
         self.model_fn = model.model_fn
+        self.model_fn_no_options = (model.model_fn_no_options
+                                    or model.model_fn)
         self.compute_logits_fn = model.compute_logits_fn
         self.pooler_fn = model.pooler_fn
         self.combine_hidden_states_fn = model.combine_hidden_states_fn
@@ -1319,6 +1332,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
     def capture_model(self) -> None:
         self.compilation_manager.capture_model()
+        if self.block_diffusion_strategy is not None:
+            with jax.set_mesh(self.mesh):
+                self.block_diffusion_strategy.precompile()
 
     @time_function
     def execute_model(
@@ -1350,6 +1366,11 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if self._continue_decode_output is not None:
             output = self._continue_decode_output
             self._continue_decode_output = None
+            return output
+
+        if self._generation_strategy_output is not None:
+            output = self._generation_strategy_output
+            self._generation_strategy_output = None
             return output
 
         if self.execute_model_state is None:
@@ -1550,6 +1571,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
     ) -> JaxIntermediateTensors | ModelRunnerOutput | None:
         self.persistent_batch_manager.update_states(
             scheduler_output, self.get_mrope_input_positions_fn)
+        if self.block_diffusion_strategy is not None:
+            self.block_diffusion_strategy.on_scheduler_update(
+                scheduler_output.finished_req_ids)
         if not scheduler_output.total_num_scheduled_tokens:
             if self.scheduler_config.async_scheduling and self._pre_async_results is not None:
                 self._modify_prev_results()
@@ -1570,6 +1594,9 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 # raise Exception(
                 #     "Should not schedule a request that does nothing!")
             return EMPTY_MODEL_RUNNER_OUTPUT
+
+        if self.block_diffusion_strategy is not None:
+            return self.block_diffusion_strategy.execute(scheduler_output)
 
         # Check if the entire batch is in the decode phase.
         # request_distribution[0] tracks the number of decode requests.


### PR DESCRIPTION
# Experimental: Fast-dLLM v2 block diffusion on TPU

> **Status: experimental and opt-in.** None of the new scheduling, diffusion,
> or RPA settings are enabled by default. The reported result is specific to
> the model, hardware, runtime, prompt, and concurrency contract below.

## Summary

This change adds the block-diffusion execution path and the serving fixes
needed to convert its lower sequential-forward count into end-to-end TPU
throughput:

- dual-cache q32/q8 denoising;
- exact output-budget trimming;
- forced q32 anchor commits and calibrated q8 acceptance;
- donated KV-cache buffers;
- bounded, strict cohort admission;
- adaptive cohort routing across two independent DP engines;
- correct pause, abort, and request-ID reuse handling;
- optional mixed-RPA tiling for the selected experimental profile.

## Measured result

The topology-matched comparison uses one TPU v7x `2x2x1` slice, TP4 x DP2,
one API process, global concurrency 32, and the same OpenAI chat request.

| Profile | Output tok/s | Mean E2E | Relative throughput | Relative E2E speed |
|---|---:|---:|---:|---:|
| Autoregressive control | 4,790 | 1,653 ms | 1.000x | 1.000x |
| Block diffusion | 9,920 | 816 ms | **2.071x** | **2.026x** |

The diffusion result is the median of three independently warmed 320-request
runs: `9,878`, `9,958`, and `9,920` output tok/s. Every run completed without
request failures and preserved the same denoise-forward signature.

Additional safety checks:

- fixed essay, c32: `6,190 tok/s`, `660 ms`;
- Janet, c1: `633 tok/s`, `404 ms`;
- GSM8K-128: `43/128`, equal to the locked pre-optimization baseline, with
  five paired improvements and five paired regressions.

## Exact provenance

- TPU inference commit:
  `39d8547963df462651363f2eb7b912e7f988b931`
- Public model: `Efficient-Large-Model/Fast_dLLM_v2_7B`
- Model revision: `0661abf5f9f0ee338970d091052a26c8efa51974`
- Runtime image:
  `vllm/vllm-tpu@sha256:ae6b36412fdab94aef161bfaea17c4a20c12de7290714d8a17cdb64dd63606c4`
- Runtime-reported vLLM version: `0.26.1rc1.dev911+g9842d7014`
- Hardware: one TPU v7x `2x2x1` slice, four physical chips/eight JAX devices
- Normalized model config SHA256:
  `e89a83489b1c552801ae062ab84476137ec921f0923cb9d15fbfcac68304ef5d`
- Chat template SHA256:
  `44a492c3e3affb4354dc73ab48bbe7fd6890baa04fd782835d4986b5e9120d2f`

## Public reproduction

### 1. Check out and install

Follow the repository TPU installation guide, using the pinned runtime above,
then check out the measured source commit:

```bash
git clone https://github.com/ethannnnnn/tpu-inference.git
cd tpu-inference
git checkout 39d8547963df462651363f2eb7b912e7f988b931
```

The measured container mounted this checkout ahead of the packaged plugin:

```bash
export PYTHONPATH="$PWD${PYTHONPATH:+:$PYTHONPATH}"
```

### 2. Download and normalize the public checkpoint

```bash
python3 -m pip install --upgrade huggingface_hub
hf download Efficient-Large-Model/Fast_dLLM_v2_7B \
  --revision 0661abf5f9f0ee338970d091052a26c8efa51974 \
  --local-dir "$PWD/Fast_dLLM_v2_7B"
```

The public checkpoint advertises a custom model class. The TPU run used the
same weights with the Qwen2-compatible configuration in Appendix A. Save that
appendix as `Fast_dLLM_v2_7B/config.json`. Save Appendix B as
`matched_chat_template.jinja`, then verify both hashes shown above.

### 3. Start the diffusion server

```bash
export VLLM_USE_V1=1
export TPU_BACKEND_TYPE=jax
export TPU_MULTIPROCESS_DP=1
export RPA_V3_MIXED_BLOCK_SIZES=32,2048,32,512

vllm serve "$PWD/Fast_dLLM_v2_7B" \
  --served-model-name fast-dllm-v2 \
  --host 0.0.0.0 \
  --port 8000 \
  --tensor-parallel-size 4 \
  --data-parallel-size 2 \
  --api-server-count 1 \
  --generation-config vllm \
  --chat-template "$PWD/matched_chat_template.jinja" \
  --max-model-len 8192 \
  --max-num-seqs 16 \
  --max-num-batched-tokens 8192 \
  --gpu-memory-utilization 0.4 \
  --dtype bfloat16 \
  --kv-cache-dtype bfloat16 \
  --block-size 32 \
  --no-enable-prefix-caching \
  --no-enable-chunked-prefill \
  --no-async-scheduling \
  --no-enable-log-requests \
  --additional-config='{"compilation_sizes":[2304],"generation_strategy":"block_diffusion","diffusion":{"model_adapter":"seeded_shifted","block_size":32,"mask_token_id":151665,"sub_block_size":8,"confidence_threshold":0.9,"temperature":0.0,"use_dual_cache":true,"q8_log_confidence_bias":0.23,"force_q32_anchor_commit":true,"trim_final_block_candidates":true,"cohort_max_wait_ms":5000.0,"cohort_quiet_wait_ms":2.0,"cohort_strict_waves":true,"cohort_round_robin_dp":true}}'
```

### 4. Run the exact Janet c32 benchmark

Save the benchmark client from Appendix C as `benchmark_r51_oss.py`, then run:

```bash
python3 benchmark_r51_oss.py \
  --endpoint http://127.0.0.1:8000 \
  --model fast-dllm-v2 \
  --concurrency 32 \
  --warm-requests 32 \
  --requests 320 \
  --trials 3 \
  --max-tokens 256 \
  --expect-min-tps 9580 \
  --output r51-benchmark.json
```

The client sends one user message, no system message, temperature `0`, top-p
`1`, no server-side stop strings, no minimum-token override, and closes each
HTTP connection. Output throughput is total `usage.completion_tokens` divided
by wall time. E2E is measured from POST until the full response arrives.

### 5. Reproduce the AR control

Use `Qwen/Qwen2.5-7B-Instruct` at revision
`a09a35458c702b33eeacc393d103063234e8bc28`, the same runtime and chat
template, and commit `703cd5c91598168ac1171807de78167aa0d595f8`.

```bash
export TPU_MULTIPROCESS_DP=1
export ATTN_BUCKETIZED_NUM_REQS=true
export ATTN_CUSTOM_NUM_REQS_BUCKETS=1,2,3,4,8,16
unset RPA_V3_MIXED_BLOCK_SIZES

vllm serve Qwen/Qwen2.5-7B-Instruct \
  --revision a09a35458c702b33eeacc393d103063234e8bc28 \
  --served-model-name qwen2.5-7b-ar \
  --tensor-parallel-size 4 \
  --data-parallel-size 2 \
  --api-server-count 1 \
  --generation-config vllm \
  --chat-template "$PWD/matched_chat_template.jinja" \
  --max-model-len 8192 \
  --max-num-seqs 16 \
  --max-num-batched-tokens 8192 \
  --gpu-memory-utilization 0.4 \
  --dtype bfloat16 \
  --kv-cache-dtype bfloat16 \
  --block-size 32 \
  --no-enable-prefix-caching \
  --no-enable-chunked-prefill \
  --no-async-scheduling
```

Run the same benchmark client with `--model qwen2.5-7b-ar`.

## Limitations

- The 2x result is workload-specific. Fixed-essay throughput improved by
  approximately `1.29x`, not `2x`.
- GSM8K-128 remains `43/128`; this is no regression against the locked
  baseline, but it is not a claim of high absolute accuracy.
- The selected RPA tiling changes numerical trajectories and gives back an
  intermediate five-example GSM8K gain observed before the tiling change.
- The AR measurement used the earlier commit identified above. Subsequent
  production changes are diffusion-only/default-off for AR, but the commit
  difference is disclosed rather than hidden.
- Broader workloads and full GSM8K should be evaluated before enabling this
  profile by default.


<details>
<summary>Appendix A: normalized model config</summary>

```json
{
  "architectures": [
    "Qwen2ForCausalLM"
  ],
  "attention_dropout": 0.0,
  "bd_size": 32,
  "block_size": 32,
  "bos_token_id": 151643,
  "eos_token_id": 151645,
  "hidden_act": "silu",
  "hidden_size": 3584,
  "initializer_range": 0.02,
  "intermediate_size": 18944,
  "mask_token_id": 151665,
  "max_position_embeddings": 32768,
  "max_window_layers": 28,
  "model_type": "qwen2",
  "num_attention_heads": 28,
  "num_hidden_layers": 28,
  "num_key_value_heads": 4,
  "pad_token_id": 151645,
  "rms_norm_eps": 1e-06,
  "rope_scaling": null,
  "rope_theta": 1000000.0,
  "sliding_window": null,
  "sub_block_size": 8,
  "tie_word_embeddings": false,
  "torch_dtype": "bfloat16",
  "transformers_version": "4.53.1",
  "use_cache": true,
  "use_sliding_window": false,
  "vocab_size": 152064
}
```
</details>

<details>
<summary>Appendix B: matched chat template</summary>

```jinja
{%- for message in messages %}
{{- '<|im_start|>' + message['role'] + '\n' + message['content'] + '<|im_end|>\n' }}
{%- endfor %}
{%- if add_generation_prompt %}
{{- '<|im_start|>assistant\n' }}
{%- endif %}
```
</details>

<details>
<summary>Appendix C: portable benchmark client</summary>

```python
#!/usr/bin/env python3
"""Portable OpenAI-compatible benchmark for the R51 Janet c32 profile."""

from __future__ import annotations

import argparse
import concurrent.futures
import hashlib
import json
import statistics
import time
import urllib.request
from dataclasses import dataclass
from pathlib import Path
from typing import Any


DEFAULT_PROMPT = (
    "Q: Janet’s ducks lay 16 eggs per day. She eats three for breakfast "
    "every morning and bakes muffins for her friends every day with four. "
    "She sells the remainder at the farmers' market daily for $2 per fresh "
    "duck egg. How much in dollars does she make every day at the farmers' "
    "market?\nA: Let's think step by step."
)


@dataclass(frozen=True)
class RequestResult:
    latency_seconds: float
    completion_tokens: int
    response_text: str


def _request_once(
    endpoint: str,
    model: str,
    prompt: str,
    max_tokens: int,
    timeout_seconds: float,
) -> RequestResult:
    body = json.dumps({
        "model": model,
        "messages": [{"role": "user", "content": prompt}],
        "temperature": 0.0,
        "top_p": 1.0,
        "max_tokens": max_tokens,
        "stream": False,
        "n": 1,
    }).encode("utf-8")
    request = urllib.request.Request(
        f"{endpoint.rstrip('/')}/v1/chat/completions",
        data=body,
        headers={
            "Connection": "close",
            "Content-Type": "application/json",
        },
        method="POST",
    )
    started = time.perf_counter()
    with urllib.request.urlopen(request, timeout=timeout_seconds) as response:
        payload = json.load(response)
    latency = time.perf_counter() - started
    usage = payload.get("usage") or {}
    completion_tokens = usage.get("completion_tokens")
    if not isinstance(completion_tokens, int):
        raise RuntimeError("response did not include usage.completion_tokens")
    choices = payload.get("choices") or []
    if len(choices) != 1:
        raise RuntimeError(f"expected exactly one choice, got {len(choices)}")
    text = choices[0].get("message", {}).get("content")
    if not isinstance(text, str):
        raise RuntimeError("response did not include choices[0].message.content")
    return RequestResult(latency, completion_tokens, text)


def _run_batch(args: argparse.Namespace, requests: int) -> dict[str, Any]:
    started = time.perf_counter()
    with concurrent.futures.ThreadPoolExecutor(
            max_workers=args.concurrency) as executor:
        futures = [
            executor.submit(
                _request_once,
                args.endpoint,
                args.model,
                args.prompt,
                args.max_tokens,
                args.timeout_seconds,
            ) for _ in range(requests)
        ]
        results = [future.result() for future in futures]
    wall_seconds = time.perf_counter() - started
    completion_tokens = sum(result.completion_tokens for result in results)
    response_corpus = "\n<|response|>\n".join(
        result.response_text for result in results).encode("utf-8")
    return {
        "requests": requests,
        "failed": 0,
        "wall_seconds": wall_seconds,
        "output_tokens": completion_tokens,
        "output_tokens_per_second": completion_tokens / wall_seconds,
        "mean_e2e_seconds": statistics.fmean(
            result.latency_seconds for result in results),
        "median_e2e_seconds": statistics.median(
            result.latency_seconds for result in results),
        "response_corpus_sha256": hashlib.sha256(response_corpus).hexdigest(),
    }


def _parse_args() -> argparse.Namespace:
    parser = argparse.ArgumentParser()
    parser.add_argument("--endpoint", default="http://127.0.0.1:8000")
    parser.add_argument("--model", default="fast-dllm-v2")
    parser.add_argument("--prompt", default=DEFAULT_PROMPT)
    parser.add_argument("--concurrency", type=int, default=32)
    parser.add_argument("--warm-requests", type=int, default=32)
    parser.add_argument("--requests", type=int, default=320)
    parser.add_argument("--trials", type=int, default=3)
    parser.add_argument("--max-tokens", type=int, default=256)
    parser.add_argument("--timeout-seconds", type=float, default=300.0)
    parser.add_argument("--expect-min-tps", type=float, default=0.0)
    parser.add_argument("--output", type=Path)
    args = parser.parse_args()
    for name in ("concurrency", "warm_requests", "requests", "trials",
                 "max_tokens"):
        if getattr(args, name) < 1:
            parser.error(f"--{name.replace('_', '-')} must be positive")
    return args


def main() -> int:
    args = _parse_args()
    trials = []
    for trial_index in range(args.trials):
        warmup = _run_batch(args, args.warm_requests)
        measurement = _run_batch(args, args.requests)
        trials.append({
            "trial": trial_index + 1,
            "warmup": warmup,
            "measurement": measurement,
        })
    throughputs = [
        trial["measurement"]["output_tokens_per_second"]
        for trial in trials
    ]
    mean_e2e = [
        trial["measurement"]["mean_e2e_seconds"] for trial in trials
    ]
    summary = {
        "schema_version": 1,
        "endpoint": args.endpoint,
        "model": args.model,
        "prompt_sha256": hashlib.sha256(
            args.prompt.encode("utf-8")).hexdigest(),
        "concurrency": args.concurrency,
        "max_tokens": args.max_tokens,
        "minimum_tokens": None,
        "temperature": 0.0,
        "top_p": 1.0,
        "stream": False,
        "trials": trials,
        "median_output_tokens_per_second": statistics.median(throughputs),
        "median_mean_e2e_seconds": statistics.median(mean_e2e),
        "performance_gate": {
            "minimum_output_tokens_per_second": args.expect_min_tps,
            "passed": statistics.median(throughputs) >= args.expect_min_tps,
        },
    }
    rendered = json.dumps(summary, indent=2, sort_keys=True) + "\n"
    print(rendered, end="")
    if args.output is not None:
        args.output.write_text(rendered, encoding="utf-8")
    return 0 if summary["performance_gate"]["passed"] else 1


if __name__ == "__main__":
    raise SystemExit(main())
```
</details>
