### PR TITLE
feat: RLVllmSampler weight sync via Raiden, bound in-process in the EngineCore worker

### DIFF
--- a/tpu_inference/rl/raiden_worker_sync.py
+++ b/tpu_inference/rl/raiden_worker_sync.py
@@ -1,0 +1,310 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the tpu-inference project
+"""Binds a TPUWorker's live model weights to the Raiden transport, in-process.
+
+This runs inside the EngineCore subprocess (where `TPUWorker` and its live
+TPU-resident `jax.Array`s actually live), dispatched via
+`collective_rpc`/`RLVllmSampler._call_worker_method`. Only plain-data
+metadata (see `RaidenWorkerSync.metadata_dict`) crosses back over that RPC
+boundary -- never the arrays themselves, which vLLM's msgpack-based RPC
+serializer cannot carry anyway (`flax.nnx.statelib.State is not
+serializable`), and which would be disconnected host copies rather than the
+live device buffers if forced through pickle.
+
+This intentionally duplicates the binding mechanics of tunix's
+`tunix.experimental.worker.raiden_synchronizer.RaidenSynchronizer` (native
+Raiden wheel calls, `nnx.State` flattening, `TensorMetadata` construction)
+rather than importing it: `tpu_inference.rl.vllm_sampler` documents itself as
+having no dependency on Tunix, and this code runs in the worker subprocess,
+the wrong side of that boundary to relax it. The two copies should be kept in
+sync by hand if the binding contract changes; the tunix side is the
+canonical registration-metadata *shape* (see `weight_sync.dict_to_metadata`,
+which this module's `metadata_dict()` output is built to satisfy) and the
+trainer-side `RaidenSynchronizer.work_unit_metadata()` is the reference
+implementation this ports from.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import Any, List, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+
+_ws_lib: Any = None
+try:
+    from tpu_raiden.api.jax import weight_synchronizer as _ws_lib  # pylint: disable=g-import-not-at-top
+except ImportError:
+    try:
+        from tpu_sync.api.jax import weight_synchronizer as _ws_lib  # pylint: disable=g-import-not-at-top
+    except ImportError:
+        _ws_lib = None
+
+
+def local_ip() -> str:
+    for family, probe in (
+        (socket.AF_INET, ("8.8.8.8", 80)),
+        (socket.AF_INET6, ("2001:4860:4860::8888", 80)),
+    ):
+        try:
+            s = socket.socket(family, socket.SOCK_DGRAM)
+            try:
+                s.connect(probe)
+                ip = s.getsockname()[0]
+            finally:
+                s.close()
+            return f"[{ip}]" if ":" in ip else ip
+        except OSError:
+            continue
+    return "localhost"
+
+
+def is_maxtext_model(model: Any) -> bool:
+    """True if `model` is `maxtext_vllm_adapter.adapter.MaxTextForCausalLM`.
+
+    Checked by class name rather than an isinstance/import so this module
+    (and its callers) never need a maxtext dependency, and so the check
+    survives whatever wrapping tpu-inference's model loader does to the
+    instance before it reaches `TPUWorker`/`RLVllmSampler` -- see
+    `extract_weight_state`.
+    """
+    return type(model).__name__ == "MaxTextForCausalLM"
+
+
+def extract_weight_state(state: Any, model: Any) -> Any:
+    """Returns the Param state ready for Raiden binding/inspection.
+
+    `model_loader.get_flax_model` sets `TPUModelRunner.state` to the
+    *already-split* `nnx.State` of the model wrapper returned by
+    `_get_nnx_model` (`ModelInterface(state=..., model=jit_model, ...)`,
+    `tpu_runner.py`'s `load_model`: `self.state = model.state; self.model =
+    model.model`) -- so `runner.state` is set for every model, and callers
+    that check `runner.state is not None` before falling back to
+    `nnx.state(runner.model, ...)` will always take the `state` branch. For
+    `MaxTextForCausalLM`, that pre-split state nests the actual MaxText
+    Transformer's params one level down, at the wrapper's own `model` key
+    (`state["model"]`), not under `base` the way the trainer's
+    `TunixMaxTextAdapter` wraps it. Both branches need the same unwrap-and-
+    rename, so this is a single function called from both.
+
+    Args:
+      state: `runner.state` (may be None).
+      model: `runner.model` (may be None) -- only used to type-check for
+        MaxText; when `state` is None this is also state-extracted directly.
+
+    Returns:
+      The best available Param state, or None if neither `state` nor `model`
+      is available (callers should fall back to `state_leaves`).
+    """
+    maxtext = is_maxtext_model(model)
+    if state is not None:
+        if maxtext:
+            try:
+                return {"base": state["model"]}
+            except Exception:
+                pass
+        return state
+    if model is not None:
+        try:
+            from flax import nnx
+            if maxtext:
+                inner = getattr(model, "model", None)
+                if inner is not None:
+                    return {"base": nnx.state(inner, nnx.Param)}
+            return nnx.state(model, nnx.Param)
+        except Exception:
+            pass
+    return None
+
+
+def flatten_weights(state: Any) -> Tuple[List[str], List[Any]]:
+    """Returns (names, arrays) for every array leaf, in stable tree order."""
+    names, arrays = [], []
+    for path, leaf in jax.tree_util.tree_leaves_with_path(state):
+        arr = getattr(leaf, "value", leaf)
+        if hasattr(arr, "shape") and hasattr(arr, "dtype"):
+            names.append(jax.tree_util.keystr(path))
+            arrays.append(arr)
+    return names, arrays
+
+
+def _bindable(arr: Any) -> bool:
+    """True if the native layer can bind this leaf."""
+    try:
+        if not hasattr(arr, "shape") or not hasattr(arr, "dtype"):
+            return False
+        if arr.ndim < 1:
+            return False
+        if not jnp.issubdtype(arr.dtype, jnp.floating):
+            return False
+        devices = arr.devices()
+        if not devices:
+            return False
+        return all(getattr(d, "platform", "?") == "tpu" for d in devices)
+    except Exception:
+        return False
+
+
+def _filter_bindable(
+    names: List[str], arrays: List[Any]
+) -> Tuple[List[str], List[Any]]:
+    """Drops leaves the native layer cannot bind; binding them is undefined
+    behavior (observed: random RuntimeError or SIGSEGV on RNG-key arrays)."""
+    keep_names: List[str] = []
+    keep_arrays: List[Any] = []
+    for name, arr in zip(names, arrays):
+        if _bindable(arr):
+            if hasattr(arr, "block_until_ready"):
+                try:
+                    arr.block_until_ready()
+                except Exception:
+                    pass
+            keep_names.append(name)
+            keep_arrays.append(arr)
+    return keep_names, keep_arrays
+
+
+def _axis_name(axis: Any) -> str:
+    if axis is None:
+        return ""
+    if isinstance(axis, str):
+        return axis
+    return ",".join(axis)
+
+
+def _tensor_metadata_dict(name: str, arr: Any, layer_idx: int) -> dict:
+    sharding: Any = getattr(arr, "sharding", None)
+    spec = tuple(getattr(sharding, "spec", ()) or ())
+    spec = (spec + (None,) * arr.ndim)[: arr.ndim]
+    try:
+        local = sharding.shard_shape(tuple(arr.shape))
+        mesh_shape = tuple(g // l for g, l in zip(arr.shape, local))
+    except Exception:  # pylint: disable=broad-exception-caught
+        mesh_shape = (1,) * arr.ndim
+    return {
+        "name": name,
+        "shape": list(arr.shape),
+        "mesh_shape": list(mesh_shape),
+        "layout": list(reversed(range(arr.ndim))),
+        "item_size": arr.dtype.itemsize,
+        "layer_idx": layer_idx,
+        "sharding_spec": [_axis_name(a) for a in spec],
+    }
+
+
+class RaidenWorkerSync:
+    """One TPUWorker's weights on the Raiden transport, plus wire-safe metadata.
+
+    In-process counterpart to tunix's `RaidenSynchronizer` -- see module
+    docstring for why this is a separate implementation rather than a shared
+    import. Meant to be constructed once per `TPUWorker` and reused (rebind
+    on every sync round) via `bind()`.
+    """
+
+    def __init__(
+        self,
+        job_name: str,
+        *,
+        worker_index: int = 0,
+        parallelism: int = 4,
+        bind_ip: Optional[str] = None,
+    ):
+        self.job_name = job_name
+        self.worker_index = worker_index
+        self.names: List[str] = []
+        self.arrays: List[Any] = []
+        self.ip = bind_ip or local_ip()
+        self._parallelism = parallelism
+        self._sync: Any = None
+
+    @property
+    def bound(self) -> bool:
+        return bool(self.names)
+
+    def bind(self, state: Any) -> None:
+        """Binds (or rebinds after a weight update) this worker's weights."""
+        self.names, self.arrays = _filter_bindable(*flatten_weights(state))
+        if _ws_lib is None:
+            return
+        if self._sync is None:
+            self._sync = _ws_lib.WeightSynchronizer(
+                self.arrays,
+                local_port=0,
+                parallelism=self._parallelism,
+                unsafe_skip_buffer_lock=True,
+                listener_port=0,
+                bind_ip=None,
+            )
+        else:
+            self._sync.bind_weights(self.arrays)
+
+    def _require_sync(self, op: str) -> Any:
+        if self._sync is None:
+            raise RuntimeError(f"{self.job_name}: bind() must run before {op}")
+        return self._sync
+
+    def h2d(self) -> None:
+        self._require_sync("h2d()").h2d()
+
+    def d2h(self) -> None:
+        self._require_sync("d2h()").d2h()
+
+    def metrics(self) -> dict:
+        if self._sync is None:
+            return {}
+        if hasattr(self._sync, "get_metrics"):
+            return self._sync.get_metrics()
+        if hasattr(self._sync, "metrics"):
+            return self._sync.metrics()
+        return {}
+
+    def checksums(self, sample: int = 3) -> dict:
+        """Per-tensor float32 abs-sums for cross-process verification."""
+
+        def total(arr):
+            return float(jnp.sum(jnp.abs(arr).astype(jnp.float32)))
+
+        return {
+            name: total(arr) for name, arr in list(zip(self.names, self.arrays))[:sample]
+        }
+
+    def metadata_dict(self) -> dict:
+        """Wire-safe (plain-data-only) registration metadata.
+
+        Shaped to satisfy `tunix.experimental.orchestrator.weight_sync.dict_to_metadata`
+        on the receiving (tunix) side of the RPC boundary.
+        """
+        variables = [
+            _tensor_metadata_dict(name, arr, idx)
+            for idx, (name, arr) in enumerate(zip(self.names, self.arrays))
+        ]
+        mesh_axes: tuple = ()
+        mesh_shape = None
+        for arr in self.arrays:
+            mesh = getattr(getattr(arr, "sharding", None), "mesh", None)
+            if mesh is not None:
+                mesh_axes = tuple(mesh.axis_names)
+                mesh_shape = tuple(mesh.shape[a] for a in mesh.axis_names)
+                break
+        if mesh_shape is None:
+            mesh_axes = ("fsdp",)
+            mesh_shape = (1,)
+        data_addr = f"{self.ip}:{self._sync.local_port}" if self._sync else ""
+        control_addr = (
+            f"{self.ip}:{self._sync.listener_port}"
+            if self._sync and self._sync.listener_port
+            else ""
+        )
+        num_shards = self._sync.num_shards if self._sync else 1
+        return {
+            "unit": {
+                "job_name": self.job_name,
+                "job_replica_id": str(self.worker_index) if self.worker_index else "",
+            },
+            "shards": [data_addr] * num_shards if data_addr else [],
+            "control_plane_rpc_address": control_addr,
+            "mesh_shape": list(mesh_shape),
+            "variables": variables,
+            "mesh_axes": list(mesh_axes) if mesh_axes else None,
+        }

--- a/tpu_inference/rl/vllm_sampler.py
+++ b/tpu_inference/rl/vllm_sampler.py
@@ -10,6 +10,7 @@ without importing or depending on Tunix.
 """
 
 import asyncio
+import inspect
 import logging
 import os
 import time
@@ -27,12 +28,21 @@ logger = logging.getLogger(__name__)
 
 
 def _get_val(obj: Any, key: str, default: Any = None) -> Any:
-    """Helper to extract an attribute or dict key seamlessly from any duck-typed request."""
+    """Helper to extract an attribute or dict key seamlessly from any duck-typed request.
+
+    Falls back to `default` both when `key` is absent and when it's present
+    but explicitly `None` -- request dataclasses across callers (e.g. tunix's
+    rollout requests) commonly default optional sampling fields to `None`
+    rather than omitting them, and vLLM's `SamplingParams` rejects `None` for
+    fields like `top_k` that it compares numerically.
+    """
     if obj is None:
         return default
     if isinstance(obj, dict):
-        return obj.get(key, default)
-    return getattr(obj, key, default)
+        val = obj.get(key, default)
+    else:
+        val = getattr(obj, key, default)
+    return default if val is None else val
 
 
 class RLVllmSampler:
@@ -340,17 +350,100 @@ class RLVllmSampler:
             "tpu_worker_ips": worker_ips,
         }
 
+    async def _call_worker_method(self, method_name: str, *args: Any, **kwargs: Any) -> list[Any]:
+        """Dispatches a method call across TPU workers via collective_rpc or direct execution."""
+        if self._engine is None:
+            return []
+        engine_obj = getattr(self._engine, "engine", self._engine)
+        if hasattr(engine_obj, "collective_rpc"):
+            try:
+                result = engine_obj.collective_rpc(method_name, args=args, kwargs=kwargs)
+                # AsyncLLMEngine.collective_rpc is a coroutine function (it awaits
+                # self.engine_core.collective_rpc_async internally); other engine
+                # objects may expose a plain sync collective_rpc. Handle both.
+                if inspect.isawaitable(result):
+                    result = await result
+                return result
+            except Exception as e:
+                logger.debug("engine.collective_rpc(%s) failed: %s", method_name, e)
+        model_executor = getattr(engine_obj, "model_executor", None)
+        if model_executor and hasattr(model_executor, "collective_rpc"):
+            try:
+                result = model_executor.collective_rpc(method_name, args=args, kwargs=kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                return result
+            except Exception as e:
+                logger.debug("model_executor.collective_rpc(%s) failed: %s", method_name, e)
+
+        results = []
+        for w in self._get_tpu_workers():
+            if hasattr(w, method_name):
+                fn = getattr(w, method_name)
+                r = fn(*args, **kwargs)
+                if inspect.isawaitable(r):
+                    r = await r
+                results.append(r)
+        return results
+
+    async def collective_rpc(self, method_name: str, *args: Any, **kwargs: Any) -> list[Any]:
+        """Public API to execute collective_rpc across TPU workers."""
+        return await self._call_worker_method(method_name, *args, **kwargs)
+
+    async def get_weights_state(self) -> list[Any]:
+        """Returns the PyTree of weights or state from active TPU workers."""
+        states = await self._call_worker_method("get_weights_state")
+        if not states:
+            for w in self._get_tpu_workers():
+                if hasattr(w, "get_weights_state"):
+                    st = w.get_weights_state()
+                else:
+                    runner = getattr(w, "model_runner", None)
+                    st = getattr(runner, "state_leaves",
+                                None) if runner is not None else None
+                if st is not None:
+                    states.append(st)
+        return states
+
+    async def bind_raiden_sync(self, worker_index: int = 0, parallelism: int = 4) -> None:
+        """Binds Raiden to each TPU worker's live weights, in-process.
+
+        `get_weights_state()` cannot back a rollout-side weight sync: the
+        live `nnx.State` it returns has to be dispatched back across
+        `collective_rpc` into this (parent) process to be useful, but vLLM's
+        RPC transport can't serialize `nnx.State`/live TPU arrays, and even a
+        pickle-based fallback would bind Raiden to a disconnected host copy
+        rather than the device buffers actually being served. Binding must
+        happen in the worker subprocess instead -- see
+        `tpu_worker.TPUWorker.bind_raiden_sync` and `raiden_worker_sync`.
+        """
+        await self._call_worker_method("bind_raiden_sync", worker_index, parallelism)
+
+    async def get_raiden_metadata(self) -> list[dict]:
+        """Wire-safe registration metadata for each worker's current Raiden binding."""
+        return await self._call_worker_method("get_raiden_metadata")
+
+    async def raiden_h2d(self) -> list[dict]:
+        """Blocks each worker until its just-landed transfer is visible on-device.
+
+        Returns each worker's checksums dict (empty unless VERIFY_WEIGHTS=true).
+        """
+        return await self._call_worker_method("raiden_h2d")
+
+    async def raiden_metrics(self) -> list[dict]:
+        return await self._call_worker_method("raiden_metrics")
+
     async def pre_weight_sync(
         self,
         sync_request: Any = None,
         free_kv_cache: bool = True,
         **kwargs: Any,
     ) -> None:
-        """Phase 1: Pauses intake, clears prefix cache, and calls start_weight_update()."""
+        """Phase 1: Pauses intake, clears prefix cache, and drops KV cache via delete_kv_cache()."""
         self._policy_version = _get_val(sync_request, "policy_version",
                                         self._policy_version)
-        logger.info("Executing pre_weight_sync (policy_version=%d)",
-                    self._policy_version)
+        logger.info("Executing pre_weight_sync (policy_version=%d, free_kv_cache=%s)",
+                    self._policy_version, free_kv_cache)
 
         if sync_request is not None:
             rid = _get_val(sync_request, "req_id")
@@ -360,19 +453,19 @@ class RLVllmSampler:
         await self.pause()
         await self._clear_prefix_cache()
 
-        if self._engine and hasattr(self._engine, "start_weight_update"):
-            self._engine.start_weight_update(free_kv_cache=free_kv_cache)
+        if free_kv_cache:
+            await self._call_worker_method("delete_kv_cache")
+            self._kv_cache_freed = True
 
     async def weight_sync(
         self,
         sync_request: Any = None,
         **kwargs: Any,
     ) -> None:
-        """Phase 2: Calls TPUWorker.update_weights(update_info)."""
+        """Phase 2: Coordinates weight synchronization barrier across TPU workers."""
         logger.info("Executing weight_sync update on TPU workers...")
         u_info = _get_val(sync_request, "extra_config") or {}
-        if self._engine:
-            self._engine.update_weights(u_info)
+        await self._call_worker_method("update_weights", u_info)
         await asyncio.sleep(0.01)
 
     async def post_weight_sync(
@@ -380,14 +473,17 @@ class RLVllmSampler:
         sync_request: Any = None,
         **kwargs: Any,
     ) -> None:
-        """Phase 3: Calls TPUWorker.finish_weight_update()."""
+        """Phase 3: Restores KV cache via reinitialize_kv_cache() and resumes serving."""
         rid = None
         if sync_request is not None:
             rid = _get_val(sync_request, "req_id")
         logger.info("Executing post_weight_sync (req_id=%s)...", rid)
 
-        if self._engine:
-            self._engine.finish_weight_update()
+        if getattr(self, "_kv_cache_freed", False):
+            await self._call_worker_method("reinitialize_kv_cache")
+            self._kv_cache_freed = False
+        else:
+            await self._call_worker_method("finish_weight_update")
 
         self._cache_valid = True
         if rid:

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -776,6 +776,87 @@ class TPUWorker(WorkerBase):
     def reinitialize_kv_cache(self) -> None:
         self.model_runner.reinitialize_kv_cache()
 
+    def _extract_weight_state(self) -> Any:
+        """Builds the (possibly `nnx.State`) weight PyTree from the runner.
+
+        Shared by `get_weights_state` (returns the live PyTree -- callers in
+        this same process only, e.g. the CPU-side fallback in
+        `RLVllmSampler.get_weights_state`) and `bind_raiden_sync` (binds it to
+        Raiden in-process; never sends the PyTree itself across the
+        collective_rpc boundary, which cannot serialize `nnx.State`/live TPU
+        arrays -- see `raiden_worker_sync` module docstring).
+
+        `TPUModelRunner.state` is set unconditionally by `load_model()` (see
+        `raiden_worker_sync.extract_weight_state`), so the MaxText unwrap has
+        to apply there too, not just to the `nnx.state(runner.model, ...)`
+        fallback -- that fallback is dead code once `runner.state` is set,
+        which is always.
+        """
+        from tpu_inference.rl import raiden_worker_sync  # pylint: disable=g-import-not-at-top
+
+        result = raiden_worker_sync.extract_weight_state(
+            getattr(self.model_runner, "state", None),
+            getattr(self.model_runner, "model", None),
+        )
+        if result is not None:
+            return result
+        return getattr(self.model_runner, "state_leaves", None)
+
+    def get_weights_state(self) -> Any:
+        """Returns model weights state / PyTree from the runner.
+
+        Only safe to call from this same process -- the result may be an
+        `nnx.State` full of live TPU arrays, which vLLM's collective_rpc
+        transport cannot serialize. Callers that cross the RPC boundary (e.g.
+        the rollout adapter) must use `bind_raiden_sync`/`get_raiden_metadata`
+        instead, which only ever return plain-data metadata.
+        """
+        return self._extract_weight_state()
+
+    def bind_raiden_sync(self, worker_index: int = 0, parallelism: int = 4) -> dict:
+        """Binds this worker's live weights to Raiden, in-process, and
+        returns wire-safe registration metadata (never the arrays).
+
+        Reuses (rebinds) `self._raiden_worker_sync` across sync rounds, the
+        same way the trainer side reuses `MaxTextTrainingEngine._raiden_sync`.
+        """
+        from tpu_inference.rl import raiden_worker_sync  # pylint: disable=g-import-not-at-top
+
+        state = self._extract_weight_state()
+        if getattr(self, "_raiden_worker_sync", None) is None:
+            self._raiden_worker_sync = raiden_worker_sync.RaidenWorkerSync(
+                job_name="rollout",
+                worker_index=worker_index,
+                parallelism=parallelism,
+            )
+        self._raiden_worker_sync.bind(state)
+        return self._raiden_worker_sync.metadata_dict()
+
+    def get_raiden_metadata(self) -> dict:
+        """Re-fetches the current binding's wire-safe metadata without rebinding."""
+        sync = getattr(self, "_raiden_worker_sync", None)
+        if sync is None or not sync.bound:
+            return {}
+        return sync.metadata_dict()
+
+    def raiden_h2d(self) -> dict:
+        """Blocks until the transfer that just landed is visible on-device.
+
+        Returns tensor checksums when `VERIFY_WEIGHTS=true`, matching the
+        trainer side's `RaidenSynchronizer.checksums()` debug logging.
+        """
+        sync = getattr(self, "_raiden_worker_sync", None)
+        if sync is None:
+            raise RuntimeError("bind_raiden_sync must run before raiden_h2d.")
+        sync.h2d()
+        if os.environ.get("VERIFY_WEIGHTS", "").lower() == "true":
+            return sync.checksums()
+        return {}
+
+    def raiden_metrics(self) -> dict:
+        sync = getattr(self, "_raiden_worker_sync", None)
+        return sync.metrics() if sync is not None else {}
+
     def reset_encoder_cache(self) -> None:
         self.model_runner.reset_encoder_cache()
 


### PR DESCRIPTION
## Summary

Adds `RLVllmSampler`'s Raiden (native TPU-to-TPU weight transfer) weight-sync lifecycle — `bind_raiden_sync`/`get_raiden_metadata`/`raiden_h2d`/`raiden_metrics` — binding a worker's live model weights to Raiden **in-process inside the vLLM EngineCore subprocess** (where the TPU-resident weight arrays actually live), returning only plain-data metadata across `collective_rpc` back to the parent process. This is required rather than optional: shipping the live `nnx.State` itself back across that RPC boundary crashes (vLLM's msgpack transport can't serialize it), and even pickled through would bind Raiden to a disconnected host copy rather than the device buffers actually being served.

Companion PRs (same feature, other two repos):
- tunix: https://github.com/google/tunix/pull/1960
- maxtext: https://github.com/AI-Hypercomputer/maxtext/pull/4970

## Test plan
- [x] Unit tests: `pytest tests/rl/test_vllm_sampler.py` (6 passed, 1 pre-existing unrelated failure)
- [x] Live 2-slice v5p-8 GKE end-to-end run: this rollout (loading MaxText's native model via `maxtext_vllm_adapter`) + a MaxText `MaxTextTrainingEngine` trainer, launched via tunix's `k8s_launcher.sh`, 2 GRPO steps completed with real Raiden weight-sync rounds, checksum-verified between trainer (source) and this rollout (destination)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
