### PR TITLE
feat: RLVllmSampler weight sync via Raiden

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -53,6 +53,9 @@
 # Worker Management
 /tpu_inference/worker/ @sixiang-google @mrjunwan-lang @jrplatin @vanbasten23 @wenxindongwork @Lumosis
 
+# RL Rollout / Weight Sync
+/tpu_inference/rl/ @wenxindongwork
+
 # Speculative Decoding
 /tpu_inference/spec_decode/ @Lumosis @gxd3
 /tpu_inference/layers/jax/sample/rejection_sampler.py @Lumosis @gxd3
@@ -95,6 +98,7 @@
 /tests/runner/ @kyuyeunk @jrplatin @wenxindongwork @sixiang-google @mrjunwan-lang @gxd3 @a1yssan13
 /tests/spec_decode/ @Lumosis @gxd3
 /tests/worker/ @sixiang-google @mrjunwan-lang @jrplatin @vanbasten23 @wenxindongwork
+/tests/rl/ @wenxindongwork
 /tests/e2e/ @pv97 @wenxindongwork @jrplatin @Lumosis @gxd3
 /tests/offload/ @juncgu-google @richardsliu
 /tests/scripts/ @jrplatin @QiliangCui

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -54,7 +54,7 @@
 /tpu_inference/worker/ @sixiang-google @mrjunwan-lang @jrplatin @vanbasten23 @wenxindongwork @Lumosis
 
 # RL Rollout / Weight Sync
-/tpu_inference/rl/ @wenxindongwork
+/tpu_inference/rl/ @wenxindongwork @pv97
 
 # Speculative Decoding
 /tpu_inference/spec_decode/ @Lumosis @gxd3
@@ -98,7 +98,7 @@
 /tests/runner/ @kyuyeunk @jrplatin @wenxindongwork @sixiang-google @mrjunwan-lang @gxd3 @a1yssan13
 /tests/spec_decode/ @Lumosis @gxd3
 /tests/worker/ @sixiang-google @mrjunwan-lang @jrplatin @vanbasten23 @wenxindongwork
-/tests/rl/ @wenxindongwork
+/tests/rl/ @wenxindongwork @pv97
 /tests/e2e/ @pv97 @wenxindongwork @jrplatin @Lumosis @gxd3
 /tests/offload/ @juncgu-google @richardsliu
 /tests/scripts/ @jrplatin @QiliangCui

--- a/tests/rl/test_raiden_worker_sync.py
+++ b/tests/rl/test_raiden_worker_sync.py
@@ -80,8 +80,12 @@ class TestRaidenWorkerSyncMetadataDict(unittest.TestCase):
     def test_raises_without_a_sharded_array(self):
         sync = rws.RaidenWorkerSync("rollout")
         sync.names = ["w"]
-        sync.arrays = [SimpleNamespace(shape=(2,), dtype=SimpleNamespace(itemsize=4),
-                                       sharding=None, ndim=1)]
+        sync.arrays = [
+            SimpleNamespace(shape=(2, ),
+                            dtype=SimpleNamespace(itemsize=4),
+                            sharding=None,
+                            ndim=1)
+        ]
         with self.assertRaises(RuntimeError):
             sync.metadata_dict()
 

--- a/tests/rl/test_raiden_worker_sync.py
+++ b/tests/rl/test_raiden_worker_sync.py
@@ -1,0 +1,96 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the tpu-inference project
+"""Unit tests for tpu_inference.rl.raiden_worker_sync."""
+
+import unittest
+from types import SimpleNamespace
+
+from tpu_inference.rl import raiden_worker_sync as rws
+
+
+class MaxTextForCausalLM:
+    """Named to match the real class by `__name__`; see `is_maxtext_model`."""
+
+
+class TestIsMaxtextModel(unittest.TestCase):
+
+    def test_matches_by_class_name(self):
+        self.assertTrue(rws.is_maxtext_model(MaxTextForCausalLM()))
+
+    def test_none_model(self):
+        self.assertFalse(rws.is_maxtext_model(None))
+
+    def test_other_model(self):
+        self.assertFalse(rws.is_maxtext_model(object()))
+
+
+class TestExtractWeightState(unittest.TestCase):
+
+    def test_maxtext_unwraps_model_key(self):
+        state = {"model": {"params": 1}}
+        result = rws.extract_weight_state(state, MaxTextForCausalLM())
+        self.assertEqual(result, {"base": {"params": 1}})
+
+    def test_maxtext_missing_model_key_falls_back_to_state(self):
+        state = {"other": {"params": 1}}
+        result = rws.extract_weight_state(state, MaxTextForCausalLM())
+        self.assertIs(result, state)
+
+    def test_non_maxtext_returns_state_as_is(self):
+        state = {"params": 1}
+        result = rws.extract_weight_state(state, object())
+        self.assertIs(result, state)
+
+    def test_no_state_no_model_returns_none(self):
+        self.assertIsNone(rws.extract_weight_state(None, None))
+
+    def test_maxtext_model_without_state_and_no_inner_model_returns_none(self):
+        model = MaxTextForCausalLM()  # no `.model` attribute
+        self.assertIsNone(rws.extract_weight_state(None, model))
+
+
+class TestFlattenWeights(unittest.TestCase):
+
+    def test_flattens_leaves_with_shape_and_dtype(self):
+        leaf = SimpleNamespace(shape=(2, 2), dtype="float32")
+        names, arrays = rws.flatten_weights({"w": leaf})
+        self.assertEqual(len(names), 1)
+        self.assertIs(arrays[0], leaf)
+
+    def test_skips_leaves_without_shape_or_dtype(self):
+        names, arrays = rws.flatten_weights({"w": 3})
+        self.assertEqual(names, [])
+        self.assertEqual(arrays, [])
+
+
+class TestAxisName(unittest.TestCase):
+
+    def test_none(self):
+        self.assertEqual(rws._axis_name(None), "")
+
+    def test_str(self):
+        self.assertEqual(rws._axis_name("fsdp"), "fsdp")
+
+    def test_tuple(self):
+        self.assertEqual(rws._axis_name(("fsdp", "tp")), "fsdp,tp")
+
+
+class TestRaidenWorkerSyncMetadataDict(unittest.TestCase):
+
+    def test_raises_without_a_sharded_array(self):
+        sync = rws.RaidenWorkerSync("rollout")
+        sync.names = ["w"]
+        sync.arrays = [SimpleNamespace(shape=(2,), dtype=SimpleNamespace(itemsize=4),
+                                       sharding=None, ndim=1)]
+        with self.assertRaises(RuntimeError):
+            sync.metadata_dict()
+
+    def test_bound_is_false_until_bind(self):
+        sync = rws.RaidenWorkerSync("rollout")
+        self.assertFalse(sync.bound)
+        sync.names = ["w"]
+        self.assertTrue(sync.bound)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/rl/test_vllm_sampler.py
+++ b/tests/rl/test_vllm_sampler.py
@@ -159,12 +159,10 @@ class TestRLVllmSamplerInference(unittest.TestCase):
 class TestRLVllmSamplerWeightSync(unittest.TestCase):
     """Tests RLVllmSampler weight synchronization with duck-typed requests."""
 
