### PR TITLE
Use tokamax release version to unblock TPU-inference release.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -25,4 +25,4 @@ hypothesis==6.151.9
 sortedcontainers==2.4.0
 # Upstream pins to 5.5.3 https://github.com/vllm-project/vllm/blob/de3fe8dc62f3d77eb8dab8125ca90436f606bccb/requirements/test/nightly-torch.txt#L32
 transformers>=5.8.0
-tokamax @ git+https://github.com/openxla/tokamax.git@5802a3d225c661be603cefbea9843c7e928f6dd0
+tokamax==0.0.13


### PR DESCRIPTION
# Description

Using Tokamax commit sha currently blocks TPU-inferece's release. Use the Tokamax release (ahead of the current commit sha) to unblock the release.

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
