### PR TITLE
[CI] Auto-retry DCN P/D disagg steps once on transient TPU session init failure

### DIFF
--- a/.buildkite/features/DCN-Based_P-D_disaggregation.yml
+++ b/.buildkite/features/DCN-Based_P-D_disaggregation.yml
@@ -16,6 +16,12 @@ steps:
   - label: "${TPU_VERSION:-tpu6e} Correctness tests for DCN-based P/D disaggregation"
     key: "${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_CorrectnessTest"
     soft_fail: true
+    # exit 75 = EX_TEMPFAIL from run_disagg_multi_host.sh: transient TPU
+    # session init failure (infra); real failures exit 1 and are not retried.
+    retry:
+      automatic:
+        - exit_status: 75
+          limit: 1
     env:
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       MODEL: "Qwen/Qwen3-0.6B"
@@ -46,6 +52,12 @@ steps:
   - label: "${TPU_VERSION:-tpu6e} Performance tests for DCN-based P/D disaggregation"
     key: "${TPU_VERSION:-tpu6e}_DCN_based_P-D_disaggregation_PerformanceTest"
     soft_fail: true
+    # exit 75 = EX_TEMPFAIL from run_disagg_multi_host.sh: transient TPU
+    # session init failure (infra); real failures exit 1 and are not retried.
+    retry:
+      automatic:
+        - exit_status: 75
+          limit: 1
     env:
       TPU_VERSION: "${TPU_VERSION:-tpu6e}"
       MODEL: "Qwen/Qwen3-0.6B"

--- a/.buildkite/pipeline_jax.yml
+++ b/.buildkite/pipeline_jax.yml
@@ -428,6 +428,12 @@ steps:
       - label: "${TPU_VERSION:-tpu6e} E2E test for Multihost DCN-based P/D disaggregation"
         key: ${TPU_VERSION:-tpu6e}_test_25
         soft_fail: true
+        # exit 75 = EX_TEMPFAIL from run_disagg_multi_host.sh: transient TPU
+        # session init failure (infra); real failures exit 1 and are not retried.
+        retry:
+          automatic:
+            - exit_status: 75
+              limit: 1
         env:
           USE_PREBUILT_IMAGE: "1"
           TPU_VERSION: "${TPU_VERSION:-tpu6e}"

--- a/examples/disagg/run_disagg_multi_host.sh
+++ b/examples/disagg/run_disagg_multi_host.sh
@@ -18,9 +18,22 @@
 
 set -e
 
