### PR TITLE
runner: gate prompt-logprobs precompile behind SKIP_PROMPT_LOGPROBS_PRECOMPILE (fixes multi-host startup hang / redundant precompile)

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     PREFILL_SLICES: str = ""
     DECODE_SLICES: str = ""
     SKIP_JAX_PRECOMPILE: bool = False
+    SKIP_PROMPT_LOGPROBS_PRECOMPILE: bool = False
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     MODEL_IMPL_TYPE: str = "auto"
     DRAFT_MODEL_IMPL_TYPE: str = "auto"
@@ -247,6 +248,13 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Skip JAX precompilation step during initialization
     "SKIP_JAX_PRECOMPILE":
     env_bool("SKIP_JAX_PRECOMPILE", default=False),
+    # Skip the auxiliary prompt-logprobs precompile loop specifically. The prompt
+    # logprobs graph is off the execution path unless prompt_logprobs is requested
+    # (return_logprobs=False), so precompiling it is pure startup overhead there. On
+    # the bare-SPMD multi-host backend it can also hang startup at the compile-time
+    # rendezvous if hosts diverge on the loop trip count. Default off = no change.
+    "SKIP_PROMPT_LOGPROBS_PRECOMPILE":
+    env_bool("SKIP_PROMPT_LOGPROBS_PRECOMPILE", default=False),
     # Check for XLA recompilation during execution
     "VLLM_XLA_CHECK_RECOMPILATION":
     env_bool("VLLM_XLA_CHECK_RECOMPILATION", default=False),

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -1100,6 +1100,14 @@ class CompilationManager:
                         num_reqs=num_reqs,
                     )
 
+        if envs.SKIP_PROMPT_LOGPROBS_PRECOMPILE:
+            logger.info(
+                "Skipping compute_and_gather_prompt_logprobs precompilation "
+                "(SKIP_PROMPT_LOGPROBS_PRECOMPILE=1). The prompt-logprobs graph is "
+                "off the execution path unless prompt_logprobs is requested.")
+            self._gather_logprobs_precompiled = True
+            return
+
         logger.info(
             "Compiling compute_and_gather_prompt_logprobs with different input shapes."
         )


### PR DESCRIPTION
### What

Adds an env gate `SKIP_PROMPT_LOGPROBS_PRECOMPILE` (default **False** → no change for existing users) that skips only the prompt-logprobs branch of `CompilationManager._precompile_gather_logprobs`. The sampled-token `compute_and_gather_logprobs` precompile above it is untouched.

Fixes / addresses #3455.

### Why

`_precompile_gather_logprobs` unconditionally compiles `compute_and_gather_prompt_logprobs` over the prompt-token padding buckets. That graph is **off the execution path unless `prompt_logprobs` is requested** (`return_logprobs=False`), so the precompile is pure engine-startup overhead in that common case.

On the bare-SPMD multi-host backend (#3262) it is worse than overhead: a `jit` over the multi-host mesh is a collective, so all hosts must enter the same compilation with the same trip count. If they diverge, startup **deadlocks at the compile-time rendezvous** — observed hanging at `Precompile worker0 compute_and_gather_prompt_logprobs` with no step ever emitted, on TPU v7x 4×4×4 (64 chips) collocated GRPO rollout.

### Change

```python
if envs.SKIP_PROMPT_LOGPROBS_PRECOMPILE:
    logger.info("Skipping compute_and_gather_prompt_logprobs precompilation ...")
    self._gather_logprobs_precompiled = True
    return
```
Placed between the sampled-token block (kept) and the prompt-logprobs loop (skipped). The `_gather_logprobs_precompiled` flag is still set so the pre-KV-cache-alloc idempotency guard behaves as before.

### Correctness

`prompt_logprobs` is not requested under stock `return_logprobs=False` (only sampled-token logprobs are consumed), so skipping its *precompile* leaves the graph off the execution path — no cold-compile / missing-cache assertion mid-decode. Loss-neutral. Default-off means zero behavior change unless the operator opts in.

### Testing

- `SKIP_PROMPT_LOGPROBS_PRECOMPILE=1`: engine startup no longer enters the prompt-logprobs precompile; on the bare-SPMD 64-chip collocated setup this clears the startup hang and the run reaches steady GRPO cycles (correctness gate: loss trend, reward distribution, EOS counts, mean completion length all healthy).
- Default (unset / `0`): behavior identical to before (verified the branch is not taken).
