### PR TITLE
[CI] Fail the mm benchmark when it produced no decoded tokens

### DIFF
--- a/tests/e2e/benchmarking/mm_bench_recipe.sh
+++ b/tests/e2e/benchmarking/mm_bench_recipe.sh
@@ -98,8 +98,12 @@ checkThroughput() {
     # mid-benchmark, `vllm bench serve` still counts every request whose HTTP
     # response headers arrived before the death as "successful", so it reports a
     # short duration and a high req/s with no tokens produced at all. Require
-    # actual decoded output so a dead engine cannot score a pass.
-    generated_tokens=$(awk '/Total generated tokens:/ {print $NF}' "$BENCHMARK_LOG_FILE")
+    # actual decoded output, and no failed request, so that neither a dead engine
+    # nor one that died part-way through the run can score a pass.
+    # Both use the last occurrence in the log, so a re-run appended to the same
+    # file is judged on its own summary.
+    generated_tokens=$(awk '/Total generated tokens:/ {v=$NF} END {print v}' "$BENCHMARK_LOG_FILE")
+    failed_requests=$(awk '/Failed requests:/ {v=$NF} END {print v}' "$BENCHMARK_LOG_FILE")
 
     case "$generated_tokens" in
         '' )
@@ -119,19 +123,40 @@ checkThroughput() {
             tokens_pass=1
             ;;
     esac
+
+    case "$failed_requests" in
+        '' )
+            echo "Failed requests: NOT FOUND"
+            requests_pass=0
+            ;;
+        *[!0-9]* )
+            echo "Failed requests: '$failed_requests' (not a number)"
+            requests_pass=0
+            ;;
+        0 )
+            echo "Failed requests: 0"
+            requests_pass=1
+            ;;
+        * )
+            echo "Failed requests: $failed_requests"
+            requests_pass=0
+            ;;
+    esac
     echo
 
     echo "--- Summary ---"
     # Ensure pass flags are initialized if extraction fails
     : "${throughput_pass:=0}"
     : "${tokens_pass:=0}"
+    : "${requests_pass:=0}"
 
-    if [ "$throughput_pass" -eq 1 ] && [ "$tokens_pass" -eq 1 ]; then
+    if [ "$throughput_pass" -eq 1 ] && [ "$tokens_pass" -eq 1 ] && [ "$requests_pass" -eq 1 ]; then
         echo "Overall: PASSED"
     else
         echo "Overall: FAILED"
         [ "$throughput_pass" -eq 0 ] && echo "Reason: Throughput check failed or value not found."
         [ "$tokens_pass" -eq 0 ] && echo "Reason: Benchmark produced no decoded tokens -- the server likely died mid-run (grep the server log for EngineDeadError / RESOURCE_EXHAUSTED)."
+        [ "$requests_pass" -eq 0 ] && echo "Reason: Benchmark had failed requests -- the server did not serve the whole workload (grep the server log for EngineDeadError / RESOURCE_EXHAUSTED)."
         exit_code=1
     fi
 }

--- a/tests/e2e/benchmarking/mm_bench_recipe.sh
+++ b/tests/e2e/benchmarking/mm_bench_recipe.sh
@@ -94,15 +94,44 @@ checkThroughput() {
     fi
     echo
 
+    # Throughput alone does not prove the run worked. If the EngineCore dies
+    # mid-benchmark, `vllm bench serve` still counts every request whose HTTP
+    # response headers arrived before the death as "successful", so it reports a
+    # short duration and a high req/s with no tokens produced at all. Require
+    # actual decoded output so a dead engine cannot score a pass.
+    generated_tokens=$(awk '/Total generated tokens:/ {print $NF}' "$BENCHMARK_LOG_FILE")
+
+    case "$generated_tokens" in
+        '' )
+            echo "Total generated tokens: NOT FOUND"
+            tokens_pass=0
+            ;;
+        *[!0-9]* )
+            echo "Total generated tokens: '$generated_tokens' (not a number)"
+            tokens_pass=0
+            ;;
+        0 )
+            echo "Total generated tokens: 0"
+            tokens_pass=0
+            ;;
+        * )
+            echo "Total generated tokens: $generated_tokens"
+            tokens_pass=1
+            ;;
+    esac
+    echo
+
     echo "--- Summary ---"
     # Ensure pass flags are initialized if extraction fails
     : "${throughput_pass:=0}"