+# EX_TEMPFAIL from sysexits.h. The Buildkite steps that run this harness declare
+# `retry: automatic: - exit_status: 75` so that ONLY the known-transient infra
+# failures below (a TPU runtime session that fails to start) get re-run once.
+# Every real failure still exits 1 and is never retried.
+EXIT_TEMPFAIL=75
+
 # Function to print logs on exit
 print_logs_on_exit() {
-  echo "--- Script exiting, displaying logs ---"
+  # Capture the status the script is exiting with before running anything else.
+  # This trap body runs under `set -e`, so any failing command below would both
+  # abort the trap and overwrite the exit status -- which would silently turn
+  # EXIT_TEMPFAIL into some other code and defeat the exit-code-keyed retry.
+  local exit_code=$?
+  set +e
+
+  echo "--- Script exiting with status ${exit_code}, displaying logs ---"
 
   # The logs are written inside containers to /root/logs, which is mapped from $LOG_DIR on the host.
   LOG_DIR=$HOME/logs
@@ -57,6 +70,9 @@ print_logs_on_exit() {
     echo "Log directory '$LOG_DIR' not found."
   fi
   echo "--- End of logs ---"
+
+  # Restore the original status so it propagates to the caller.
+  exit "$exit_code"
 }
 
 # Register the cleanup function to be called on script exit (normal or error)
@@ -81,6 +97,38 @@ TEST_MODE=${TEST_MODE:=1} # if 1, run benchmark; if 2, run correctness; if 3, ru
 ############################
 
 echo "--- The HOME variable is : $HOME ---"
+
+# If the server log carries the known TPU runtime session-init signature, end the
+# whole harness with EXIT_TEMPFAIL so Buildkite retries the step. Returns normally
+# for anything else, leaving the caller to fail the usual way.
+#
+# The signature, raised from tpu_inference/worker/tpu_worker.py init_device ->
+# jax.devices() inside a RayWorkerProc, looks like:
+#   RuntimeError: Unable to initialize backend 'tpu': INTERNAL: TPU initialization
+#   failed: GRPC_ERROR error message: START_SESSION failed. ... Max # of tries(=3) exhausted.
+#
+# The match is deliberately restricted to two fixed strings (grep -F) so generic
+# words like "Error" can never trigger a retry. It is still a heuristic, not proof
+# of a flake: START_SESSION also fails deterministically for misconfiguration --
+# a wrong TPU_PROCESS_BOUNDS / TPU_PROCESS_ADDRESSES, or chips still held by a
+# leaked container from an earlier run. Retrying cannot fix those, so the cost is
+# one extra harness run (~10 min) before the step fails for real. `limit: 1` on
+# the Buildkite steps is what bounds that cost to a single wasted run; do not
+# widen this pattern or raise the limit without redoing that arithmetic.
+exit_if_transient_tpu_init_failure() {
+  local container_name=$1
+  local log_path=$2
+  local service_name=$3
+  local port=$4
+
+  if docker exec "$container_name" grep -qF \
+      -e 'TPU initialization failed: GRPC_ERROR' \
+      -e 'START_SESSION failed' \
+      "$log_path" 2>/dev/null; then
+    echo "[disagg-harness] Transient TPU runtime session failure (START_SESSION / TPU initialization failed: GRPC_ERROR) in ${container_name}:${log_path} while waiting for ${service_name} on port ${port}; this is an infra flake, not a test failure. Exiting with EX_TEMPFAIL=${EXIT_TEMPFAIL} so Buildkite retry.automatic re-runs this step once."
+    exit "$EXIT_TEMPFAIL"
+  fi
+}
 
 wait_for_server() {
   local port=$1
@@ -117,6 +165,7 @@ wait_for_server() {
       echo "Error: $service_name on $port (PID $pid) died inside container while waiting for health check."
       echo "Displaying logs from $container_name:$log_path"
       docker exec "$container_name" cat "$log_path"
+      exit_if_transient_tpu_init_failure "$container_name" "$log_path" "$service_name" "$port"
       return 1
     fi
 
@@ -126,6 +175,7 @@ wait_for_server() {
   echo "Error: $service_name on $port failed to become healthy within the timeout."
   echo "Displaying logs from $container_name:$log_path"
   docker exec "$container_name" cat "$log_path"
+  exit_if_transient_tpu_init_failure "$container_name" "$log_path" "$service_name" "$port"
   return 1
 }
 


### PR DESCRIPTION
## Problem

The multi-host DCN-based P/D disaggregation CI jobs (`examples/disagg/run_disagg_multi_host.sh`, launched via `.buildkite/scripts/run_disagg.sh`) intermittently fail because the prefill `vllm serve` dies during engine init with a transient TPU runtime session error, before any test logic runs:

```
jax.errors.JaxRuntimeError: INTERNAL: TPU initialization failed: GRPC_ERROR error message: START_SESSION failed. Contact GCE with UUID: ... if this is recurring. Max # of tries(=3) exhausted.
RuntimeError: Unable to initialize backend 'tpu': INTERNAL: TPU initialization failed: GRPC_ERROR error message: START_SESSION failed. ...
```

raised from `tpu_inference/worker/tpu_worker.py` `init_device` -> `jax.devices()` inside a `RayWorkerProc`. The harness then reports `Error: vllm serve on 8400 (PID ...) died inside container while waiting for health check.` and exits 1.

The same signature appears on several different agents, so this is a fleet-wide infra flake, not one bad host and not a code regression:

- https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24635#01a0231f-0aa7-44b7-b515-11dd4ff8610a (nightly 2026-08-21, `tpu7x Correctness tests for DCN-based P/D disaggregation`, agent tpu7x-8-ci-6)
- https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24603 (2026-08-20, multihost DCN E2E, agent tpu7x-8-ci-15)
- https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24280 (2026-08-14, multihost DCN E2E, agent tpu7x-8-ci-6)
- https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24094 (2026-08-11, `tpu7x Performance tests for DCN-based P/D disaggregation`, agent tpu7x-8-ci-10)

Since 2026-08-08 these DCN P/D jobs on `tpu-inference-ci` main are ~403 passed / 6 failed; 4 of the 6 are this signature. A plain manual retry passes.

## Why this fix

**Exit-code-keyed retry, not a blanket retry.** `exit_status: "*"` would mask real regressions: any genuine correctness or performance failure would be silently re-run and could pass by chance, and every real failure would cost double the TPU time on an already contended multi-host queue. Keying on a dedicated exit code means the harness itself decides what is retryable — it only emits `75` after positively matching the two known-transient log strings, and every other failure keeps exiting 1 and fails fast on the first attempt.

**In the harness, not in `tpu_worker.py`.** The failure is at the host/runtime layer, not in Python: libtpu has already exhausted its own internal retries by the time we see this (`Max # of tries(=3) exhausted`), so retrying `jax.devices()` in-process would just re-hit the same wedged session on the same host. What actually clears it is a fresh process/container on a fresh scheduling attempt, which is exactly what a Buildkite step retry gives us. Adding retry logic to `tpu_worker.py` would also affect every workload, not just this CI harness.

## Change

- `examples/disagg/run_disagg_multi_host.sh`
  - Add `EXIT_TEMPFAIL=75` (EX_TEMPFAIL from `sysexits.h`), with a comment explaining that the Buildkite steps key their `retry.automatic` off this code.
  - Add `exit_if_transient_tpu_init_failure <container> <log_path> <service> <port>`, which greps the server log with `grep -F` for exactly two fixed strings — `TPU initialization failed: GRPC_ERROR` and `START_SESSION failed` — and on a match prints one self-contained line naming the subsystem, signature, container/log path, service and port, what it means and what happens next, then exits `EXIT_TEMPFAIL`. Nothing generic (e.g. bare `Error`) is matched, so a real failure is never misclassified as transient.
  - Both `wait_for_server` failure paths — "died inside container" and "failed to become healthy within the timeout" — call that helper after dumping the log; otherwise behaviour is unchanged (`return 1`).
  - `print_logs_on_exit` now captures `$?` first, turns off `errexit`, reports the status in its banner (`--- Script exiting with status N, displaying logs ---`), and re-exits with the captured status. This is required for correctness of the above: the `EXIT` trap ran under `set -e`, so any failing command inside it (e.g. a `cat` on a log that disappeared) both aborted the trap and overwrote the script's exit status — which would silently destroy the very exit code the retry keys off.
- `.buildkite/features/DCN-Based_P-D_disaggregation.yml` — add `retry.automatic` on exit status 75, limit 1, to the `Correctness tests for DCN-based P/D disaggregation` and `Performance tests for DCN-based P/D disaggregation` steps (the two `Record ...` steps are untouched).
- `.buildkite/pipeline_jax.yml` — same block on the `E2E test for Multihost DCN-based P/D disaggregation` step (`${TPU_VERSION:-tpu6e}_test_25`).

The match is a heuristic, and the code comment says so: `START_SESSION failed` can also be emitted for deterministic misconfiguration (a wrong `TPU_PROCESS_BOUNDS` / `TPU_PROCESS_ADDRESSES`, or chips still held by a leaked container from an earlier run). A retry cannot fix those, so the cost in that case is one extra harness run (~10 min) before the step fails for real. `limit: 1` is what bounds that cost to a single wasted run.

## Validation

**Buildkite semantics, verified empirically** on a dev build with four CPU-queue probe steps — https://buildkite.com/tpu-commons/tpu-inference-dev/builds/930:

| Probe | Config | Result |
|---|---|---|
| A | `soft_fail: true` + `retry.automatic exit_status: 75`, script exits 75 | automatic retry fired (`retry_source.retry_type=automatic`, `retries_count=1`) |
| B | same without `soft_fail`, exits 75 | retried (control — `soft_fail` does not suppress the retry) |
| C | `soft_fail: true` + retry-on-75, script exits **1** | **not** retried |
| D | exits 75 on attempt 0, 0 on attempt 1 | step `passed`; a downstream step running `buildkite-agent step get outcome --step probe_d` (what `record_step_result.sh` does) returned `passed` |

So the `retry:` block fires on exactly the intended code, coexists with `soft_fail: true`, leaves real failures alone, and the `Record …` steps observe the outcome of the retried attempt rather than the failed first one.

Consistent with the flake diagnosis, the originating failure https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24635#01a0231f-0aa7-44b7-b515-11dd4ff8610a passed on manual retry, landing on a different agent (tpu7x-8-ci-14).

**Harness-side validation.** There is no TPU on the machine this was written on, so the real harness was not executed. Instead the modified `print_logs_on_exit` + `exit_if_transient_tpu_init_failure` + `wait_for_server` were extracted verbatim, `docker`/`curl` stubbed, and driven from a `set -ex` wrapper mimicking `run_disagg.sh`:

- "died inside container" path, transient signature present -> wrapper exits **75**, `[disagg-harness] ...` line printed once.
- "died inside container" path, signature absent -> wrapper exits **1**, no line.
- timeout path, transient signature present -> wrapper exits **75**.
- timeout path, signature absent -> wrapper exits **1**.
- Exit banner reads `--- Script exiting with status 75, displaying logs ---`.
- A separate stub reproduced the trap hazard on the pre-change trap shape: with a failing command inside the `EXIT` trap under `set -e`, `exit 75` reached the caller as **2**. With the status-preserving trap the same stub yields 75 / 1 / 0 for tempfail / real failure / success.

**Repo tooling.**

- `bash .buildkite/scripts/validate_buildkite_ymls.sh` (bk 3.55.0): `✅ Pipeline file is valid` for both YAML files, `Result: SUCCESS`, rc=0.
- `bash .buildkite/scripts/validate_pipeline_metadata.sh` (yq 4.53.6): `✅ Metadata verification passed.`, rc=0.
- `yq` confirms exactly three steps carry a `retry` block, all parsing to `automatic: [{exit_status: 75, limit: 1}]` with `exit_status` as an integer.
- `shellcheck examples/disagg/run_disagg_multi_host.sh`: clean, rc=0 (the file carries `# shellcheck disable=all`). With that directive stripped, the warning multiset is identical before and after this change — 13 SC2086, 2 SC2178, 2 SC2128, 1 SC2155, all pre-existing and unrelated; none are fixed here.
- `bash -n` on `run_disagg_multi_host.sh` and `run_disagg.sh`: OK.
- Repo pre-commit hooks ran on commit: `addlicense`, `shellcheck`, `Detect missing __init__.py`, `Check for spaces in all filenames`, `Sign-off Commit` all Passed; python hooks skipped (no `.py` changed). No new files. Added lines have no trailing whitespace and all three files end with a newline.

**Still unobserved:** the retry path has not fired against a live occurrence of the real flake in the real harness. That can only be confirmed the next time it happens in CI.

## Not covered

- **The single-host script.** `examples/disagg/run_disagg_single_host.sh` and its step are deliberately untouched — the observed failures are all multi-host, and the single-host path has not shown this signature. If it does, the same helper can be lifted.
- **Other transient signatures.** Only the two strings above are treated as retryable. Other known-flaky infra modes seen elsewhere in this CI (libtpu lockfile contention, "TPU already in use", stale device handles, out-of-space agents) are *not* matched and will still fail the step on the first attempt. Widening the match should be done deliberately, one proven signature at a time.
- **`limit: 1`.** A single retry, chosen because a manual re-run has so far always been enough. It will not rescue a run that hits the transient failure twice in a row; that would show up as a normal red and is the intended behaviour.

Tests: CI-only change; validated yml with the repo validators and the exit-code propagation with a local bash stub.
