### PR TITLE
[NOT READY TO REVIEW] [CODEOWNERS] Add @jrplatin as an owner of /tests/layers/ and /tests/models/

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -85,7 +85,7 @@
 /tests/kernels/ @kyuyeunk @bythew3i @a1yssan13
 /tests/kernels/deepseek_v4 @gxd3 @a1yssan13 @inucool12
 /tests/kernels/rpa_v3_cp/ @kyuyeunk @wenxindongwork @weiyu0824 
-/tests/layers/ @kyuyeunk @lk-chen
+/tests/layers/ @kyuyeunk @lk-chen @jrplatin
 /tests/layers/jax/ @kyuyeunk @lk-chen @jrplatin
 /tests/lora/ @vanbasten23 @kyuyeunk
 /tests/models/ @kyuyeunk @lk-chen

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -88,7 +88,7 @@
 /tests/layers/ @kyuyeunk @lk-chen @jrplatin
 /tests/layers/jax/ @kyuyeunk @lk-chen @jrplatin
 /tests/lora/ @vanbasten23 @kyuyeunk
-/tests/models/ @kyuyeunk @lk-chen
+/tests/models/ @kyuyeunk @lk-chen @jrplatin
 /tests/models/jax/ @kyuyeunk @lk-chen @jrplatin
 /tests/layers/jax/sample/test_rejection_sampler.py @Lumosis @gxd3
 /tests/platforms/ @sixiang-google @mrjunwan-lang


### PR DESCRIPTION
## What

Adds `@jrplatin` to the two CODEOWNERS entries that were owned by exactly
`@kyuyeunk` and `@lk-chen`:

```diff
-/tests/layers/ @kyuyeunk @lk-chen
+/tests/layers/ @kyuyeunk @lk-chen @jrplatin
-/tests/models/ @kyuyeunk @lk-chen
+/tests/models/ @kyuyeunk @lk-chen @jrplatin
```

These are the only two entries in the file with that owner pair; nothing else is
changed.

## Why

Both owners are out of office, so any PR touching `tests/layers/common/`,
`tests/layers/vllm/`, or the top level of `tests/models/` cannot satisfy the
required CODEOWNER review and is blocked regardless of how many other approvals
it has.

`@jrplatin` is already an owner of, for each entry:

| Entry | Production counterpart already owned | Child subtree already owned |
|---|---|---|
| `/tests/layers/` | `/tpu_inference/layers/` | `/tests/layers/jax/` |
| `/tests/models/` | `/tpu_inference/models/` | `/tests/models/jax/` |

So this is consistent with the "Tests mirror production-code ownership" comment
directly above that block, and it removes a two-person single point of failure
in both places.