+    : "${tokens_pass:=0}"
 
-    if [ "$throughput_pass" -eq 1 ]; then
+    if [ "$throughput_pass" -eq 1 ] && [ "$tokens_pass" -eq 1 ]; then
         echo "Overall: PASSED"
     else
         echo "Overall: FAILED"
         [ "$throughput_pass" -eq 0 ] && echo "Reason: Throughput check failed or value not found."
+        [ "$tokens_pass" -eq 0 ] && echo "Reason: Benchmark produced no decoded tokens -- the server likely died mid-run (grep the server log for EngineDeadError / RESOURCE_EXHAUSTED)."
         exit_code=1
     fi
 }


### PR DESCRIPTION
## Problem

`mm_bench_recipe.sh` decides pass/fail from request throughput alone. That is not enough to prove the run worked: if the EngineCore dies mid-benchmark, `vllm bench serve` still counts every request whose HTTP response headers arrived before the death as *successful*, so it reports a very short duration and a **high** req/s having produced **zero** tokens — and the step passes.

This is not hypothetical; it hid three real failures in the 2026-08-20 `MODEL_IMPL_TYPE=vllm` nightly ([build 24593](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24593)) and in the dev runs used to validate #3406:

| Run | Reported | Reality |
|---|---|---|
| tpu6e Qwen2.5-VL-7B (24593) | `PASSED`, 5.94 req/s, 21.56 s | `RESOURCE_EXHAUSTED` loading `jit__flash_attention` in the ViT attention → `EngineDeadError`; `Total generated tokens: 0` |
| tpu7x/tpu6e gemma-4 E2B+E4B (dev 918/919) | `PASSED`, 16–19 req/s, ~7 s | `RuntimeError: PyTorch is not linked with support for jax devices` in `_process_image_input` → engine dead; 0 tokens (fixed by #3406) |

The Qwen2.5-VL one had been "passing" this way since May.

## Change

Require the benchmark to have actually served the workload, by adding two conditions to the existing throughput check:

- `Total generated tokens:` must be present, numeric and non-zero — catches an engine that died before producing any output;
- `Failed requests:` must be present, numeric and zero — catches an engine that died part-way through, where some requests completed and tokens are therefore non-zero (raised in review by @lk-chen, who has hit this).

Both are read from the last occurrence in the log, since `BENCHMARK_LOG_FILE` is appended with `tee -a`. The failure messages point at the server log and the two signatures worth grepping for.

Throughput checking is unchanged, so a run that is genuinely too slow still fails for the throughput reason, and a healthy run is unaffected.

## Tests

Replayed the patched `checkThroughput` against three real archived benchmark logs:

| log | tokens | failed reqs | req/s | floor | verdict |
|---|---|---|---|---|---|
| tpu6e Qwen2.5-VL, 24593 — engine OOM-died | 0 | 0 | 5.94 | 0.76 | **FAILED** (tokens) — *was PASSED* |
| tpu7x gemma-4 E2B, dev 918 — died part-way | 0 | 16 | 16.63 | 0.0 | **FAILED** (tokens + failed reqs) — *was PASSED* |
| synthetic: healthy log with failed reqs injected | 16384 | 7 | 1.09 | 0.0 | **FAILED** (failed reqs only) |
| tpu7x gemma-4 E2B, dev 927 — healthy | 16384 | 0 | 1.09 | 0.0 | PASSED — *unchanged* |
| tpu7x Qwen2.5-VL, 24593 — healthy but slow | 16384 | 0 | 0.04 | 0.76 | FAILED (throughput only) — *unchanged* |

## Note on landing order

This turns the tpu6e Qwen2.5-VL-7B benchmark on the vllm variant from a false green into an honest red. #3446 marks that step `unverified` on the vllm variant (the torchax vision tower runs eager and OOMs there), so landing #3446 first — or both together — keeps the nightly clean. Every other benchmark step currently produces real tokens.

