### PR TITLE
[CI] Mark Qwen2.5-VL-7B benchmarks as unverified on the vllm (torchax) nightly variant

### DIFF
--- a/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
@@ -71,7 +71,20 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh
+        if [ "${MODEL_IMPL_TYPE:-auto}" = "vllm" ]; then
+          echo "Qwen2.5-VL-7B benchmarks are not supported on the vllm (torchax)" \
+               "path. Its vision tower has no compiled route there -- the model is" \
+               "not in vision_tower_jit's JITTABLE_ARCHS and vLLM's Qwen2_5_VL does" \
+               "not declare supports_encoder_cudagraph, so MMEncoderJitManager" \
+               "declines it -- and the encoder runs eager: 0.04 req/s on tpu7x" \
+               "(vs 2.03 req/s on the JAX path) and an HBM OOM inside the ViT" \
+               "attention on tpu6e. Recording as unverified until the torchax" \
+               "multimodal path gets a compiled vision tower."
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark" "unverified"
+        else
+          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh
+        fi
+
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen2.5-VL-7B-Instruct"
     key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
     depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"


### PR DESCRIPTION
## Problem

`tpu7x Performance benchmarks for Qwen/Qwen2.5-VL-7B-Instruct` has failed on **every** `MODEL_IMPL_TYPE=vllm` nightly since 2026-05-21 ([build 18298](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/18298) onward; most recently [24593](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24593) at `Request throughput: 0.04` vs the `>= 0.76` floor). Its tpu6e twin reports `passed` but is a false green.

**Root cause — the vision tower has no compiled route on the torchax path.** `vision_tower_jit.py` logs *"Qwen2_5_VLForConditionalGeneration's vision tower does NOT support JIT compilation"* (the class is not in `JITTABLE_ARCHS`), and vLLM's `Qwen2_5_VLForConditionalGeneration` does not declare `supports_encoder_cudagraph`, so `maybe_create_mm_encoder_jit_manager` declines it as well. The encoder therefore runs eager, op-by-op through torchax dispatch, for every admitted request:

- **tpu7x:** requests are admitted every 10–30 s while decode stalls; `Mean TPOT 8258 ms`, `Mean TTFT 1619 s`, 3280 s total → 0.04 req/s.
- **tpu6e:** dies during the run — `jax.errors.JaxRuntimeError: RESOURCE_EXHAUSTED … Error loading program 'jit__flash_attention': Attempting to reserve 96.31M … 51.80M free` inside `tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py:194 vllm_vit_sdpa` (ViT attention) → `EngineDeadError`. All 128 streaming requests had already returned HTTP 200 headers, so `vllm bench serve` scored `Successful requests: 128`, `Total generated tokens: 0`, 21.56 s → 5.94 req/s → **PASSED**.

The JAX path is unaffected and healthy: the default nightly runs this model as `auto` → `flax_nnx` and passes for real (2.03 req/s on tpu7x, 1.75 on tpu6e, 16384 generated tokens — [build 24592](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24592)).

For the record, the job has never genuinely passed on torchax. Before 2026-05-21 it "passed" in seconds with 0 generated tokens because the engine crashed at `qwen2_5_vl.py:682 rotary_pos_emb_thw` (torchax *"mixed math between XLATensor and torch.Tensor"*); the vLLM LKG bump that landed for the 05-21 nightly included [vllm#42347](https://github.com/vllm-project/vllm/pull/42347), which moves `pos_ids` to the device in that function and removed the crash — exposing the slow eager encoder underneath.

A permanently-red job is not a regression signal; it only hides real regressions in the nightly report.

## Change

On the vllm variant only, skip the Qwen2.5-VL-7B Benchmark run and record the step as `unverified` via buildkite-agent meta-data — the same pattern #3404 and #3414 established for DFlash and gemma-4. `unverified` maps to `❓ Untested` in the support matrix (`record_step_result.sh`), so the matrix stays truthful instead of claiming torchax support.

Unit tests and Accuracy are untouched: both pass on the vllm path today. The default (`auto`) and `flax_nnx` variants are untouched and keep running the benchmark exactly as before — verified by simulating the gate at all three interpolated values:

```
[vllm]     -> meta-data set tpu7x_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark unverified
[auto]     -> run mm_bench_recipe.sh
[flax_nnx] -> run mm_bench_recipe.sh
```

Once the torchax multimodal path gets a compiled vision tower (a `qwen2_5_vl_patcher` along the lines of `qwen3_vl_patcher.py`, or encoder-cudagraph support upstream), this gate should be reverted so the vllm variant benchmarks for real.

## Tests

`.buildkite`-only change. Validated locally: the file parses as YAML, the emitted command block passes `bash -n`, the meta-data key matches the step `key:` exactly, and the gate was simulated at all three `MODEL_IMPL_TYPE` values (output above).
