### PR TITLE
[releases/v0.28.0] Cherry-pick #3446: mark Qwen2.5-VL-7B benchmarks unverified on the vllm (torchax) nightly variant

### DIFF
--- a/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
+++ b/.buildkite/models/Qwen_Qwen2_5-VL-7B-Instruct.yml
@@ -71,7 +71,20 @@ steps:
       queue: "${TPU_QUEUE_SINGLE:-tpu_v6e_queue}"
     commands:
       - |
-        .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh
+        if [ "${MODEL_IMPL_TYPE:-auto}" = "vllm" ]; then
+          echo "Qwen2.5-VL-7B benchmarks are not supported on the vllm (torchax)" \
+               "path. Its vision tower has no compiled route there -- the model is" \
+               "not in vision_tower_jit's JITTABLE_ARCHS and vLLM's Qwen2_5_VL does" \
+               "not declare supports_encoder_cudagraph, so MMEncoderJitManager" \
+               "declines it -- and the encoder runs eager: 0.04 req/s on tpu7x" \
+               "(vs 2.03 req/s on the JAX path) and an HBM OOM inside the ViT" \
+               "attention on tpu6e. Recording as unverified until the torchax" \
+               "multimodal path gets a compiled vision tower."
+          buildkite-agent meta-data set "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark" "unverified"
+        else
+          .buildkite/scripts/run_in_docker.sh bash /workspace/tpu_inference/tests/e2e/benchmarking/mm_bench_recipe.sh
+        fi
+
   - label: "${TPU_VERSION:-tpu6e} Record performance benchmark result for Qwen/Qwen2.5-VL-7B-Instruct"
     key: "${TPU_VERSION:-tpu6e}_record_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"
     depends_on: "${TPU_VERSION:-tpu6e}_Qwen_Qwen2_5-VL-7B-Instruct_Benchmark"


### PR DESCRIPTION
Cherry-pick of #3446 (approved there; single commit `5beab9b89`) onto `releases/v0.28.0`.

The `MODEL_IMPL_TYPE=vllm` nightly variant has failed the Qwen2.5-VL-7B tpu7x performance benchmark on every run since 2026-05-21 (its vision tower has no compiled route on the torchax path, so the encoder runs eager: 0.04 req/s vs the 0.76 floor; the tpu6e twin is a false green that dies with an HBM OOM in ViT attention after headers are sent). #3446 gates the benchmark on the vllm variant only and records it `unverified`, keeping the support matrix truthful; `auto`/`flax_nnx` are untouched.

Needed on the release branch so the vllm-variant nightly validating `releases/v0.28.0` (base nightly: build 24691, passed) can go green.