### PR TITLE
examples(dapo_tpu_async): collocated GRPO async-overlap reproduction (refs #3456, #3455)

### DIFF
--- a/examples/dapo_tpu_async/README.md
+++ b/examples/dapo_tpu_async/README.md
@@ -1,0 +1,54 @@
+# Collocated GRPO async-overlap reproduction (TPU v7x, single 64-chip slice)
+
+A reproducible reference for the async inter-wave rollout overlap discussed in
+issue #3456 (async scheduling under `UniProcExecutor`) and issue #3455
+(prompt-logprobs precompile). This extends the sync recipe in
+[`examples/dapo_tpu`](../dapo_tpu) with the async-overlap levers and documents
+the measured effect on a collocated GRPO rollout+train cycle.
+
+## Setup
+
+- **Hardware:** TPU v7x (Ironwood), 4×4×4, 64 chips, single slice
+- **Placement:** collocated — trainer + rollout share all 64 chips in one
+  `jax.distributed` session (not two slices)
+- **Model / workload:** Gemma-class 2B, decode-light GRPO — global batch 1024,
+  8 generations/prompt, prompt cap 512, response cap 64 (≈28 tok mean, EOS-terminated),
+  temperature 0.7
+- **Rollout mesh:** DP16 × TP8 (per-process DP, single-host `UniProcExecutor`)
+- **vLLM:** a current LKG (the pinned `d626108b…` or newer) where
+  `UniProcExecutor.supports_async_scheduling()` returns `True` — see the note below.
+
+## The levers
+
+| Lever | How | What it does |
+|---|---|---|
+| Async inter-wave overlap | `async_scheduling: true` in the engine config | rollout wave N+1 enqueues while wave N's `device_get` is in flight — attacks the rollout dispatch bubble |
+| Skip prompt-logprobs precompile | `SKIP_PROMPT_LOGPROBS_PRECOMPILE=1` (see #3455 / PR #3457) | avoids the redundant prompt-logprobs precompile (off the execution path when `prompt_logprobs` is not requested; also avoids a multi-host startup hang) |
+| Async collectives | `LIBTPU_INIT_ARGS="--xla_tpu_prefer_async_allgather_to_allreduce=true --xla_enable_async_all_gather=true"` | keeps the decode collectives off the synchronous critical path (also clears a `0x176` ICI decode stall on collocated SPMD) |
+| SparseCore collective offload | `LIBTPU_INIT_ARGS+=" --xla_tpu_enable_sparse_core_collective_offload_all_gather=true --xla_tpu_enable_sparse_core_collective_offload_all_reduce=true --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=true"` | offloads rollout collectives off the TensorCore. Compiles cleanly on cold v7x; unlike the latency-hiding-scheduler, which blew up HLO compile here |
+
+> **Important (issue #3456):** on **older** vLLM, `UniProcExecutor.supports_async_scheduling()`
+> returned `False`, so the engine silently reset `async_scheduling` `true → false`
+> and the runner's async branch was dead code (the rollout sat ~90% device-idle).
+> On a **current** vLLM LKG this is already fixed — `supports_async_scheduling()`
+> returns `True` and the config's `async_scheduling: true` is honored. So the
+> reproduction requirement is simply: **use a current vLLM LKG and set
+> `async_scheduling: true`**. No source override is needed. This example exists to
+> make that reproducible end-to-end.
+
+## Measured result (TPU v7x, 64 chips, collocated, correctness-gated)
+
+| Config | Warm rollout+advantage chunk | Warm cycle (opt-to-opt) |
+|---|---|---|
+| Sync (no async overlap) | ~15.7 s | ~99–106 s |
+| **+ async overlap (this example)** | **~13.6 s (~15% faster)** | **~94 s median** (best ~84 s) |
+
+Correctness gate (both configs): loss trend, reward distribution, EOS counts, and
+mean completion length all healthy and matched vs the sync path under a fixed seed —
+async is a reordering, not a workload change.
+
+## Run
+
+See [`config_template.yaml`](./config_template.yaml) for the full set of keys and
+[`launch.sh`](./launch.sh) for a one-command launch (adapt the model path and the
+launcher to your environment; the async levers themselves are the portable part).

--- a/examples/dapo_tpu_async/config_template.yaml
+++ b/examples/dapo_tpu_async/config_template.yaml
@@ -1,0 +1,28 @@
+# Collocated GRPO async-overlap reproduction — config keys that matter.
+# See README.md for the measured result and the issue references (#3455, #3456).
+# This shows the async-overlap DELTA vs examples/dapo_tpu/config_template.yaml;
+# copy that base recipe and set the keys below.
+
+# --- workload (decode-light GRPO, held frozen) ---
+batch_size: 1024
+num_generations: 8              # GRPO group size (= rollout.n)
+max_prefill_predict_length: 512 # prompt cap
+max_target_length: 576          # 512 prompt + 64 response
+decode_sampling_temperature: 0.7
+
+# --- collocated placement: trainer + rollout share all 64 chips ---
+trainer_devices_fraction: 1.0
+sampler_devices_fraction: 1.0
+rollout_data_parallelism: 16
+rollout_tensor_parallelism: 8
+train_micro_batch_size: 8
+rollout_micro_batch_size: 256
+hbm_utilization_vllm: 0.75
+max_num_batched_tokens: 8192
+enable_continue_decode: true    # fused on-device decode loop
+
+# --- THE ASYNC-OVERLAP LEVER (issue #3456) ---
+# On a current vLLM LKG (UniProcExecutor.supports_async_scheduling()==True) this
+# is honored on the single-host uni path and enables rollout wave N+1 to enqueue
+# while wave N's device_get is in flight.
+async_scheduling: true

--- a/examples/dapo_tpu_async/launch.sh
+++ b/examples/dapo_tpu_async/launch.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# Collocated GRPO async-overlap reproduction launcher (TPU v7x, 64 chips).
+# The portable part is the env/flag block below; adapt the model path + your
+# own job launcher (GKE JobSet, xpk, etc.) around it.
+set -euo pipefail
+
+# (1) Skip the redundant prompt-logprobs precompile — see #3455 / PR #3457.
+export SKIP_PROMPT_LOGPROBS_PRECOMPILE=1
+
+# (2) Async collectives off the synchronous critical path + SparseCore offload.
+#     The first two also clear a 0x176 ICI decode stall on collocated SPMD.
+export LIBTPU_INIT_ARGS="\
+--xla_tpu_prefer_async_allgather_to_allreduce=true \
+--xla_enable_async_all_gather=true \
+--xla_tpu_enable_sparse_core_collective_offload_all_gather=true \
+--xla_tpu_enable_sparse_core_collective_offload_all_reduce=true \
+--xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=true"
+
+# (3) Generous engine timeouts so the (longer) async compile is not killed by a
+#     watchdog on a cold jax-cache. Not needed once the cache is warm.
+export VLLM_ENGINE_ITERATION_TIMEOUT_S=1200
+export VLLM_RPC_TIMEOUT=1200000
+
+# (4) async_scheduling: true lives in the config (config_template.yaml).
+#     On a current vLLM LKG this is honored on the uni path (issue #3456).
+
+echo "Async-overlap reproduction env set. Launch your DAPO/GRPO job with"
+echo "config_template.yaml (async_scheduling: true) on a 64-chip v7x slice."


### PR DESCRIPTION
### What

Adds `examples/dapo_tpu_async/` — a reproducible reference for the **async inter-wave rollout overlap** on a collocated GRPO cycle (TPU v7x, single 64-chip slice), extending the sync recipe in `examples/dapo_tpu` (#3165).

Provides the concrete PoC reference requested in **#3456** (and uses the flag from **#3455** / PR **#3457**).

### Why

#3456 documented that async scheduling was silently disabled under `UniProcExecutor` on older vLLM. On a **current** vLLM LKG this is already fixed (`UniProcExecutor.supports_async_scheduling()` returns `True`), so `async_scheduling: true` is honored on the single-host `uni` path. This example makes reproducing the async-overlap win **end-to-end and citable** — a reader shouldn't have to reconstruct the flag set from the issue thread.

### Contents

- `README.md` — setup, the lever table, the issue-#3456 note (older-vLLM gate vs current-LKG behavior), and the measured result.
- `config_template.yaml` — the async-overlap delta vs the sync base (`async_scheduling: true`, collocated placement keys).
- `launch.sh` — the portable env/flag block (`SKIP_PROMPT_LOGPROBS_PRECOMPILE`, async-collective + SparseCore-offload `LIBTPU_INIT_ARGS`, engine timeouts).

### Measured (TPU v7x, 64 chips, collocated, correctness-gated)

| Config | Warm rollout+advantage chunk | Warm cycle (opt-to-opt) |
|---|---|---|
| Sync | ~15.7 s | ~99–106 s |
| + async overlap | **~13.6 s (~15% faster)** | **~94 s median** (best ~84 s) |

Correctness gate (both): loss trend, reward distribution, EOS counts, mean completion length all healthy and matched vs sync under a fixed seed (async is a reordering, not a workload change).

### Note

Docs/example only — no library code changes. Complements PR #3457 (the `SKIP_PROMPT_LOGPROBS_PRECOMPILE` gate) and the sync recipe #3165.
