### PR TITLE
Fix GDN v3 metadata padding for partial sequence tiles

### DIFF
--- a/tests/kernels/gdn_metadata_v3_test.py
+++ b/tests/kernels/gdn_metadata_v3_test.py
@@ -1,0 +1,84 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import parameterized
+
+from tpu_inference.kernels.gdn.v3 import config, metadata
+
+
+class GDNMetadataTest(parameterized.TestCase):
+
+    @parameterized.named_parameters(
+        dict(testcase_name="single_sequence", max_seqs=1),
+        dict(testcase_name="partial_second_tile", max_seqs=5),
+    )
+    def test_batched_metadata_pads_partial_tile(self, max_seqs):
+        tile_size = 4
+        padded_max_seqs = ((max_seqs + tile_size - 1) // tile_size) * tile_size
+        padding = padded_max_seqs - max_seqs
+        dtypes = config.Dtypes(*([jnp.float32] * 5))
+        cfg = config.GDNConfig(
+            mode=config.GDNMode.BATCHED,
+            dtypes=dtypes,
+            batch_size=16,
+            dim_size=1,
+            kernel_size=4,
+            tile_size=tile_size,
+            num_kq_heads=1,
+            num_v_heads=1,
+            kq_head_dim=1,
+            v_head_dim=1,
+        )
+
+        metadata_ref = metadata.compute_batched_seq_metadata(
+            cfg=cfg,
+            seq_lens=jnp.full(max_seqs, 21, dtype=jnp.int32),
+            query_start_loc=jnp.arange(max_seqs + 1, dtype=jnp.int32),
+            state_indices=jnp.arange(1, max_seqs + 1, dtype=jnp.int32),
+            read_offsets=jnp.arange(max_seqs, dtype=jnp.int32),
+            end_seq=jnp.array(max_seqs, dtype=jnp.int32),
+        )
+
+        def pad(values):
+            return np.pad(values, (0, padding))
+
+        is_valid = pad(np.ones(max_seqs, dtype=np.bool_))
+        expected = {
+            "p_id_to_s_idx": np.arange(padded_max_seqs),
+            "p_id_to_r_base": pad(np.arange(max_seqs)),
+            "p_id_to_r_size": pad(np.ones(max_seqs, dtype=np.int32)),
+            "p_id_is_first_tile": is_valid,
+            "p_id_is_last_tile": is_valid,
+            "s_idx_has_initial_state": is_valid,
+            "s_idx_to_state_indices": pad(np.arange(1, max_seqs + 1)),
+            "s_idx_to_read_offset": pad(np.arange(max_seqs)),
+        }
+        actual = {
+            "p_id_to_s_idx": metadata_ref.p_id_to_s_idx.data,
+            "p_id_to_r_base": metadata_ref.p_id_to_r_base.data,
+            "p_id_to_r_size": metadata_ref.p_id_to_r_size.data,
+            "p_id_is_first_tile": metadata_ref.p_id_is_first_tile.data,
+            "p_id_is_last_tile": metadata_ref.p_id_is_last_tile.data,
+            "s_idx_has_initial_state": metadata_ref.s_idx_has_initial_state,
+            "s_idx_to_state_indices": metadata_ref.s_idx_to_state_indices,
+            "s_idx_to_read_offset": metadata_ref.s_idx_to_read_offset,
+        }
+
+        self.assertEqual(int(metadata_ref.num_tiles),
+                         padded_max_seqs // tile_size)
+        for name, expected_value in expected.items():
+            with self.subTest(name=name):
+                np.testing.assert_array_equal(actual[name], expected_value)

--- a/tpu_inference/kernels/gdn/v3/metadata.py
+++ b/tpu_inference/kernels/gdn/v3/metadata.py
@@ -37,21 +37,33 @@ def compute_batched_seq_metadata(
     """
 
     max_seqs = seq_lens.size
-    all_seqs = jnp.arange(max_seqs)
+    padded_max_seqs = pl.cdiv(max_seqs, cfg.tile_size) * cfg.tile_size
+    seq_padding = padded_max_seqs - max_seqs
+    all_seqs = jnp.arange(padded_max_seqs)
 
     # NOTE: Only supports use case where query_lens[i] <= cfg.window_size where
     # i < end_seq. This must be guaranteed by the function caller.
     # TODO(kyuyeunk): Add error handling when above condition is not met.
-    query_lens = query_start_loc[1:] - query_start_loc[:-1]
-    is_valid_seqs = jnp.where(all_seqs < end_seq, True, False)
-    has_initial_state = (seq_lens - query_lens) > 0
-    all_valid_seqs = jnp.where(is_valid_seqs, all_seqs, 0)
+    query_starts = query_start_loc[:-1]
+    query_lens = query_start_loc[1:] - query_starts
+    query_starts = jnp.pad(query_starts, (0, seq_padding))
+    query_lens = jnp.pad(query_lens, (0, seq_padding))
+    seq_lens = jnp.pad(seq_lens, (0, seq_padding))
+    state_indices = jnp.pad(state_indices, (0, seq_padding))
+    read_offsets = jnp.pad(read_offsets, (0, seq_padding))
+
+    # Metadata is read a full tile at a time. Fill partial tiles with
+    # zero-length requests that use the reserved null state slot.
+    is_valid_seqs = (all_seqs < end_seq) & (all_seqs < max_seqs)
+    has_initial_state = is_valid_seqs & ((seq_lens - query_lens) > 0)
+    state_indices = jnp.where(is_valid_seqs, state_indices, 0)
+    read_offsets = jnp.where(is_valid_seqs, read_offsets, 0)
 
     return memory_ref.MetadataRef.create(
         cfgs=cfg,
-        num_tiles=pl.cdiv(end_seq, cfg.tile_size),
-        p_id_to_s_idx=all_valid_seqs,
-        p_id_to_r_base=query_start_loc[all_valid_seqs],
+        num_tiles=pl.cdiv(jnp.minimum(end_seq, max_seqs), cfg.tile_size),
+        p_id_to_s_idx=all_seqs,
+        p_id_to_r_base=jnp.where(is_valid_seqs, query_starts, 0),
         p_id_to_r_size=jnp.where(is_valid_seqs, query_lens, 0),
         p_id_is_first_tile=is_valid_seqs,
         p_id_is_last_tile=is_valid_seqs,


### PR DESCRIPTION
# Description

Pad GDN v3 batched sequence metadata to complete sequence tiles before invoking the Pallas kernel.

I ran into this while trying Qwen3.5-9B on a Kaggle v5e-8 TPU with `max_num_seqs=1`, which is a pretty normal setup when testing or benchmarking a single request. The model loaded successfully, but generation crashed during decode inside `fused_conv1d_gdn_batched`:

```text
Scalar error PC ... HLO: fused_conv1d_gdn_batched.1
JaxRuntimeError: The program continuator has halted unexpectedly
SLICE_FAILURE_SW_INJECT_ERROR
Terminating the libtpu controller process because an anomalous TPUworker process is detected
```

`libtpu` terminated the TPU worker and the notebook kernel could not recover, so the Kaggle runtime had to be recycled. Changing only `max_num_seqs` from 1 to 4 allowed the same checkpoint and prompt to generate successfully (`TPU load succeeded`).

This pointed to a mismatch between the four-sequence decode tile and the one-entry metadata buffers. The kernel consumes complete metadata tiles with bounds checks disabled, but the previous implementation allocated metadata for only `max_seqs`. When `max_seqs` was not divisible by `tile_size`, the final tile could read past those buffers.

This change:

- pads sequence metadata to a complete tile;
- maps padded entries to the reserved null state slot with zero request length;
- clamps `num_tiles` to the actual sequence capacity; and
- adds direct metadata regressions for a single sequence and a partial second tile.

No documentation changes are needed because this fixes an internal kernel invariant without changing the public API. It follows the kernel's existing padding convention by representing unused positions as zero-length entries mapped to the reserved null state slot.

# Tests

- `pre-commit run --files tests/kernels/gdn_metadata_v3_test.py tpu_inference/kernels/gdn/v3/metadata.py` — all configured hooks passed.
- `pytest tests/kernels/gdn_metadata_v3_test.py` on CPU JAX — both new regression cases passed.
- Kaggle v5e-8, JAX/JAXLIB 0.11.0, libtpu 0.0.44:
  - the full GDN v3 suite plus temporary one-request and five-request end-to-end cases passed 15/15;
  - five additional repetitions of both temporary end-to-end cases passed 10/10.

Separately, in the linked notebooks, I called `compute_batched_seq_metadata` with 384 combinations of `tile_size`, `max_seqs`, and `end_seq`, then inspected the metadata it returned. Before the fix, 206 combinations returned metadata sized to `max_seqs` instead of a complete tile, while 178 were already tile-aligned. With the fix, all 384 combinations returned complete, safely padded metadata. This was a standalone diagnostic, not 384 repository tests.

Original failure and `max_num_seqs=1` vs. `4` confirmation: https://www.kaggle.com/code/xuanyangge/qwen3-5-9b-vllm-tpu-load-smoke

Fix evidence notebook: https://www.kaggle.com/code/xuanyangge/gdn-v3-partial-decode-tile-pr-evidence

Unpatched baseline notebook: https://colab.research.google.com/drive/1kPcz8ySPXiRptl5yoQor7eHT0dOzTxlL

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation. (No documentation change required.)
