### PR TITLE
[Bugfix] Compile the Qwen2.5-VL vision tower on the torchax path (mm-encoder JIT padding + ViT pad-segment fixes)

### DIFF
--- a/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
@@ -69,6 +69,13 @@ steps:
     soft_fail: true
     agents:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
+    env:
+      # Without this the torchax (MODEL_IMPL_TYPE=vllm) vision tower has no
+      # compiled route: MMEncoderJITManager is never created, so all 32 ViT
+      # blocks run op-by-op through the torchax dispatch for every image.
+      # The flag is inert for the JAX-native model, which does not implement
+      # vLLM's SupportsEncoderCudaGraph protocol.
+      COMPILATION_CONFIG: '{"cudagraph_mm_encoder": true}'
     commands:
       - |
         .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh

--- a/tests/layers/common/test_attention_interface.py
+++ b/tests/layers/common/test_attention_interface.py
@@ -21,7 +21,8 @@ import pytest
 from jax.sharding import Mesh
 
 from tpu_inference.layers.common.attention_interface import (
-    attention, mla_attention, sharded_ragged_paged_attention)
+    attention, mla_attention, segment_ids_from_cu_seqlens,
+    sharded_ragged_paged_attention)
 from tpu_inference.layers.common.attention_metadata import (
     AttentionMetadata, SharedAttentionMetadata)
 from tpu_inference.layers.common.sharding import ShardingAxisName
@@ -499,3 +500,54 @@ def test_mla_attention(monkeypatch, mesh):
     assert kernel_kwargs["num_queries_per_block"] == (1, 16, 16)
     assert kernel_kwargs["mixed_q_split"] == 1
     assert kernel_kwargs["sm_scale"] == 0.1
+
+
+class TestSegmentIdsFromCuSeqlens:
+    """`segment_ids_from_cu_seqlens` must give padding positions their own
+    segment id.
+
+    Wherever q/k/v are padded past `cu_seqlens[-1]` — e.g. the mm-encoder
+    budget path, where `pixel_values` is padded up to the token budget — a
+    `jnp.repeat(..., total_repeat_length=...)` construction would fill those
+    rows with the LAST real segment id, letting pad tokens attend together
+    with the last real sequence whenever `cu_seqlens` has no trailing empty
+    segment.
+    """
+
+    def test_trailing_positions_get_pad_segment(self):
+        """Positions >= cu_seqlens[-1] get id num_segs, not the last real id."""
+        cu = jnp.array([0, 4, 10], dtype=jnp.int32)
+        seg = segment_ids_from_cu_seqlens(cu, 16)
+        expected = [0] * 4 + [1] * 6 + [2] * 6
+        np.testing.assert_array_equal(np.asarray(seg), np.array(expected))
+
+    def test_exact_fit_has_no_pad_segment(self):
+        """total_len == cu_seqlens[-1]: every position belongs to a real seg."""
+        cu = jnp.array([0, 4, 10], dtype=jnp.int32)
+        seg = segment_ids_from_cu_seqlens(cu, 10)
+        np.testing.assert_array_equal(np.asarray(seg),
+                                      np.array([0] * 4 + [1] * 6))
+
+    def test_padded_cu_seqlens_with_empty_trailing_segments(self):
+        """cu_seqlens padded by repeating the last offset (empty sequences):
+        real positions keep their ids and pad positions still get num_segs."""
+        # 2 real sequences (0..3, 4..9) padded out to 4 sequence slots.
+        cu = jnp.array([0, 4, 10, 10, 10], dtype=jnp.int32)
+        seg = segment_ids_from_cu_seqlens(cu, 14)
+        expected = [0] * 4 + [1] * 6 + [4] * 4
+        np.testing.assert_array_equal(np.asarray(seg), np.array(expected))
+
+    def test_leading_empty_segment(self):
+        """An empty leading segment must not swallow position 0."""
+        cu = jnp.array([0, 0, 6], dtype=jnp.int32)
+        seg = segment_ids_from_cu_seqlens(cu, 8)
+        np.testing.assert_array_equal(np.asarray(seg),
+                                      np.array([1] * 6 + [2] * 2))
+
+    def test_jit_traced_matches_eager(self):
+        """cu_seqlens is a traced array under jax.jit (torchax tensor -> jax
+        array); only total_len is static, so ids must match the eager result."""
+        cu = jnp.array([0, 4, 10, 10], dtype=jnp.int32)
+        eager = segment_ids_from_cu_seqlens(cu, 16)
+        jitted = jax.jit(segment_ids_from_cu_seqlens, static_argnums=1)(cu, 16)
+        np.testing.assert_array_equal(np.asarray(jitted), np.asarray(eager))

--- a/tests/layers/vllm/ops/test_scaled_dot_product_attention.py
+++ b/tests/layers/vllm/ops/test_scaled_dot_product_attention.py
@@ -77,6 +77,42 @@ class TestAttnDpBatchAxisFix:
         assert out.shape == (1, 128, 2, 64)
 
 
