### PR TITLE
[PCP] Remove unnecessary copy op before cache phase

### DIFF
--- a/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
@@ -2378,9 +2378,14 @@ def ragged_paged_attention(
             pl.BlockSpec(memory_space=pltpu.HBM),  # kv_cache
         ]
 
+        # A launch that never writes the cache (update_kv_cache=False, e.g. the
+        # PCP ring cache phase) emits NO cache output and does not alias the
+        # cache: an aliased-but-unwritten output of a communicating custom
+        # call makes XLA copy the whole cache around the launch.
         out_specs = [
             pl.BlockSpec(memory_space=pltpu.HBM),  # o
-            pl.BlockSpec(memory_space=pltpu.HBM),  # updated_kv_cache
+            pl.BlockSpec(memory_space=pltpu.HBM)
+            if update_kv_cache else None,  # updated_kv_cache
         ]
 
         bkv_stride = num_kv_heads_x2_per_kv_packing
@@ -2461,26 +2466,31 @@ def ragged_paged_attention(
 
         out_shape = [
             pltpu.HBM(shape=q.shape, dtype=q.dtype),
-            pltpu.HBM(shape=kv_cache.shape, dtype=kv_cache.dtype),
+            pltpu.HBM(shape=kv_cache.shape, dtype=kv_cache.dtype)
+            if update_kv_cache else None,
             pltpu.HBM(shape=lse_hbm.shape, dtype=lse_hbm.dtype)
             if return_lse else None,
         ] if tpu_version >= 7 else [
             jax.ShapeDtypeStruct(shape=q.shape, dtype=q.dtype),
-            jax.ShapeDtypeStruct(shape=kv_cache.shape, dtype=kv_cache.dtype),
+            jax.ShapeDtypeStruct(shape=kv_cache.shape, dtype=kv_cache.dtype)
+            if update_kv_cache else None,
             jax.ShapeDtypeStruct(shape=lse_hbm.shape, dtype=lse_hbm.dtype)
             if return_lse else None,
         ]
 
-        input_output_aliases = {
-            num_active_scalers: 0,  # q -> o
-            num_active_scalers + 2: 1,  # kv_cache -> updated_kv_cache
-        }
+        input_output_aliases = {num_active_scalers: 0}  # q -> o
+        lse_out_idx = 1
+        if update_kv_cache:
+            # kv_cache -> updated_kv_cache
+            input_output_aliases[num_active_scalers + 2] = 1
+            lse_out_idx = 2
         in_specs.append(
             pl.BlockSpec(memory_space=pltpu.HBM) if return_lse else None)
         out_specs.append(
             pl.BlockSpec(memory_space=pltpu.HBM) if return_lse else None)
         if return_lse:
-            input_output_aliases[num_active_scalers + 3] = 2  # lse -> lse_out
+            input_output_aliases[num_active_scalers +
+                                 3] = lse_out_idx  # lse -> lse_out
 
         scope_name = f"RPA{case.symbol}-p_{page_size}-bq_{bq_sz}_{bq_csz}-bkv_{bkv_sz}_{bkv_csz}"
         if sliding_window is not None:
@@ -2554,11 +2564,11 @@ def ragged_paged_attention(
                 return kernel(*scalar_prefetches, *hbms)
 
         outputs = run(scalar_prefetches, hbm_buffers)
-        # (o, updated_kv_cache, lse)
-        if return_lse:
-            return outputs
-        else:
-            return outputs[0], outputs[1], None
+        # (o, updated_kv_cache, lse); the cache is untouched when not written.
+        o, updated_kv_cache, lse = outputs
+        if not update_kv_cache:
+            updated_kv_cache = kv_cache
+        return o, updated_kv_cache, (lse if return_lse else None)
 
     def _prepare_block_sizes(block_sizes, case):
         if block_sizes is None:

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
@@ -2378,10 +2378,6 @@ def ragged_paged_attention(
             pl.BlockSpec(memory_space=pltpu.HBM),  # kv_cache
         ]
 
-        # A launch that never writes the cache (update_kv_cache=False, e.g. the
-        # PCP ring cache phase) emits NO cache output and does not alias the
-        # cache: an aliased-but-unwritten output of a communicating custom
-        # call makes XLA copy the whole cache around the launch.
         out_specs = [
             pl.BlockSpec(memory_space=pltpu.HBM),  # o
             pl.BlockSpec(memory_space=pltpu.HBM)


### PR DESCRIPTION
## Summary

`rpa_v3_cp` declared `kv_cache -> updated_kv_cache` in `input_output_aliases` on every launch, including launches that never write the cache. The PCP ring cache phase runs with `update_kv_cache=False` and `pcp_forward` discards that output, handing the original cache to the current-phase launch. Because the old value is still live across an in-place *communicating* custom call, XLA inserts a copy of the **entire per-layer KV cache** before every ring launch.

This PR emits no cache output and no alias when `update_kv_cache=False` (the `None` slot in `out_shape`/`out_specs` is preserved by Pallas, so the kernel simply receives `updated_kv_cache_hbm_ref=None`, which that path never touches) and returns the input cache. The cache-writing launch is unchanged. Kernel-only change, +23/-13.

## Evidence

* Compiled model step on main (Qwen3-8B PCP2xTP4 serve, XLA dump): a step with a cached prefix has **36 x `copy.NNNN.args_12_ = bf16[2700,256,2,2,128] copy(...)`**, one per layer, each feeding the ring launch chain; a step without a ring launch has 0.
* Wrapper micro-benchmark profile (pcp4xtp2 bf16, 4 GB cache/rank, 8k ctx): `copy.32.args_12_` = **828 us** before a 199 us ring kernel; with this change the copy is gone (step 1.35 -> 0.67 ms).
* Threading the ring launch's cache output into the current launch (DCP-style) does **not** help: XLA then copies the parameter in *and* the result out (2 x 826 us). Only removing the alias removes the copies.
* Ablation (comm off / compute off) shows the ring's DMA was already hidden at every context (exposed <= 0.08 ms/step below 64k); the copy was the whole reason the ring lost to tp8 / gather-KV at short context.

## Micro-benchmark: cumulative TTFT (`pcp_vs_tp_benchmark.py` from #3478)

Qwen3.5 head config (NQ=32 NKV=2 HD=256), CH=4k, bf16, v7x-8, 1M-token cache with `--cache-slack 4` (~1 GB per rank, a production-sized per-layer cache), attention + the layer collectives (o_proj all-reduce over the model axis; for PCP also the all-gather over pcp into the MLP layout). `main` = origin/main ring; `+ #3459` = this PR.

```
Qwen3.5: NQ=32 NKV=2 HD=256, 8 devices, CH=4k, bf16, 1M-token cache x4 slack (~1 GB/rank), attention + o_proj all-reduce (+ pcp all-gather) -- cumulative TTFT (ms), baseline tp8

┌─────────┬─────────────┬────────────────────────┬────────────────────────┬────────────────────────┬────────────────────────┐
│ Context │ tp8 (8 dev) │     pcp4xtp2 main      │    pcp4xtp2 + #3459    │     pcp8xtp1 main      │    pcp8xtp1 + #3459    │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 1k      │ 0.57        │ 0.77 (34.1% slower)    │ 0.71 (24.9% slower)    │ 0.67 (16.8% slower)    │ 0.62 (9.1% slower)     │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 2k      │ 0.59        │ 0.73 (23.1% slower)    │ 0.75 (26.0% slower)    │ 0.69 (16.8% slower)    │ 0.64 (8.7% slower)     │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 4k      │ 0.65        │ 0.74 (13.8% slower)    │ 0.78 (20.7% slower)    │ 0.68 (4.8% slower)     │ 0.66 (1.9% slower)     │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 8k      │ 1.45        │ 2.53 (1.75x slower)    │ 1.75 (20.7% slower)    │ 2.53 (1.75x slower)    │ 1.68 (15.7% slower)    │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 16k     │ 3.48        │ 6.45 (1.85x slower)    │ 4.08 (17.0% slower)    │ 6.78 (1.95x slower)    │ 4.27 (22.4% slower)    │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 32k     │ 9.29        │ 15.70 (1.69x slower)   │ 10.03 (7.9% slower)    │ 18.70 (2.01x slower)   │ 12.85 (38.3% slower)   │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 64k     │ 27.90       │ 40.12 (43.8% slower)   │ 27.87 (=)              │ 55.89 (2.00x slower)   │ 43.44 (1.56x slower)   │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 128k    │ 93.11       │ 112.36 (20.7% slower)  │ 86.85 (6.7% faster)    │ 184.35 (1.98x slower)  │ 158.76 (1.71x slower)  │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 256k    │ 336.45      │ 350.92 (4.3% slower)   │ 299.55 (11.0% faster)  │ 659.25 (1.96x slower)  │ 607.29 (1.81x slower)  │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 512k    │ 1275.27     │ 1209.56 (5.2% faster)  │ 1105.19 (13.3% faster) │ 2470.04 (1.94x slower) │ 2365.47 (1.85x slower) │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 1M      │ 4943.09     │ 4431.81 (10.3% faster) │ 4220.32 (14.6% faster) │ 9526.72 (1.93x slower) │ 9318.27 (1.89x slower) │
└─────────┴─────────────┴────────────────────────┴────────────────────────┴────────────────────────┴────────────────────────┘
```

The copy scales with the per-layer cache size: at `--cache-slack 1` (256 MB/rank for this shape) main's copy is ~0.2 ms/step and the two columns are within noise; the 8k step in the profile (1 GB/rank) is 1.35 -> 0.67 ms. `pcp8xtp1` stays ICI-bound in bf16 (4 cache passes per step with a 256-row Q tile) with or without the copy.

## E2E: Qwen3-235B-A22B-Instruct-2507-FP8, PCP2 x TP4 (max-num-batched-tokens 16384, max-num-seqs 1, 10 random prompts, output 1)

| input | chunks | main | this PR | delta |
|---|---|---|---|---|
| 1k mean TTFT | 1 | 476.2 ms | 476.0 ms | - |
| 4k mean TTFT | 1 | 1436.5 ms | 1440.0 ms | - |
| 8k mean TTFT | 1 | 2695.9 ms | 2701.2 ms | - |
| 16k mean TTFT | 1 | 5780.1 ms | 5784.3 ms | - |
| 32k mean TTFT | 2 | 13562.9 ms | 13300.0 ms | -1.9% |
| 64k mean TTFT | 4 | 34512.5 ms | 33749.4 ms | -2.2% |
| 256k mean TTFT | 16 | 317.58 s | 313.63 s | -1.2% |
| 256k benchmark duration | 16 | 576.70 s | 569.55 s | -1.2% |
| 256k total throughput | 16 | 4545 tok/s | 4602 tok/s | +1.3% |

Single-chunk prompts never run the ring launch, so they are unchanged by construction. The saving per ring launch is one full per-layer cache copy (~0.3 ms x 94 layers per chunk on this config); it grows with per-layer cache size.

## Tests

* `tests/kernels/rpa_v3_cp/ragged_paged_attention_kernel_cp_test.py`: 30/30 on v7x
* `tests/layers/common/test_pcp_attention_interface.py`: 16/16 on v7x

## Correctness (offline inference)

Qwen3-8B-Base, greedy, `max_num_batched_tokens=1024` (2-7 prefill chunks per prompt so the ring cache phase runs), four needle-retrieval prompts of 1411 / 2796 / 5114 / 6056 tokens, 24 generated tokens each. Generated token ids are **identical** across PCP2xTP4 with this PR, PCP2xTP4 on main, and TP4 (no PCP); every answer retrieves the needle (code + city) planted in the first chunk.