-    @patch("tpu_inference.rl.vllm_sampler.RLVllmSampler._get_tpu_workers")
-    def test_weight_sync_calls_tpu_worker_apis(self, mock_get_workers):
+    @patch("tpu_inference.rl.vllm_sampler.RLVllmSampler._call_worker_method")
+    def test_weight_sync_calls_tpu_worker_apis(self, mock_call_worker_method):
 
-        mock_worker_0 = MagicMock()
-        mock_worker_1 = MagicMock()
-        mock_get_workers.return_value = [mock_worker_0, mock_worker_1]
+        mock_call_worker_method.return_value = []
 
         args = AsyncEngineArgs(model="Qwen/Qwen2.5-1.5B",
                                tensor_parallel_size=2)
@@ -174,10 +172,6 @@ class TestRLVllmSamplerWeightSync(unittest.TestCase):
         mock_engine.pause_background_loop = AsyncMock()
         mock_engine.resume_background_loop = AsyncMock()
         mock_engine.reset_prefix_cache = AsyncMock()
-        mock_engine.init_weight_transfer_engine = MagicMock()
-        mock_engine.start_weight_update = MagicMock()
-        mock_engine.update_weights = MagicMock()
-        mock_engine.finish_weight_update = MagicMock()
         sampler._engine = mock_engine
         sampler._is_running = True
 
@@ -193,21 +187,21 @@ class TestRLVllmSamplerWeightSync(unittest.TestCase):
 
             await sampler.pre_weight_sync(req_pre)
             mock_engine.pause_background_loop.assert_called_once()
-            mock_engine.start_weight_update.assert_called_once_with(
-                free_kv_cache=True)
+            mock_call_worker_method.assert_called_once_with("delete_kv_cache")
             self.assertEqual(await sampler.get_transfer_status("transfer_99"),
                              "IN_PROGRESS")
 
+            mock_call_worker_method.reset_mock()
             req_sync = {"extra_config": {"dma_channel": 1}}
             await sampler.weight_sync(req_sync)
-            mock_engine.update_weights.assert_called_once()
-            call_arg = mock_engine.update_weights.call_args[0][0]
-            update_dict = getattr(call_arg, "update_info", call_arg)
-            self.assertEqual(update_dict, {"dma_channel": 1})
+            mock_call_worker_method.assert_called_once_with(
+                "update_weights", {"dma_channel": 1})
 
+            mock_call_worker_method.reset_mock()
             req_post = SimpleNamespace(req_id="transfer_99")
             await sampler.post_weight_sync(req_post)