+class TestVitSdpaPadSegments:
+    """`vllm_vit_sdpa` must hand the kernel segment ids in which every padded
+    position (kernel 128-alignment padding AND mm-encoder budget padding) sits
+    in its own trailing segment."""
+
+    def _capture_seg_ids(self, q_seq_len, cu_seqlens):
+        q = k = v = jnp.ones((1, q_seq_len, 2, 64), dtype=jnp.float32)
+        with mock.patch.object(sdpa_ops,
+                               'sharded_flash_attention') as mock_sfa:
+            mock_sfa.return_value = mock.MagicMock(
+                return_value=jnp.ones((1, 2, q_seq_len,
+                                       64), dtype=jnp.float32))
+            vllm_vit_sdpa(q, k, v, cu_seqlens=cu_seqlens)
+        attn_fn = mock_sfa.return_value
+        seg_ids = attn_fn.call_args[0][3]
+        return np.asarray(seg_ids.q[0]), np.asarray(seg_ids.kv[0])
+
+    def test_budget_padding_gets_dedicated_segment(self):
+        """Full batch (no empty trailing cu_seqlens entry) with padded q/k/v:
+        the tail must NOT inherit the last image's segment id."""
+        # 2 images covering [0, 64) and [64, 192); 192..255 is budget padding.
+        q_seg, kv_seg = self._capture_seg_ids(256, [0, 64, 192])
+        expected = np.array([0] * 64 + [1] * 128 + [2] * 64)
+        np.testing.assert_array_equal(q_seg, expected)
+        np.testing.assert_array_equal(kv_seg, expected)
+
+    def test_kernel_alignment_padding_gets_dedicated_segment(self):
+        """The 128-alignment pad rows keep their dedicated trailing segment."""
+        # seq_len 100 -> q_pad 28; one image covering the whole real range.
+        q_seg, kv_seg = self._capture_seg_ids(100, [0, 100])
+        assert q_seg.shape == (128, )
+        np.testing.assert_array_equal(q_seg[:100], np.zeros(100))
+        np.testing.assert_array_equal(q_seg[100:], np.ones(28))
+        np.testing.assert_array_equal(kv_seg, q_seg)
+
+
 class TestVitVmemLimit:
     """The ViT flash attention must raise the scoped-vmem limit above the
     32MiB pallas default: large flattened image sequences exceed it

--- a/tests/runner/test_mm_encoder_jit_manager.py
+++ b/tests/runner/test_mm_encoder_jit_manager.py
@@ -25,9 +25,12 @@ from torchax.interop import jax_view
 from vllm.config import (CompilationConfig, ModelConfig, MultiModalConfig,
                          VllmConfig, set_current_vllm_config)
 from vllm.distributed.parallel_state import (ensure_model_parallel_initialized,
-                                             init_distributed_environment)
+                                             init_distributed_environment,
+                                             model_parallel_is_initialized)
 from vllm.engine.arg_utils import EngineArgs
 from vllm.model_executor.model_loader import get_model as vllm_get_model
+from vllm.model_executor.models.qwen2_5_vl import \
+    _pad_cumulative_seqlens_buffer
 from vllm.v1.worker.encoder_cudagraph_defs import (
     EncoderCudaGraphCaptureInputs, EncoderCudaGraphConfig,
     EncoderCudaGraphReplayBuffers)
@@ -181,15 +184,26 @@ class TestAdapterPostprocessEncoderOutput:
 
 
 class TestPadToTemplate:
-    """Test MMEncoderJITManager._pad_to_template — zero-padding, slicing, and dtype-casting.
+    """Test MMEncoderJITManager._pad_to_template — per-key padding logic,
+    slicing, and dtype-casting.
 
     Pure torch logic — tested without a full manager init by constructing a
-    bare instance via object.__new__ and setting only budget_templates.
+    bare instance via object.__new__ and setting the few attributes the method
+    reads (budget_templates, config, max_batch_size).
     """
 
-    def _manager(self, template: dict) -> MMEncoderJITManager:
+    def _manager(self,
+                 template: dict,
+                 padding_logics: dict | None = None) -> MMEncoderJITManager:
         m = object.__new__(MMEncoderJITManager)
         m.budget_templates = {256: template}
+        m.max_batch_size = 4
+        m.config = EncoderCudaGraphConfig(
+            modalities=["image"],
+            buffer_keys=list(template),
+            out_hidden_size=64,
+            padding_logics=padding_logics or {},
+        )
         return m
 
     def test_general_case_zeros_then_copies(self):
@@ -230,6 +244,66 @@ class TestPadToTemplate:
         result = self._manager({"pv": tmpl})._pad_to_template({"pv": src}, 256)
         assert result["pv"].dtype == torch.bfloat16
         assert torch.all(result["pv"][:4] == 1.0)
+
+    def test_padding_logic_from_config_is_used(self):
+        """A key with a registered padding logic must use it instead of the
+        zero-fill default.
+
+        Qwen2.5-VL registers `_pad_cumulative_seqlens_buffer` for cu_seqlens /
+        cu_window_seqlens and leaves cu_window_seqlens UNPADDED at replay time.
+        Zero-filling the tail makes `lens = cu[1:] - cu[:-1]` go negative and
+        the ViT attention builds garbage segment ids, so the tail must repeat
+        the last cumulative offset (= empty trailing sequences) instead.
+        """
+        tmpl = torch.zeros(6, dtype=torch.int32)
+        src = torch.tensor([0, 4, 10], dtype=torch.int32)
+        manager = self._manager({"cu_window_seqlens": tmpl},
+                                padding_logics={
+                                    "cu_window_seqlens":
+                                    _pad_cumulative_seqlens_buffer
+                                })
+        result = manager._pad_to_template({"cu_window_seqlens": src}, 256)
+        torch.testing.assert_close(
+            result["cu_window_seqlens"],
+            torch.tensor([0, 4, 10, 10, 10, 10], dtype=torch.int32))
+
+    def test_no_padding_logic_still_zero_pads(self):
+        """Keys without a registered logic keep the upstream default: zero the
+        buffer, slice-copy src onto its head."""
+        tmpl = torch.zeros(6, dtype=torch.int32)
+        src = torch.tensor([1, 2, 3], dtype=torch.int32)
+        result = self._manager({
+            "window_index": tmpl
+        })._pad_to_template({"window_index": src}, 256)
+        torch.testing.assert_close(
+            result["window_index"],
+            torch.tensor([1, 2, 3, 0, 0, 0], dtype=torch.int32))
+
+    def test_template_shaped_src_is_cast_to_template_dtype(self):
+        """src already template-shaped but a different dtype: cast, otherwise
+        the jit signature changes and every request recompiles."""
+        tmpl = torch.zeros(4, 2, dtype=torch.bfloat16)
+        src = torch.ones(4, 2, dtype=torch.float32)
+        result = self._manager({"pv": tmpl})._pad_to_template({"pv": src}, 256)
+        assert result["pv"].dtype == torch.bfloat16
+        assert result["pv"].shape == (4, 2)
+        assert torch.all(result["pv"] == 1.0)
+
+    def test_oversized_src_raises_with_shapes(self):
+        """A replay buffer longer than its template is a packing bug — fail
+        loudly with the key and both shapes, not a bare copy_ error."""
+        tmpl = torch.zeros(4, 2)
+        src = torch.ones(9, 2)
+        with pytest.raises(ValueError, match="leading-dim overflow"):
+            self._manager({"pv": tmpl})._pad_to_template({"pv": src}, 256)
+
+    def test_trailing_dim_mismatch_raises_with_shapes(self):
+        """Only the leading dim is padded, so a differing trailing dim is a
+        layout bug and must fail loudly rather than slice-copy silently."""
+        tmpl = torch.zeros(8, 2)
+        src = torch.ones(4, 3)
+        with pytest.raises(ValueError, match="trailing-dim mismatch"):
+            self._manager({"pv": tmpl})._pad_to_template({"pv": src}, 256)
 
 
 class TestMMEncoderJITManagerInit:
