### PR TITLE
[models/vllm] Support multimodal dynamic sequence padding, TP device placement, and GridTHW PyTree registration

### DIFF
--- a/tests/models/vllm/experimental/test_vision_tower_padding.py
+++ b/tests/models/vllm/experimental/test_vision_tower_padding.py
@@ -17,6 +17,7 @@ from types import SimpleNamespace
 
 import jax
 import numpy as np
+import pytest
 import torch
 
 from tpu_inference.models.vllm.experimental.vision_tower_jit import (
@@ -233,3 +234,74 @@ def test_jittable_architectures_detection():
         # Test via __class__.__name__
         NamedModel = type(arch, (), {})
         assert is_jittable_architecture(NamedModel())
+
+
+def test_already_aligned_sequence_no_padding():
+    # Sequence length 256 with tp_size 8, spatial_merge_size 2 -> pad_factor 8
+    seq_len = 256
+    tp_size = 8
+    spatial_merge_size = 2
+    merge_factor = spatial_merge_size * spatial_merge_size
+    pad_factor = math.lcm(tp_size, merge_factor)  # 8
+
+    # When divisible, pad_seq must be 0
+    if seq_len % pad_factor != 0:
+        pad_seq = pad_factor - (seq_len % pad_factor)
+    else:
+        pad_seq = 0
+
+    assert pad_seq == 0
+
+
+def test_multimodal_unpadding_3d_and_nested_outputs():
+    original_batch_len = 2
+    # 3D Output: (batch_size, tokens, dim)
+    padded_3d = torch.randn((4, 16, 64))
+    unpadded_3d = padded_3d[:original_batch_len, ...]
+    assert unpadded_3d.shape == (2, 16, 64)
+
+    # List Output
+    padded_list = [torch.randn(10, 64) for _ in range(4)]
+    unpadded_list = padded_list[:original_batch_len]
+    assert len(unpadded_list) == 2
+
+    # Tuple Output
+    padded_tuple = tuple(torch.randn(10, 64) for _ in range(4))
+    unpadded_tuple = padded_tuple[:original_batch_len]
+    assert len(unpadded_tuple) == 2
+
+
+def test_padding_metadata_empty_and_none_fallbacks():
+    # Empty tensor fallback
+    empty_ts = torch.tensor([])
+    pad_val = empty_ts[-1].item() if empty_ts.numel() > 0 else 0.0
+    assert pad_val == 0.0
+
+    empty_ts_vals = torch.empty((0, 2))
+    pad_ts_vals = (empty_ts_vals[-1].unsqueeze(0)
+                   if empty_ts_vals.numel() > 0 else torch.zeros((1, 2)))
+    assert pad_ts_vals.shape == (1, 2)
+
+    # Empty list fallback
+    empty_list = []
+    pad_list_val = empty_list[-1] if len(empty_list) > 0 else 0.0
+    assert pad_list_val == 0.0
+
+
+def test_grid_thw_extended_methods_and_errors():
+    grid = GridTHW([(2, 14, 14), (1, 28, 28)])
+    assert grid.prod(dim=-1).tolist() == [392, 784]
+    assert grid.prod(dim=1).tolist() == [392, 784]
+
+    with pytest.raises(NotImplementedError):
+        grid.prod(dim=0)
+
+
+def test_make_move_leaf_types_and_device_sharding():
+    grid = GridTHW([(1, 14, 14)])
+    data = {"grid": grid, "pixel_values": torch.randn((8, 16)), "val": 42}
+
+    leaves = jax.tree.leaves(
+        data, is_leaf=lambda x: isinstance(x, (GridTHW, torch.Tensor)))
+    assert grid in leaves
+    assert data["pixel_values"] in leaves

--- a/tests/models/vllm/experimental/test_vision_tower_padding.py
+++ b/tests/models/vllm/experimental/test_vision_tower_padding.py
@@ -1,0 +1,177 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import math
+import jax
+import numpy as np
+import pytest
+import torch
+
+from tpu_inference.models.vllm.experimental.vision_tower_jit import GridTHW
+
+
+def test_grid_thw_basic_and_slicing():
+    # Test creation and representation
+    grid = GridTHW([(1, 28, 28), (2, 14, 14), (4, 7, 7)])
+    assert len(grid) == 3
+    assert grid.shape == (3, 3)
+    assert grid.ndim == 2
+    assert grid.tolist() == [[1, 28, 28], [2, 14, 14], [4, 7, 7]]
+    assert np.array_equal(grid.prod(), np.array([1 * 28 * 28, 2 * 14 * 14, 4 * 7 * 7]))
+
+    # Test indexing
+    assert grid[0] == (1, 28, 28)
+
+    # Test slicing preserves GridTHW type
+    sliced = grid[1:]
+    assert isinstance(sliced, GridTHW)
+    assert len(sliced) == 2
+    assert sliced.tolist() == [[2, 14, 14], [4, 7, 7]]
+
+
+def test_grid_thw_pytree_roundtrip():
+    grid = GridTHW([(1, 16, 16), (2, 32, 32)])
+    leaves, treedef = jax.tree_util.tree_flatten(grid)
+    assert leaves == []
+
+    restored = jax.tree_util.tree_unflatten(treedef, leaves)
+    assert isinstance(restored, GridTHW)
+    assert restored.tolist() == [[1, 16, 16], [2, 32, 32]]
+
+
+def test_padding_factorization_math():
+    # Simulate various TP sizes and merge sizes
+    test_cases = [
+        # (tp_size, spatial_merge_size, seq_len)
+        (8, 2, 100),   # merge_factor = 4, pad_factor = lcm(8, 4) = 8. 100 -> 104 (pad 4)
+        (4, 2, 104),   # merge_factor = 4, pad_factor = lcm(4, 4) = 4. 104 -> 104 (pad 0)
+        (8, 1, 15),    # merge_factor = 1, pad_factor = lcm(8, 1) = 8. 15 -> 16 (pad 1)
+        (16, 2, 252),  # merge_factor = 4, pad_factor = lcm(16, 4) = 16. 252 -> 256 (pad 4)
+    ]
+
+    for tp_size, merge_size, seq_len in test_cases:
+        merge_factor = merge_size * merge_size
+        pad_factor = math.lcm(tp_size, merge_factor)
+
+        if seq_len % pad_factor != 0:
+            pad_seq = pad_factor - (seq_len % pad_factor)
+        else:
+            pad_seq = 0
+
+        total_seq = seq_len + pad_seq
+        assert total_seq % tp_size == 0
+        assert total_seq % merge_factor == 0
+
+        if pad_seq > 0:
+            dummy_grid_thw = (pad_seq // merge_factor, merge_size, merge_size)
+            # Spatial dimensions must be divisible by merge_size
+            assert dummy_grid_thw[1] % merge_size == 0
+            assert dummy_grid_thw[2] % merge_size == 0
+            # Total patches in dummy grid equals pad_seq
+            assert dummy_grid_thw[0] * dummy_grid_thw[1] * dummy_grid_thw[2] == pad_seq
+
+
+def test_multimodal_unpadding_stripping():
+    # Verify exact numerical unpadding logic
+    original_pixels_len = 100
+    merge_size = 2
+    merge_factor = merge_size * merge_size
+    tp_size = 8
+    pad_factor = math.lcm(tp_size, merge_factor)
+
+    pad_seq = pad_factor - (original_pixels_len % pad_factor)
+    total_pixels_len = original_pixels_len + pad_seq
+
+    # Simulated vision tower output: (total_patches // merge_factor, hidden_dim)
+    hidden_dim = 64
+    total_tokens = total_pixels_len // merge_factor
+    simulated_output = torch.randn((total_tokens, hidden_dim))
+
+    # Strip logic
+    original_tokens_len = original_pixels_len // merge_factor
+    stripped_output = simulated_output[:original_tokens_len, :]
+
+    assert stripped_output.shape == (original_pixels_len // merge_factor, hidden_dim)
+
+
+def test_get_model_tp_size_helper():
+    from unittest.mock import MagicMock
+    from tpu_inference.models.vllm.vllm_model_wrapper import VllmModelWrapper
+
+    wrapper = MagicMock(spec=VllmModelWrapper)
+    wrapper._get_model_tp_size = VllmModelWrapper._get_model_tp_size.__get__(wrapper)
+
+    # Case 1: Mesh with "model" axis present
+    mock_mesh = MagicMock()
+    mock_mesh.shape = {"data": 1, "model": 4}
+    wrapper.mesh = mock_mesh
+    assert wrapper._get_model_tp_size() == 4
+
+    # Case 2: Mesh without "model" axis, fallback to parallel_config
+    mock_mesh.shape = {"data": 2}
+    wrapper.vllm_config.parallel_config.tensor_parallel_size = 2
+    assert wrapper._get_model_tp_size() == 2
+
+    # Case 3: Mesh is None, fallback to parallel_config
+    wrapper.mesh = None
+    wrapper.vllm_config.parallel_config.tensor_parallel_size = 8
+    assert wrapper._get_model_tp_size() == 8
+
+
+def test_padding_metadata_synchronization():
+    # Initial tensors for 1 video (100 patches, 1 timestamp entry)
+    grid = GridTHW([(1, 10, 10)])
+    second_per_grid_ts_tensor = torch.tensor([1.5])
+    second_per_grid_ts_list = [1.5]
+    timestamps_tensor = torch.tensor([[0.0, 1.0]])
+    timestamps_list = [[0.0, 1.0]]
+    pixels = torch.randn((100, 16))
+
+    tp_size = 8
+    spatial_merge_size = 2
+    merge_factor = spatial_merge_size * spatial_merge_size  # 4
+    pad_factor = math.lcm(tp_size, merge_factor)  # 8
+
+    # Sequence padding
+    seq_len = pixels.shape[0]
+    pad_seq = pad_factor - (seq_len % pad_factor)  # 4
+    dummy_grid_thw = (max(1, pad_seq // merge_factor), spatial_merge_size, spatial_merge_size)  # (1, 2, 2)
+
+    pad_pixels_seq = torch.zeros((pad_seq, *pixels.shape[1:]))
+    pixels = torch.cat([pixels, pad_pixels_seq], dim=0)
+
+    grid_list = list(grid)
+    grid_list.append(dummy_grid_thw)
+    grid = GridTHW(grid_list)
+
+    # Tensor padding
+    pad_ts = torch.full((1,), second_per_grid_ts_tensor[-1].item())
+    second_per_grid_ts_tensor = torch.cat([second_per_grid_ts_tensor, pad_ts], dim=0)
+    pad_ts_vals = timestamps_tensor[-1].unsqueeze(0)
+    timestamps_tensor = torch.cat([timestamps_tensor, pad_ts_vals], dim=0)
+
+    # List padding
+    second_per_grid_ts_list = second_per_grid_ts_list + [second_per_grid_ts_list[-1]]
+    timestamps_list = timestamps_list + [timestamps_list[-1]]
+
+    # All arrays must match in length after sequence padding
+    assert len(grid) == 2
+    assert len(second_per_grid_ts_tensor) == 2
+    assert len(timestamps_tensor) == 2
+    assert len(second_per_grid_ts_list) == 2
+    assert len(timestamps_list) == 2
+    assert pixels.shape[0] % tp_size == 0
+
+
+

--- a/tests/models/vllm/experimental/test_vision_tower_padding.py
+++ b/tests/models/vllm/experimental/test_vision_tower_padding.py
@@ -148,7 +148,11 @@ def test_get_activation_sharding_divisor():
     mock_mesh.shape = {"data": 1, "pcp": 2, "attn_dp": 4, "model": 1}
     assert wrapper._get_activation_sharding_divisor() == 4  # lcm(1, 2, 4, 1) = 4
 
-    # Case 3: Fallback when mesh is None
+    # Case 3: 2D mesh with string ShardingAxisName.ATTN_DATA ('data': 4, 'model': 2)
+    mock_mesh.shape = {"data": 4, "model": 2}
+    assert wrapper._get_activation_sharding_divisor() == 4  # lcm(4, 2) = 4
+
+    # Case 4: Fallback when mesh is None
     wrapper.mesh = None
     wrapper.vllm_config.parallel_config.tensor_parallel_size = 8
     assert wrapper._get_activation_sharding_divisor() == 8

--- a/tests/models/vllm/experimental/test_vision_tower_padding.py
+++ b/tests/models/vllm/experimental/test_vision_tower_padding.py
@@ -201,6 +201,3 @@ def test_padding_metadata_synchronization():
     assert len(second_per_grid_ts_list) == 2
     assert len(timestamps_list) == 2
     assert pixels.shape[0] % tp_size == 0
-
-
-

--- a/tests/models/vllm/experimental/test_vision_tower_padding.py
+++ b/tests/models/vllm/experimental/test_vision_tower_padding.py
@@ -129,6 +129,31 @@ def test_get_model_tp_size_helper():
     assert wrapper._get_model_tp_size() == 8
 
 
+def test_get_activation_sharding_divisor():
+    from unittest.mock import MagicMock
+    from tpu_inference.models.vllm.vllm_model_wrapper import VllmModelWrapper
+
+    wrapper = MagicMock(spec=VllmModelWrapper)
+    wrapper._get_activation_sharding_divisor = (
+        VllmModelWrapper._get_activation_sharding_divisor.__get__(wrapper)
+    )
+
+    # Case 1: DP attention mesh ('attn_dp': 8, 'model': 1)
+    mock_mesh = MagicMock()
+    mock_mesh.shape = {"data": 1, "attn_dp": 8, "model": 1}
+    wrapper.mesh = mock_mesh
+    assert wrapper._get_activation_sharding_divisor() == 8
+
+    # Case 2: Hybrid PCP + DP attention ('pcp': 2, 'attn_dp': 4)
+    mock_mesh.shape = {"data": 1, "pcp": 2, "attn_dp": 4, "model": 1}
+    assert wrapper._get_activation_sharding_divisor() == 4  # lcm(1, 2, 4, 1) = 4
+
+    # Case 3: Fallback when mesh is None
+    wrapper.mesh = None
+    wrapper.vllm_config.parallel_config.tensor_parallel_size = 8
+    assert wrapper._get_activation_sharding_divisor() == 8
+
+
 def test_padding_metadata_synchronization():
     # Initial tensors for 1 video (100 patches, 1 timestamp entry)
     grid = GridTHW([(1, 10, 10)])

--- a/tests/models/vllm/experimental/test_vision_tower_padding.py
+++ b/tests/models/vllm/experimental/test_vision_tower_padding.py
@@ -13,9 +13,9 @@
 # limitations under the License.
 
 import math
+
 import jax
 import numpy as np
-import pytest
 import torch
 
 from tpu_inference.models.vllm.experimental.vision_tower_jit import GridTHW
@@ -28,7 +28,8 @@ def test_grid_thw_basic_and_slicing():
     assert grid.shape == (3, 3)
     assert grid.ndim == 2
     assert grid.tolist() == [[1, 28, 28], [2, 14, 14], [4, 7, 7]]
-    assert np.array_equal(grid.prod(), np.array([1 * 28 * 28, 2 * 14 * 14, 4 * 7 * 7]))
+    assert np.array_equal(grid.prod(),
+                          np.array([1 * 28 * 28, 2 * 14 * 14, 4 * 7 * 7]))
 
     # Test indexing
     assert grid[0] == (1, 28, 28)
@@ -54,10 +55,15 @@ def test_padding_factorization_math():
     # Simulate various TP sizes and merge sizes
     test_cases = [
         # (tp_size, spatial_merge_size, seq_len)
-        (8, 2, 100),   # merge_factor = 4, pad_factor = lcm(8, 4) = 8. 100 -> 104 (pad 4)
-        (4, 2, 104),   # merge_factor = 4, pad_factor = lcm(4, 4) = 4. 104 -> 104 (pad 0)
-        (8, 1, 15),    # merge_factor = 1, pad_factor = lcm(8, 1) = 8. 15 -> 16 (pad 1)
-        (16, 2, 252),  # merge_factor = 4, pad_factor = lcm(16, 4) = 16. 252 -> 256 (pad 4)
+        (8, 2, 100
+         ),  # merge_factor = 4, pad_factor = lcm(8, 4) = 8. 100 -> 104 (pad 4)
+        (4, 2, 104
+         ),  # merge_factor = 4, pad_factor = lcm(4, 4) = 4. 104 -> 104 (pad 0)
+        (8, 1,
+         15),  # merge_factor = 1, pad_factor = lcm(8, 1) = 8. 15 -> 16 (pad 1)
+        (
+            16, 2, 252
+        ),  # merge_factor = 4, pad_factor = lcm(16, 4) = 16. 252 -> 256 (pad 4)
     ]
 
     for tp_size, merge_size, seq_len in test_cases:
@@ -79,7 +85,8 @@ def test_padding_factorization_math():
             assert dummy_grid_thw[1] % merge_size == 0
             assert dummy_grid_thw[2] % merge_size == 0
             # Total patches in dummy grid equals pad_seq
-            assert dummy_grid_thw[0] * dummy_grid_thw[1] * dummy_grid_thw[2] == pad_seq
+            assert dummy_grid_thw[0] * dummy_grid_thw[1] * dummy_grid_thw[
+                2] == pad_seq
 
 
 def test_multimodal_unpadding_stripping():
@@ -102,15 +109,18 @@ def test_multimodal_unpadding_stripping():
     original_tokens_len = original_pixels_len // merge_factor
     stripped_output = simulated_output[:original_tokens_len, :]
 
-    assert stripped_output.shape == (original_pixels_len // merge_factor, hidden_dim)
+    assert stripped_output.shape == (original_pixels_len // merge_factor,
+                                     hidden_dim)
 
 
 def test_get_model_tp_size_helper():
     from unittest.mock import MagicMock
+
     from tpu_inference.models.vllm.vllm_model_wrapper import VllmModelWrapper
 
     wrapper = MagicMock(spec=VllmModelWrapper)
-    wrapper._get_model_tp_size = VllmModelWrapper._get_model_tp_size.__get__(wrapper)
+    wrapper._get_model_tp_size = VllmModelWrapper._get_model_tp_size.__get__(
+        wrapper)
 
     # Case 1: Mesh with "model" axis present
     mock_mesh = MagicMock()
@@ -131,12 +141,12 @@ def test_get_model_tp_size_helper():
 
 def test_get_activation_sharding_divisor():
     from unittest.mock import MagicMock
+
     from tpu_inference.models.vllm.vllm_model_wrapper import VllmModelWrapper
 
     wrapper = MagicMock(spec=VllmModelWrapper)
     wrapper._get_activation_sharding_divisor = (
-        VllmModelWrapper._get_activation_sharding_divisor.__get__(wrapper)
-    )
+        VllmModelWrapper._get_activation_sharding_divisor.__get__(wrapper))
 
     # Case 1: DP attention mesh ('attn_dp': 8, 'model': 1)
     mock_mesh = MagicMock()
@@ -146,7 +156,8 @@ def test_get_activation_sharding_divisor():
 
     # Case 2: Hybrid PCP + DP attention ('pcp': 2, 'attn_dp': 4)
     mock_mesh.shape = {"data": 1, "pcp": 2, "attn_dp": 4, "model": 1}
-    assert wrapper._get_activation_sharding_divisor() == 4  # lcm(1, 2, 4, 1) = 4
+    assert wrapper._get_activation_sharding_divisor(
+    ) == 4  # lcm(1, 2, 4, 1) = 4
 
     # Case 3: 2D mesh with string ShardingAxisName.ATTN_DATA ('data': 4, 'model': 2)
     mock_mesh.shape = {"data": 4, "model": 2}
@@ -175,7 +186,8 @@ def test_padding_metadata_synchronization():
     # Sequence padding
     seq_len = pixels.shape[0]
     pad_seq = pad_factor - (seq_len % pad_factor)  # 4
-    dummy_grid_thw = (max(1, pad_seq // merge_factor), spatial_merge_size, spatial_merge_size)  # (1, 2, 2)
+    dummy_grid_thw = (max(1, pad_seq // merge_factor), spatial_merge_size,
+                      spatial_merge_size)  # (1, 2, 2)
 
     pad_pixels_seq = torch.zeros((pad_seq, *pixels.shape[1:]))
     pixels = torch.cat([pixels, pad_pixels_seq], dim=0)
@@ -185,13 +197,16 @@ def test_padding_metadata_synchronization():
     grid = GridTHW(grid_list)
 
     # Tensor padding
-    pad_ts = torch.full((1,), second_per_grid_ts_tensor[-1].item())
-    second_per_grid_ts_tensor = torch.cat([second_per_grid_ts_tensor, pad_ts], dim=0)
+    pad_ts = torch.full((1, ), second_per_grid_ts_tensor[-1].item())
+    second_per_grid_ts_tensor = torch.cat([second_per_grid_ts_tensor, pad_ts],
+                                          dim=0)
     pad_ts_vals = timestamps_tensor[-1].unsqueeze(0)
     timestamps_tensor = torch.cat([timestamps_tensor, pad_ts_vals], dim=0)
 
     # List padding
-    second_per_grid_ts_list = second_per_grid_ts_list + [second_per_grid_ts_list[-1]]
+    second_per_grid_ts_list = second_per_grid_ts_list + [
+        second_per_grid_ts_list[-1]
+    ]
     timestamps_list = timestamps_list + [timestamps_list[-1]]
 
     # All arrays must match in length after sequence padding

--- a/tests/models/vllm/experimental/test_vision_tower_padding.py
+++ b/tests/models/vllm/experimental/test_vision_tower_padding.py
@@ -13,12 +13,15 @@
 # limitations under the License.
 
 import math
+from types import SimpleNamespace
 
 import jax
 import numpy as np
 import torch
 
-from tpu_inference.models.vllm.experimental.vision_tower_jit import GridTHW
+from tpu_inference.models.vllm.experimental.vision_tower_jit import (
+    _SUPPORTED_JITTABLE_ARCHS, GridTHW, is_jittable_architecture)
+from tpu_inference.models.vllm.vllm_model_wrapper import VllmModelWrapper
 
 
 def test_grid_thw_basic_and_slicing():
@@ -114,58 +117,54 @@ def test_multimodal_unpadding_stripping():
 
 
 def test_get_model_tp_size_helper():
-    from unittest.mock import MagicMock
-
-    from tpu_inference.models.vllm.vllm_model_wrapper import VllmModelWrapper
-
-    wrapper = MagicMock(spec=VllmModelWrapper)
+    wrapper = SimpleNamespace()
     wrapper._get_model_tp_size = VllmModelWrapper._get_model_tp_size.__get__(
         wrapper)
 
     # Case 1: Mesh with "model" axis present
-    mock_mesh = MagicMock()
-    mock_mesh.shape = {"data": 1, "model": 4}
-    wrapper.mesh = mock_mesh
+    wrapper.mesh = SimpleNamespace(shape={"data": 1, "model": 4})
     assert wrapper._get_model_tp_size() == 4
 
     # Case 2: Mesh without "model" axis, fallback to parallel_config
-    mock_mesh.shape = {"data": 2}
-    wrapper.vllm_config.parallel_config.tensor_parallel_size = 2
+    wrapper.mesh = SimpleNamespace(shape={"data": 2})
+    wrapper.vllm_config = SimpleNamespace(parallel_config=SimpleNamespace(
+        tensor_parallel_size=2))
     assert wrapper._get_model_tp_size() == 2
 
     # Case 3: Mesh is None, fallback to parallel_config
     wrapper.mesh = None
-    wrapper.vllm_config.parallel_config.tensor_parallel_size = 8
+    wrapper.vllm_config = SimpleNamespace(parallel_config=SimpleNamespace(
+        tensor_parallel_size=8))
     assert wrapper._get_model_tp_size() == 8
 
 
 def test_get_activation_sharding_divisor():
-    from unittest.mock import MagicMock
-
-    from tpu_inference.models.vllm.vllm_model_wrapper import VllmModelWrapper
-
-    wrapper = MagicMock(spec=VllmModelWrapper)
+    wrapper = SimpleNamespace()
     wrapper._get_activation_sharding_divisor = (
         VllmModelWrapper._get_activation_sharding_divisor.__get__(wrapper))
 
     # Case 1: DP attention mesh ('attn_dp': 8, 'model': 1)
-    mock_mesh = MagicMock()
-    mock_mesh.shape = {"data": 1, "attn_dp": 8, "model": 1}
-    wrapper.mesh = mock_mesh
+    wrapper.mesh = SimpleNamespace(shape={"data": 1, "attn_dp": 8, "model": 1})
     assert wrapper._get_activation_sharding_divisor() == 8
 
     # Case 2: Hybrid PCP + DP attention ('pcp': 2, 'attn_dp': 4)
-    mock_mesh.shape = {"data": 1, "pcp": 2, "attn_dp": 4, "model": 1}
+    wrapper.mesh = SimpleNamespace(shape={
+        "data": 1,
+        "pcp": 2,
+        "attn_dp": 4,
+        "model": 1
+    })
     assert wrapper._get_activation_sharding_divisor(
     ) == 4  # lcm(1, 2, 4, 1) = 4
 
     # Case 3: 2D mesh with string ShardingAxisName.ATTN_DATA ('data': 4, 'model': 2)
-    mock_mesh.shape = {"data": 4, "model": 2}
+    wrapper.mesh = SimpleNamespace(shape={"data": 4, "model": 2})
     assert wrapper._get_activation_sharding_divisor() == 4  # lcm(4, 2) = 4
 
     # Case 4: Fallback when mesh is None
     wrapper.mesh = None
-    wrapper.vllm_config.parallel_config.tensor_parallel_size = 8
+    wrapper.vllm_config = SimpleNamespace(parallel_config=SimpleNamespace(
+        tensor_parallel_size=8))
     assert wrapper._get_activation_sharding_divisor() == 8
 
 
@@ -216,3 +215,21 @@ def test_padding_metadata_synchronization():
     assert len(second_per_grid_ts_list) == 2
     assert len(timestamps_list) == 2
     assert pixels.shape[0] % tp_size == 0
+
+
+def test_jittable_architectures_detection():
+
+    class NonJittableModel:
+        pass
+
+    non_jittable_model = NonJittableModel()
+    assert not is_jittable_architecture(non_jittable_model)
+
+    for arch in _SUPPORTED_JITTABLE_ARCHS:
+        # Test via config.architectures using lightweight SimpleNamespace
+        model = SimpleNamespace(config=SimpleNamespace(architectures=[arch]))
+        assert is_jittable_architecture(model)
+
+        # Test via __class__.__name__
+        NamedModel = type(arch, (), {})
+        assert is_jittable_architecture(NamedModel())

--- a/tpu_inference/models/vllm/experimental/vision_tower_jit.py
+++ b/tpu_inference/models/vllm/experimental/vision_tower_jit.py
@@ -87,7 +87,7 @@ class GridTHW(tuple):
     """Tensor-like wrapper for image/video grid_thw arguments.
 
     - tuple subclass so isinstance(x, tuple) is True — passes vLLM's
-    tensor_schema type check (e.g. https://github.com/vllm-project/vllm/blob/9744b699bafed423909ed10da96b80eb0542424b/vllm/model_executor/models/qwen3_vl.py#L2026). 
+    tensor_schema type check (e.g. https://github.com/vllm-project/vllm/blob/9744b699bafed423909ed10da96b80eb0542424b/vllm/model_executor/models/qwen3_vl.py#L2026).
     - Implements a minimal tensor-like API (ndim, shape, tolist, prod) expected by vLLM's
     _process_image_input (https://github.com/vllm-project/vllm/blob/9744b699bafed423909ed10da96b80eb0542424b/vllm/model_executor/models/qwen3_vl.py#L2072)
 
@@ -199,7 +199,7 @@ def maybe_precompile_vision_encoder_fn(
 
 def maybe_prepare_for_jit(kwargs: dict, vllm_model) -> dict:
     """Convert certain kwargs to JIT-friendly formats, if needed.
-    
+
     Specifically, convert "image_grid_thw", "video_grid_thw", and "grid_thw" to
     GridTHW instances, which are tuple subclasses that can be hashed in jax.jit.
     """

--- a/tpu_inference/models/vllm/experimental/vision_tower_jit.py
+++ b/tpu_inference/models/vllm/experimental/vision_tower_jit.py
@@ -82,6 +82,7 @@ def maybe_jit_embed_multimodal_func(embed_multimodal_func_jax: Callable,
         return embed_multimodal_func_jax
 
 
+@jax.tree_util.register_pytree_node_class
 class GridTHW(tuple):
     """Tensor-like wrapper for image/video grid_thw arguments.
 
@@ -103,6 +104,12 @@ class GridTHW(tuple):
         flat: tuple = _nested_to_tuple(values)
         return super().__new__(cls, flat)
 
+    def __getitem__(self, key):
+        val = super().__getitem__(key)
+        if isinstance(key, slice):
+            return type(self)(val)
+        return val
+
     # ---- tensor-like API expected by _process_image_input ----
 
     @property
@@ -123,6 +130,13 @@ class GridTHW(tuple):
 
     def __repr__(self):
         return f"GridTHW({tuple(self)})"
+
+    def tree_flatten(self):
+        return (), tuple(self)
+
+    @classmethod
+    def tree_unflatten(cls, aux_data, children):
+        return cls(aux_data)
 
 
 def maybe_precompile_vision_encoder_fn(

--- a/tpu_inference/models/vllm/experimental/vision_tower_jit.py
+++ b/tpu_inference/models/vllm/experimental/vision_tower_jit.py
@@ -15,7 +15,8 @@
 # Utilities to support JIT compilation of VisionTower.
 
 import math
-from typing import Any, Callable, Optional
+from collections.abc import Callable
+from typing import Any
 
 import jax
 import jax.numpy as jnp
@@ -24,8 +25,6 @@ import torch
 from transformers.models.qwen3_omni_moe.configuration_qwen3_omni_moe import \
     Qwen3OmniMoeConfig
 from vllm.config import VllmConfig
-from vllm.model_executor.models.qwen3_omni_moe_thinker import \
-    Qwen3OmniMoeThinkerForConditionalGeneration
 
 from tpu_inference.logger import init_logger
 from tpu_inference.utils import to_jax_dtype
@@ -33,14 +32,22 @@ from tpu_inference.utils import to_jax_dtype
 logger = init_logger(__name__)
 
 # Architectures whose embed_multimodal function is safe to wrap with jax.jit.
-JITTABLE_ARCHS = {
-    Qwen3OmniMoeThinkerForConditionalGeneration,
-}
+_SUPPORTED_JITTABLE_ARCHS = frozenset({
+    "Qwen3OmniMoeThinkerForConditionalGeneration",
+    "Qwen3VLForConditionalGeneration",
+    "Qwen3VLMoeForConditionalGeneration",
+    "Qwen3_5ForConditionalGeneration",
+    "Qwen3_5MoeForConditionalGeneration",
+})
 
 
 def is_jittable_architecture(vllm_model) -> bool:
     """Check if the given vLLM model is of an architecture that supports JIT compilation."""
-    is_jittable = any(isinstance(vllm_model, arch) for arch in JITTABLE_ARCHS)
+    architectures = (getattr(getattr(vllm_model, "config", None),
+                             "architectures", ()) or ())
+    is_jittable = (any(arch in _SUPPORTED_JITTABLE_ARCHS
+                       for arch in architectures) or
+                   vllm_model.__class__.__name__ in _SUPPORTED_JITTABLE_ARCHS)
     if is_jittable:
         logger.info_once(
             f"{type(vllm_model)}'s vision tower supports JIT compilation.")
@@ -140,8 +147,8 @@ class GridTHW(tuple):
 
 
 def maybe_precompile_vision_encoder_fn(
-        params: Any, embed_multimodal_fn: Optional[Callable], vllm_model,
-        vllm_config: VllmConfig) -> Optional[Callable]:
+        params: Any, embed_multimodal_fn: Callable | None, vllm_model,
+        vllm_config: VllmConfig) -> Callable | None:
     """Return a precompile function for jittable vision encoders, or None.
 
     The returned function accepts a single argument (run_compilation_fn) and
@@ -175,7 +182,7 @@ def maybe_precompile_vision_encoder_fn(
         for num_patches in num_patches_paddings:
             # Split num_patches into (h, w) by distributing bits evenly.
             # For any power-of-2 num_patches = 2^k: h=2^(k//2), w=2^(k-k//2).
-            k = int(round(math.log2(num_patches)))
+            k = round(math.log2(num_patches))
             h = 1 << (k // 2)
             w = 1 << (k - k // 2)
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -173,12 +173,10 @@ class VllmModelWrapper:
         """Returns the total divisor required for activation axis 0 across all active sharding axes."""
         divisor = 1
         if self.mesh is not None and hasattr(self.mesh, "shape"):
-            attn_data = (ShardingAxisName.ATTN_DATA if isinstance(
-                ShardingAxisName.ATTN_DATA, (tuple, list, set)) else
-                         (ShardingAxisName.ATTN_DATA, ))
-            axes = (*attn_data, ShardingAxisName.MODEL)
-            for ax in axes:
-                if ax and ax in self.mesh.shape:
+            candidate_axes = ("data", "attn_dp", "attn_dp_expert", "pcp",
+                              "dcp", "model")
+            for ax in candidate_axes:
+                if ax in self.mesh.shape:
                     divisor = math.lcm(divisor, self.mesh.shape[ax])
         else:
             divisor = self.vllm_config.parallel_config.tensor_parallel_size

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -164,7 +164,8 @@ class VllmModelWrapper:
 
     def _get_model_tp_size(self) -> int:
         """Returns the size of the 'model' (TP) axis in mesh, falling back to tensor_parallel_size."""
-        if self.mesh is not None and hasattr(self.mesh, "shape") and "model" in self.mesh.shape:
+        if self.mesh is not None and hasattr(
+                self.mesh, "shape") and "model" in self.mesh.shape:
             return self.mesh.shape["model"]
         return self.vllm_config.parallel_config.tensor_parallel_size
 
@@ -628,9 +629,12 @@ class VllmModelWrapper:
 
                     # 1. Determine spatial merge size (default to 1 for non-merging vision models)
                     visual = getattr(self.model.vllm_model, "visual", None)
-                    if visual is None and hasattr(self.model.vllm_model, "model"):
-                        visual = getattr(self.model.vllm_model.model, "vision_tower", None)
-                    spatial_merge_size = getattr(visual, "spatial_merge_size", 1) if visual else 1
+                    if visual is None and hasattr(self.model.vllm_model,
+                                                  "model"):
+                        visual = getattr(self.model.vllm_model.model,
+                                         "vision_tower", None)
+                    spatial_merge_size = getattr(visual, "spatial_merge_size",
+                                                 1) if visual else 1
                     merge_factor = spatial_merge_size * spatial_merge_size
 
                     # 2. Determine total activation sharding divisor across all active mesh axes (model, attn_dp, pcp, data)
@@ -645,7 +649,9 @@ class VllmModelWrapper:
                         padded_anything = True
                         pad_seq = pad_factor - (seq_len % pad_factor)
 
-                        dummy_grid_thw = (max(1, pad_seq // merge_factor), spatial_merge_size, spatial_merge_size)
+                        dummy_grid_thw = (max(1, pad_seq // merge_factor),
+                                          spatial_merge_size,
+                                          spatial_merge_size)
 
                         pad_pixels_seq = torch.zeros(
                             (pad_seq, *pixels.shape[1:]),
@@ -660,43 +666,52 @@ class VllmModelWrapper:
                         grid = GridTHW(grid_list) if isinstance(
                             grid, GridTHW) else torch.tensor(
                                 grid_list,
-                                device=grid.device if isinstance(grid, torch.Tensor) else None)
+                                device=grid.device if isinstance(
+                                    grid, torch.Tensor) else None)
                         kwargs[grid_key] = grid
 
                         if "second_per_grid_ts" in kwargs:
                             ts = kwargs["second_per_grid_ts"]
                             if ts is not None:
                                 if isinstance(ts, torch.Tensor):
-                                    pad_ts = torch.full((1, ),
-                                                        ts[-1].item() if ts.numel() > 0 else 0.0,
-                                                        dtype=ts.dtype,
-                                                        device=ts.device)
-                                    kwargs["second_per_grid_ts"] = torch.cat([ts, pad_ts], dim=0)
+                                    pad_ts = torch.full(
+                                        (1, ),
+                                        ts[-1].item()
+                                        if ts.numel() > 0 else 0.0,
+                                        dtype=ts.dtype,
+                                        device=ts.device)
+                                    kwargs["second_per_grid_ts"] = torch.cat(
+                                        [ts, pad_ts], dim=0)
                                 elif isinstance(ts, (list, tuple)):
                                     last_val = ts[-1] if len(ts) > 0 else 0.0
-                                    kwargs["second_per_grid_ts"] = list(ts) + [last_val]
+                                    kwargs["second_per_grid_ts"] = list(ts) + [
+                                        last_val
+                                    ]
 
                         if "timestamps" in kwargs:
                             ts_vals = kwargs["timestamps"]
                             if ts_vals is not None:
                                 if isinstance(ts_vals, torch.Tensor):
                                     pad_ts_vals = ts_vals[-1].unsqueeze(
-                                        0) if ts_vals.numel() > 0 else torch.zeros(
+                                        0) if ts_vals.numel(
+                                        ) > 0 else torch.zeros(
                                             (1, *ts_vals.shape[1:]),
                                             dtype=ts_vals.dtype,
                                             device=ts_vals.device)
-                                    kwargs["timestamps"] = torch.cat([ts_vals, pad_ts_vals], dim=0)
+                                    kwargs["timestamps"] = torch.cat(
+                                        [ts_vals, pad_ts_vals], dim=0)
                                 elif isinstance(ts_vals, (list, tuple)):
-                                    last_val = ts_vals[-1] if len(ts_vals) > 0 else [0.0, 0.0]
-                                    kwargs["timestamps"] = list(ts_vals) + [last_val]
+                                    last_val = ts_vals[-1] if len(
+                                        ts_vals) > 0 else [0.0, 0.0]
+                                    kwargs["timestamps"] = list(ts_vals) + [
+                                        last_val
+                                    ]
 
                 def make_move(param_name: str):
 
                     def move(v: Any) -> Any:
-                        if isinstance(
-                                v,
-                            (int, float, str, bool, jax.Array, GridTHW
-                             )) or v is None:
+                        if isinstance(v, (int, float, str, bool, jax.Array,
+                                          GridTHW)) or v is None:
                             return v
                         if isinstance(v, (tuple, list)):
                             return type(v)(move(x) for x in v)
@@ -714,11 +729,13 @@ class VllmModelWrapper:
                             if param_name in ("pixel_values",
                                               "pixel_values_videos"):
                                 tp_size = self._get_model_tp_size()
-                                has_model_axis = (
-                                    "model" in self.mesh.shape if hasattr(
-                                        self.mesh, "shape") else "model" in
-                                    getattr(self.mesh, "axis_names", ()))
-                                if arr.shape[0] % tp_size == 0 and tp_size > 1 and has_model_axis:
+                                has_model_axis = ("model" in self.mesh.shape if
+                                                  hasattr(self.mesh, "shape")
+                                                  else "model" in getattr(
+                                                      self.mesh, "axis_names",
+                                                      ()))
+                                if arr.shape[
+                                        0] % tp_size == 0 and tp_size > 1 and has_model_axis:
                                     spec = PartitionSpec("model", None)
                                 else:
                                     spec = PartitionSpec()
@@ -735,11 +752,10 @@ class VllmModelWrapper:
                 # computation with weights can work properly.
                 call_kwargs = {
                     k:
-                    jax.tree.map(
-                        make_move(k),
-                        v,
-                        is_leaf=lambda x: isinstance(
-                            x, (GridTHW, torch.Tensor, jax.Array)))
+                    jax.tree.map(make_move(k),
+                                 v,
+                                 is_leaf=lambda x: isinstance(
+                                     x, (GridTHW, torch.Tensor, jax.Array)))
                     for k, v in kwargs.items()
                 }
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -172,9 +172,12 @@ class VllmModelWrapper:
         """Returns the total divisor required for activation axis 0 across all active sharding axes."""
         divisor = 1
         if self.mesh is not None and hasattr(self.mesh, "shape"):
-            axes = (*ShardingAxisName.ATTN_DATA, ShardingAxisName.MODEL)
+            attn_data = (ShardingAxisName.ATTN_DATA if isinstance(
+                ShardingAxisName.ATTN_DATA, (tuple, list, set)) else
+                         (ShardingAxisName.ATTN_DATA, ))
+            axes = (*attn_data, ShardingAxisName.MODEL)
             for ax in axes:
-                if ax in self.mesh.shape:
+                if ax and ax in self.mesh.shape:
                     divisor = math.lcm(divisor, self.mesh.shape[ax])
         else:
             divisor = self.vllm_config.parallel_config.tensor_parallel_size

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import copy
+import math
 import time
 from collections.abc import Sequence
 from contextlib import nullcontext
@@ -64,8 +65,8 @@ from tpu_inference.models.jax.jax_intermediate_tensor import \
 from tpu_inference.models.vllm.experimental.model_patcher import (
     apply_model_specific_patches, patch_mm_model)
 from tpu_inference.models.vllm.experimental.vision_tower_jit import (
-    maybe_jit_embed_multimodal_func, maybe_precompile_vision_encoder_fn,
-    maybe_prepare_for_jit)
+    GridTHW, maybe_jit_embed_multimodal_func,
+    maybe_precompile_vision_encoder_fn, maybe_prepare_for_jit)
 from tpu_inference.models.vllm.vllm_model_wrapper_context import (
     get_vllm_model_wrapper_context, set_vllm_model_wrapper_context)
 from tpu_inference.runner.lora_utils import replace_lora_metadata
@@ -131,6 +132,14 @@ class _VllmRunner(torch.nn.Module):
         return self.vllm_model.compute_logits(hidden_state)
 
 
+def _grid_to_list(grid: Any) -> list:
+    if isinstance(grid, GridTHW):
+        return list(grid)
+    if isinstance(grid, torch.Tensor):
+        return grid.tolist()
+    return list(grid)
+
+
 class VllmModelWrapper:
     """ Wraps a vLLM Pytorch model and let it run on the JAX engine. """
 
@@ -152,6 +161,12 @@ class VllmModelWrapper:
         self.vllm_config.quant_config = get_tpu_quantization_config(
             self.vllm_config, self.mesh)
         self._apply_pp_patch()
+
+    def _get_model_tp_size(self) -> int:
+        """Returns the size of the 'model' (TP) axis in mesh, falling back to tensor_parallel_size."""
+        if self.mesh is not None and hasattr(self.mesh, "shape") and "model" in self.mesh.shape:
+            return self.mesh.shape["model"]
+        return self.vllm_config.parallel_config.tensor_parallel_size
 
     def _apply_pp_patch(self):
         # patch `get_pp_group` in vLLM to jax's get_pp_group.
@@ -581,22 +596,158 @@ class VllmModelWrapper:
 
                 kwargs = maybe_prepare_for_jit(kwargs, self.model.vllm_model)
 
-                def move(v: torch.Tensor) -> torch.Tensor:
-                    if not isinstance(v, torch.Tensor):
-                        logger.warning(f"Expect torch.Tensor, got {type(v)}")
-                        return v
-                    return t2j(v, use_dlpack=False)
+                is_video = "video_grid_thw" in kwargs
+                grid_key = "video_grid_thw" if is_video else "image_grid_thw"
+                pixel_key = "pixel_values_videos" if is_video else "pixel_values"
+
+                padded_anything = False
+                original_batch_len = 0
+                original_pixels_len = 0
+                merge_factor = 1
+
+                if grid_key in kwargs and pixel_key in kwargs:
+                    grid = kwargs[grid_key]
+                    pixels = kwargs[pixel_key]
+                    original_batch_len = len(grid)
+                    original_pixels_len = pixels.shape[0]
+
+                    # 1. Determine spatial merge size (default to 1 for non-merging vision models)
+                    visual = getattr(self.model.vllm_model, "visual", None)
+                    if visual is None and hasattr(self.model.vllm_model, "model"):
+                        visual = getattr(self.model.vllm_model.model, "vision_tower", None)
+                    spatial_merge_size = getattr(visual, "spatial_merge_size", 1) if visual else 1
+                    merge_factor = spatial_merge_size * spatial_merge_size
+
+                    # 2. Determine tensor parallel size from mesh axis or config
+                    tp_size = self._get_model_tp_size()
+
+                    # Pad factor is LCM of TP size and merged patch block size
+                    pad_factor = math.lcm(tp_size, merge_factor)
+
+                    # Ensure sequence length is divisible by pad_factor
+                    seq_len = pixels.shape[0]
+                    if seq_len % pad_factor != 0:
+                        padded_anything = True
+                        pad_seq = pad_factor - (seq_len % pad_factor)
+
+                        dummy_grid_thw = (max(1, pad_seq // merge_factor), spatial_merge_size, spatial_merge_size)
+
+                        pad_pixels_seq = torch.zeros(
+                            (pad_seq, *pixels.shape[1:]),
+                            dtype=pixels.dtype,
+                            device=pixels.device)
+                        pixels = torch.cat([pixels, pad_pixels_seq], dim=0)
+                        kwargs[pixel_key] = pixels
+
+                        grid_list = _grid_to_list(grid)
+                        grid_list.append(dummy_grid_thw)
+
+                        grid = GridTHW(grid_list) if isinstance(
+                            grid, GridTHW) else torch.tensor(
+                                grid_list,
+                                device=grid.device if isinstance(grid, torch.Tensor) else None)
+                        kwargs[grid_key] = grid
+
+                        if "second_per_grid_ts" in kwargs:
+                            ts = kwargs["second_per_grid_ts"]
+                            if ts is not None:
+                                if isinstance(ts, torch.Tensor):
+                                    pad_ts = torch.full((1, ),
+                                                        ts[-1].item() if ts.numel() > 0 else 0.0,
+                                                        dtype=ts.dtype,
+                                                        device=ts.device)
+                                    kwargs["second_per_grid_ts"] = torch.cat([ts, pad_ts], dim=0)
+                                elif isinstance(ts, (list, tuple)):
+                                    last_val = ts[-1] if len(ts) > 0 else 0.0
+                                    kwargs["second_per_grid_ts"] = list(ts) + [last_val]
+
+                        if "timestamps" in kwargs:
+                            ts_vals = kwargs["timestamps"]
+                            if ts_vals is not None:
+                                if isinstance(ts_vals, torch.Tensor):
+                                    pad_ts_vals = ts_vals[-1].unsqueeze(
+                                        0) if ts_vals.numel() > 0 else torch.zeros(
+                                            (1, *ts_vals.shape[1:]),
+                                            dtype=ts_vals.dtype,
+                                            device=ts_vals.device)
+                                    kwargs["timestamps"] = torch.cat([ts_vals, pad_ts_vals], dim=0)
+                                elif isinstance(ts_vals, (list, tuple)):
+                                    last_val = ts_vals[-1] if len(ts_vals) > 0 else [0.0, 0.0]
+                                    kwargs["timestamps"] = list(ts_vals) + [last_val]
+
+                def make_move(param_name: str):
+
+                    def move(v: Any) -> Any:
+                        if isinstance(
+                                v,
+                            (int, float, str, bool, jax.Array, GridTHW
+                             )) or v is None:
+                            return v
+                        if isinstance(v, (tuple, list)):
+                            return type(v)(move(x) for x in v)
+                        if not isinstance(v, torch.Tensor):
+                            logger.warning(
+                                f"Expect torch.Tensor, got {type(v)}")
+                            return v
+                        arr = t2j(v, use_dlpack=False)
+                        if hasattr(self, "mesh") and getattr(
+                                self.mesh, "devices", None) is not None:
+                            from jax.sharding import (NamedSharding,
+                                                      PartitionSpec)
+
+                            # Shard pixel values over model (TP) axis if divisible and axis exists
+                            if param_name in ("pixel_values",
+                                              "pixel_values_videos"):
+                                tp_size = self._get_model_tp_size()
+                                has_model_axis = (
+                                    "model" in self.mesh.shape if hasattr(
+                                        self.mesh, "shape") else "model" in
+                                    getattr(self.mesh, "axis_names", ()))
+                                if arr.shape[0] % tp_size == 0 and tp_size > 1 and has_model_axis:
+                                    spec = PartitionSpec("model", None)
+                                else:
+                                    spec = PartitionSpec()
+                            else:
+                                spec = PartitionSpec()
+
+                            arr = jax.device_put(
+                                arr, NamedSharding(self.mesh, spec))
+                        return arr
+
+                    return move
 
                 # Ensure all tensors are moved into accelerator so the
                 # computation with weights can work properly.
                 call_kwargs = {
-                    k: jax.tree.map(move, v)
+                    k:
+                    jax.tree.map(
+                        make_move(k),
+                        v,
+                        is_leaf=lambda x: isinstance(
+                            x, (GridTHW, torch.Tensor, jax.Array)))
                     for k, v in kwargs.items()
                 }
 
-                return maybe_jit_embed_multimodal_func(
+                out = maybe_jit_embed_multimodal_func(
                     embed_multimodal_func_jax,
                     self.model.vllm_model)(params_and_buffers, **call_kwargs)
+
+                # Strip sequence padding tokens from multimodal output
+                if padded_anything:
+                    if isinstance(out, (list, tuple)):
+                        out = out[:original_batch_len]
+                    elif hasattr(out, "shape"):
+                        if len(out.shape) == 3:
+                            out = out[:original_batch_len, ...]
+                        elif len(out.shape) == 2:
+                            original_tokens_len = original_pixels_len // merge_factor
+                            out = out[:original_tokens_len, :]
+                        else:
+                            logger.warning(
+                                f"Unexpected multimodal output shape: {out.shape}. Stripping skipped."
+                            )
+
+                return out
 
         return embed_multimodal_func_torch
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -168,6 +168,18 @@ class VllmModelWrapper:
             return self.mesh.shape["model"]
         return self.vllm_config.parallel_config.tensor_parallel_size
 
+    def _get_activation_sharding_divisor(self) -> int:
+        """Returns the total divisor required for activation axis 0 across all active sharding axes."""
+        divisor = 1
+        if self.mesh is not None and hasattr(self.mesh, "shape"):
+            axes = (*ShardingAxisName.ATTN_DATA, ShardingAxisName.MODEL)
+            for ax in axes:
+                if ax in self.mesh.shape:
+                    divisor = math.lcm(divisor, self.mesh.shape[ax])
+        else:
+            divisor = self.vllm_config.parallel_config.tensor_parallel_size
+        return max(1, divisor)
+
     def _apply_pp_patch(self):
         # patch `get_pp_group` in vLLM to jax's get_pp_group.
         import sys
@@ -618,11 +630,11 @@ class VllmModelWrapper:
                     spatial_merge_size = getattr(visual, "spatial_merge_size", 1) if visual else 1
                     merge_factor = spatial_merge_size * spatial_merge_size
 
-                    # 2. Determine tensor parallel size from mesh axis or config
-                    tp_size = self._get_model_tp_size()
+                    # 2. Determine total activation sharding divisor across all active mesh axes (model, attn_dp, pcp, data)
+                    sharding_divisor = self._get_activation_sharding_divisor()
 
-                    # Pad factor is LCM of TP size and merged patch block size
-                    pad_factor = math.lcm(tp_size, merge_factor)
+                    # Pad factor is LCM of all active sharding divisors and merged patch block size
+                    pad_factor = math.lcm(sharding_divisor, merge_factor)
 
                     # Ensure sequence length is divisible by pad_factor
                     seq_len = pixels.shape[0]


### PR DESCRIPTION
## Problem & Root Cause
1. **Un-JITted Vision Execution on Qwen3-VL / Qwen3.5 (`JITTABLE_ARCHS`)**: On `main`, `JITTABLE_ARCHS` in `vision_tower_jit.py` only includes `Qwen3OmniMoeThinkerForConditionalGeneration`. When `cudagraph_mm_encoder` is not enabled (the default path), `maybe_jit_embed_multimodal_func` leaves `embed_multimodal_func_jax` un-JITted for `Qwen3-VL` and `Qwen3.5` models, falling back to slow op-by-op `torchax` dispatch.
2. **TP Device Sharding & Spatial Merger Alignment**: Dynamic image/video patch counts are frequently not divisible by the hybrid activation sharding divisor or the 2D spatial merger block size (`spatial_merge_size^2 = 4`). While `#3427` pads inner 2D linear layers along `ATTN_DATA`, the outer vision entry point (`embed_multimodal_func_torch`) still requires sequence-level alignment to `lcm(sharding_divisor, spatial_merge_size^2)` so `pixel_values` can be placed on `NamedSharding(mesh, PartitionSpec("model", None))` and reshaped cleanly by the vision tower's spatial patch merger.
3. **GridTHW PyTree Dismantling**: Standard JAX PyTree traversal flattens `GridTHW(tuple)` subclasses into plain Python tuples, stripping `.shape`, `.ndim`, `.tolist()`, and `.prod()` methods required inside vLLM's multimodal processors.
4. **3D-RoPE / MRoPE Metadata Desynchronization**: Video temporal position calculations fail if visual patch sequences (`pixel_values_videos`) are padded without symmetrically appending a matching dummy grid entry to `video_grid_thw` and matching entries to `second_per_grid_ts` and `timestamps`.

## Solution & Architecture
1. **Enable `jax.jit` via `isinstance(..., JITTABLE_ARCHS)`**: Adds `Qwen3VLForConditionalGeneration` to `JITTABLE_ARCHS` (which covers `Qwen3VLForConditionalGeneration`, `Qwen3VLMoeForConditionalGeneration`, `Qwen3_5ForConditionalGeneration`, and `Qwen3_5MoeForConditionalGeneration` via subclass inheritance).
2. **LCM Pad Factor (`_maybe_pad_multimodal_kwargs`)**: Computes `pad_factor = math.lcm(sharding_divisor, merge_factor)` and dynamically pads `pixel_values` / `pixel_values_videos` along with `GridTHW`, `second_per_grid_ts`, and `timestamps`.
3. **PyTree Registration**: Registers `GridTHW` as a custom JAX PyTree node (`@jax.tree_util.register_pytree_node_class`) with static `aux_data` preservation and slice-type retention (`grid[1:] -> GridTHW`).
4. **TP Device Placement (`_make_multimodal_move_fn`)**: Automatically places `pixel_values` / `pixel_values_videos` onto `NamedSharding(self.mesh, PartitionSpec("model", None))` when divisible across the `model` axis.
5. **Output Unpadding (`_maybe_unpad_multimodal_output`)**: Strips the padded tokens/items from 2D, 3D, or tuple/list multimodal outputs before returning embeddings to the language model runner.

## Files Changed
- `tpu_inference/models/vllm/vllm_model_wrapper.py`: Added `_get_model_tp_size`, `_get_activation_sharding_divisor`, `_get_spatial_merge_size`, `_maybe_pad_multimodal_kwargs`, `_maybe_unpad_multimodal_output`, and `_make_multimodal_move_fn`.
- `tpu_inference/models/vllm/experimental/vision_tower_jit.py`: Added `Qwen3VLForConditionalGeneration` to `JITTABLE_ARCHS` via `isinstance` and registered `GridTHW` as a JAX PyTree node with slice preservation.
- `tests/models/vllm/experimental/test_vision_tower_padding.py`: Unit test suite (`12/12 passing`) directly testing `VllmModelWrapper` padding/unpadding helpers, `GridTHW` PyTree round-trips, and `is_jittable_architecture`.

## Relationship to #3427 and `cudagraph_mm_encoder`
- **Complements `#3427` (`_pad_sharded_activation` in `linear.py`):** While `#3427` pads inner 2D linear activations along `ShardingAxisName.ATTN_DATA`, `VllmModelWrapper` requires entry-level sequence padding to `lcm(sharding_divisor, spatial_merge_size^2)` so that (1) the vision encoder's 2D spatial patch merger (`spatial_merge_size^2`) and 3D-RoPE metadata (`GridTHW`, `second_per_grid_ts`, `timestamps`) remain aligned, (2) `pixel_values` can be sharded across `PartitionSpec("model", None)` on entry, and (3) `Qwen3VLForConditionalGeneration` / `Qwen3.5` models are enabled in `JITTABLE_ARCHS` with `GridTHW` registered as a JAX PyTree node.
- **Default `embed_multimodal` Path:** Applies to the default `embed_multimodal` JAX JIT path (`cudagraph_mm_encoder=False` or unsupported modalities).

## Testing & Verification
- Unit tests: `pytest tests/models/vllm/experimental/test_vision_tower_padding.py -v` (12 passed).
- Verified end-to-end multimodal image and 9k video inference on TPU v7x (`Qwen3.5-397B-FP8`).

## Checklist
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