-            mock_engine.finish_weight_update.assert_called_once()
+            mock_call_worker_method.assert_called_once_with(
+                "reinitialize_kv_cache")
             mock_engine.reset_prefix_cache.assert_called_once()
             mock_engine.resume_background_loop.assert_called_once()
             self.assertEqual(await sampler.get_transfer_status("transfer_99"),

--- a/tests/rl/test_vllm_sampler.py
+++ b/tests/rl/test_vllm_sampler.py
@@ -187,7 +187,8 @@ class TestRLVllmSamplerWeightSync(unittest.TestCase):
 
             await sampler.pre_weight_sync(req_pre)
             mock_engine.pause_background_loop.assert_called_once()
-            mock_call_worker_method.assert_called_once_with("delete_kv_cache")
+            mock_call_worker_method.assert_called_once_with(
+                "start_weight_update", free_kv_cache=True)
             self.assertEqual(await sampler.get_transfer_status("transfer_99"),
                              "IN_PROGRESS")
 
@@ -201,7 +202,7 @@ class TestRLVllmSamplerWeightSync(unittest.TestCase):
             req_post = SimpleNamespace(req_id="transfer_99")
             await sampler.post_weight_sync(req_post)
             mock_call_worker_method.assert_called_once_with(
-                "reinitialize_kv_cache")
+                "finish_weight_update")
             mock_engine.reset_prefix_cache.assert_called_once()
             mock_engine.resume_background_loop.assert_called_once()
             self.assertEqual(await sampler.get_transfer_status("transfer_99"),

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -83,6 +83,7 @@ if TYPE_CHECKING:
     VLLM_TPU_BUCKET_PADDING_GAP: int = 0
     VLLM_INCREMENTAL_FP8_LOADING: bool = False
     TPU_MESH_SORT_BY_COORDS: bool = False
+    VERIFY_WEIGHTS: bool = False
 
 
 def env_with_choices(
@@ -494,6 +495,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # when initializing large FP8 models on smaller RAM TPUs such as TPU8i.
     "VLLM_INCREMENTAL_FP8_LOADING":
     env_bool("VLLM_INCREMENTAL_FP8_LOADING", default=False),
+    # RL weight sync: verify tensor checksums after each Raiden H2D transfer.
+    "VERIFY_WEIGHTS":
+    env_bool("VERIFY_WEIGHTS", default=False),
 }
 
 

--- a/tpu_inference/rl/raiden_worker_sync.py
+++ b/tpu_inference/rl/raiden_worker_sync.py
@@ -1,0 +1,263 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the tpu-inference project
+"""Binds a TPUWorker's live model weights to the Raiden transport, in-process.
+
+Runs inside the EngineCore subprocess where the live TPU arrays live; only
+plain-data metadata (`RaidenWorkerSync.metadata_dict`) crosses the
+`collective_rpc` boundary back to `RLVllmSampler`.
+
+Duplicates (rather than imports) tunix's
+`raiden_synchronizer.RaidenSynchronizer` binding mechanics, since
+`vllm_sampler.py` has no Tunix dependency. Keep the two in sync by hand;
+tunix's `weight_sync.dict_to_metadata` defines the metadata shape.
+"""
+
+from __future__ import annotations
+
+import socket
+from typing import Any, List, Optional, Tuple
+
+import jax
+import jax.numpy as jnp
+
+_ws_lib: Any = None
+_RAIDEN_IMPORT_ERROR: Optional[Exception] = None
+try:
+    from tpu_sync.api.jax import weight_synchronizer as _ws_lib  # pylint: disable=g-import-not-at-top
+except ImportError as exc:
+    _RAIDEN_IMPORT_ERROR = exc
+
+
+def local_ip() -> str:
+    for family, probe in (
+        (socket.AF_INET, ("8.8.8.8", 80)),
+        (socket.AF_INET6, ("2001:4860:4860::8888", 80)),
+    ):
+        try:
+            s = socket.socket(family, socket.SOCK_DGRAM)
+            try:
+                s.connect(probe)
+                ip = s.getsockname()[0]
+            finally:
+                s.close()
+            return f"[{ip}]" if ":" in ip else ip
+        except OSError:
+            continue
+    return "localhost"
+
+
+def is_maxtext_model(model: Any) -> bool:
+    """True if `model` is a MaxTextForCausalLM (checked by class name to
+    avoid a maxtext dependency)."""
+    return type(model).__name__ == "MaxTextForCausalLM"
+
+
+def extract_weight_state(state: Any, model: Any) -> Any:
+    """Returns the Param state ready for Raiden binding/inspection.
+
+    For MaxText, params nest one level down under the wrapper's `model`
+    key (not `base`, unlike the trainer side); unwrapped here either way.
+    """
+    maxtext = is_maxtext_model(model)
+    if state is not None:
+        if maxtext:
+            try:
+                return {"base": state["model"]}
+            except (KeyError, TypeError):
+                pass
+        return state
+    if model is not None:
+        from flax import nnx
+        if maxtext:
+            inner = getattr(model, "model", None)
+            if inner is not None:
+                return {"base": nnx.state(inner, nnx.Param)}
+            return None
+        return nnx.state(model, nnx.Param)
+    return None
+
+
+def flatten_weights(state: Any) -> Tuple[List[str], List[Any]]:
+    """Returns (names, arrays) for every array leaf, in stable tree order."""
+    names, arrays = [], []
+    for path, leaf in jax.tree_util.tree_leaves_with_path(state):
+        arr = getattr(leaf, "value", leaf)
+        if hasattr(arr, "shape") and hasattr(arr, "dtype"):
+            names.append(jax.tree_util.keystr(path))
+            arrays.append(arr)
+    return names, arrays
+
+
+def _bindable(arr: Any) -> bool:
+    """True if the native layer can bind this leaf."""
+    try:
+        if not hasattr(arr, "shape") or not hasattr(arr, "dtype"):
+            return False
+        if arr.ndim < 1:
+            return False
+        if not jnp.issubdtype(arr.dtype, jnp.floating):
+            return False
+        devices = arr.devices()
+        if not devices:
+            return False
+        return all(getattr(d, "platform", "?") == "tpu" for d in devices)
+    except Exception:
+        return False
+
+
+def _filter_bindable(
+    names: List[str], arrays: List[Any]
+) -> Tuple[List[str], List[Any]]:
+    """Drops leaves the native layer cannot bind (e.g. RNG-key arrays)."""
+    keep_names: List[str] = []
+    keep_arrays: List[Any] = []
+    for name, arr in zip(names, arrays):
+        if _bindable(arr):
+            if hasattr(arr, "block_until_ready"):
+                arr.block_until_ready()
+            keep_names.append(name)
+            keep_arrays.append(arr)
+    return keep_names, keep_arrays
+
+
+def _axis_name(axis: Any) -> str:
+    if axis is None:
+        return ""
+    if isinstance(axis, str):
+        return axis
+    return ",".join(axis)
+
+
+def _tensor_metadata_dict(name: str, arr: Any, layer_idx: int) -> dict:
+    sharding: Any = getattr(arr, "sharding", None)
+    spec = tuple(getattr(sharding, "spec", ()) or ())
+    spec = (spec + (None,) * arr.ndim)[: arr.ndim]
+    try:
+        local = sharding.shard_shape(tuple(arr.shape))
+        mesh_shape = tuple(g // l for g, l in zip(arr.shape, local))
+    except Exception:  # pylint: disable=broad-exception-caught
+        mesh_shape = (1,) * arr.ndim
+    return {
+        "name": name,
+        "shape": list(arr.shape),
+        "mesh_shape": list(mesh_shape),
+        "layout": list(reversed(range(arr.ndim))),
+        "item_size": arr.dtype.itemsize,
+        "layer_idx": layer_idx,
+        "sharding_spec": [_axis_name(a) for a in spec],
+    }
+
+
+class RaidenWorkerSync:
+    """One TPUWorker's weights on the Raiden transport, plus wire-safe metadata.
+
+    In-process counterpart to tunix's `RaidenSynchronizer`. Construct once
+    per `TPUWorker`, rebind on every sync round via `bind()`.
+    """
+
+    def __init__(
+        self,
+        job_name: str,
+        *,
+        worker_index: int = 0,
+        parallelism: int = 4,
+        bind_ip: Optional[str] = None,
+    ):
+        self.job_name = job_name
+        self.worker_index = worker_index
+        self.names: List[str] = []
+        self.arrays: List[Any] = []
+        self.ip = bind_ip or local_ip()
+        self._parallelism = parallelism
+        self._sync: Any = None
+
+    @property
+    def bound(self) -> bool:
+        return bool(self.names)
+
+    def bind(self, state: Any) -> None:
+        """Binds (or rebinds after a weight update) this worker's weights."""
+        self.names, self.arrays = _filter_bindable(*flatten_weights(state))
+        if _ws_lib is None:
+            raise RuntimeError(
+                f"{self.job_name}: tpu_sync is not importable, cannot bind "
+                f"weight_synchronizer. Original error: {_RAIDEN_IMPORT_ERROR}")
+        if self._sync is None:
+            self._sync = _ws_lib.WeightSynchronizer(
+                self.arrays,
+                local_port=0,
+                parallelism=self._parallelism,
+                unsafe_skip_buffer_lock=True,
+                listener_port=0,
+                bind_ip=None,
+            )
+        else:
+            self._sync.bind_weights(self.arrays)
+
+    def _require_sync(self, op: str) -> Any:
+        if self._sync is None:
+            raise RuntimeError(f"{self.job_name}: bind() must run before {op}")
+        return self._sync
+
+    def h2d(self) -> None:
+        # h2d() is async; block so a checksum/read right after sees the
+        # transferred data.
+        self._require_sync("h2d()").h2d()
+        jax.block_until_ready(self.arrays)
+
+    def metrics(self) -> dict:
+        if self._sync is None:
+            return {}
+        getter = getattr(self._sync, "get_metrics",
+                        getattr(self._sync, "metrics", None))
+        return getter() if getter is not None else {}
+
+    def checksums(self, sample: int = 3) -> dict:
+        """Per-tensor float32 abs-sums for cross-process verification."""
+
+        def total(arr):
+            return float(jnp.sum(jnp.abs(arr).astype(jnp.float32)))
+
+        return {
+            name: total(arr) for name, arr in list(zip(self.names, self.arrays))[:sample]
+        }
+
+    def metadata_dict(self) -> dict:
+        """Wire-safe registration metadata, shaped for tunix's
+        `weight_sync.dict_to_metadata`."""
+        # Positional index, not name-derived -- must match tunix's side.
+        variables = [
+            _tensor_metadata_dict(name, arr, idx)
+            for idx, (name, arr) in enumerate(zip(self.names, self.arrays))
+        ]
+        mesh_axes: tuple = ()
+        mesh_shape = None
+        for arr in self.arrays:
+            mesh = getattr(getattr(arr, "sharding", None), "mesh", None)
+            if mesh is not None:
+                mesh_axes = tuple(mesh.axis_names)
+                mesh_shape = tuple(mesh.shape[a] for a in mesh.axis_names)
+                break
+        if mesh_shape is None:
+            raise RuntimeError(
+                f"{self.job_name}: no bound array carries a sharding mesh; "
+                "cannot determine mesh_shape/mesh_axes for registration "
+                "metadata.")
+        data_addr = f"{self.ip}:{self._sync.local_port}" if self._sync else ""
+        control_addr = (
+            f"{self.ip}:{self._sync.listener_port}"
+            if self._sync and self._sync.listener_port
+            else ""
+        )
+        num_shards = self._sync.num_shards if self._sync else 1
+        return {
+            "unit": {
+                "job_name": self.job_name,
+                "job_replica_id": str(self.worker_index) if self.worker_index else "",
+            },
+            "shards": [data_addr] * num_shards if data_addr else [],
+            "control_plane_rpc_address": control_addr,
+            "mesh_shape": list(mesh_shape),
+            "variables": variables,
+            "mesh_axes": list(mesh_axes) if mesh_axes else None,
+        }

--- a/tpu_inference/rl/raiden_worker_sync.py
+++ b/tpu_inference/rl/raiden_worker_sync.py
@@ -23,7 +23,8 @@ import jax.numpy as jnp
 _ws_lib: Any = None
 _RAIDEN_IMPORT_ERROR: Optional[Exception] = None
 try:
-    from tpu_sync.api.jax import weight_synchronizer as _ws_lib  # pylint: disable=g-import-not-at-top
+    from tpu_sync.api.jax import \
+        weight_synchronizer as _ws_lib  # pylint: disable=g-import-not-at-top
 except ImportError as exc:
     _RAIDEN_IMPORT_ERROR = exc
 
@@ -105,9 +106,8 @@ def _bindable(arr: Any) -> bool:
         return False
 
 
-def _filter_bindable(
-    names: List[str], arrays: List[Any]
-) -> Tuple[List[str], List[Any]]:
+def _filter_bindable(names: List[str],
+                     arrays: List[Any]) -> Tuple[List[str], List[Any]]:
     """Drops leaves the native layer cannot bind (e.g. RNG-key arrays)."""
     keep_names: List[str] = []
     keep_arrays: List[Any] = []
@@ -131,12 +131,12 @@ def _axis_name(axis: Any) -> str:
 def _tensor_metadata_dict(name: str, arr: Any, layer_idx: int) -> dict:
     sharding: Any = getattr(arr, "sharding", None)
     spec = tuple(getattr(sharding, "spec", ()) or ())
-    spec = (spec + (None,) * arr.ndim)[: arr.ndim]
+    spec = (spec + (None, ) * arr.ndim)[:arr.ndim]
     try:
         local = sharding.shard_shape(tuple(arr.shape))
-        mesh_shape = tuple(g // l for g, l in zip(arr.shape, local))
+        mesh_shape = tuple(g // s for g, s in zip(arr.shape, local))
     except Exception:  # pylint: disable=broad-exception-caught
-        mesh_shape = (1,) * arr.ndim
+        mesh_shape = (1, ) * arr.ndim
     return {
         "name": name,
         "shape": list(arr.shape),
@@ -209,7 +209,7 @@ class RaidenWorkerSync:
         if self._sync is None:
             return {}
         getter = getattr(self._sync, "get_metrics",
-                        getattr(self._sync, "metrics", None))
+                         getattr(self._sync, "metrics", None))
         return getter() if getter is not None else {}
 
     def checksums(self, sample: int = 3) -> dict:
@@ -219,7 +219,8 @@ class RaidenWorkerSync:
             return float(jnp.sum(jnp.abs(arr).astype(jnp.float32)))
 
         return {
-            name: total(arr) for name, arr in list(zip(self.names, self.arrays))[:sample]
+            name: total(arr)
+            for name, arr in list(zip(self.names, self.arrays))[:sample]
         }
 
     def metadata_dict(self) -> dict:
@@ -244,16 +245,15 @@ class RaidenWorkerSync:
                 "cannot determine mesh_shape/mesh_axes for registration "
                 "metadata.")
         data_addr = f"{self.ip}:{self._sync.local_port}" if self._sync else ""
-        control_addr = (
-            f"{self.ip}:{self._sync.listener_port}"
-            if self._sync and self._sync.listener_port
-            else ""
-        )
+        control_addr = (f"{self.ip}:{self._sync.listener_port}"
+                        if self._sync and self._sync.listener_port else "")
         num_shards = self._sync.num_shards if self._sync else 1
         return {
             "unit": {
-                "job_name": self.job_name,
-                "job_replica_id": str(self.worker_index) if self.worker_index else "",
+                "job_name":
+                self.job_name,
+                "job_replica_id":
+                str(self.worker_index) if self.worker_index else "",
             },
             "shards": [data_addr] * num_shards if data_addr else [],
             "control_plane_rpc_address": control_addr,

--- a/tpu_inference/rl/vllm_sampler.py
+++ b/tpu_inference/rl/vllm_sampler.py
@@ -338,7 +338,8 @@ class RLVllmSampler:
             "tpu_worker_ips": worker_ips,
         }
 
-    async def _call_worker_method(self, method_name: str, *args: Any, **kwargs: Any) -> list[Any]:
+    async def _call_worker_method(self, method_name: str, *args: Any,
+                                  **kwargs: Any) -> list[Any]:
         """Dispatches a method call across TPU workers via collective_rpc.
 
         `AsyncLLMEngine` (an alias of `vllm.v1.engine.async_llm.AsyncLLM`)
@@ -346,13 +347,17 @@ class RLVllmSampler:
         """
         if self._engine is None:
             return []
-        return await self._engine.collective_rpc(method_name, args=args, kwargs=kwargs)
+        return await self._engine.collective_rpc(method_name,
+                                                 args=args,
+                                                 kwargs=kwargs)
 
     async def get_weights_state(self) -> list[Any]:
         """Returns the PyTree of weights or state from active TPU workers."""
         return await self._call_worker_method("get_weights_state")
 
-    async def bind_raiden_sync(self, worker_index: int = 0, parallelism: int = 4) -> None:
+    async def bind_raiden_sync(self,
+                               worker_index: int = 0,
+                               parallelism: int = 4) -> None:
         """Binds Raiden to each TPU worker's live weights, in-process.
 
         `get_weights_state()` cannot back a rollout-side weight sync: the
@@ -364,7 +369,8 @@ class RLVllmSampler:
         happen in the worker subprocess instead -- see
         `tpu_worker.TPUWorker.bind_raiden_sync`.
         """
-        await self._call_worker_method("bind_raiden_sync", worker_index, parallelism)
+        await self._call_worker_method("bind_raiden_sync", worker_index,
+                                       parallelism)
 
     async def get_raiden_metadata(self) -> list[dict]:
         """Wire-safe registration metadata for each worker's current Raiden binding."""
@@ -389,8 +395,9 @@ class RLVllmSampler:
         """Phase 1: Pauses intake, clears prefix cache, and drops KV cache via delete_kv_cache()."""
         self._policy_version = _get_val(sync_request, "policy_version",
                                         self._policy_version)
-        logger.info("Executing pre_weight_sync (policy_version=%d, free_kv_cache=%s)",
-                    self._policy_version, free_kv_cache)
+        logger.info(
+            "Executing pre_weight_sync (policy_version=%d, free_kv_cache=%s)",
+            self._policy_version, free_kv_cache)
 
         if sync_request is not None:
             rid = _get_val(sync_request, "req_id")

--- a/tpu_inference/rl/vllm_sampler.py
+++ b/tpu_inference/rl/vllm_sampler.py
@@ -10,6 +10,7 @@ without importing or depending on Tunix.
 """
 
 import asyncio
+import inspect
 import logging
 import os
 import time
@@ -27,12 +28,21 @@ logger = logging.getLogger(__name__)
 
 
 def _get_val(obj: Any, key: str, default: Any = None) -> Any:
-    """Helper to extract an attribute or dict key seamlessly from any duck-typed request."""
+    """Helper to extract an attribute or dict key seamlessly from any duck-typed request.
+
+    Falls back to `default` both when `key` is absent and when it's present
+    but explicitly `None` -- request dataclasses across callers (e.g. tunix's
+    rollout requests) commonly default optional sampling fields to `None`
+    rather than omitting them, and vLLM's `SamplingParams` rejects `None` for
+    fields like `top_k` that it compares numerically.
+    """
     if obj is None:
         return default
     if isinstance(obj, dict):
-        return obj.get(key, default)
-    return getattr(obj, key, default)
+        val = obj.get(key, default)
+    else:
+        val = getattr(obj, key, default)
+    return default if val is None else val
 
 
 class RLVllmSampler:
@@ -57,6 +67,7 @@ class RLVllmSampler:
         self._mesh: Any | None = None
         self._transfer_statuses: dict[str, str] = {}
         self._policy_version = 0
+        self._kv_cache_freed = False
 
     def _get_tpu_workers(self) -> list[Any]:
         """Retrieves active TPUWorker instances from underlying model executor."""
@@ -84,17 +95,6 @@ class RLVllmSampler:
 
         self._engine = AsyncLLMEngine.from_engine_args(self.engine_args)
         self._is_running = True
-
-        init_info = {
-            "model_path": self.engine_args.model,
-            "tp_size": self.engine_args.tensor_parallel_size,
-        }
-        if self._engine:
-            try:
-                await self._engine.init_weight_transfer_engine(init_info)
-            except Exception as e:
-                logger.warning(
-                    "Failed to initialize weight transfer engine: %s", e)
 
         logger.info("RLVllmSampler started successfully.")
 
@@ -340,17 +340,92 @@ class RLVllmSampler:
             "tpu_worker_ips": worker_ips,
         }
 
+    async def _call_worker_method(self, method_name: str, *args: Any, **kwargs: Any) -> list[Any]:
+        """Dispatches a method call across TPU workers via collective_rpc or direct execution."""
+        if self._engine is None:
+            return []
+        engine_obj = getattr(self._engine, "engine", self._engine)
+        last_error: Exception | None = None
+        # AsyncLLMEngine.collective_rpc is a coroutine function; other engine
+        # objects may expose a plain sync collective_rpc. Handle both.
+        if hasattr(engine_obj, "collective_rpc"):
+            try:
+                result = engine_obj.collective_rpc(method_name, args=args, kwargs=kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                return result
+            except Exception as e:
+                logger.warning("engine.collective_rpc(%s) failed: %s", method_name, e)
+                last_error = e
+        model_executor = getattr(engine_obj, "model_executor", None)
+        if model_executor and hasattr(model_executor, "collective_rpc"):
+            try:
+                result = model_executor.collective_rpc(method_name, args=args, kwargs=kwargs)
+                if inspect.isawaitable(result):
+                    result = await result
+                return result
+            except Exception as e:
+                logger.warning("model_executor.collective_rpc(%s) failed: %s", method_name, e)
+                last_error = e
+
+        workers = self._get_tpu_workers()
+        results = []
+        for w in workers:
+            if hasattr(w, method_name):
+                fn = getattr(w, method_name)
+                r = fn(*args, **kwargs)
+                if inspect.isawaitable(r):
+                    r = await r
+                results.append(r)
+        if not results and workers and last_error is not None:
+            raise RuntimeError(
+                f"_call_worker_method({method_name}) failed on all dispatch "
+                f"paths: {last_error}") from last_error
+        return results
+
+    async def get_weights_state(self) -> list[Any]:
+        """Returns the PyTree of weights or state from active TPU workers."""
+        return await self._call_worker_method("get_weights_state")
+
+    async def bind_raiden_sync(self, worker_index: int = 0, parallelism: int = 4) -> None:
+        """Binds Raiden to each TPU worker's live weights, in-process.
+
+        `get_weights_state()` cannot back a rollout-side weight sync: the
+        live `nnx.State` it returns has to be dispatched back across
+        `collective_rpc` into this (parent) process to be useful, but vLLM's
+        RPC transport can't serialize `nnx.State`/live TPU arrays, and even a
+        pickle-based fallback would bind Raiden to a disconnected host copy
+        rather than the device buffers actually being served. Binding must
+        happen in the worker subprocess instead -- see
+        `tpu_worker.TPUWorker.bind_raiden_sync`.
+        """
+        await self._call_worker_method("bind_raiden_sync", worker_index, parallelism)
+
+    async def get_raiden_metadata(self) -> list[dict]:
+        """Wire-safe registration metadata for each worker's current Raiden binding."""
+        return await self._call_worker_method("get_raiden_metadata")
+
+    async def raiden_h2d(self) -> list[dict]:
+        """Blocks each worker until its just-landed transfer is visible on-device.
+
+        Returns each worker's checksums dict (empty unless VERIFY_WEIGHTS=true).
+        """
+        return await self._call_worker_method("raiden_h2d")
+
+    async def raiden_metrics(self) -> list[dict]:
+        return await self._call_worker_method("raiden_metrics")
+
     async def pre_weight_sync(
         self,
         sync_request: Any = None,
         free_kv_cache: bool = True,
         **kwargs: Any,
     ) -> None:
-        """Phase 1: Pauses intake, clears prefix cache, and calls start_weight_update()."""
+        """Phase 1: Pauses intake, clears prefix cache, and drops KV cache via delete_kv_cache()."""
         self._policy_version = _get_val(sync_request, "policy_version",
                                         self._policy_version)
-        logger.info("Executing pre_weight_sync (policy_version=%d)",
-                    self._policy_version)
+        logger.info("Executing pre_weight_sync (policy_version=%d, free_kv_cache=%s)",
+                    self._policy_version, free_kv_cache)
 
         if sync_request is not None:
             rid = _get_val(sync_request, "req_id")
@@ -360,19 +435,19 @@ class RLVllmSampler:
         await self.pause()
         await self._clear_prefix_cache()
 
-        if self._engine and hasattr(self._engine, "start_weight_update"):
-            self._engine.start_weight_update(free_kv_cache=free_kv_cache)
+        if free_kv_cache:
+            await self._call_worker_method("delete_kv_cache")
+            self._kv_cache_freed = True
 
     async def weight_sync(
         self,
         sync_request: Any = None,
         **kwargs: Any,
     ) -> None:
-        """Phase 2: Calls TPUWorker.update_weights(update_info)."""
+        """Phase 2: Coordinates weight synchronization barrier across TPU workers."""
         logger.info("Executing weight_sync update on TPU workers...")
         u_info = _get_val(sync_request, "extra_config") or {}
-        if self._engine:
-            self._engine.update_weights(u_info)
+        await self._call_worker_method("update_weights", u_info)
         await asyncio.sleep(0.01)
 
     async def post_weight_sync(
@@ -380,14 +455,17 @@ class RLVllmSampler:
         sync_request: Any = None,
         **kwargs: Any,
     ) -> None:
-        """Phase 3: Calls TPUWorker.finish_weight_update()."""
+        """Phase 3: Restores KV cache via reinitialize_kv_cache() and resumes serving."""
         rid = None
         if sync_request is not None:
             rid = _get_val(sync_request, "req_id")
         logger.info("Executing post_weight_sync (req_id=%s)...", rid)
 
-        if self._engine:
-            self._engine.finish_weight_update()
+        if getattr(self, "_kv_cache_freed", False):
+            await self._call_worker_method("reinitialize_kv_cache")
+            self._kv_cache_freed = False
+        else:
+            await self._call_worker_method("finish_weight_update")
 
         self._cache_valid = True
         if rid:

--- a/tpu_inference/rl/vllm_sampler.py
+++ b/tpu_inference/rl/vllm_sampler.py
@@ -10,7 +10,6 @@ without importing or depending on Tunix.
 """
 
 import asyncio
-import inspect
 import logging
 import os
 import time
@@ -67,7 +66,6 @@ class RLVllmSampler:
         self._mesh: Any | None = None
         self._transfer_statuses: dict[str, str] = {}
         self._policy_version = 0
-        self._kv_cache_freed = False
 
     def _get_tpu_workers(self) -> list[Any]:
         """Retrieves active TPUWorker instances from underlying model executor."""
@@ -341,47 +339,14 @@ class RLVllmSampler:
         }
 
     async def _call_worker_method(self, method_name: str, *args: Any, **kwargs: Any) -> list[Any]:
-        """Dispatches a method call across TPU workers via collective_rpc or direct execution."""
+        """Dispatches a method call across TPU workers via collective_rpc.
+
+        `AsyncLLMEngine` (an alias of `vllm.v1.engine.async_llm.AsyncLLM`)
+        always exposes an async `collective_rpc`.
+        """
         if self._engine is None:
             return []
-        engine_obj = getattr(self._engine, "engine", self._engine)
-        last_error: Exception | None = None
-        # AsyncLLMEngine.collective_rpc is a coroutine function; other engine
-        # objects may expose a plain sync collective_rpc. Handle both.
-        if hasattr(engine_obj, "collective_rpc"):
-            try:
-                result = engine_obj.collective_rpc(method_name, args=args, kwargs=kwargs)
-                if inspect.isawaitable(result):
-                    result = await result
-                return result
-            except Exception as e:
-                logger.warning("engine.collective_rpc(%s) failed: %s", method_name, e)
-                last_error = e
-        model_executor = getattr(engine_obj, "model_executor", None)
-        if model_executor and hasattr(model_executor, "collective_rpc"):
-            try:
-                result = model_executor.collective_rpc(method_name, args=args, kwargs=kwargs)
-                if inspect.isawaitable(result):
-                    result = await result
-                return result
-            except Exception as e:
-                logger.warning("model_executor.collective_rpc(%s) failed: %s", method_name, e)
-                last_error = e
-
-        workers = self._get_tpu_workers()
-        results = []
-        for w in workers:
-            if hasattr(w, method_name):
-                fn = getattr(w, method_name)
-                r = fn(*args, **kwargs)
-                if inspect.isawaitable(r):
-                    r = await r
-                results.append(r)
-        if not results and workers and last_error is not None:
-            raise RuntimeError(
-                f"_call_worker_method({method_name}) failed on all dispatch "
-                f"paths: {last_error}") from last_error
-        return results
+        return await self._engine.collective_rpc(method_name, args=args, kwargs=kwargs)
 
     async def get_weights_state(self) -> list[Any]:
         """Returns the PyTree of weights or state from active TPU workers."""
@@ -435,9 +400,11 @@ class RLVllmSampler:
         await self.pause()
         await self._clear_prefix_cache()
 
-        if free_kv_cache:
-            await self._call_worker_method("delete_kv_cache")
-            self._kv_cache_freed = True
+        # `AsyncLLMEngine.start_weight_update()` takes no arguments, so it
+        # can't forward `free_kv_cache` to the worker -- go through
+        # collective_rpc directly instead of the engine-level wrapper.
+        await self._call_worker_method("start_weight_update",
+                                       free_kv_cache=free_kv_cache)
 
     async def weight_sync(
         self,
@@ -461,11 +428,7 @@ class RLVllmSampler:
             rid = _get_val(sync_request, "req_id")
         logger.info("Executing post_weight_sync (req_id=%s)...", rid)
 
-        if getattr(self, "_kv_cache_freed", False):
-            await self._call_worker_method("reinitialize_kv_cache")
-            self._kv_cache_freed = False
-        else:
-            await self._call_worker_method("finish_weight_update")
+        await self._call_worker_method("finish_weight_update")
 
         self._cache_valid = True
         if rid:

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -179,6 +179,7 @@ class TPUWorker(WorkerBase):
 
     _weight_update_active: bool = False
     _kv_cache_freed: bool = False
+    _raiden_rl_weight_sync: Any = None
 
     def __init__(
         self,
@@ -726,6 +727,19 @@ class TPUWorker(WorkerBase):
         port = get_kv_transfer_port()
         return (int(self.topology_order_id), ip, int(port))
 
+    def init_weight_transfer_engine(self, init_info: Dict[str, Any]) -> None:
+        """Prepare the transport.
+
+        Binds this worker's live weights to Raiden's `WeightSynchronizer`
+        so subsequent `raiden_h2d`/`get_raiden_metadata` calls have
+        something to operate on.
+        """
+        logger.info("init_weight_transfer_engine: %s", sorted(init_info or {}))
+        self.bind_raiden_sync(
+            worker_index=init_info.get("worker_index", 0),
+            parallelism=init_info.get("parallelism", 4),
+        )
+
     def start_weight_update(self, free_kv_cache: bool = True) -> None:
         """Open a weight update session.
 
@@ -768,12 +782,14 @@ class TPUWorker(WorkerBase):
     def reinitialize_kv_cache(self) -> None:
         self.model_runner.reinitialize_kv_cache()
 
-    def _extract_weight_state(self) -> Any:
+    def get_weights_state(self) -> Any:
         """Builds the weight PyTree (possibly `nnx.State`) from the runner.
 
-        Used by `get_weights_state` (same-process callers only -- the
-        result can hold live TPU arrays, unserializable over collective_rpc)
-        and `bind_raiden_sync` (binds it to Raiden in-process instead).
+        Same-process callers only -- the result can hold live TPU arrays,
+        unserializable over collective_rpc. Used directly by same-process
+        callers, and by `bind_raiden_sync` to bind Raiden in-process.
+        Cross the collective_rpc boundary via `bind_raiden_sync` /
+        `get_raiden_metadata` instead.
         """
         from tpu_inference.rl import raiden_worker_sync  # pylint: disable=g-import-not-at-top
 
@@ -782,16 +798,8 @@ class TPUWorker(WorkerBase):
             getattr(self.model_runner, "model", None),
         )
 
-    def get_weights_state(self) -> Any:
-        """Returns model weights state / PyTree from the runner.
-
-        Same-process callers only; use `bind_raiden_sync`/`get_raiden_metadata`
-        to cross the collective_rpc boundary.
-        """
-        return self._extract_weight_state()
-
     def _require_raiden_sync(self, op: str) -> Any:
-        sync = getattr(self, "_raiden_worker_sync", None)
+        sync = self._raiden_rl_weight_sync
         if sync is None:
             raise RuntimeError(f"bind_raiden_sync must run before {op}.")
         return sync
@@ -801,15 +809,15 @@ class TPUWorker(WorkerBase):
         registration metadata (never the arrays)."""
         from tpu_inference.rl import raiden_worker_sync  # pylint: disable=g-import-not-at-top
 
-        state = self._extract_weight_state()
-        if getattr(self, "_raiden_worker_sync", None) is None:
-            self._raiden_worker_sync = raiden_worker_sync.RaidenWorkerSync(
+        state = self.get_weights_state()
+        if self._raiden_rl_weight_sync is None:
+            self._raiden_rl_weight_sync = raiden_worker_sync.RaidenWorkerSync(
                 job_name="rollout",
                 worker_index=worker_index,
                 parallelism=parallelism,
             )
-        self._raiden_worker_sync.bind(state)
-        return self._raiden_worker_sync.metadata_dict()
+        self._raiden_rl_weight_sync.bind(state)
+        return self._raiden_rl_weight_sync.metadata_dict()
 
     def get_raiden_metadata(self) -> dict:
         """Re-fetches the current binding's wire-safe metadata without rebinding."""
@@ -822,7 +830,7 @@ class TPUWorker(WorkerBase):
         """
         sync = self._require_raiden_sync("raiden_h2d")
         sync.h2d()
-        if os.environ.get("VERIFY_WEIGHTS", "").lower() == "true":
+        if envs.VERIFY_WEIGHTS:
             return sync.checksums()
         return {}
 

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -726,14 +726,6 @@ class TPUWorker(WorkerBase):
         port = get_kv_transfer_port()
         return (int(self.topology_order_id), ip, int(port))
 
-    def init_weight_transfer_engine(self, init_info: Dict[str, Any]) -> None:
-        """Prepare the transport.
-
-        No setup is needed today; Raiden will build its `WeightSynchronizer`
-        here.
-        """
-        logger.info("init_weight_transfer_engine: %s", sorted(init_info or {}))
-
     def start_weight_update(self, free_kv_cache: bool = True) -> None:
         """Open a weight update session.
 
@@ -775,6 +767,67 @@ class TPUWorker(WorkerBase):
 
     def reinitialize_kv_cache(self) -> None:
         self.model_runner.reinitialize_kv_cache()
+
+    def _extract_weight_state(self) -> Any:
+        """Builds the weight PyTree (possibly `nnx.State`) from the runner.
+
+        Used by `get_weights_state` (same-process callers only -- the
+        result can hold live TPU arrays, unserializable over collective_rpc)
+        and `bind_raiden_sync` (binds it to Raiden in-process instead).
+        """
+        from tpu_inference.rl import raiden_worker_sync  # pylint: disable=g-import-not-at-top
+
+        return raiden_worker_sync.extract_weight_state(
+            getattr(self.model_runner, "state", None),
+            getattr(self.model_runner, "model", None),
+        )
+
+    def get_weights_state(self) -> Any:
+        """Returns model weights state / PyTree from the runner.
+
+        Same-process callers only; use `bind_raiden_sync`/`get_raiden_metadata`
+        to cross the collective_rpc boundary.
+        """
+        return self._extract_weight_state()
+
+    def _require_raiden_sync(self, op: str) -> Any:
+        sync = getattr(self, "_raiden_worker_sync", None)
+        if sync is None:
+            raise RuntimeError(f"bind_raiden_sync must run before {op}.")
+        return sync
+
+    def bind_raiden_sync(self, worker_index: int = 0, parallelism: int = 4) -> dict:
+        """Binds this worker's live weights to Raiden and returns wire-safe
+        registration metadata (never the arrays)."""
+        from tpu_inference.rl import raiden_worker_sync  # pylint: disable=g-import-not-at-top
+
+        state = self._extract_weight_state()
+        if getattr(self, "_raiden_worker_sync", None) is None:
+            self._raiden_worker_sync = raiden_worker_sync.RaidenWorkerSync(
+                job_name="rollout",
+                worker_index=worker_index,
+                parallelism=parallelism,
+            )
+        self._raiden_worker_sync.bind(state)
+        return self._raiden_worker_sync.metadata_dict()
+
+    def get_raiden_metadata(self) -> dict:
+        """Re-fetches the current binding's wire-safe metadata without rebinding."""
+        return self._require_raiden_sync("get_raiden_metadata").metadata_dict()
+
+    def raiden_h2d(self) -> dict:
+        """Blocks until the transfer that just landed is visible on-device.
+
+        Returns tensor checksums when `VERIFY_WEIGHTS=true`.
+        """
+        sync = self._require_raiden_sync("raiden_h2d")
+        sync.h2d()
+        if os.environ.get("VERIFY_WEIGHTS", "").lower() == "true":
+            return sync.checksums()
+        return {}
+
+    def raiden_metrics(self) -> dict:
+        return self._require_raiden_sync("raiden_metrics").metrics()
 
     def reset_encoder_cache(self) -> None:
         self.model_runner.reset_encoder_cache()

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -791,7 +791,8 @@ class TPUWorker(WorkerBase):
         Cross the collective_rpc boundary via `bind_raiden_sync` /
         `get_raiden_metadata` instead.
         """
-        from tpu_inference.rl import raiden_worker_sync  # pylint: disable=g-import-not-at-top
+        from tpu_inference.rl import \
+            raiden_worker_sync  # pylint: disable=g-import-not-at-top
 
         return raiden_worker_sync.extract_weight_state(
             getattr(self.model_runner, "state", None),
@@ -804,10 +805,13 @@ class TPUWorker(WorkerBase):
             raise RuntimeError(f"bind_raiden_sync must run before {op}.")
         return sync
 
-    def bind_raiden_sync(self, worker_index: int = 0, parallelism: int = 4) -> dict:
+    def bind_raiden_sync(self,
+                         worker_index: int = 0,
+                         parallelism: int = 4) -> dict:
         """Binds this worker's live weights to Raiden and returns wire-safe
         registration metadata (never the arrays)."""
-        from tpu_inference.rl import raiden_worker_sync  # pylint: disable=g-import-not-at-top
+        from tpu_inference.rl import \
+            raiden_worker_sync  # pylint: disable=g-import-not-at-top
 
         state = self.get_weights_state()
         if self._raiden_rl_weight_sync is None:


### PR DESCRIPTION
# Description

Adds an in-process weight synchronization path so RLVllmSampler (the RL rollout sampler in tpu_inference) can bind its live TPU-resident model weights to Raiden's WeightSynchronizer transport and be driven by tunix's VllmSamplerAdapter


# Tests

Testing

- tests/rl/test_vllm_sampler.py (7 tests) — updated for the new _call_worker_method-based dispatch, all pass
- tests/rl/test_raiden_worker_sync.py (15 tests, new) — all pass

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