@@ -275,28 +349,78 @@ def _image_mm_kwargs(t=1, h=4, w=4):
     # Derived from Qwen3.5-0.8B vision_config:
     #   patch_size=16, temporal_patch_size=2, in_channels=3,
     _PATCH_FEAT = 2 * 16 * 16 * 3  # temporal_patch_size * patch_size^2 * in_channels
+    # Seeded on the grid so a failure reproduces run to run.
+    gen = torch.Generator().manual_seed(hash((t, h, w)) & 0xFFFFFFFF)
     return {
-        "pixel_values": torch.randn(t * h * w,
-                                    _PATCH_FEAT,
-                                    dtype=torch.bfloat16),
+        "pixel_values":
+        torch.randn(t * h * w,
+                    _PATCH_FEAT,
+                    dtype=torch.bfloat16,
+                    generator=gen),
         "image_grid_thw": [(t, h, w)],
     }
 
 
-@pytest.fixture(scope="module")
-def qwen35_mm_encoder():
-    engine_args = EngineArgs(
-        model="Qwen/Qwen3.5-0.8B",
-        max_model_len=256,
-        max_num_batched_tokens=256,
-        max_num_seqs=4,
-        dtype="bfloat16",
-        load_format="dummy",
-        limit_mm_per_prompt={"image": 1},
-    )
+def _reinit_params_for_sensitivity(params: dict, seed: int = 0) -> dict:
+    """Replace vLLM's dummy weights with a non-degenerate random init.
+
+    ``load_format="dummy"`` fills EVERY parameter — norm scales included — with
+    uniform(-1e-3, 1e-3). In that regime each ViT block's residual contribution
+    is ~1e-9 of the residual stream, so the encoder output is essentially
+    ``patch_embed`` + ``merger`` and is numerically INSENSITIVE to which tokens
+    the attention actually sees: a padded-vs-eager comparison then passes even
+    when budget-padding rows leak into a real image's attention segment
+    (measured on Qwen2.5-VL-3B: max|out| 1.0e-3, and the same 7.5e-6 max
+    difference with and without that bug).
+
+    Re-init norm scales to 1, biases to 0 and every other float parameter to
+    normal(0, 0.02) so the blocks actually shape the output and the comparison
+    has teeth. The same weights feed both the padded JIT path and the eager
+    reference, so equivalence still has to hold exactly.
+    """
+    key = jax.random.key(seed)
+    out: dict = {}
+    for i, (name, value) in enumerate(sorted(params.items())):
+        if not (hasattr(value, "dtype")
+                and jnp.issubdtype(value.dtype, jnp.floating)):
+            out[name] = value
+        elif name.endswith(".bias"):
+            out[name] = jnp.zeros_like(value)
+        elif "norm" in name or "ln_" in name:
+            out[name] = jnp.ones_like(value)
+        else:
+            out[name] = (jax.random.normal(
+                jax.random.fold_in(key, i), value.shape, dtype=jnp.float32) *
+                         0.02).astype(value.dtype)
+    return out
+
+
+def _build_mm_encoder_manager(engine_args: EngineArgs,
+                              params_transform=None,
+                              **compilation_overrides):
+    """Load a real model with dummy weights and build a live manager.
+
+    Shared by the per-model integration fixtures. The torch distributed init is
+    process-global, so it runs at most once even with several fixtures.
+
+    Args:
+      engine_args: Model/scheduler args; ``load_format="dummy"`` keeps this to
+        a config download plus random weights.
+      params_transform: Optional callable applied to the sharded jax parameter
+        dict before the manager is built (see
+        ``_reinit_params_for_sensitivity``).
+      compilation_overrides: Extra ``compilation_config`` attributes to set
+        (e.g. ``encoder_cudagraph_max_vision_items_per_batch``).
+
+    Returns:
+      ``(manager, mesh)`` — the mesh must be active (``jax.set_mesh``) around
+      any call that reaches the vision attention kernel.
+    """
     vllm_config = engine_args.create_engine_config()
     vllm_config.device_config.device = "cpu"
     vllm_config.compilation_config.cudagraph_mm_encoder = True
+    for key, value in compilation_overrides.items():
+        setattr(vllm_config.compilation_config, key, value)
 
     # sharded_flash_attention uses batch_axis="data" and head_axis="model";
     # both axes must be present. With one device both are size-1 (replicated).
@@ -310,27 +434,117 @@ def qwen35_mm_encoder():
                                     device=jax.devices()[0],
                                     need_pp=False)
 
+    # TPUPlatform.check_and_update_config attaches `sharding_config` to the
+    # VllmConfig as a plain attribute — it is not a declared dataclass field.
+    # Models with a nested text config (Qwen2.5-VL) call
+    # VllmConfig.with_hf_config -> vllm.config.utils.replace during init, which
+    # rebuilds the config from __dict__ and raises "Field 'sharding_config' not
+    # found in VllmConfig" on any extra key. Same hasattr/delattr dance as
+    # VllmModelWrapper.load_weights in
+    # tpu_inference/models/vllm/vllm_model_wrapper.py (which strips it from its
+    # load-time config copy); keep the two in sync. Re-attached below because
+    # the manager and the sharding helpers run against this same config.
+    sharding_config = None
+    if hasattr(vllm_config, "sharding_config"):
+        sharding_config = vllm_config.sharding_config
+        delattr(vllm_config, "sharding_config")
+
     with (cpu_mesh_context(), mock_patch("torch._sync", return_value=None),
           set_current_vllm_config(vllm_config)):
-        temp_file = tempfile.mkstemp()[1]
-        init_distributed_environment(
-            1,
-            0,
-            local_rank=0,
-            distributed_init_method=f"file://{temp_file}",
-            backend="gloo")
-        ensure_model_parallel_initialized(1, 1)
+        if not model_parallel_is_initialized():
+            temp_file = tempfile.mkstemp()[1]
+            init_distributed_environment(
+                1,
+                0,
+                local_rank=0,
+                distributed_init_method=f"file://{temp_file}",
+                backend="gloo")
+            ensure_model_parallel_initialized(1, 1)
         vllm_model = vllm_get_model(vllm_config=vllm_config)
+
+    if sharding_config is not None:
+        vllm_config.sharding_config = sharding_config
 
     vllm_runner = _VllmRunner(vllm_model)
     params_jax = jax_view(shard_model_to_tpu(vllm_runner, mesh))
+    if params_transform is not None:
+        params_jax = params_transform(params_jax)
     manager = MMEncoderJITManager(
         vllm_config=vllm_config,
         vllm_runner=vllm_runner,
         vllm_model=vllm_model,
         params_and_buffers=params_jax,
     )
-    yield manager, mesh
+    return manager, mesh
+
+
+@pytest.fixture(scope="module")
+def qwen35_mm_encoder():
+    yield _build_mm_encoder_manager(
+        EngineArgs(
+            model="Qwen/Qwen3.5-0.8B",
+            max_model_len=256,
+            max_num_batched_tokens=256,
+            max_num_seqs=4,
+            dtype="bfloat16",
+            load_format="dummy",
+            limit_mm_per_prompt={"image": 1},
+        ))
+
+
+@pytest.fixture(scope="module")
+def qwen25vl_mm_encoder():
+    """Qwen2.5-VL on the torchax path — the model the nightly benchmark runs.
+
+    Shrunk to the smallest shape that still covers both padding hazards, so
+    the class stays cheap enough for the "JAX unit tests part2" job:
+
+    * ``vision_config.depth=2`` with ``fullatt_block_indexes=[1]`` keeps one
+      window-attention block (layer 0, driven by ``cu_window_seqlens`` — the
+      buffer whose padding logic matters) and one full-attention block
+      (layer 1, driven by ``cu_seqlens`` — the buffer whose trailing budget
+      padding must land in its own segment). The stock 32 blocks only repeat
+      those two cases. Every other vision hyper-parameter — patch_size 14,
+      temporal_patch_size 2, in_channels 3, spatial_merge_size 2, window_size
+      112, out_hidden_size 2048 — is untouched, so all the geometry the test
+      computes stays the real model's.
+    * ``text_config.num_hidden_layers=1`` because the language model is never
+      run here; it only inflates dummy-weight init and sharding time.
+
+    max_vision_items_per_batch is pinned to 2 so a batch of exactly
+    max_batch_size real items (the case where cu_seqlens has NO trailing empty
+    segment, yet pixel_values is still padded up to the budget) is reachable
+    without building large images.
+    """
+    yield _build_mm_encoder_manager(
+        EngineArgs(
+            model="Qwen/Qwen2.5-VL-3B-Instruct",
+            max_model_len=512,
+            max_num_batched_tokens=512,
+            max_num_seqs=4,
+            dtype="bfloat16",
+            load_format="dummy",
+            # video must be 0, otherwise the manager sizes cu_seqlens for
+            # frames and captures a video-shaped grid.
+            limit_mm_per_prompt={
+                "image": 4,
+                "video": 0
+            },
+            # Nested dicts land on the sub-configs via
+            # ModelConfig._apply_dict_overrides -> _update_nested, which runs
+            # before hf_text_config / model_arch_config are derived.
+            hf_overrides={
+                "vision_config": {
+                    "depth": 2,
+                    "fullatt_block_indexes": [1],
+                },
+                "text_config": {
+                    "num_hidden_layers": 1
+                },
+            },
+        ),
+        params_transform=_reinit_params_for_sensitivity,
+        encoder_cudagraph_max_vision_items_per_batch=2)
 
 
 class TestMMEncoderJITManagerIntegration:
@@ -398,3 +612,154 @@ class TestMMEncoderJITManagerIntegration:
         )
         assert manager.graph_hits > hits_before, (
             "graph_hits must increment for a within-budget image")
+
+
+# Qwen2.5-VL vision_config: in_channels=3, temporal_patch_size=2,
+# patch_size=14, spatial_merge_size=2, out_hidden_size=2048. The
+# qwen25vl_mm_encoder fixture only overrides depth / fullatt_block_indexes, so
+# every value below is still the stock model's.
+_QWEN25VL_PATCH_FEAT = 3 * 2 * 14 * 14  # 1176
+_QWEN25VL_SPATIAL_MERGE = 2
+_QWEN25VL_OUT_HIDDEN = 2048
+
+
+def _qwen25vl_mm_kwargs(grids):
+    """Build image mm_kwargs for a list of (t, h, w) Qwen2.5-VL grids.
+
+    h and w must be multiples of spatial_merge_size (2). pixel_values rows are
+    concatenated per item in grid order, matching how the model's
+    select_encoder_cudagraph_items slices a batch back apart.
+    """
+    total_patches = sum(t * h * w for t, h, w in grids)
+    # Seeded on the grids so a failure reproduces run to run.
+    gen = torch.Generator().manual_seed(
+        hash(tuple(tuple(g) for g in grids)) & 0xFFFFFFFF)
+    return {
+        "pixel_values":
+        torch.randn(total_patches,
+                    _QWEN25VL_PATCH_FEAT,
+                    dtype=torch.bfloat16,
+                    generator=gen),
+        "image_grid_thw": [tuple(g) for g in grids],
+    }
+
+
+def _qwen25vl_out_tokens(grid) -> int:
+    t, h, w = grid
+    return t * (h // _QWEN25VL_SPATIAL_MERGE) * (w // _QWEN25VL_SPATIAL_MERGE)
+
+
+class TestQwen25VLMMEncoderJITIntegration:
+    """Correctness of the budget-padded JIT encoder path for Qwen2.5-VL.
+
+    The nightly accuracy job for this model is text-only (gsm8k), so nothing
+    else in CI compares the compiled vision path against eager. Two padding
+    hazards are covered here:
+
+    * cu_window_seqlens comes back UNPADDED from
+      prepare_encoder_cudagraph_replay_buffers, so _pad_to_template must apply
+      the model's cumulative-seqlens padding logic (repeat the last offset)
+      instead of zero-filling the tail.
+    * pixel_values is padded up to the token budget, so the ViT attention must
+      keep the pad rows in their own segment. For a batch of exactly
+      max_batch_size items cu_seqlens has no trailing empty segment, and a
+      "repeat the last id" segment-id construction merges the pad rows into
+      the last image.
+    """
+
+    # Relative tolerance on max|out|. Measured on the fixture's 2-block
+    # Qwen2.5-VL-3B with the sensitivity re-init: the correct padded path lands
+    # at 0.0066-0.0071 of max|out| (bf16 + attention over a different padded
+    # length); zero-padding cu_window_seqlens instead of repeating its last
+    # offset gives 0.3073-0.3186, and filling the trailing segment ids with the
+    # last real id gives 0.3194-0.3393. 0.1 sits ~14x above the correct path
+    # and ~3x below either bug.
+    _REL_TOL = 0.1
+
+    @staticmethod
+    def _clear_rope_cache(manager):
+        """Drop visual.get_rope_by_thw's lru_cache before a test.
+
+        It is keyed on (t, h, w) only, and the tensors it caches are plain
+        torch or torchax depending on which path filled it first, so a
+        previous test's entries must not leak into this one.
+        """
+        manager.model.visual.get_rope_by_thw.cache_clear()
+
+    def _assert_padded_matches_eager(self, manager, mesh, grids):
+        self._clear_rope_cache(manager)
+        mm_kwargs = _qwen25vl_mm_kwargs(grids)
+        with jax.set_mesh(mesh):
+            # Run the budget path BEFORE the eager reference. Both go through
+            # visual.get_rope_by_thw, which is @lru_cache'd on (t, h, w); the
+            # eager path runs inside the torchax env and seeds that cache with
+            # torchax tensors, which then blow up in the replay-buffer prep
+            # (plain torch, outside the env). This ordering only matters here:
+            # _execute_local routes an item to the budget path or to eager
+            # purely by its token count, i.e. by its (t, h, w), so in
+            # production a geometry that goes eager always goes eager and its
+            # cached tensors never reach the replay-buffer prep. This test is
+            # the only place both paths see the same geometry.
+            padded = manager.execute(mm_kwargs)
+            eager = [
+                manager.model.encoder_eager_forward(
+                    manager.model.select_encoder_cudagraph_items(
+                        mm_kwargs, [i])) for i in range(len(grids))
+            ]
+        jax.block_until_ready((padded, eager))
+
+        assert len(padded) == len(grids)
+        for i, grid in enumerate(grids):
+            got = np.asarray(padded[i], dtype=np.float32)
+            want = np.asarray(eager[i], dtype=np.float32)
+            assert got.shape == want.shape, (
+                f"item {i} grid={grid}: padded {got.shape} != eager "
+                f"{want.shape}")
+            scale = float(np.abs(want).max())
+            assert scale > 1e-3, (
+                f"item {i} grid={grid}: eager output is all ~0 "
+                f"(max|out|={scale:.2e}); the comparison below cannot "
+                f"discriminate — the model weights are degenerate")
+            max_diff = float(np.abs(got - want).max())
+            assert max_diff <= self._REL_TOL * scale, (
+                f"item {i} grid={grid}: budget-padded encoder output differs "
+                f"from eager by {max_diff:.4f} "
+                f"({max_diff / scale:.4f} of max|out|={scale:.4f}, allowed "
+                f"{self._REL_TOL}); a metadata buffer was padded with zeros "
+                f"instead of its registered padding logic, or pad rows leaked "
+                f"into a real image's attention segment")
+
+    def test_execute_single_image(self, qwen25vl_mm_encoder):
+        """One within-budget image: right output shape and a graph hit."""
+        manager, mesh = qwen25vl_mm_encoder
+        self._clear_rope_cache(manager)
+        grid = (1, 4, 4)
+        mm_kwargs = _qwen25vl_mm_kwargs([grid])
+
+        hits_before = manager.graph_hits
+        with jax.set_mesh(mesh):
+            result = manager.execute(mm_kwargs)
+        jax.block_until_ready(result)
+
+        assert len(result) == 1
+        assert isinstance(result[0], jax.Array)
+        assert result[0].shape == (_qwen25vl_out_tokens(grid),
+                                   _QWEN25VL_OUT_HIDDEN)
+        assert manager.graph_hits == hits_before + 1
+
+    def test_padded_matches_eager_mixed_grids(self, qwen25vl_mm_encoder):
+        """Multi-image batch with different grids: every item must match the
+        eager single-item forward."""
+        manager, mesh = qwen25vl_mm_encoder
+        self._assert_padded_matches_eager(manager, mesh, [(1, 4, 4), (1, 6, 8),
+                                                          (1, 8, 8)])
+
+    def test_padded_matches_eager_full_batch(self, qwen25vl_mm_encoder):
+        """Exactly max_batch_size items, all below the budget: cu_seqlens has
+        no trailing empty segment, so the budget pad rows have nothing to hide
+        behind."""
+        manager, mesh = qwen25vl_mm_encoder
+        assert manager.max_batch_size == 2, (
+            "fixture pins max_vision_items_per_batch=2 so this batch is full")
+        self._assert_padded_matches_eager(manager, mesh, [(1, 4, 4),
+                                                          (1, 6, 6)])

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -64,6 +64,40 @@ ragged_paged_attention_hd64 = rpa_hd64.ragged_paged_attention_hd64
 get_kv_cache_shape_hd64 = rpa_hd64.get_kv_cache_shape
 
 
+def segment_ids_from_cu_seqlens(cu_seqlens: jax.Array,
+                                total_len: int) -> jax.Array:
+    """Build a per-position segment id vector from cumulative sequence lengths.
+
+    Position ``p`` belongs to segment ``i`` when
+    ``cu_seqlens[i] <= p < cu_seqlens[i + 1]``; every position at or beyond
+    ``cu_seqlens[-1]`` is padding and gets the dedicated id ``num_segs``
+    (``= len(cu_seqlens) - 1``), which no real sequence uses. That keeps
+    padding tokens out of the last real sequence's attention block.
+
+    The alternative ``jnp.repeat(arange(num_segs), lens,
+    total_repeat_length=total_len)`` fills the trailing positions with the LAST
+    segment id instead, which silently merges padding into the last real
+    sequence unless ``cu_seqlens`` happens to end with an empty (padded)
+    segment. That matters wherever q/k/v are padded past ``cu_seqlens[-1]`` --
+    e.g. the mm-encoder budget path, where ``pixel_values`` is padded up to the
+    token budget.
+
+    Args:
+      cu_seqlens: 1-D cumulative offsets, ``[0, l0, l0+l1, ...]``. May be a
+        traced array (repeated trailing offsets = empty segments are fine).
+      total_len: Static length of the id vector to produce.
+
+    Returns:
+      int32 array of shape ``(total_len,)``. The shape depends only on the
+      static ``total_len`` / ``len(cu_seqlens)``, so this is jit-safe.
+    """
+    cu = jnp.asarray(cu_seqlens)
+    positions = jnp.arange(total_len, dtype=cu.dtype)
+    # searchsorted(side="right") over the segment *end* offsets gives exactly
+    # sum(p >= cu_seqlens[1:]): the count of segments that end at or before p.
+    return jnp.searchsorted(cu[1:], positions, side="right").astype(jnp.int32)
+
+
 def sharded_flash_attention(
     mesh: Mesh,
     causal: bool = True,

--- a/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
+++ b/tpu_inference/layers/vllm/ops/scaled_dot_product_attention.py
@@ -18,8 +18,8 @@ import jax.numpy as jnp
 import torch
 from torchax.ops.jtorch import register_function
 
-from tpu_inference.layers.common.attention_interface import \
-    sharded_flash_attention
+from tpu_inference.layers.common.attention_interface import (
+    segment_ids_from_cu_seqlens, sharded_flash_attention)
 
 # ViT flash-attention on large flattened image sequences needs more scoped
 # vmem than the 32MiB pallas default (~37MiB at bf16[1,16,25344,80]); 64MiB
@@ -143,29 +143,15 @@ def vllm_vit_sdpa(
         value = jnp.pad(value, ((0, 0), (0, 0), (0, kv_pad), (0, 0)))
 
     if cu_seqlens is not None:
-        # Compute individual sequence lengths from cumulative sequence lengths.
-        cu_seqlens_arr = jnp.array(cu_seqlens)
-        lens = cu_seqlens_arr[1:] - cu_seqlens_arr[:-1]
-        num_segs = lens.shape[0]
-
-        # Create segment IDs for each token by repeating the sequence index by its length.
-        q_real_seg = jnp.repeat(jnp.arange(num_segs),
-                                lens,
-                                total_repeat_length=q_seq_len)
-        kv_real_seg = q_real_seg
-
-        # Pad segment IDs if sequence lengths are not multiples of 128.
-        if q_pad > 0:
-            q_pad_seg = jnp.full((q_pad, ), num_segs)
-            q_seg = jnp.concatenate([q_real_seg, q_pad_seg])
-        else:
-            q_seg = q_real_seg
-
-        if kv_pad > 0:
-            kv_pad_seg = jnp.full((kv_pad, ), num_segs)
-            kv_seg = jnp.concatenate([kv_real_seg, kv_pad_seg])
-        else:
-            kv_seg = kv_real_seg
+        # Build the segment ids straight over the PADDED length. Every position
+        # >= cu_seqlens[-1] -- both the kernel's 128-alignment padding and the
+        # mm-encoder budget padding baked into pixel_values -- lands in the
+        # dedicated trailing segment `num_segs`, so pad tokens never attend
+        # together with the last real image.
+        cu_seqlens_arr = jnp.asarray(cu_seqlens)
+        q_seg = segment_ids_from_cu_seqlens(cu_seqlens_arr, q_seq_len + q_pad)
+        kv_seg = segment_ids_from_cu_seqlens(cu_seqlens_arr,
+                                             kv_seq_len + kv_pad)
 
         # Broadcast from 1D (seq_len,) to 2D (batch, seq_len) to match kernel expectations.
         q_seg = jnp.broadcast_to(q_seg, (batch, q_seg.shape[0]))

--- a/tpu_inference/models/jax/qwen2_5_vl.py
+++ b/tpu_inference/models/jax/qwen2_5_vl.py
@@ -31,8 +31,8 @@ from vllm.transformers_utils.config import set_default_rope_theta
 
 from tpu_inference import utils as utils
 from tpu_inference.distributed.jax_parallel_state import get_pp_group
-from tpu_inference.layers.common.attention_interface import \
-    sharded_flash_attention
+from tpu_inference.layers.common.attention_interface import (
+    segment_ids_from_cu_seqlens, sharded_flash_attention)
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.jax.layers import FlaxUtils
 from tpu_inference.layers.jax.linear import JaxLmHead
@@ -198,8 +198,9 @@ def generate_window_segment_ids(cu_seqlens: jax.Array, seq_len: int,
     Returns:
         A SegmentIds object for flash_attention.
     """
-    indices = jnp.arange(seq_len, dtype=jnp.int32)
-    segment_ids = jnp.searchsorted(cu_seqlens[1:], indices, side='right') + 1
+    # Shared 0-based ids (positions >= cu_seqlens[-1] get num_segs), shifted to
+    # 1-based here so this kernel can keep 0 for the trailing padding below.
+    segment_ids = segment_ids_from_cu_seqlens(cu_seqlens, seq_len) + 1
     padding_segment_ids = jnp.zeros(padded_seq_len - seq_len, dtype=jnp.int32)
     segment_ids = jnp.concatenate([segment_ids, padding_segment_ids])
     segment_ids = segment_ids.reshape(1, -1)

--- a/tpu_inference/runner/mm_encoder_jit_manager.py
+++ b/tpu_inference/runner/mm_encoder_jit_manager.py
@@ -148,7 +148,12 @@ class _TorchaxEncoderModelAdapter:
         # the inherited _execute_local can stay in plain-torch context (its
         # replay-buffer prep indexes model Parameters, which must NOT run
         # under the torchax dispatch).
-        with torchax.default_env():
+        # ``enable_torch_wrap(False)`` is required for the same reason as in
+        # ``run_budget_forward``: with the torch custom-op layer on, vllm.ir
+        # ops (e.g. ``vllm_ir.rms_norm`` in the ViT block norms) reach torchax
+        # as opaque OpOverloads it has no lowering for, and dispatch dies with
+        # "torchax Tensors can only do math within the torchax environment".
+        with torchax.default_env(), enable_torch_wrap(False):
             torchax_kwargs = {
                 k: jax.tree.map(self._torchax_view_if_torch, v)
                 for k, v in mm_kwargs.items()
@@ -331,14 +336,23 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
         replay_values: dict[str, torch.Tensor],
         budget: int,
     ) -> dict[str, torch.Tensor]:
-        """Zero-and-copy each replay tensor into a template-shaped buffer.
+        """Copy each replay tensor into a template-shaped buffer.
 
-        Mirrors the GPU manager's ``_copy_padded_buffer`` default (the
-        parent's ``_run_budget_graph`` does this per buffer_key). Here we pad
-        *every* template key because the jit call needs a fresh, fully
+        Mirrors the GPU manager's per-key copy in ``_run_budget_graph``: the
+        buffer starts zeroed and the model-supplied
+        ``EncoderCudaGraphConfig.padding_logics`` entry for the key decides how
+        the replay values land in it, falling back to the upstream
+        ``_copy_padded_buffer`` (zero tail) when the key has no entry. Here we
+        pad *every* template key because the jit call needs a fresh, fully
         materialised input dict each step (no persistent buffers).
-        cu_seqlens / scalars pass through because ``prepare_encoder_metadata``
-        already padded them.
+
+        Honouring ``padding_logics`` is required for correctness, not just
+        parity: Qwen2.5-VL registers ``_pad_cumulative_seqlens_buffer`` for
+        ``cu_seqlens`` / ``cu_window_seqlens`` and leaves ``cu_window_seqlens``
+        UNPADDED at replay time. A zero tail there makes
+        ``lens = cu[1:] - cu[:-1]`` go negative and the ViT attention build
+        garbage segment ids; the registered logic repeats the last cumulative
+        offset instead, which represents empty trailing sequences.
         """
         template = self.budget_templates[budget]
         padded: dict[str, torch.Tensor] = {}
@@ -356,13 +370,31 @@ class MMEncoderJITManager(EncoderCudaGraphManager):
                 continue
             if src.shape == tmpl.shape:
                 # Already template-shaped (e.g. cu_seqlens padded by
-                # max_batch_size at metadata-prep time).
-                padded[key] = src
+                # max_batch_size at metadata-prep time). Still cast to the
+                # template dtype — a differing dtype would change the jit
+                # signature and force a recompile per request.
+                padded[key] = (src if src.dtype == tmpl.dtype else src.to(
+                    dtype=tmpl.dtype))
                 continue
-            # General case: zero buffer, then slice-copy src onto its head.
+            # Only the leading dim is padded; the trailing dims must match
+            # exactly or the slice-copy below writes the wrong layout.
+            if (src.shape[0] > tmpl.shape[0]
+                    or src.shape[1:] != tmpl.shape[1:]):
+                reason = ("leading-dim overflow" if src.shape[0]
+                          > tmpl.shape[0] else "trailing-dim mismatch")
+                raise ValueError(
+                    f"[mm_encoder_jit] replay buffer does not fit its budget "
+                    f"template ({reason}): key={key} "
+                    f"src_shape={tuple(src.shape)} "
+                    f"template_shape={tuple(tmpl.shape)} budget={budget} "
+                    f"max_batch_size={self.max_batch_size}; the batch was "
+                    f"packed into a token budget whose capture inputs do not "
+                    f"fit this key.")
+            # General case: zeroed buffer + the model's per-key padding logic.
             buf = torch.zeros_like(tmpl)
-            n = src.shape[0]
-            buf[:n] = src.to(dtype=tmpl.dtype, device=tmpl.device)
+            padding_logic = self.config.padding_logics.get(
+                key, EncoderCudaGraphManager._copy_padded_buffer)
+            padding_logic(buf, src.to(dtype=tmpl.dtype, device=tmpl.device))
             padded[key] = buf
         return padded
 


### PR DESCRIPTION
## Problem

On the torchax path (`MODEL_IMPL_TYPE=vllm`) Qwen2.5-VL-7B's multimodal benchmark has never genuinely passed. Nightly 24593 / 24660:

- **tpu7x**: 0.04 req/s (bar 0.76), mean TPOT 8.3 s, mean TTFT 27 min — the whole engine crawls, not just prefill.
- **tpu6e**: EngineCore dies with `RESOURCE_EXHAUSTED` inside `vllm_vit_sdpa` → `jit__flash_attention` (96 MiB needed, 52 MiB free); the run reported `Total generated tokens: 0` and was scored PASSED until #3447.

The JAX-native model runs the same recipe at 1.18–1.29 req/s.

## Root cause

The vision tower runs **eager** under torchax: every image goes op-by-op through all 32 ViT blocks, each `vllm_vit_sdpa` call launching a standalone flash-attention program, and every engine step waits behind it. Nothing enables `compilation_config.cudagraph_mm_encoder`, so `maybe_create_mm_encoder_jit_manager` returns `None` (log: `Qwen2_5_VLForConditionalGeneration's vision tower does NOT support JIT compilation`).

vLLM's `Qwen2_5_VLForConditionalGeneration` implements `SupportsEncoderCudaGraph` (since vllm-project/vllm@f5bb701fa2, in our LKG), so the compiled route is `MMEncoderJITManager` — the same mechanism the gemma-4 26B/31B benchmarks already use. Turning it on exposed two correctness bugs in that route, which this PR fixes first:

1. **`MMEncoderJITManager._pad_to_template` ignored `EncoderCudaGraphConfig.padding_logics`** and zero-filled every replay buffer. Qwen2.5-VL registers `_pad_cumulative_seqlens_buffer` (repeat the last offset) for `cu_seqlens`/`cu_window_seqlens` and returns `cu_window_seqlens` **unpadded** at replay, so the zero tail made `lens = cu[1:] - cu[:-1]` negative and the ViT built garbage window-attention segment ids. Now the per-key logic is applied (upstream `_copy_padded_buffer` fallback), a template-shaped buffer is cast to the template dtype (stable jit signature), and an over-large replay buffer raises a `[mm_encoder_jit]`-tagged error naming key/shapes/budget.
2. **`vllm_vit_sdpa` gave budget-padding tokens the last image's segment id.** `jnp.repeat(..., total_repeat_length=L)` fills positions past `sum(lens)` with the last id; on the padded JIT path `pixel_values` is padded to the budget, so for a full batch (no trailing empty `cu_seqlens` entry) the pad rows attended together with the last image. Segment ids are now `searchsorted(cu_seqlens[1:], pos, side="right")` over the padded length, so every position ≥ `cu_seqlens[-1]` lands in the dedicated trailing segment.
3. The manager's eager fallback (`encoder_eager_forward`) now enters `enable_torch_wrap(False)` like `run_budget_forward` does; without it vllm.ir ops in the ViT norms reach torchax as opaque OpOverloads and abort.

Then the benchmark step for Qwen2.5-VL-7B gets `COMPILATION_CONFIG: '{"cudagraph_mm_encoder": true}'` (gemma-4 convention). The flag is inert for the JAX-native model, which does not implement the protocol.

## Tests

- CPU unit tests: per-key padding logic / dtype cast / oversize error in `_pad_to_template`; `_segment_ids_from_cu_seqlens` (trailing pad segment, padded cu_seqlens with empty segments, leading empty segment, jit-traced == eager) and the ids `vllm_vit_sdpa` hands the kernel.
- TPU integration test (`TestQwen25VLMMEncoderJITIntegration`): real Qwen2.5-VL-3B config with dummy weights (shrunk via `hf_overrides` to 2 ViT blocks — one window, one full attention — and 1 text layer, ~80 s for the class), comparing the budget-padded JIT output with the eager forward for a mixed-grid batch and for a full `max_batch_size` batch. The nightly accuracy job is gsm8k (text only), so this is the only place the compiled vision path is checked against eager. On unfixed code the max deviation is 0.31–0.34 of max|out| (bug 1 corrupts item 0, bug 2 corrupts the last item); fixed: 0.007.

## Evidence (tpu-inference-dev)

| Build | Code | tpu7x perf | tpu6e perf | Other |
|---|---|---|---|---|
| [931](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/931) | main + flag only | 1.18 req/s, 16384 tok, 0 failed | 0.88 req/s, 16384 tok, 0 failed, no OOM | — |
| [932](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/932) | first PR SHA | 1.91 req/s, 16384 tok, 0 failed | 1.07 req/s, 16384 tok, 0 failed | gsm8k (vllm path, TP=2) 0.732 ≥ 0.72; unit tests pass on both chips |
| [934](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/934) | first PR SHA, gemma-4 | 26B: 6.72 auto / 2.12 vllm; 31B: 4.60 auto / 1.78 vllm (all 16384 tok, 0 failed) | — | `padding_logics` side effect on gemma-4's compiled encoder — no regression (bars 2.0/1.80 auto, 1.55/1.35 vllm) |
| [935](https://buildkite.com/tpu-commons/tpu-inference-dev/builds/935) | **final SHA 96e350b22** | 1.94 req/s, 16384 tok, 0 failed, TPOT 163 ms | 1.12 req/s, 16384 tok, 0 failed, TPOT 279 ms | JAX-path control with the flag present: 1.99 req/s, no manager created (flag inert on `auto`); gsm8k vllm path 0.734; 79 unit tests pass on tpu7x (170 s, incl. `tests/models/jax/test_qwen2_5_vl.py`), 76 + 3 skipped on tpu6e |

Nightly 24593 for reference: tpu7x 0.04 req/s; tpu6e dead engine / 0 tokens.

## Notes

- Supersedes #3446 (marks the benchmark `unverified` on the vllm variant); with this change that gating is not needed.
- Pairs with #3447 (benchmark fails on 0 generated tokens / failed requests).
- Known, not addressed here: `Qwen2_5_VisionTransformer.get_rope_by_thw` is `lru_cache`d on `(t, h, w)` and is reached from both the eager fallback (inside the torchax env) and the replay-buffer prep (outside). Unreachable in production: budget-vs-eager routing in `_execute_local` is a pure function of an item's token count, i.e. of its `(t, h, w)`, so a geometry that goes eager always goes eager and its cached torchax tensors never reach the replay-buffer prep. The integration test is the only place both paths see the same geometry; it clears the cache per test and runs `execute()` before its eager reference.
- `_pad_to_template` honouring `padding_logics` is model-agnostic, so it also activates gemma-4's `pad_pixel_position_ids` (`tpu_inference/models/jax/gemma4_mm.py`): pad images in a partial batch now carry the `-1` position sentinel (same as the capture template) instead of position (0,0). SigLIP encodes images independently along the batch axis and outputs are sliced per item, so real items are unaffected; verified on the dev pipeline (build 934: gemma-4 26B/31B benchmarks on both impl variants — see Evidence).
