### PR TITLE
Hierarchical Reduce Scatter TensorCore kernel (hierrs_tc) + FP8 wire

### DIFF
--- a/tests/kernels/collectives/hierrs_tc_test.py
+++ b/tests/kernels/collectives/hierrs_tc_test.py
@@ -14,6 +14,7 @@
 """Tests for hierarchical_reduce_scatter, including FP8 comm quality eval."""
 
 import os
+from unittest import mock
 
 import importlib.util as _importlib_util
 
@@ -477,6 +478,57 @@ class HierarchicalReduceScatterTest(jtu.JaxTestCase):
         print(f'[fp8_static_vs_dynamic] static-vs-dynamic SNR={snr:.1f} dB')
         self.assertGreater(snr, 10.0,
                            msg=f'static diverges from dynamic (SNR {snr:.1f} dB)')
+
+
+@jtu.with_config(jax_numpy_dtype_promotion='standard')
+class HierarchicalReduceScatterPlanningTest(jtu.JaxTestCase):
+  """Planning rules that decide HOW the kernel runs, tested without a TPU.
+
+  These cover the two decisions taken before any device work happens: how many
+  micro-batches to use, and whether the working set can live in VMEM scratch.
+  Both are pure arithmetic, so they run anywhere and in milliseconds -- which
+  matters because the on-device suite only ever exercises whatever the
+  heuristics happen to pick, and would stay green if these rules regressed.
+  """
+
+  # local_seq_len values a decode-heavy server actually reaches, per RS_PIPE_PROBE
+  # at MNBT 1024 / MoE chunk 256 on 8 devices. This is the PER-DEVICE, PRE-scatter
+  # row count -- 8x the post-scatter count that appears in the HLO.
+  PRODUCTION_ROWS = (32, 64, 128, 256, 512, 1024, 2048)
+  HIDDEN = 4096
+  BF16_ITEMSIZE = 2
+
+  def test_micro_batch_floor_is_bf16_only(self):
+    """mb=1 returns the PREVIOUS call's result on the BF16 wire.
+
+    [Step C] reads the accumulator on the line after the emit_pipeline that
+    writes it, with nothing ordering the two. Measured with a fresh input per
+    run against a psum+dynamic_slice reference: 26/30, 24/30 and 11/30 runs
+    below 40 dB SNR at 128, 256 and 512 local rows. mb>=2 is 0/30 everywhere.
+
+    The FP8 wire is exempt because quantize_chunks_to_fp8_staging already
+    separates the write from the wire read (0/200 at the production shape).
+    If that staging step is ever removed, this exemption must be re-validated
+    with fresh inputs BEFORE this test is relaxed.
+    """
+    self.assertEqual(hrs_config._MIN_SAFE_MICRO_BATCHES, 2,
+                     msg='the floor is disabled -- is RS_ALLOW_UNSAFE_MB1 set?')
+    for rows in self.PRODUCTION_ROWS:
+      bf16_mb = hrs_config.pick_num_micro_batches(rows, self.HIDDEN,
+                                                  self.BF16_ITEMSIZE, False)
+      self.assertGreaterEqual(
+          bf16_mb, 2,
+          msg=f'bf16 at local_seq_len={rows} picked mb={bf16_mb}; mb=1 is '
+              'measurably incorrect, see the docstring above')
+      self.assertLessEqual(bf16_mb, hrs_config._MAX_MICRO_BATCHES)
+
+    # The exemption is real, not vacuous: at small shapes the fitted rule wants
+    # mb=1 and the FP8 wire is allowed to take it while BF16 is not.
+    fp8_mb = hrs_config.pick_num_micro_batches(128, self.HIDDEN,
+                                               self.BF16_ITEMSIZE, True)
+    self.assertEqual(fp8_mb, 1,
+                     msg='FP8 no longer takes mb=1, so the BF16-only floor is '
+                         'not being exercised by this test')
 
 
 if __name__ == '__main__':

--- a/tests/kernels/collectives/hierrs_tc_test.py
+++ b/tests/kernels/collectives/hierrs_tc_test.py
@@ -1,0 +1,483 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for hierarchical_reduce_scatter, including FP8 comm quality eval."""
+
+import os
+
+import importlib.util as _importlib_util
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from absl.testing import absltest, parameterized
+from jax._src import test_util as jtu
+from jax.experimental import shard_map
+
+# Load the kernel by file path, bypassing tpu_inference/__init__.py (which
+# eagerly imports env_override -> vllm -> transformers -> torchvision). The
+# kernel is pure jax with zero tpu_inference imports, so loading it standalone
+# keeps this kernel unit test hermetic and runnable even when the serving
+# stack (torch / torch_tpu / torchvision) is broken or version-skewed -- a
+# kernel test shouldn't depend on the whole vLLM import graph.
+# hierrs_tc is a PACKAGE with intra-package imports, so the standalone
+# spec_from_file_location trick the monolith used cannot load it. A normal
+# import works and is verified not to drag in the vLLM graph: the package
+# imports only jax + its own modules.
+from tpu_inference.kernels.collectives.hierrs_tc import config as hrs_config
+from tpu_inference.kernels.collectives.hierrs_tc import wrapper as hrs
+
+jax.config.parse_flags_with_absl()
+
+P = jax.sharding.PartitionSpec
+
+
+def _make_mesh(num_devices: int, axis_name: str) -> jax.sharding.Mesh:
+    """Physically-ordered 1D mesh, inlined from the tpu7x path of
+    tpu_inference.utils.make_optimized_mesh.
+
+    Importing tpu_inference.utils pulls in torchax, which re-registers the
+    PrivateUse1 backend and collides with the already-registered 'tpu' backend
+    under pytest. The kernel is jax-only, so this test builds its mesh directly:
+    sort devices by physical coords (so ids 2k/2k+1 are the two chiplets of one
+    chip, which the kernel's topology math assumes) and hand them to make_mesh.
+    """
+    devices = sorted(jax.devices(), key=lambda d: d.coords)[:num_devices]
+    try:
+        axis_types = (jax.sharding.AxisType.Auto,)
+        return jax.make_mesh((num_devices,), (axis_name,), axis_types,
+                             devices=devices)
+    except Exception:
+        return jax.sharding.Mesh(
+            np.asarray(devices).reshape((num_devices,)), (axis_name,))
+
+SpongeDir: str | None = os.environ.get('TEST_UNDECLARED_OUTPUTS_DIR', None)
+
+# Minimum SNR (dB) we require for FP8 comm mode. FP8 E4M3FN gives ~2.4 bits
+# of mantissa, so we expect meaningful but bounded degradation.
+_MIN_SNR_DB = 20.0
+
+# Static scaling uses a single fixed scale for every chunk instead of a
+# per-chunk max-abs, so small partial sums under-utilize the fp8 range and
+# quality is expected to be somewhat below the dynamic path. A well-chosen
+# scale should still clear this bar.
+_MIN_STATIC_SNR_DB = 12.0
+
+# The bf16 kernel and the psum reference sum the same values in different
+# orders, so they differ by bf16 reassociation error -- not by one ULP. An
+# elementwise rtol cannot express that: wherever the true value sits near zero
+# the denominator vanishes while the absolute error does not. Measured gap on
+# the shape below is a flat 47.9 dB across every micro-batch count and seed
+# (results/measure_bf16_tol.py), so 40 dB leaves ~2x margin in power while
+# still catching a genuinely wrong reduction, which lands far lower.
+_MIN_BF16_SNR_DB = 40.0
+
+# How much worse than the psum reference the kernel may be against an exact
+# f32 ground truth. Measured: kernel 0.0053-0.0061, reference 0.0058-0.0063 --
+# the kernel is actually the more accurate of the two at several seeds, so this
+# is a regression guard rather than a fitted bound.
+_BF16_TRUTH_SLACK = 1.5
+
+
+def _snr_db(signal: jax.Array, noise: jax.Array) -> float:
+    """Signal-to-noise ratio in dB: 10*log10(||signal||^2 / ||noise||^2)."""
+    signal_power = float(jnp.sum(signal.astype(jnp.float32)**2))
+    noise_power = float(jnp.sum(noise.astype(jnp.float32)**2))
+    if noise_power == 0.0:
+        return float('inf')
+    return 10.0 * jnp.log10(signal_power / noise_power).item()
+
+
+def _reference_reduce_scatter(x: jax.Array, mesh: jax.sharding.Mesh,
+                               in_specs: P) -> jax.Array:
+    """Reference: psum over 'x' axis then slice each device's shard."""
+    axis_name = mesh.axis_names[0]
+    num_devices = mesh.devices.size
+
+    def inner(local_x):
+        reduced = jax.lax.psum(local_x, axis_name=axis_name)
+        idx = jax.lax.axis_index(axis_name)
+        chunk = local_x.shape[0] // num_devices
+        return jax.lax.dynamic_slice_in_dim(reduced, idx * chunk, chunk, axis=0)
+
+    return shard_map.shard_map(
+        inner,
+        mesh=mesh,
+        in_specs=in_specs,
+        out_specs=in_specs,
+        check_rep=False,
+    )(x)
+
+
+@jtu.with_config(jax_numpy_dtype_promotion='standard')
+class HierarchicalReduceScatterTest(jtu.JaxTestCase):
+
+    def _requires_devices(self, n: int):
+        if jax.device_count() < n:
+            self.skipTest(f'Need {n} devices, got {jax.device_count()}')
+
+    # ------------------------------------------------------------------ #
+    # Correctness: bf16 mode should match reference psum+slice            #
+    # ------------------------------------------------------------------ #
+    @parameterized.product(
+        num_micro_batches=[1, 2, 4],
+    )
+    def test_correctness_bf16(self, num_micro_batches):
+        self._requires_devices(8)
+        axis_name = 'x'
+        num_devices = jax.device_count()
+        mesh = _make_mesh(num_devices, axis_name)
+
+        seq_len, hidden = 1024, 4096
+        in_specs = P(axis_name, None)
+
+        for seed in range(3):
+            x = jax.random.normal(jax.random.key(seed), (seq_len, hidden),
+                                  dtype=jnp.bfloat16)
+            x_sharded = jax.device_put(
+                x, jax.sharding.NamedSharding(mesh, in_specs))
+
+            ref = _reference_reduce_scatter(x_sharded, mesh, in_specs)
+            out = hrs.hierarchical_reduce_scatter(
+                x_sharded,
+                mesh=mesh,
+                in_specs=in_specs,
+                num_micro_batches=num_micro_batches,
+                fp8_comm=False,
+            )
+
+            ref_f32 = jnp.asarray(ref, jnp.float32)
+            out_f32 = jnp.asarray(out, jnp.float32)
+
+            # 1. Agreement with the reference, as SNR. Both are valid bf16
+            #    reduce-scatters that sum in different orders; see
+            #    _MIN_BF16_SNR_DB for why elementwise rtol cannot be used here.
+            snr = _snr_db(ref_f32, out_f32 - ref_f32)
+            self.assertGreater(
+                snr, _MIN_BF16_SNR_DB,
+                msg=f'bf16 mb={num_micro_batches} seed={seed}: SNR {snr:.1f} dB '
+                    f'< {_MIN_BF16_SNR_DB} dB vs psum reference')
+
+            # 2. Accuracy against an exact f32 ground truth -- no collective
+            #    involved, so this catches the case where kernel AND reference
+            #    drift together, which (1) would happily pass.
+            truth = jnp.asarray(x, jnp.float32).reshape(
+                num_devices, seq_len // num_devices, hidden).sum(axis=0)
+            scale = float(jnp.max(jnp.abs(truth))) or 1.0
+            err_kernel = float(jnp.max(jnp.abs(out_f32 - truth))) / scale
+            err_ref = float(jnp.max(jnp.abs(ref_f32 - truth))) / scale
+            self.assertLess(
+                err_kernel, max(err_ref * _BF16_TRUTH_SLACK, 1e-3),
+                msg=f'bf16 mb={num_micro_batches} seed={seed}: kernel error '
+                    f'{err_kernel:.4g} vs f32 truth exceeds reference '
+                    f'{err_ref:.4g} by more than {_BF16_TRUTH_SLACK}x')
+
+            # 3. Determinism. The kernel raced for months precisely here:
+            #    identical input gave different answers run to run. A
+            #    correctness test that only ever calls the kernel once cannot
+            #    see that, which is how it stayed hidden.
+            again = hrs.hierarchical_reduce_scatter(
+                x_sharded,
+                mesh=mesh,
+                in_specs=in_specs,
+                num_micro_batches=num_micro_batches,
+                fp8_comm=False,
+            )
+            self.assertTrue(
+                bool(jnp.array_equal(jnp.asarray(again, jnp.float32), out_f32)),
+                msg=f'bf16 mb={num_micro_batches} seed={seed}: two runs on '
+                    f'identical input disagree -- race, not precision')
+
+    # ------------------------------------------------------------------ #
+    # Race regression gate                                                #
+    # ------------------------------------------------------------------ #
+    @parameterized.product(
+        num_micro_batches=[2, 4],
+        fp8_comm=[False, True],
+    )
+    def test_no_race_multi_micro_batch(self, num_micro_batches, fp8_comm):
+        """Repeat one shape many times and require bit-identical output.
+
+        Shape matters more than repetition count here. Two races were found in
+        this kernel, and NEITHER reproduced at the 128 local rows that
+        test_correctness_bf16 uses -- that test passes even with the bug
+        deliberately restored. 512 local rows with num_micro_batches=4 was wrong
+        in 157 of 200 runs, so this is the configuration a gate has to exercise.
+
+        Both failures were write-after-read hazards on a shared buffer, which
+        makes them timing-dependent: a single call can easily come back correct.
+        Comparing repeated calls is what exposes them.
+        """
+        self._requires_devices(8)
+        axis_name = 'x'
+        num_devices = jax.device_count()
+        mesh = _make_mesh(num_devices, axis_name)
+
+        seq_len, hidden = 4096, 4096          # 512 local rows on 8 devices
+        in_specs = P(axis_name, None)
+        runs = 12
+
+        x = jax.random.normal(jax.random.key(0), (seq_len, hidden),
+                              dtype=jnp.bfloat16)
+        x_sharded = jax.device_put(
+            x, jax.sharding.NamedSharding(mesh, in_specs))
+        truth = jnp.asarray(x, jnp.float32).reshape(
+            num_devices, seq_len // num_devices, hidden).sum(axis=0)
+        scale = float(jnp.max(jnp.abs(truth))) or 1.0
+        kw = dict(fp8_min_rows=0, fp8_static_scale=1.0) if fp8_comm else {}
+        tol = 0.15 if fp8_comm else 0.05
+
+        first, worst = None, 0.0
+        for i in range(runs):
+            out = jnp.asarray(hrs.hierarchical_reduce_scatter(
+                x_sharded, mesh=mesh, in_specs=in_specs,
+                num_micro_batches=num_micro_batches, fp8_comm=fp8_comm, **kw),
+                jnp.float32)
+            worst = max(worst, float(jnp.max(jnp.abs(out - truth))) / scale)
+            if first is None:
+                first = out
+            else:
+                self.assertTrue(
+                    bool(jnp.array_equal(first, out)),
+                    msg=f'mb={num_micro_batches} fp8={fp8_comm}: run {i} '
+                        f'differs from run 0 on identical input -- race')
+
+        self.assertLess(
+            worst, tol,
+            msg=f'mb={num_micro_batches} fp8={fp8_comm}: max relative error '
+                f'{worst:.4g} over {runs} runs exceeds {tol}')
+
+    # ------------------------------------------------------------------ #
+    # Quality evaluation: FP8 comm vs bf16 baseline                      #
+    # ------------------------------------------------------------------ #
+    @parameterized.product(
+        seq_len=[512, 1024, 2048],
+        hidden=[2048, 4096, 8192],
+    )
+    def test_fp8_comm_quality(self, seq_len, hidden):
+        """FP8 comm output should have acceptable SNR vs bf16 baseline.
+
+        This is the primary evaluation gate before enabling real FP8 wire
+        transfers in Phase 2. If this test fails, FP8 quality is too poor
+        for production use at that shape.
+        """
+        self._requires_devices(8)
+        axis_name = 'x'
+        num_devices = jax.device_count()
+        mesh = _make_mesh(num_devices, axis_name)
+        in_specs = P(axis_name, None)
+
+        snr_values = []
+        max_errors = []
+        for seed in range(5):
+            x = jax.random.normal(jax.random.key(seed), (seq_len, hidden),
+                                  dtype=jnp.bfloat16)
+            x_sharded = jax.device_put(
+                x, jax.sharding.NamedSharding(mesh, in_specs))
+
+            out_bf16 = hrs.hierarchical_reduce_scatter(
+                x_sharded,
+                mesh=mesh,
+                in_specs=in_specs,
+                fp8_comm=False,
+            )
+            out_fp8 = hrs.hierarchical_reduce_scatter(
+                x_sharded,
+                mesh=mesh,
+                in_specs=in_specs,
+                fp8_comm=True,
+            )
+
+            noise = out_fp8.astype(jnp.float32) - out_bf16.astype(jnp.float32)
+            snr = _snr_db(out_bf16, noise)
+            max_err = float(jnp.max(jnp.abs(noise)))
+
+            snr_values.append(snr)
+            max_errors.append(max_err)
+
+        avg_snr = sum(snr_values) / len(snr_values)
+        avg_max_err = sum(max_errors) / len(max_errors)
+
+        print(
+            f'[fp8_quality seq={seq_len} hidden={hidden}] '
+            f'SNR={avg_snr:.1f} dB, avg_max_err={avg_max_err:.4f}')
+
+        self.assertGreater(
+            avg_snr,
+            _MIN_SNR_DB,
+            msg=f'FP8 comm SNR {avg_snr:.1f} dB < threshold {_MIN_SNR_DB} dB '
+            f'for seq_len={seq_len}, hidden={hidden}. FP8 quality too poor.',
+        )
+
+    # ------------------------------------------------------------------ #
+    # Smoke: fp8_comm=True doesn't crash and produces finite outputs      #
+    # ------------------------------------------------------------------ #
+    def test_fp8_comm_no_nan(self):
+        self._requires_devices(8)
+        axis_name = 'x'
+        num_devices = jax.device_count()
+        mesh = _make_mesh(num_devices, axis_name)
+        in_specs = P(axis_name, None)
+
+        # Use a larger range to stress the FP8 scale computation.
+        x = jax.random.normal(jax.random.key(42), (1024, 4096),
+                               dtype=jnp.bfloat16) * 10.0
+        x_sharded = jax.device_put(x,
+                                    jax.sharding.NamedSharding(mesh, in_specs))
+
+        out = hrs.hierarchical_reduce_scatter(
+            x_sharded,
+            mesh=mesh,
+            in_specs=in_specs,
+            fp8_comm=True,
+        )
+        self.assertTrue(jnp.all(jnp.isfinite(out)),
+                        'fp8_comm produced NaN or Inf')
+
+    # ------------------------------------------------------------------ #
+    # Edge case: all-zero input must not produce NaN with FP8 comm        #
+    # ------------------------------------------------------------------ #
+    def test_fp8_comm_zero_input(self):
+        self._requires_devices(8)
+        axis_name = 'x'
+        num_devices = jax.device_count()
+        mesh = _make_mesh(num_devices, axis_name)
+        in_specs = P(axis_name, None)
+
+        x = jnp.zeros((1024, 4096), dtype=jnp.bfloat16)
+        x_sharded = jax.device_put(x,
+                                    jax.sharding.NamedSharding(mesh, in_specs))
+
+        out = hrs.hierarchical_reduce_scatter(
+            x_sharded,
+            mesh=mesh,
+            in_specs=in_specs,
+            fp8_comm=True,
+        )
+        self.assertTrue(jnp.all(jnp.isfinite(out)),
+                        'fp8_comm produced NaN on zero input')
+        self.assertAllClose(out, jnp.zeros_like(out), atol=0.0)
+
+    # ------------------------------------------------------------------ #
+    # Static scaling: fixed wire scale vs bf16 baseline                   #
+    # ------------------------------------------------------------------ #
+    @parameterized.product(
+        seq_len=[1024, 2048],
+        hidden=[4096, 8192],
+    )
+    def test_fp8_static_scale_quality(self, seq_len, hidden):
+        """Static-scale FP8 output should have acceptable SNR vs bf16.
+
+        Uses fp8_min_rows=0 to force the FP8 wire at every tested size (the
+        default env gate would otherwise silently fall back to bf16 below
+        ~2048 rows and make this comparison vacuous).
+        """
+        self._requires_devices(8)
+        axis_name = 'x'
+        num_devices = jax.device_count()
+        mesh = _make_mesh(num_devices, axis_name)
+        in_specs = P(axis_name, None)
+
+        snr_values = []
+        for seed in range(5):
+            x = jax.random.normal(jax.random.key(seed), (seq_len, hidden),
+                                  dtype=jnp.bfloat16)
+            x_sharded = jax.device_put(
+                x, jax.sharding.NamedSharding(mesh, in_specs))
+
+            out_bf16 = hrs.hierarchical_reduce_scatter(
+                x_sharded, mesh=mesh, in_specs=in_specs, fp8_comm=False)
+
+            # Data-driven static scale with 2x headroom: map the largest final
+            # value to ~half of fp8's range so partial sums that momentarily
+            # exceed the final (sign cancellation) still avoid saturation.
+            max_abs = float(jnp.max(jnp.abs(out_bf16.astype(jnp.float32))))
+            static_scale =  hrs_config.FP8_E4M3_MAX / (2.0 * max(max_abs, 1e-6))
+
+            out_static = hrs.hierarchical_reduce_scatter(
+                x_sharded, mesh=mesh, in_specs=in_specs, fp8_comm=True,
+                fp8_static_scale=static_scale, fp8_min_rows=0)
+
+            self.assertTrue(jnp.all(jnp.isfinite(out_static)),
+                            'static-scale fp8 produced NaN or Inf')
+            noise = out_static.astype(jnp.float32) - out_bf16.astype(jnp.float32)
+            snr_values.append(_snr_db(out_bf16, noise))
+
+        avg_snr = sum(snr_values) / len(snr_values)
+        print(f'[fp8_static seq={seq_len} hidden={hidden}] '
+              f'SNR={avg_snr:.1f} dB (scale from bf16 max, 2x headroom)')
+        self.assertGreater(
+            avg_snr, _MIN_STATIC_SNR_DB,
+            msg=f'static-scale SNR {avg_snr:.1f} dB < {_MIN_STATIC_SNR_DB} dB '
+            f'for seq_len={seq_len}, hidden={hidden}.')
+
+    # ------------------------------------------------------------------ #
+    # Static scaling: zero input must not divide-by-zero / NaN            #
+    # ------------------------------------------------------------------ #
+    def test_fp8_static_scale_zero_input(self):
+        self._requires_devices(8)
+        axis_name = 'x'
+        num_devices = jax.device_count()
+        mesh = _make_mesh(num_devices, axis_name)
+        in_specs = P(axis_name, None)
+
+        x = jnp.zeros((1024, 4096), dtype=jnp.bfloat16)
+        x_sharded = jax.device_put(x,
+                                    jax.sharding.NamedSharding(mesh, in_specs))
+
+        out = hrs.hierarchical_reduce_scatter(
+            x_sharded, mesh=mesh, in_specs=in_specs, fp8_comm=True,
+            fp8_static_scale=0.0625, fp8_min_rows=0)
+        self.assertTrue(jnp.all(jnp.isfinite(out)),
+                        'static-scale fp8 produced NaN on zero input')
+        self.assertAllClose(out, jnp.zeros_like(out), atol=0.0)
+
+    # ------------------------------------------------------------------ #
+    # Static vs dynamic: both paths run and land in the same ballpark     #
+    # ------------------------------------------------------------------ #
+    def test_fp8_static_vs_dynamic(self):
+        self._requires_devices(8)
+        axis_name = 'x'
+        num_devices = jax.device_count()
+        mesh = _make_mesh(num_devices, axis_name)
+        in_specs = P(axis_name, None)
+
+        x = jax.random.normal(jax.random.key(7), (2048, 4096),
+                              dtype=jnp.bfloat16)
+        x_sharded = jax.device_put(x,
+                                    jax.sharding.NamedSharding(mesh, in_specs))
+
+        out_bf16 = hrs.hierarchical_reduce_scatter(
+            x_sharded, mesh=mesh, in_specs=in_specs, fp8_comm=False)
+        max_abs = float(jnp.max(jnp.abs(out_bf16.astype(jnp.float32))))
+        static_scale =  hrs_config.FP8_E4M3_MAX / (2.0 * max(max_abs, 1e-6))
+
+        out_dyn = hrs.hierarchical_reduce_scatter(
+            x_sharded, mesh=mesh, in_specs=in_specs, fp8_comm=True,
+            fp8_min_rows=0)
+        out_static = hrs.hierarchical_reduce_scatter(
+            x_sharded, mesh=mesh, in_specs=in_specs, fp8_comm=True,
+            fp8_static_scale=static_scale, fp8_min_rows=0)
+
+        self.assertTrue(jnp.all(jnp.isfinite(out_dyn)))
+        self.assertTrue(jnp.all(jnp.isfinite(out_static)))
+        # A well-chosen static scale should track dynamic closely.
+        diff = out_static.astype(jnp.float32) - out_dyn.astype(jnp.float32)
+        snr = _snr_db(out_dyn, diff)
+        print(f'[fp8_static_vs_dynamic] static-vs-dynamic SNR={snr:.1f} dB')
+        self.assertGreater(snr, 10.0,
+                           msg=f'static diverges from dynamic (SNR {snr:.1f} dB)')
+
+
+if __name__ == '__main__':
+    absltest.main()

--- a/tests/kernels/collectives/hierrs_tc_test.py
+++ b/tests/kernels/collectives/hierrs_tc_test.py
@@ -530,6 +530,51 @@ class HierarchicalReduceScatterPlanningTest(jtu.JaxTestCase):
                      msg='FP8 no longer takes mb=1, so the BF16-only floor is '
                          'not being exercised by this test')
 
+  def test_work_set_is_six_bytes_per_element_on_both_wires(self):
+    """FP8 halves what crosses the wire but does NOT shrink the working set.
+
+    running_sum and recv_buf are BF16 on both wires (2 B/elem each); the FP8
+    wire swaps the BF16 phase-2 landing buffer for two 1-byte staging buffers.
+    Both land on 6 B/elem. A comment that assumed otherwise under-counted these
+    buffers by 8x and claimed they fit in VMEM at every shape.
+    """
+    for rows in self.PRODUCTION_ROWS:
+      elems = rows * self.HIDDEN
+      bf16 = hrs._work_set_bytes(rows, self.HIDDEN, self.BF16_ITEMSIZE,
+                                False, 8, 8)
+      self.assertEqual(bf16, 6 * elems)
+
+      # num_scale_slots only adds the two f32 scale buffers, which are tiny.
+      fp8 = hrs._work_set_bytes(rows, self.HIDDEN, self.BF16_ITEMSIZE,
+                               True, 8, 8)
+      scale_bytes = 2 * 8 * 8 * hrs_config.SCALE_LANE * 4
+      self.assertEqual(fp8, 6 * elems + scale_bytes)
+
+  def test_work_scratch_falls_back_when_it_cannot_fit(self):
+    """The VMEM claim is sized from the shape, and refuses shapes that do not fit.
+
+    At 2048 local rows the working set (48.1 MiB) plus scoped scratch plus the
+    operand is 74.5 MiB against 58.9 MiB usable -- no setting makes that fit, so
+    the kernel must fall back to the pl.ANY/HBM form rather than fail to
+    compile. At 1024 the same total is 42.5 MiB and must be accepted.
+    """
+    fake_info = mock.Mock(vmem_capacity_bytes=64 * 2**20)
+    with mock.patch.object(hrs.pltpu, 'get_tpu_info', return_value=fake_info):
+      for rows, mb, expected in ((256, 1, True), (512, 1, True),
+                                 (1024, 1, True), (2048, 2, False)):
+        enabled, frac = hrs._plan_work_scratch(rows, self.HIDDEN,
+                                               self.BF16_ITEMSIZE, True, 8,
+                                               8 * mb, mb, 0.95)
+        self.assertEqual(
+            enabled, expected,
+            msg=f'local_seq_len={rows} mb={mb}: VMEM scratch enabled={enabled}, '
+                f'expected {expected}')
+        if enabled:
+          # The claim must cover the need exactly, not a fixed fraction: an
+          # under-claim raises CompileTimeScopedVmemOom at compile time.
+          self.assertGreater(frac, 0.0)
+          self.assertLess(frac, 1.0)
+
 
 if __name__ == '__main__':
     absltest.main()

--- a/tests/kernels/collectives/hierrs_tc_test.py
+++ b/tests/kernels/collectives/hierrs_tc_test.py
@@ -530,38 +530,43 @@ class HierarchicalReduceScatterPlanningTest(jtu.JaxTestCase):
                      msg='FP8 no longer takes mb=1, so the BF16-only floor is '
                          'not being exercised by this test')
 
-  def test_work_set_is_six_bytes_per_element_on_both_wires(self):
-    """FP8 halves what crosses the wire but does NOT shrink the working set.
+  def test_work_set_is_three_bytes_per_element_on_both_wires(self):
+    """Packed working buffers cost 3 B/elem of input on EITHER wire.
 
-    running_sum and recv_buf are BF16 on both wires (2 B/elem each); the FP8
-    wire swaps the BF16 phase-2 landing buffer for two 1-byte staging buffers.
-    Both land on 6 B/elem. A comment that assumed otherwise under-counted these
-    buffers by 8x and claimed they fit in VMEM at every shape.
+    Working buffers only ever touch this device's chunk parity
+    (ChunkLocator.pack), so they are allocated at half the input's rows.
+    Unpacked the cost was 6 B/elem on both wires -- running_sum + recv_buf at
+    2 B each, plus either the bf16 landing buffer (2 B) or the two fp8
+    staging buffers (1 B + 1 B). Packing halves both wires equally; fp8
+    still halves only the wire, never the working set.
     """
     for rows in self.PRODUCTION_ROWS:
       elems = rows * self.HIDDEN
       bf16 = hrs._work_set_bytes(rows, self.HIDDEN, self.BF16_ITEMSIZE,
                                 False, 8, 8)
-      self.assertEqual(bf16, 6 * elems)
+      self.assertEqual(bf16, 3 * elems)
 
       # num_scale_slots only adds the two f32 scale buffers, which are tiny.
       fp8 = hrs._work_set_bytes(rows, self.HIDDEN, self.BF16_ITEMSIZE,
                                True, 8, 8)
       scale_bytes = 2 * 8 * 8 * hrs_config.SCALE_LANE * 4
-      self.assertEqual(fp8, 6 * elems + scale_bytes)
+      self.assertEqual(fp8, 3 * elems + scale_bytes)
 
   def test_work_scratch_falls_back_when_it_cannot_fit(self):
     """The VMEM claim is sized from the shape, and refuses shapes that do not fit.
 
-    At 2048 local rows the working set (48.1 MiB) plus scoped scratch plus the
-    operand is 74.5 MiB against 58.9 MiB usable -- no setting makes that fit, so
-    the kernel must fall back to the pl.ANY/HBM form rather than fail to
-    compile. At 1024 the same total is 42.5 MiB and must be accepted.
+    With packed working buffers the production shape now fits: at 2048 local
+    rows the working set is ~24.3 MiB, and with scoped scratch plus the
+    operand the total is ~50.7 MiB against 58.9 MiB usable. Before packing
+    the same shape totalled 74.5 MiB and had to fall back -- that flip is the
+    point of packing. 4096 is still over budget and must fall back to the
+    pl.ANY/HBM form rather than fail to compile.
     """
     fake_info = mock.Mock(vmem_capacity_bytes=64 * 2**20)
     with mock.patch.object(hrs.pltpu, 'get_tpu_info', return_value=fake_info):
       for rows, mb, expected in ((256, 1, True), (512, 1, True),
-                                 (1024, 1, True), (2048, 2, False)):
+                                 (1024, 1, True), (2048, 2, True),
+                                 (4096, 4, False)):
         enabled, frac = hrs._plan_work_scratch(rows, self.HIDDEN,
                                                self.BF16_ITEMSIZE, True, 8,
                                                8 * mb, mb, 0.95)

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -67,6 +67,9 @@ if TYPE_CHECKING:
     VLLM_TPU_PATCH_MM_EMBEDDINGS: bool = False
     ENABLE_RS_KERNEL: bool = False
     USE_GMM_FUSED_RS_KERNEL: bool = False
+    RS_KERNEL_BACKEND: str = "sc"
+    VLLM_TPU_FP8_REDUCE_SCATTER: bool = False
+    VLLM_TPU_FP8_RS_STATIC_SCALE: float | None = None
     NUM_PRECOMPILE_WORKERS: int = 1
     DP_SCHED_BATCH_PREFILL: bool = False
     DP_SCHED_BATCH_PREFILL_FLUSH_TIMEOUT_MS: int = 10000
@@ -171,6 +174,29 @@ def env_bool(env_name: str,
         return parsed_value
 
     return _get_bool_env
+
+
+def env_positive_float_or_none(
+        env_name: str) -> Callable[[], float | None]:
+    """Tri-state positive float: unset/empty -> None; otherwise a float > 0.
+
+    Used for knobs where absence selects a different code path (here, None ->
+    dynamic FP8 scaling) and any provided value must be strictly positive
+    (the reduce-scatter kernel computes 1/scale, so 0 would divide by zero).
+    """
+
+    def _get() -> float | None:
+        value = os.getenv(env_name)
+        if value is None or value.strip() == "":
+            return None
+        parsed = float(value)
+        if not parsed > 0.0:
+            raise ValueError(
+                f"{env_name} must be a positive float (got {value!r}); "
+                f"unset it to use dynamic scaling.")
+        return parsed
+
+    return _get
 
 
 def env_str_list(env_name: str) -> Callable[[], list[str]]:
@@ -416,6 +442,23 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Enable fused GMM reduce-scatter kernel for MoE
     "USE_GMM_FUSED_RS_KERNEL":
     env_bool("USE_GMM_FUSED_RS_KERNEL", default=False),
+    # Which hierarchical reduce-scatter implementation ENABLE_RS_KERNEL
+    # selects. "sc" is the SparseCore kernel (default, unchanged
+    # behaviour); "tc" is the TensorCore kernel in hierrs_tc, which is
+    # the only backend that implements the FP8 wire below.
+    "RS_KERNEL_BACKEND":
+    env_with_choices("RS_KERNEL_BACKEND", "sc", ["sc", "tc"]),
+    # Transfer Phase-2 (inter-chip) reduce-scatter data as float8_e4m3fn on the
+    # ICI wire, dequantizing + accumulating in BF16 on arrival. Only takes
+    # effect when ENABLE_RS_KERNEL is also set. Default off (BF16 wire).
+    "VLLM_TPU_FP8_REDUCE_SCATTER":
+    env_bool("VLLM_TPU_FP8_REDUCE_SCATTER", default=False),
+    # Fixed FP8 scale for the Phase-2 reduce-scatter wire. Unset/empty ->
+    # per-chunk dynamic scaling (max|x|/448, the default). A positive float ->
+    # static scaling at that factor, skipping the send-side max-abs reduction.
+    # Only takes effect with ENABLE_RS_KERNEL + VLLM_TPU_FP8_REDUCE_SCATTER.
+    "VLLM_TPU_FP8_RS_STATIC_SCALE":
+    env_positive_float_or_none("VLLM_TPU_FP8_RS_STATIC_SCALE"),
     # Number of worker threads for parallel XLA precompilation.
     "NUM_PRECOMPILE_WORKERS":
     lambda: int(os.getenv("NUM_PRECOMPILE_WORKERS") or "1"),

--- a/tpu_inference/kernels/collectives/hierrs_tc/__init__.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tpu_inference/kernels/collectives/hierrs_tc/config.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/config.py
@@ -1,0 +1,295 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Static config objects for TensorCore Reduce-Scatter."""
+
+import dataclasses
+import math
+import os
+
+import jax
+import jax.experimental.pallas.tpu as pltpu
+import jax.numpy as jnp
+
+# jnp.finfo(jnp.float8_e4m3fn).max
+FP8_E4M3_MAX = 448.0
+
+# f32 lanes per scale slot -> 128 * 4 = 512 B, the minimum DMA inner slice.
+SCALE_LANE = 128
+
+# Minimum local rows (tokens per chip) for the FP8 wire. Below this the transfer
+# is latency-bound and FP8's quant/dequant cannot pay for the halved bytes
+# (measured crossover ~2048 rows on tpu7x-8). Shapes are static at trace time,
+# so this is a compile-time choice per token bucket.
+#
+# One of only TWO environment knobs in this kernel (the other is
+# VLLM_TPU_FP8_RS_STATIC_SCALE below). Every other flag the monolithic version
+# carried was experiment scaffolding and has been collapsed to its shipping
+# behaviour; see the module history for what was removed and why.
+FP8_COMM_MIN_ROWS = int(os.environ.get("VLLM_TPU_FP8_RS_MIN_TOKENS", "2048"))
+
+# Selects STATIC FP8 scaling and sets its value. Unset/empty -> per-chunk
+# DYNAMIC scaling (the default). A positive float -> static at that factor;
+# 16 is the calibrated value for this model, within 0.08 dB of the dynamic
+# ceiling on real activations.
+#
+# Static is the faster arm: it drops the send-side max-abs reduction AND the
+# scale transfer, taking the fp8 phase-2 wire from 2 remote copies + 4
+# semaphore arrays per chunk down to 1 + 2. Dynamic is kept as the
+# calibration-free fallback for shapes/models this scale was not tuned on.
+_static_scale_env = os.environ.get("VLLM_TPU_FP8_RS_STATIC_SCALE", "").strip()
+FP8_STATIC_SCALE: float | None = (float(_static_scale_env)
+                                  if _static_scale_env else None)
+
+
+def next_multiple_of(val: int, multiple: int) -> int:
+    """Rounds `val` up to the next multiple of `multiple`."""
+    return ((val + multiple - 1) // multiple) * multiple
+
+
+# Target bytes of local input per micro-batch, per wire. The two differ by 4x
+# for a mechanical reason: the FP8 wire re-pays the quantize staging pass once
+# per micro-batch, and that pass is ~7.4 us of near-pure FIXED cost (measured by
+# removal: 8.4 us at 512 local rows against 7.3 us at 2048 -- four times the
+# data for less time). So splitting finer is expensive for FP8. BF16 has no such
+# pass; extra micro-batches cost it only DMA issues while buying more
+# DMA/compute overlap, so it wants small stages.
+#
+# Keyed on BYTES PER MICRO-BATCH, never on mb or on row count. The FP8 penalty
+# tracks STAGE SIZE, not stage count: mb=8 is optimal at a 64 MiB payload
+# (8 MiB/stage) and costs +48% at a 16 MiB payload (2 MiB/stage) -- same mb,
+# opposite verdict. A rule keyed on rows cannot express that.
+_MB_STAGE_TARGET_BYTES = {False: 2 << 20, True: 8 << 20}  # bf16 : fp8
+
+# Ceiling on the micro-batch count. Above this hc_chunk_size degenerates: at
+# hidden 4096, mb=16 gives mb_size=256 and hc_chunk_size=128, a single vector
+# width. It is also the largest value measured.
+_MAX_MICRO_BATCHES = 8
+
+
+def pick_num_micro_batches(local_seq_len: int, hidden_dim_size: int,
+                           itemsize: int, fp8_comm: bool) -> int:
+    """Chooses `num_micro_batches` from bytes per micro-batch, per wire.
+
+  Fitted to a 12-cell device-time grid (mb {1,2,4,8} x local rows
+  {512,2048,8192} x {bf16, fp8-static16}, hidden 4096) with XLA psum_scatter as
+  a per-cell control at <=0.11% spread. Reproduces 6 of 6 measured optima:
+
+      payload   bf16 opt   fp8 opt
+       4 MiB       2          1
+      16 MiB       8          2
+      64 MiB       8          8      
+
+  `fp8_comm` must be the wire ACTUALLY used, i.e. resolved after the
+  FP8_COMM_MIN_ROWS downgrade -- picking the fp8 target for a call that runs
+  bf16 selects stages 4x too large.
+
+  See results/EXPERIMENTS.md, EXP-007 (grid) and EXP-008 (why the targets
+  differ).
+  """
+    target = _MB_STAGE_TARGET_BYTES[bool(fp8_comm)]
+    n = (local_seq_len * hidden_dim_size * itemsize) // target
+    mb = 1 << max(0, n.bit_length() - 1)  # floor to a power of two
+    # Keep hc_chunk_size >= 2 vector widths.
+    mb = min(mb, max(1, hidden_dim_size // 512))
+    return int(min(max(mb, 1), _MAX_MICRO_BATCHES))
+
+
+def get_capped_bounds(start, length, max_size):
+    """Calculates capped start and size for a slice to prevent out-of-bounds."""
+    capped_start = min(start, max_size)
+    capped_end = min(start + length, max_size)
+    return capped_start, capped_end - capped_start
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class Config:
+    # yapf: disable
+    """Dimensions and sharding sizes for the TensorCore hierarchical RS.
+
+  Phase 1 is intra-chip D2D (always BF16). Phase 2 is the inter-chip hypercube
+  (recursive doubling) over ICI, optionally FP8 on the wire.
+
+  ================================================================================================
+              FIGURE 1: PHASE 1 TENSOR PARTITIONING (PIPELINE MICRO-BATCHES)
+  ================================================================================================
+              |<--------------------------------- hidden_dim_size -------------------------------->|
+              |                                         |                                          |
+  Iteration:  |<---------------- mb_size -------------->|<---------------- mb_size --------------->| (x num_micro_batches)
+              +-----------------------------------------+------------------------------------------+ ---
+  seq_chunk_^ |                                         |                                          |  ^
+  size      | |         Device 0, Microbatch 0          |          Device 0, Microbatch 1          |  |
+            v +-----------------------------------------+------------------------------------------+  | local_
+  seq_chunk_^ |                                         |                                          |  | seq_len
+  size      | |         Device 1, Microbatch 0          |          Device 1, Microbatch 1          |  |
+            v +-----------------------------------------+------------------------------------------+  |
+              |                  ...                    |                    ...                   |  v
+              +-----------------------------------------+------------------------------------------+ ---
+  ================================================================================================
+
+  ================================================================================================
+            FIGURE 2: PHASE 2 TENSOR PARTITIONING (ICI CROSS-CHIP SCATTER)
+  ================================================================================================
+  Zooming into a SINGLE micro-batch column (`mb_size`) to show how Phase 2 slices
+  the chunks further for Reduce-Scatter across the i-th hypercube dimension.
+
+              |<-------------------------------- mb_size ---------------------------------------->|
+              |                                         |                                         |
+  ICI Phase 2:|<------------ hc_chunk_size ------------>|<------------ hc_chunk_size ------------>| (x num_hcube_dims)
+              +-----------------------------------------+-----------------------------------------+ ---
+  seq_chunk_^ |                                         |                                         |  ^
+  size      | |    Device 0, RS through 0th axis        |    Device 0, RS through 1st axis        |  |
+            v +-----------------------------------------+-----------------------------------------+  | local_
+  seq_chunk_^ |                                         |                                         |  | seq_len
+  size      | |    Device 1, RS through 0th axis        |    Device 1, RS through 1st axis        |  |
+            v +-----------------------------------------+-----------------------------------------+  |
+              |                  ...                    |                    ...                  |  v
+              +-----------------------------------------+-----------------------------------------+ ---
+  ================================================================================================
+  LEGEND:
+  - seq_chunk_size = local_seq_len // num_devices
+  - mb_size        = round_up(hidden_dim_size // num_micro_batches, num_lanes)
+  - hc_chunk_size  = round_up(mb_size // num_hcube_dims, num_lanes)
+
+  NOTE both mb_size and hc_chunk_size are rounded UP to a vector width rather
+  than divided exactly. A ragged tail is expected and is clamped at the slice
+  sites via get_capped_bounds; do not "simplify" these to plain division.
+  ================================================================================================
+  """
+    # yapf: enable
+
+    # Total number of devices executing this kernel.
+    num_devices: int
+    # Total hidden size dimension (e.g., 4096).
+    hidden_dim_size: int
+    # Local sequence length on this device, post-padding.
+    local_seq_len: int
+    # Input data type (e.g., bfloat16).
+    dtype: jnp.dtype
+    # FP8 chip-to-chip wire for Phase 2. Phase 1 stays BF16 either way.
+    fp8_comm: bool = False
+    # Scale for the FP8 wire. None -> per-chunk dynamic scale (max|x| / 448),
+    # which needs no calibration but costs a cross-lane reduction on the send
+    # side and a scale transfer on the wire. A positive float -> STATIC scaling
+    # at that factor, which elides both (see skip_scale_dma).
+    #
+    # Defaults to FP8_STATIC_SCALE, i.e. dynamic unless
+    # VLLM_TPU_FP8_RS_STATIC_SCALE is set.
+    #
+    # 16 is the calibrated static value: measured against 200 captured real
+    # pre-RS activations (1.68e9 elements) it gives 31.54 dB aggregate SNR
+    # against a 31.62 dB dynamic ceiling -- dynamic buys 0.08 dB. Its
+    # representable range is 448/16 = 28.0 against an observed |x| max of
+    # 13.88, so ~2x clipping headroom. Do not raise past 32 without
+    # recalibrating: range 14.0 would sit 1% under the observed max.
+    fp8_static_scale: float | None = None
+    # Pipelining unrolling factor for overlapping ALU/DMA. If None, determined
+    # by heuristic.
+    _num_micro_batches: int | None = None
+
+    def __post_init__(self):
+        assert self.cores_per_chip == 2, (
+            "This kernel architecture strictly supports 2 cores per chip, but"
+            f" found {self.cores_per_chip}.")
+        assert (self.num_chips & (self.num_chips - 1)
+                ) == 0, f"num_chips {self.num_chips} must be a power of 2"
+        assert (self.num_hcube_dims
+                >= 1), f"num_hcube_dims {self.num_hcube_dims} must be >= 1"
+        assert (self.num_micro_batches -
+                1) * self.mb_size < self.hidden_dim_size, (
+                    "Unsupported micro-batches config: num_micro_batches="
+                    f"{self.num_micro_batches} mb_size={self.mb_size} exceeds "
+                    f"hidden_dim_size={self.hidden_dim_size}")
+
+    @property
+    def cores_per_chip(self) -> int:
+        """Number of physical tensor cores per chip on this TPU architecture."""
+        return pltpu.get_tpu_info(
+        ).chip_version.num_physical_tensor_cores_per_chip
+
+    @property
+    def num_chips(self) -> int:
+        """Number of physical TPU chips (num_devices // cores_per_chip).
+
+    NOTE this is chips, not devices: tpu7x-8 is 4 chips x 2 TensorCores = 8 JAX
+    devices, and the startup banner's `num_chips=8` refers to devices.
+    """
+        return self.num_devices // self.cores_per_chip
+
+    @property
+    def num_hcube_dims(self) -> int:
+        """ICI hypercube logical network dimensions (log2(num_chips))."""
+        return int(math.log2(self.num_chips))
+
+    @property
+    def num_micro_batches(self) -> int:
+        """Pipelining unrolling factor for overlapping ALU/DMA.
+
+    If not set explicitly, chosen from bytes per micro-batch with a per-wire
+    target -- see pick_num_micro_batches. `fp8_comm` here is already the
+    resolved wire: the caller applies the FP8_COMM_MIN_ROWS downgrade before
+    building the Config.
+    """
+        if self._num_micro_batches is not None:
+            return self._num_micro_batches
+        return pick_num_micro_batches(self.local_seq_len, self.hidden_dim_size,
+                                      jnp.dtype(self.dtype).itemsize,
+                                      self.fp8_comm)
+
+    @property
+    def vector_width(self) -> int:
+        """Lane count that mb_size and hc_chunk_size are aligned up to."""
+        return pltpu.get_tpu_info().num_lanes
+
+    @property
+    def seq_chunk_size(self) -> int:
+        """Local sequence slice per device (= local_seq_len // num_devices)."""
+        return self.local_seq_len // self.num_devices
+
+    @property
+    def mb_size(self) -> int:
+        """Micro batch slice size, rounded up to a vector width."""
+        return next_multiple_of(self.hidden_dim_size // self.num_micro_batches,
+                                self.vector_width)
+
+    @property
+    def hc_chunk_size(self) -> int:
+        """Phase 2 (C2C) hypercube chunk slice size, rounded up."""
+        return next_multiple_of(self.mb_size // max(1, self.num_hcube_dims),
+                                self.vector_width)
+
+    @property
+    def packing_factor(self) -> int:
+        """Number of array elements packed into a single 32-bit word.
+
+    jnp.dtype() normalises both forms: callers pass `local_x.dtype` (a dtype
+    instance, which has .itemsize) but a bare `jnp.bfloat16` type does not.
+    """
+        return 4 // jnp.dtype(self.dtype).itemsize
+
+    @property
+    def skip_scale_dma(self) -> bool:
+        """Whether the Phase 2 scale transfer is elided.
+
+    Static only. In static mode the scale is a compile-time constant on both
+    sides and the receiver reconstructs it, so writing, sending and waiting on
+    it is pure overhead. Eliding it takes the fp8 phase-2 wire from 2 remote
+    copies + 4 semaphore arrays per chunk down to 1 + 2, the same fixed-cost
+    profile as bf16 -- and that fixed cost, not payload bytes, is what sets
+    FP8_COMM_MIN_ROWS.
+
+    Dynamic genuinely needs the sender's per-chunk value on the receive side,
+    so it keeps both the buffer and the transfer.
+    """
+        return self.fp8_comm and self.fp8_static_scale is not None

--- a/tpu_inference/kernels/collectives/hierrs_tc/config.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/config.py
@@ -75,6 +75,11 @@ _MB_STAGE_TARGET_BYTES = {False: 2 << 20, True: 8 << 20}  # bf16 : fp8
 # hidden 4096, mb=16 gives mb_size=256 and hc_chunk_size=128, a single vector
 # width. It is also the largest value measured.
 _MAX_MICRO_BATCHES = 8
+# Correctness floor for the BF16 wire -- see pick_num_micro_batches, where the
+# evidence and the scope of the floor are documented. RS_ALLOW_UNSAFE_MB1=1
+# lifts it so the underlying defect can be reproduced; it is not a tuning knob.
+_MIN_SAFE_MICRO_BATCHES = 1 if os.environ.get("RS_ALLOW_UNSAFE_MB1",
+                                              "0") == "1" else 2
 
 
 def pick_num_micro_batches(local_seq_len: int, hidden_dim_size: int,
@@ -102,6 +107,49 @@ def pick_num_micro_batches(local_seq_len: int, hidden_dim_size: int,
     mb = 1 << max(0, n.bit_length() - 1)  # floor to a power of two
     # Keep hc_chunk_size >= 2 vector widths.
     mb = min(mb, max(1, hidden_dim_size // 512))
+    # CORRECTNESS FLOOR, not a tuning choice, and BF16-ONLY.
+    #
+    # THE DEFECT. At num_micro_batches=1 the kernel returns the PREVIOUS call's
+    # result. In kernel.py, [Step C] reads running_sum_ref on the line after the
+    # [Step B] emit_pipeline that writes it, with nothing ordering the two, so
+    # the read can be issued before the write has landed. (A second instance of
+    # the same hazard exists between [Step G] and the post-loop read.) At mb>=2
+    # the extra loop iterations give the write time to land. That is masking by
+    # timing, not a fix -- the unordered access is still in the code.
+    #
+    # This is only observable with a FRESH input per call: with a fixed input a
+    # stale buffer holds a value identical to the correct one, so a reused-input
+    # test reports success. Any re-validation must vary the input every run and
+    # score against an independent psum + dynamic_slice reference.
+    #
+    # EVIDENCE (fresh input per run, count of runs below a 40 dB SNR threshold;
+    # a correct bf16 result scores ~47.9 dB). `local_seq_len` below is the
+    # PER-DEVICE, PRE-scatter row count this function receives -- 8x the
+    # post-scatter row count that appears in the HLO.
+    #
+    #   local_seq_len | bf16 mb=1        | bf16 mb=2 | fp8 mb=1
+    #             128 | 26/30 bad        | 0/30      | clean
+    #             256 | 24/30 bad        | 0/30      | clean (0/200)
+    #             512 | 2/30 - 11/30 bad | 0/30      | clean
+    #            1024 | intermittent     | 0/30      | NOT MEASURED
+    #
+    # WHY FP8 IS EXEMPT. The fp8 path runs quantize_chunks_to_fp8_staging
+    # between the write to running_sum_ref and the wire read. That work
+    # evidently lets the write land, exactly as extra micro-batches do for
+    # bf16 -- so fp8 is MASKED, not immune. Two consequences:
+    #   * If that staging step is removed or reordered, re-validate fp8 at
+    #     mb=1 with fresh inputs BEFORE relying on this exemption.
+    #   * fp8 at mb=1 is validated at local_seq_len 256, 512 and 1024. Those
+    #     are every shape a server reaches at mb=1: the caller pads each
+    #     device's chunk up to _SEQ_TILE=32 BEFORE this function is called, so
+    #     any request under 256 rows arrives here as 256, and 2048 picks mb=2.
+    #
+    # COST OF THE FLOOR. ~15% on the reduce-scatter op at 256 rows
+    # (30.1 -> 34.7 us), roughly 1.4% of step time. Remove it only once the
+    # [Step B] -> [Step C] and [Step G] -> post-loop ordering is fixed in
+    # kernel.py and re-validated with fresh inputs across the shape range.
+    if not fp8_comm:
+        mb = max(mb, _MIN_SAFE_MICRO_BATCHES)
     return int(min(max(mb, 1), _MAX_MICRO_BATCHES))
 
 

--- a/tpu_inference/kernels/collectives/hierrs_tc/dma_pipeline.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/dma_pipeline.py
@@ -1,0 +1,797 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DMA pipeline implementations for TensorCore Reduce-Scatter.
+
+`RemoteWaitBufferedRef` is a BufferedRef whose copy_in is a cross-device remote
+DMA, so the Pallas pipeline can consume peer data with the same double-buffered
+machinery it uses for local copies. `DmaManager` owns both the explicit async
+remote dispatch (phase 1 D2D, phase 2 C2C) and the emit_pipeline accumulation
+passes that consume them.
+"""
+
+import dataclasses
+import functools
+from typing import Any, Callable
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+from tpu_inference.kernels.collectives.hierrs_tc.config import (
+    FP8_E4M3_MAX, SCALE_LANE, Config, get_capped_bounds)
+from tpu_inference.kernels.collectives.hierrs_tc.topology import (ChunkLocator,
+                                                                  Topology)
+
+
+def scoped(name: str):
+    """Wraps a whole pipeline pass in one COARSE jax.named_scope.
+
+  Deliberately coarse: one region per logical pass (phase-1 accumulate,
+  quantize staging, phase-2 dequant+accumulate) rather than per DMA
+  start/wait. Fine-grained scopes wrapped precisely the DMA issue/wait
+  structure -- the region a scheduler would need to reorder -- and 9 of them
+  were removed after measuring: bitwise-identical output, isolated A/B flat,
+  e2e +0.20%, but +70 KB (8.3%) of Mosaic IR.
+
+  Applied as a decorator so a call site is never re-indented: every caller of
+  the wrapped method gets the region for free, and the diff stays reviewable.
+
+  CAVEAT, measured (results/probe_scope_visibility.py): these regions are NOT
+  currently visible to xprof. jax/_src/pallas/mosaic/lowering.py:1750 emits
+  `tpu.trace_start(message=name, level=10)` with the level hardcoded, and 10
+  is above the profiler's capture threshold. `trace_level` in
+  ProfileOptions.advanced_configuration is inert (levels 2 and 15 produced
+  byte-identical 94113-event traces) and `tpu_trace_mode` is rejected by this
+  libtpu ("Invalid tpu_trace_mode (it is not supported)"), aborting collection
+  entirely. So quant/dequant cost is obtained by DIFFERENTIAL measurement
+  instead -- stub a pass out and diff whole-kernel device time. These scopes
+  are kept for readability and for the day the capture threshold is settable.
+  """
+
+    def deco(fn):
+
+        @functools.wraps(fn)
+        def wrapper(*args, **kwargs):
+            with jax.named_scope(name):
+                return fn(*args, **kwargs)
+
+        return wrapper
+
+    return deco
+
+
+@jax.tree_util.register_dataclass
+@dataclasses.dataclass(frozen=True)
+class RemoteWaitBufferedRef(pltpu.BufferedRef):
+    """Subclass of BufferedRef that implements semaphore-synchronized memory copies.
+
+  Used to wait for remote device writes before initiating local HBM-to-VMEM
+  copies.
+  """
+
+    index_fn_with_recv_sem: Callable[..., Any] | None = dataclasses.field(
+        metadata={"static": True}, default=None)
+
+    @classmethod
+    def from_ref(
+        cls,
+        ref: pltpu.BufferedRef,
+        *,
+        index_fn_with_recv_sem: Callable | None = None,
+    ):
+        return cls(
+            index_fn_with_recv_sem=index_fn_with_recv_sem,
+            **{
+                f.name: getattr(ref, f.name)
+                for f in dataclasses.fields(pltpu.BufferedRef)
+            },
+        )
+
+    def copy_in(self, src_ref, grid_indices):
+        if self.index_fn_with_recv_sem is None:
+            super().copy_in(src_ref, grid_indices)
+            return
+        assert self.window_ref is not None
+        slot = self.current_copy_in_slot
+        chunk_slice, sem, size = self.index_fn_with_recv_sem(
+            grid_indices, src_ref)
+
+        window_ref_slice = (slot, slice(None), pl.ds(0, size))
+        if sem is not None:
+            pltpu.make_async_copy(
+                self.window_ref.at[window_ref_slice],
+                self.window_ref.at[window_ref_slice],
+                sem,
+            ).wait()
+
+        hbm_array_ref = (src_ref[0] if isinstance(src_ref,
+                                                  (tuple, list)) else src_ref)
+        assert self.sem_recvs is not None
+        pltpu.make_async_copy(
+            hbm_array_ref.at[chunk_slice],
+            self.window_ref.at[window_ref_slice],
+            self.sem_recvs.at[slot],
+        ).start()
+
+    def wait_in(self, src_ref, grid_indices):
+        if self.index_fn_with_recv_sem is None:
+            super().wait_in(src_ref, grid_indices)
+            return
+        assert self.window_ref is not None
+        wait_slot = self.current_wait_in_slot
+        _, _, size = self.index_fn_with_recv_sem(grid_indices, src_ref)
+
+        window_ref_slice = (wait_slot, slice(None), pl.ds(0, size))
+        assert self.sem_recvs is not None
+        pltpu.make_async_copy(
+            self.window_ref.at[window_ref_slice],
+            self.window_ref.at[window_ref_slice],
+            self.sem_recvs.at[wait_slot],
+        ).wait()
+
+
+# ================================================================================
+#                          CHUNK PARTITIONING MAP
+# ================================================================================
+#         |<----------------------- hidden_dim_size ------------------------>|
+#         |<----------- mb_size ----------->|                                |
+#         |<-- hc_chunk_size ->|            |                                |
+#         +--------------------+------------+---------------+----------------+ ---
+#       ^ |          |         |            |               |                |  ^
+#       | |  Chunk   |  Chunk  |  MB1 Slice |   MB2 Slice   |   MB3 Slice    |  |
+# seq_cs| |          |         |            |               |                |  | seqlen
+#       v +--------------------+------------+---------------+----------------+  |
+#       ^ |                                 |               |                |  |
+# seq_cs| |      Device Slice 1             |               |                |  |
+#       v +---------------------------------+---------------+----------------+  v
+#                                                                              ---
+# ================================================================================
+# (seq_cs = seq_chunk_size, seqlen)
+
+
+class DmaManager:
+    """Handles Pallas pipeline emission and explicit async DMA dispatching."""
+
+    def __init__(
+        self,
+        config: Config,
+        topo: Topology,
+        locator: ChunkLocator,
+        recv_bref,
+        run_bref,
+        out_bref,
+        phase1_send_sems,
+        phase1_recv_sems,
+        phase2_send_sems,
+        phase2_recv_sems,
+        # ── FP8 C2C params (None when fp8_comm=False) ──────────────────
+        fp8_send_buf=None,
+        fp8_recv_buf=None,
+        scale_send_buf=None,
+        scale_recv_buf=None,
+        fp8_p2_send_sems=None,
+        fp8_p2_recv_sems=None,
+        scale_p2_send_sems=None,
+        scale_p2_recv_sems=None,
+        # send-side pipelined BufferedRefs (output: BF16->FP8 quantize)
+        fp8_send_bref=None,
+        scale_send_bref=None,
+        # receive-side pipelined BufferedRefs
+        fp8_recv_bref=None,
+        scale_bref=None,
+        # None -> per-chunk dynamic scale (max|x| / 448). A positive float ->
+        # static: a fixed scale used by both sides, skipping the send-side
+        # max-abs reduction and the scale transfer entirely.
+        fp8_static_scale=None,
+    ):
+        self.config = config
+        self.topo = topo
+        self.locator = locator
+        self.recv_bref = recv_bref
+        self.run_bref = run_bref
+        self.out_bref = out_bref
+        self.phase1_send_sems = phase1_send_sems
+        self.phase1_recv_sems = phase1_recv_sems
+        self.phase2_send_sems = phase2_send_sems
+        self.phase2_recv_sems = phase2_recv_sems
+        self.fp8_send_buf = fp8_send_buf
+        self.fp8_recv_buf = fp8_recv_buf
+        self.scale_send_buf = scale_send_buf
+        self.scale_recv_buf = scale_recv_buf
+        self.fp8_p2_send_sems = fp8_p2_send_sems
+        self.fp8_p2_recv_sems = fp8_p2_recv_sems
+        self.scale_p2_send_sems = scale_p2_send_sems
+        self.scale_p2_recv_sems = scale_p2_recv_sems
+        self.fp8_send_bref = fp8_send_bref
+        self.scale_send_bref = scale_send_bref
+        self.fp8_recv_bref = fp8_recv_bref
+        self.scale_bref = scale_bref
+        self.fp8_static_scale = fp8_static_scale
+        # Only static mode can drop the scale transfer: dynamic genuinely needs the
+        # sender's per-chunk value on the receive side. In static mode the receiver
+        # reconstructs the identical constant, so writing/sending/waiting on it is
+        # pure overhead -- this is unconditional now, matching Config.skip_scale_dma.
+        # Only static mode can drop the scale transfer.
+        self.skip_scale_dma = fp8_static_scale is not None
+
+    def start_phase1_d2d_copies(self, src, dst, mb_idx):
+        ops = []
+        mb_start = mb_idx * self.config.mb_size
+        mb_start, mb_slice_size = get_capped_bounds(
+            mb_start, self.config.mb_size, self.config.hidden_dim_size)
+        partner_chunks = self.locator.get_phase1_chunk_idxes(
+            self.topo.partner_id)
+        for chip_idx, c_neigh in enumerate(partner_chunks):
+            mb_slice = self.locator.get_slice(chunk_idx=c_neigh,
+                                              start=mb_start,
+                                              size=mb_slice_size)
+            op = pltpu.make_async_remote_copy(
+                src_ref=src.at[mb_slice],
+                dst_ref=dst.at[mb_slice],
+                send_sem=self.phase1_send_sems.at[chip_idx, mb_idx],
+                recv_sem=self.phase1_recv_sems.at[chip_idx, mb_idx],
+                device_id=self.topo.partner_id,
+                device_id_type=pl.DeviceIdType.LOGICAL,
+            )
+            op.start()
+            ops.append(op)
+        return ops
+
+    def start_phase2_c2c_copies(self, src, dst, mb_idx, step_idx):
+        mb_ops = []
+        exponent = self.config.num_hcube_dims - 1 - step_idx
+        num_ops_in_step = 1 << exponent if exponent >= 0 else 0
+
+        for op_idx in range(num_ops_in_step):
+            for hcube_dim_idx in range(self.config.num_hcube_dims):
+                dim = (hcube_dim_idx + step_idx) % self.config.num_hcube_dims
+
+                mb_start = mb_idx * self.locator.mb_stride
+                chunk_start = mb_start + hcube_dim_idx * self.config.hc_chunk_size
+                chunk_start, k_size = get_capped_bounds(
+                    chunk_start, self.config.hc_chunk_size,
+                    self.config.hidden_dim_size)
+
+                neigh_device_id = self.topo.get_neighbor_device_id(dim)
+                my_chunk_idx = self.locator.get_phase2_chunk_idx(
+                    self.topo.cur_id, step_idx, op_idx, hcube_dim_idx)
+                neighbor_chunk_idx = self.locator.get_phase2_chunk_idx(
+                    neigh_device_id, step_idx, op_idx, hcube_dim_idx)
+
+                if k_size > 0:
+                    mb_slice = self.locator.get_slice(neighbor_chunk_idx,
+                                                      chunk_start, k_size)
+                    op = pltpu.make_async_remote_copy(
+                        src_ref=src.at[mb_slice],
+                        dst_ref=dst.at[mb_slice],
+                        send_sem=self.phase2_send_sems.at[step_idx, mb_idx,
+                                                          hcube_dim_idx,
+                                                          op_idx],
+                        recv_sem=self.phase2_recv_sems.at[step_idx, mb_idx,
+                                                          hcube_dim_idx,
+                                                          op_idx],
+                        device_id=neigh_device_id,
+                        device_id_type=pl.DeviceIdType.LOGICAL,
+                    )
+                    op.start()
+                    mb_ops.append((
+                        op,
+                        step_idx,
+                        mb_idx,
+                        hcube_dim_idx,
+                        op_idx,
+                        my_chunk_idx,
+                        chunk_start,
+                        k_size,
+                    ))
+        return mb_ops
+
+    @scoped("p1_accum")
+    def run_phase1_accumulate_pipeline(
+        self,
+        src1,
+        src2,
+        dst,
+        in_index_fn,
+        out_index_fn,
+        hbm_index_fn,
+        block_size,
+        mb_idx,
+    ):
+        """Orchestrates a D2D accumulation pipeline on a 1D chip grid."""
+
+        def accum_body(s1_ref, s2_ref, d_ref):
+            d_ref[...] = s1_ref[...] + s2_ref[...]
+
+        grid = (self.config.num_chips, )
+
+        def in_index_fn_with_recv_sem(grid_indices, ref):
+            hbm_index, size = hbm_index_fn(grid_indices, ref)
+            (chip_idx, ) = grid_indices
+            sem = self.phase1_recv_sems.at[chip_idx, mb_idx]
+            return hbm_index, sem, size
+
+        in_spec = pl.BlockSpec(
+            block_shape=(self.config.seq_chunk_size, block_size),
+            index_map=in_index_fn,
+        )
+        out_spec = pl.BlockSpec(
+            block_shape=(self.config.seq_chunk_size, block_size),
+            index_map=out_index_fn,
+        )
+
+        s1_bref = RemoteWaitBufferedRef.from_ref(
+            self.recv_bref.with_spec(in_spec),
+            index_fn_with_recv_sem=in_index_fn_with_recv_sem,
+        )
+        s2_bref = RemoteWaitBufferedRef.from_ref(
+            self.run_bref.with_spec(in_spec))
+        d_bref = RemoteWaitBufferedRef.from_ref(
+            self.out_bref.with_spec(out_spec))
+
+        pltpu.emit_pipeline(
+            accum_body,
+            grid=grid,
+            in_specs=[in_spec, in_spec],
+            out_specs=[out_spec],
+        )(src1, src2, dst, allocations=[s1_bref, s2_bref, d_bref])
+
+    @scoped("p2_accum")
+    def run_phase2_accumulate_pipeline(
+        self,
+        src1,
+        src2,
+        dst,
+        in_index_fn,
+        out_index_fn,
+        hbm_index_fn,
+        block_size,
+        mb_idx,
+        step_idx,
+    ):
+        """Orchestrates a C2C accumulation pipeline."""
+
+        def accum_body(s1_ref, s2_ref, d_ref):
+            d_ref[...] = s1_ref[...] + s2_ref[...]
+
+        exponent = self.config.num_hcube_dims - 1 - step_idx
+        num_ops_in_step = 1 << exponent if exponent >= 0 else 0
+        grid = (num_ops_in_step, self.config.num_hcube_dims)
+
+        def in_index_fn_with_recv_sem(grid_indices, ref):
+            hbm_index, size = hbm_index_fn(grid_indices, ref)
+            op_idx, hcube_dim_idx = grid_indices
+            sem = self.phase2_recv_sems.at[step_idx, mb_idx, hcube_dim_idx,
+                                           op_idx]
+            return hbm_index, sem, size
+
+        in_spec = pl.BlockSpec(
+            block_shape=(self.config.seq_chunk_size, block_size),
+            index_map=in_index_fn,
+        )
+        out_spec = pl.BlockSpec(
+            block_shape=(self.config.seq_chunk_size, block_size),
+            index_map=out_index_fn,
+        )
+
+        s1_bref = RemoteWaitBufferedRef.from_ref(
+            self.recv_bref.with_spec(in_spec),
+            index_fn_with_recv_sem=in_index_fn_with_recv_sem,
+        )
+        s2_bref = RemoteWaitBufferedRef.from_ref(
+            self.run_bref.with_spec(in_spec))
+        d_bref = RemoteWaitBufferedRef.from_ref(
+            self.out_bref.with_spec(out_spec))
+
+        pltpu.emit_pipeline(
+            accum_body,
+            grid=grid,
+            in_specs=[in_spec, in_spec],
+            out_specs=[out_spec],
+        )(src1, src2, dst, allocations=[s1_bref, s2_bref, d_bref])
+
+    def _scale_slot(self, step_idx, mb_idx, hcube_dim_idx, op_idx):
+        """Flatten (step, mb, hcube_dim, op) → a single scale buffer column."""
+        max_ops = 2**(self.config.num_hcube_dims - 1)
+        return (step_idx * self.config.num_micro_batches *
+                self.config.num_hcube_dims * max_ops +
+                mb_idx * self.config.num_hcube_dims * max_ops +
+                hcube_dim_idx * max_ops + op_idx)
+
+    @scoped("quant_stage")
+    def quantize_chunks_to_fp8_staging(self, src_hbm, mb_idx, step_idx):
+        """Pipelined quantize of every Phase-2 chunk this device SENDs this step.
+
+    Send-side mirror of run_phase2_dequant_accumulate_pipeline: emit_pipeline
+    double-buffers the BF16 source chunk (HBM->VMEM load), the FP8 staging
+    chunk and the scale (both VMEM->HBM stores), so the DMA engine prefetches
+    chunk s+1 while the VPU quantizes chunk s. This replaces the old serial
+    load/wait → quantize → store/wait → scale-store/wait chain (6 blocking
+    HBM round-trips per chunk).
+
+    Reads BF16 from src_hbm (running_sum_ref); writes FP8 to fp8_send_buf and
+    the per-chunk scale to scale_send_buf.  Must complete before
+    start_phase2_c2c_copies_fp8 is called.
+    """
+        assert self.run_bref is not None
+        assert self.fp8_send_bref is not None
+        assert self.scale_send_bref is not None
+        assert self.fp8_send_buf is not None
+        assert self.scale_send_buf is not None
+
+        exponent = self.config.num_hcube_dims - 1 - step_idx
+        num_ops_in_step = 1 << exponent if exponent >= 0 else 0
+        if num_ops_in_step == 0:
+            return
+        grid = (num_ops_in_step, self.config.num_hcube_dims)
+
+        def quant_body(bf16_ref, fp8_ref, scale_ref=None):
+            # Per-tensor quantize at a fixed static scale. There is no
+            # cross-lane max-abs reduction to do -- that is the send-side win of
+            # static mode -- and the round trip stays consistent because the
+            # recv side dequantizes with the identical constant.
+            data_f32 = bf16_ref[...].astype(jnp.float32)
+            if self.fp8_static_scale is not None:
+                # scale is "units per fp8 step": quant divides by it, dequant
+                # multiplies. 1/fp8_static_scale mirrors the dynamic convention
+                # so both paths share the identical clip/cast below.
+                #
+                # NO non-finite guard on this path -- deliberate, and measured.
+                # There used to be a `where(isfinite(x), x, 0.0)` here. It cost
+                # 0.587 us, 0.59% of the kernel and 7.9% of the quant stage
+                # (EXP-013), and it never had anything to catch: 0 NaN reached
+                # this kernel's input across 192,352 unpermute calls with the
+                # guard disabled, even though gmm2_res itself carried up to
+                # 45,101 NaN elements per call (EXP-014). Quality unchanged
+                # (EXP-015, mmlu_pro 0.8204 +/- 0.0071 vs 0.8232 stock).
+                #
+                # WHY IT IS SAFE, and the condition that keeps it safe:
+                # the NaN lives in rows of gmm2_res that this EP shard never
+                # writes (gmm_wrapper passes zero_initialize=False). Only the
+                # ONE-HOT unpermute reads them -- it contracts over the full
+                # batch axis, and 0 * NaN = NaN, so a single poisoned row makes
+                # 100% of the output NaN (EXP-010). ragged_gather_reduce never
+                # loads an unowned row, so nothing reaches us.
+                #
+                # ==> This depends on ONEHOT_MOE_PERMUTE_THRESHOLD=0, the
+                #     library default (envs.py), which makes the gather path
+                #     unconditional. Raising it re-arms the one-hot matmul and
+                #     removes the only reason this path can drop the guard.
+                #     If that threshold is ever raised, restore the guard.
+                scale = 1.0 / self.fp8_static_scale
+            else:
+                # Cross-lane max-abs reduction. This is what static mode buys
+                # its send-side win by skipping -- and it is why the guard is
+                # KEPT here and only here: one non-finite value makes this
+                # scale NaN and takes the whole chunk with it, so dynamic is
+                # structurally far more exposed than static, where a NaN would
+                # stay local to its own element.
+                data_f32 = jnp.where(jnp.isfinite(data_f32), data_f32, 0.0)
+                scale = jnp.max(jnp.abs(data_f32)) / FP8_E4M3_MAX
+                scale = jnp.where(scale == 0.0, 1.0, scale)
+            fp8_ref[...] = jnp.clip(data_f32 / scale, -FP8_E4M3_MAX,
+                                    FP8_E4M3_MAX).astype(jnp.float8_e4m3fn)
+            # Dynamic must stage the scale for transfer; static does not --
+            # the receiver reconstructs the identical constant, so under
+            # skip_scale_dma the buffer, the DMA and the wait all disappear.
+            if scale_ref is not None:
+                scale_ref[...] = jnp.full((1, SCALE_LANE), scale, jnp.float32)
+
+        # Data + scale land at neigh_chunk_idx (the chunk destined for the
+        # neighbor) — same index the serial path wrote, and the same index
+        # start_phase2_c2c_copies_fp8 reads back.
+        def send_data_index_fn(op_idx, hcube_dim_idx):
+            dim = (hcube_dim_idx + step_idx) % self.config.num_hcube_dims
+            neigh_device_id = self.topo.get_neighbor_device_id(dim)
+            neigh_chunk_idx = self.locator.get_phase2_chunk_idx(
+                neigh_device_id, step_idx, op_idx, hcube_dim_idx)
+            mb_col_idx = mb_idx * self.config.num_hcube_dims + hcube_dim_idx
+            return (neigh_chunk_idx, mb_col_idx)
+
+        def send_scale_index_fn(op_idx, hcube_dim_idx):
+            dim = (hcube_dim_idx + step_idx) % self.config.num_hcube_dims
+            neigh_device_id = self.topo.get_neighbor_device_id(dim)
+            neigh_chunk_idx = self.locator.get_phase2_chunk_idx(
+                neigh_device_id, step_idx, op_idx, hcube_dim_idx)
+            slot = self._scale_slot(step_idx, mb_idx, hcube_dim_idx, op_idx)
+            # block_shape (1, SCALE_LANE) -> element (neigh_chunk_idx, slot*128).
+            # Return the BLOCK index (neigh_chunk_idx, slot), NOT slot*SCALE_LANE.
+            return (neigh_chunk_idx, slot)
+
+        bf16_spec = pl.BlockSpec(
+            block_shape=(self.config.seq_chunk_size,
+                         self.config.hc_chunk_size),
+            index_map=send_data_index_fn,
+        )
+        fp8_spec = pl.BlockSpec(
+            block_shape=(self.config.seq_chunk_size,
+                         self.config.hc_chunk_size),
+            index_map=send_data_index_fn,
+        )
+        scale_spec = pl.BlockSpec(block_shape=(1, SCALE_LANE),
+                                  index_map=send_scale_index_fn)
+
+        src_bref = RemoteWaitBufferedRef.from_ref(
+            self.run_bref.with_spec(bf16_spec))
+        fp8_out_bref = RemoteWaitBufferedRef.from_ref(
+            self.fp8_send_bref.with_spec(fp8_spec))
+        scale_out_bref = RemoteWaitBufferedRef.from_ref(
+            self.scale_send_bref.with_spec(scale_spec))
+
+        if self.skip_scale_dma:
+            pltpu.emit_pipeline(
+                quant_body,
+                grid=grid,
+                in_specs=[bf16_spec],
+                out_specs=[fp8_spec],
+            )(src_hbm, self.fp8_send_buf, allocations=[src_bref, fp8_out_bref])
+        else:
+            pltpu.emit_pipeline(
+                quant_body,
+                grid=grid,
+                in_specs=[bf16_spec],
+                out_specs=[fp8_spec, scale_spec],
+            )(
+                src_hbm,
+                self.fp8_send_buf,
+                self.scale_send_buf,
+                allocations=[src_bref, fp8_out_bref, scale_out_bref],
+            )
+
+    def start_phase2_c2c_copies_fp8(self, mb_idx, step_idx):
+        """Start Phase-2 inter-chip copies using FP8 buffers (8-bit wire transfer).
+
+    Assumes quantize_chunks_to_fp8_staging has already been called for this
+    (mb_idx, step_idx).  Returns list of op tuples for later accounting.
+    """
+        assert self.fp8_send_buf is not None
+        assert self.fp8_recv_buf is not None
+        assert self.fp8_p2_send_sems is not None
+        assert self.fp8_p2_recv_sems is not None
+        assert self.scale_send_buf is not None
+        assert self.scale_recv_buf is not None
+        assert self.scale_p2_send_sems is not None
+        assert self.scale_p2_recv_sems is not None
+
+        mb_ops = []
+        exponent = self.config.num_hcube_dims - 1 - step_idx
+        num_ops_in_step = 1 << exponent if exponent >= 0 else 0
+
+        for op_idx in range(num_ops_in_step):
+            for hcube_dim_idx in range(self.config.num_hcube_dims):
+                dim = (hcube_dim_idx + step_idx) % self.config.num_hcube_dims
+
+                mb_start = mb_idx * self.locator.mb_stride
+                chunk_start = mb_start + hcube_dim_idx * self.config.hc_chunk_size
+                chunk_start, k_size = get_capped_bounds(
+                    chunk_start, self.config.hc_chunk_size,
+                    self.config.hidden_dim_size)
+                if k_size <= 0:
+                    continue
+
+                neigh_device_id = self.topo.get_neighbor_device_id(dim)
+                my_chunk_idx = self.locator.get_phase2_chunk_idx(
+                    self.topo.cur_id, step_idx, op_idx, hcube_dim_idx)
+                neigh_chunk_idx = self.locator.get_phase2_chunk_idx(
+                    neigh_device_id, step_idx, op_idx, hcube_dim_idx)
+                slot = self._scale_slot(step_idx, mb_idx, hcube_dim_idx,
+                                        op_idx)
+
+                data_slice = self.locator.get_slice(neigh_chunk_idx,
+                                                    chunk_start, k_size)
+                scale_slice = (
+                    pl.ds(neigh_chunk_idx, 1),
+                    pl.ds(slot * SCALE_LANE, SCALE_LANE),
+                )
+
+                # ── 8-bit FP8 data transfer ───────────────────────────────────
+                data_op = pltpu.make_async_remote_copy(
+                    src_ref=self.fp8_send_buf.at[data_slice],
+                    dst_ref=self.fp8_recv_buf.at[data_slice],
+                    send_sem=self.fp8_p2_send_sems.at[step_idx, mb_idx,
+                                                      hcube_dim_idx, op_idx],
+                    recv_sem=self.fp8_p2_recv_sems.at[step_idx, mb_idx,
+                                                      hcube_dim_idx, op_idx],
+                    device_id=neigh_device_id,
+                    device_id_type=pl.DeviceIdType.LOGICAL,
+                )
+                data_op.start()
+
+                # ── scale transfer ───────────────────────────────────────────
+                # Negligible in BYTES (512 B) but not in cost: it is a second DMA issue
+                # plus two more semaphore arrays per chunk, which is what doubles fp8's
+                # fixed cost against bf16. Static mode does not need it at all.
+                if self.skip_scale_dma:
+                    scale_op = None
+                else:
+                    scale_op = pltpu.make_async_remote_copy(
+                        src_ref=self.scale_send_buf.at[scale_slice],
+                        dst_ref=self.scale_recv_buf.at[scale_slice],
+                        send_sem=self.scale_p2_send_sems.at[step_idx, mb_idx,
+                                                            hcube_dim_idx,
+                                                            op_idx],
+                        recv_sem=self.scale_p2_recv_sems.at[step_idx, mb_idx,
+                                                            hcube_dim_idx,
+                                                            op_idx],
+                        device_id=neigh_device_id,
+                        device_id_type=pl.DeviceIdType.LOGICAL,
+                    )
+                    scale_op.start()
+
+                mb_ops.append((
+                    data_op,
+                    scale_op,
+                    step_idx,
+                    mb_idx,
+                    hcube_dim_idx,
+                    op_idx,
+                    my_chunk_idx,
+                    chunk_start,
+                    k_size,
+                ))
+        return mb_ops
+
+    @scoped("p2_dequant_accum")
+    def run_phase2_dequant_accumulate_pipeline(self, running_sum_ref, dst_ref,
+                                               mb_idx, step_idx, is_last_step):
+        """Pipelined FP8 dequant + BF16 accumulate for Phase 2.
+
+    Replaces the serial wait-loop. emit_pipeline double-buffers the FP8 recv
+    chunk, the running-sum chunk, and the scale, so the ICI engine prefetches
+    chunk s+1 while the VPU dequantizes/accumulates chunk s.
+    """
+        assert self.fp8_recv_bref is not None
+        assert self.scale_bref is not None
+        assert self.fp8_p2_recv_sems is not None
+        assert self.scale_p2_recv_sems is not None
+        assert self.fp8_recv_buf is not None
+        assert self.scale_recv_buf is not None
+        assert self.run_bref is not None
+        assert self.out_bref is not None
+
+        exponent = self.config.num_hcube_dims - 1 - step_idx
+        num_ops_in_step = 1 << exponent if exponent >= 0 else 0
+        if num_ops_in_step == 0:
+            return
+        grid = (num_ops_in_step, self.config.num_hcube_dims)
+
+        def accum_body(fp8_ref, run_ref, *rest):
+            # rest is (scale_ref, d_ref), or just (d_ref,) when the scale transfer
+            # has been elided -- static mode reconstructs the identical constant, so
+            # the sender and receiver still agree by construction.
+            fp8_out_ref = None
+            # Under skip_scale_dma (static) `rest` carries the destination ref
+            # alone and the receiver reconstructs the sender's constant, so the
+            # two agree by construction. Dynamic reads the transferred value.
+            if self.skip_scale_dma:
+                (d_ref, ) = rest
+                scale_ref = None
+            else:
+                scale_ref, d_ref = rest
+            if self.fp8_static_scale is not None:
+                scale = 1.0 / self.fp8_static_scale
+            else:
+                scale = scale_ref[0, 0]
+            recv_dq = (fp8_ref[...].astype(jnp.float32) * scale).astype(
+                jnp.bfloat16)
+            acc = recv_dq + run_ref[...]
+            d_ref[...] = acc
+            # Fused producer store: this block IS a whole transfer chunk (both sides
+            # use block_shape (seq_chunk_size, hc_chunk_size)), and the next step
+            # sends a subset of the chunks written here. Quantizing now saves the
+            # staging pass its 2 B/elem re-read of exactly this data.
+            if fp8_out_ref is not None:
+                fp8_out_ref[...] = jnp.clip(
+                    acc.astype(jnp.float32) / scale, -FP8_E4M3_MAX,
+                    FP8_E4M3_MAX).astype(jnp.float8_e4m3fn)
+
+        data_index_fn = self.locator.make_phase2_index_fn(step_idx, mb_idx)
+        out_index_fn = (self.locator.make_phase2_out_index_fn(
+            step_idx, mb_idx) if is_last_step else
+                        self.locator.make_phase2_index_fn(step_idx, mb_idx))
+
+        def scale_index_fn(op_idx, hcube_dim_idx):
+            my_chunk_idx = self.locator.get_phase2_chunk_idx(
+                self.topo.cur_id, step_idx, op_idx, hcube_dim_idx)
+            slot = self._scale_slot(step_idx, mb_idx, hcube_dim_idx, op_idx)
+            return (
+                my_chunk_idx,
+                slot,
+            )  # block_shape (1, SCALE_LANE) -> element (my_chunk_idx, slot*128)
+
+        # --- recv-sem index fns: wait for remote arrival before HBM->VMEM load ---
+        def fp8_recv_sem_fn(grid_indices, ref):
+            op_idx, hcube_dim_idx = grid_indices
+            my_chunk_idx = self.locator.get_phase2_chunk_idx(
+                self.topo.cur_id, step_idx, op_idx, hcube_dim_idx)
+            mb_start = mb_idx * self.locator.mb_stride
+            mb_start_idx = mb_start + hcube_dim_idx * self.config.hc_chunk_size
+            chunk_slice = self.locator.get_slice(my_chunk_idx, mb_start_idx,
+                                                 self.config.hc_chunk_size)
+            sem = self.fp8_p2_recv_sems.at[step_idx, mb_idx, hcube_dim_idx,
+                                           op_idx]
+            return chunk_slice, sem, self.config.hc_chunk_size
+
+        def scale_recv_sem_fn(grid_indices, ref):
+            op_idx, hcube_dim_idx = grid_indices
+            my_chunk_idx = self.locator.get_phase2_chunk_idx(
+                self.topo.cur_id, step_idx, op_idx, hcube_dim_idx)
+            slot = self._scale_slot(step_idx, mb_idx, hcube_dim_idx, op_idx)
+            scale_slice = (
+                pl.ds(my_chunk_idx, 1),
+                pl.ds(slot * SCALE_LANE, SCALE_LANE),
+            )
+            sem = self.scale_p2_recv_sems.at[step_idx, mb_idx, hcube_dim_idx,
+                                             op_idx]
+            return scale_slice, sem, SCALE_LANE
+
+        fp8_spec = pl.BlockSpec(
+            block_shape=(self.config.seq_chunk_size,
+                         self.config.hc_chunk_size),
+            index_map=data_index_fn,
+        )
+        run_spec = pl.BlockSpec(
+            block_shape=(self.config.seq_chunk_size,
+                         self.config.hc_chunk_size),
+            index_map=data_index_fn,
+        )
+        out_spec = pl.BlockSpec(
+            block_shape=(self.config.seq_chunk_size,
+                         self.config.hc_chunk_size),
+            index_map=out_index_fn,
+        )
+        scale_spec = pl.BlockSpec(block_shape=(1, SCALE_LANE),
+                                  index_map=scale_index_fn)
+
+        fp8_bref = RemoteWaitBufferedRef.from_ref(
+            self.fp8_recv_bref.with_spec(fp8_spec),
+            index_fn_with_recv_sem=fp8_recv_sem_fn,
+        )
+        run_bref = RemoteWaitBufferedRef.from_ref(
+            self.run_bref.with_spec(run_spec))
+        scale_bref = RemoteWaitBufferedRef.from_ref(
+            self.scale_bref.with_spec(scale_spec),
+            index_fn_with_recv_sem=scale_recv_sem_fn,
+        )
+        out_bref = RemoteWaitBufferedRef.from_ref(
+            self.out_bref.with_spec(out_spec))
+
+        dst = dst_ref if is_last_step else running_sum_ref
+
+        if self.skip_scale_dma:
+            pltpu.emit_pipeline(
+                accum_body,
+                grid=grid,
+                in_specs=[fp8_spec, run_spec],
+                out_specs=[out_spec],
+            )(
+                self.fp8_recv_buf,
+                running_sum_ref,
+                dst,
+                allocations=[fp8_bref, run_bref, out_bref],
+            )
+        else:
+            pltpu.emit_pipeline(
+                accum_body,
+                grid=grid,
+                in_specs=[fp8_spec, run_spec, scale_spec],
+                out_specs=[out_spec],
+            )(
+                self.fp8_recv_buf,
+                running_sum_ref,
+                self.scale_recv_buf,
+                dst,
+                allocations=[fp8_bref, run_bref, scale_bref, out_bref],
+            )

--- a/tpu_inference/kernels/collectives/hierrs_tc/dma_pipeline.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/dma_pipeline.py
@@ -249,7 +249,58 @@ class DmaManager:
             ops.append(op)
         return ops
 
-    def start_phase2_c2c_copies(self, src, dst, mb_idx, step_idx):
+    def start_phase2_c2c_copies(self,
+                                mb_idx,
+                                step_idx,
+                                src=None,
+                                dst=None,
+                                fp8=False):
+        """Start Phase-2 inter-chip (C2C) copies for one micro-batch and step.
+
+    Serves BOTH wires. The hypercube walk -- which neighbour, which chunk,
+    which hidden-dim slice -- is identical for bf16 and fp8; only three things
+    differ, and all three are parameters rather than structure:
+
+      * buffers    bf16 takes `src`/`dst` explicitly (running_sum -> the
+                   separate phase-2 landing buffer); fp8 always moves
+                   fp8_send_buf -> fp8_recv_buf, which the caller has already
+                   filled via quantize_chunks_to_fp8_staging.
+      * semaphores each wire owns its own send/recv DMA semaphore arrays, so
+                   an in-flight bf16 and fp8 transfer could never alias.
+      * scale DMA  fp8 dynamic scaling sends a second, tiny (512 B) buffer
+                   alongside the payload. Negligible in bytes, NOT negligible
+                   in cost: it is another DMA issue plus two more semaphore
+                   arrays per chunk, which is what doubles fp8's fixed cost
+                   against bf16. Static scaling skips it entirely
+                   (`skip_scale_dma`), and that is the shipped configuration.
+
+    Returns a list of tuples whose first two slots are always
+    `(data_op, scale_op)`, with `scale_op` None on every path that sends no
+    scale -- bf16 always, fp8 under static scaling. Callers rely on that fixed
+    shape to drain both wires with one code path.
+    """
+        if fp8:
+            assert self.fp8_send_buf is not None
+            assert self.fp8_recv_buf is not None
+            assert self.fp8_p2_send_sems is not None
+            assert self.fp8_p2_recv_sems is not None
+            src = self.fp8_send_buf
+            dst = self.fp8_recv_buf
+            send_sems = self.fp8_p2_send_sems
+            recv_sems = self.fp8_p2_recv_sems
+            send_scale = not self.skip_scale_dma
+            if send_scale:
+                assert self.scale_send_buf is not None
+                assert self.scale_recv_buf is not None
+                assert self.scale_p2_send_sems is not None
+                assert self.scale_p2_recv_sems is not None
+        else:
+            assert src is not None and dst is not None, (
+                "the bf16 wire must be given explicit src/dst refs")
+            send_sems = self.phase2_send_sems
+            recv_sems = self.phase2_recv_sems
+            send_scale = False
+
         mb_ops = []
         exponent = self.config.num_hcube_dims - 1 - step_idx
         num_ops_in_step = 1 << exponent if exponent >= 0 else 0
@@ -263,6 +314,8 @@ class DmaManager:
                 chunk_start, k_size = get_capped_bounds(
                     chunk_start, self.config.hc_chunk_size,
                     self.config.hidden_dim_size)
+                if k_size <= 0:
+                    continue
 
                 neigh_device_id = self.topo.get_neighbor_device_id(dim)
                 my_chunk_idx = self.locator.get_phase2_chunk_idx(
@@ -270,32 +323,53 @@ class DmaManager:
                 neighbor_chunk_idx = self.locator.get_phase2_chunk_idx(
                     neigh_device_id, step_idx, op_idx, hcube_dim_idx)
 
-                if k_size > 0:
-                    mb_slice = self.locator.get_slice(neighbor_chunk_idx,
-                                                      chunk_start, k_size)
-                    op = pltpu.make_async_remote_copy(
-                        src_ref=src.at[mb_slice],
-                        dst_ref=dst.at[mb_slice],
-                        send_sem=self.phase2_send_sems.at[step_idx, mb_idx,
-                                                          hcube_dim_idx,
-                                                          op_idx],
-                        recv_sem=self.phase2_recv_sems.at[step_idx, mb_idx,
-                                                          hcube_dim_idx,
-                                                          op_idx],
+                mb_slice = self.locator.get_slice(neighbor_chunk_idx,
+                                                  chunk_start, k_size)
+                data_op = pltpu.make_async_remote_copy(
+                    src_ref=src.at[mb_slice],
+                    dst_ref=dst.at[mb_slice],
+                    send_sem=send_sems.at[step_idx, mb_idx, hcube_dim_idx,
+                                          op_idx],
+                    recv_sem=recv_sems.at[step_idx, mb_idx, hcube_dim_idx,
+                                          op_idx],
+                    device_id=neigh_device_id,
+                    device_id_type=pl.DeviceIdType.LOGICAL,
+                )
+                data_op.start()
+
+                scale_op = None
+                if send_scale:
+                    slot = self._scale_slot(step_idx, mb_idx, hcube_dim_idx,
+                                            op_idx)
+                    scale_slice = (
+                        pl.ds(neighbor_chunk_idx, 1),
+                        pl.ds(slot * SCALE_LANE, SCALE_LANE),
+                    )
+                    scale_op = pltpu.make_async_remote_copy(
+                        src_ref=self.scale_send_buf.at[scale_slice],
+                        dst_ref=self.scale_recv_buf.at[scale_slice],
+                        send_sem=self.scale_p2_send_sems.at[step_idx, mb_idx,
+                                                            hcube_dim_idx,
+                                                            op_idx],
+                        recv_sem=self.scale_p2_recv_sems.at[step_idx, mb_idx,
+                                                            hcube_dim_idx,
+                                                            op_idx],
                         device_id=neigh_device_id,
                         device_id_type=pl.DeviceIdType.LOGICAL,
                     )
-                    op.start()
-                    mb_ops.append((
-                        op,
-                        step_idx,
-                        mb_idx,
-                        hcube_dim_idx,
-                        op_idx,
-                        my_chunk_idx,
-                        chunk_start,
-                        k_size,
-                    ))
+                    scale_op.start()
+
+                mb_ops.append((
+                    data_op,
+                    scale_op,
+                    step_idx,
+                    mb_idx,
+                    hcube_dim_idx,
+                    op_idx,
+                    my_chunk_idx,
+                    chunk_start,
+                    k_size,
+                ))
         return mb_ops
 
     @scoped("p1_accum")
@@ -423,7 +497,7 @@ class DmaManager:
 
     Reads BF16 from src_hbm (running_sum_ref); writes FP8 to fp8_send_buf and
     the per-chunk scale to scale_send_buf.  Must complete before
-    start_phase2_c2c_copies_fp8 is called.
+    start_phase2_c2c_copies(..., fp8=True) is called.
     """
         assert self.run_bref is not None
         assert self.fp8_send_bref is not None
@@ -491,7 +565,7 @@ class DmaManager:
 
         # Data + scale land at neigh_chunk_idx (the chunk destined for the
         # neighbor) — same index the serial path wrote, and the same index
-        # start_phase2_c2c_copies_fp8 reads back.
+        # start_phase2_c2c_copies(..., fp8=True) reads back.
         def send_data_index_fn(op_idx, hcube_dim_idx):
             dim = (hcube_dim_idx + step_idx) % self.config.num_hcube_dims
             neigh_device_id = self.topo.get_neighbor_device_id(dim)
@@ -549,99 +623,6 @@ class DmaManager:
                 self.scale_send_buf,
                 allocations=[src_bref, fp8_out_bref, scale_out_bref],
             )
-
-    def start_phase2_c2c_copies_fp8(self, mb_idx, step_idx):
-        """Start Phase-2 inter-chip copies using FP8 buffers (8-bit wire transfer).
-
-    Assumes quantize_chunks_to_fp8_staging has already been called for this
-    (mb_idx, step_idx).  Returns list of op tuples for later accounting.
-    """
-        assert self.fp8_send_buf is not None
-        assert self.fp8_recv_buf is not None
-        assert self.fp8_p2_send_sems is not None
-        assert self.fp8_p2_recv_sems is not None
-        assert self.scale_send_buf is not None
-        assert self.scale_recv_buf is not None
-        assert self.scale_p2_send_sems is not None
-        assert self.scale_p2_recv_sems is not None
-
-        mb_ops = []
-        exponent = self.config.num_hcube_dims - 1 - step_idx
-        num_ops_in_step = 1 << exponent if exponent >= 0 else 0
-
-        for op_idx in range(num_ops_in_step):
-            for hcube_dim_idx in range(self.config.num_hcube_dims):
-                dim = (hcube_dim_idx + step_idx) % self.config.num_hcube_dims
-
-                mb_start = mb_idx * self.locator.mb_stride
-                chunk_start = mb_start + hcube_dim_idx * self.config.hc_chunk_size
-                chunk_start, k_size = get_capped_bounds(
-                    chunk_start, self.config.hc_chunk_size,
-                    self.config.hidden_dim_size)
-                if k_size <= 0:
-                    continue
-
-                neigh_device_id = self.topo.get_neighbor_device_id(dim)
-                my_chunk_idx = self.locator.get_phase2_chunk_idx(
-                    self.topo.cur_id, step_idx, op_idx, hcube_dim_idx)
-                neigh_chunk_idx = self.locator.get_phase2_chunk_idx(
-                    neigh_device_id, step_idx, op_idx, hcube_dim_idx)
-                slot = self._scale_slot(step_idx, mb_idx, hcube_dim_idx,
-                                        op_idx)
-
-                data_slice = self.locator.get_slice(neigh_chunk_idx,
-                                                    chunk_start, k_size)
-                scale_slice = (
-                    pl.ds(neigh_chunk_idx, 1),
-                    pl.ds(slot * SCALE_LANE, SCALE_LANE),
-                )
-
-                # ── 8-bit FP8 data transfer ───────────────────────────────────
-                data_op = pltpu.make_async_remote_copy(
-                    src_ref=self.fp8_send_buf.at[data_slice],
-                    dst_ref=self.fp8_recv_buf.at[data_slice],
-                    send_sem=self.fp8_p2_send_sems.at[step_idx, mb_idx,
-                                                      hcube_dim_idx, op_idx],
-                    recv_sem=self.fp8_p2_recv_sems.at[step_idx, mb_idx,
-                                                      hcube_dim_idx, op_idx],
-                    device_id=neigh_device_id,
-                    device_id_type=pl.DeviceIdType.LOGICAL,
-                )
-                data_op.start()
-
-                # ── scale transfer ───────────────────────────────────────────
-                # Negligible in BYTES (512 B) but not in cost: it is a second DMA issue
-                # plus two more semaphore arrays per chunk, which is what doubles fp8's
-                # fixed cost against bf16. Static mode does not need it at all.
-                if self.skip_scale_dma:
-                    scale_op = None
-                else:
-                    scale_op = pltpu.make_async_remote_copy(
-                        src_ref=self.scale_send_buf.at[scale_slice],
-                        dst_ref=self.scale_recv_buf.at[scale_slice],
-                        send_sem=self.scale_p2_send_sems.at[step_idx, mb_idx,
-                                                            hcube_dim_idx,
-                                                            op_idx],
-                        recv_sem=self.scale_p2_recv_sems.at[step_idx, mb_idx,
-                                                            hcube_dim_idx,
-                                                            op_idx],
-                        device_id=neigh_device_id,
-                        device_id_type=pl.DeviceIdType.LOGICAL,
-                    )
-                    scale_op.start()
-
-                mb_ops.append((
-                    data_op,
-                    scale_op,
-                    step_idx,
-                    mb_idx,
-                    hcube_dim_idx,
-                    op_idx,
-                    my_chunk_idx,
-                    chunk_start,
-                    k_size,
-                ))
-        return mb_ops
 
     @scoped("p2_dequant_accum")
     def run_phase2_dequant_accumulate_pipeline(self, running_sum_ref, dst_ref,

--- a/tpu_inference/kernels/collectives/hierrs_tc/dma_pipeline.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/dma_pipeline.py
@@ -227,6 +227,14 @@ class DmaManager:
         self.skip_scale_dma = fp8_static_scale is not None
 
     def start_phase1_d2d_copies(self, src, dst, mb_idx):
+        """Push this device's partner-parity chunks into the partner's recv_buf.
+
+    src is the FULL input operand; dst is the partner's PACKED recv_buf, so
+    the two slices differ in their row offset. pack(c_neigh) == chip_idx for
+    either parity, and c_neigh carries the PARTNER's chiplet bit -- which is
+    exactly the receiver's parity -- so the packed destination row agrees with
+    where the receiver's accumulate pipeline reads (chip_idx as well).
+    """
         ops = []
         mb_start = mb_idx * self.config.mb_size
         mb_start, mb_slice_size = get_capped_bounds(
@@ -234,12 +242,15 @@ class DmaManager:
         partner_chunks = self.locator.get_phase1_chunk_idxes(
             self.topo.partner_id)
         for chip_idx, c_neigh in enumerate(partner_chunks):
-            mb_slice = self.locator.get_slice(chunk_idx=c_neigh,
-                                              start=mb_start,
-                                              size=mb_slice_size)
+            src_slice = self.locator.get_slice(chunk_idx=c_neigh,
+                                               start=mb_start,
+                                               size=mb_slice_size)
+            dst_slice = self.locator.get_packed_slice(chunk_idx=c_neigh,
+                                                      start=mb_start,
+                                                      size=mb_slice_size)
             op = pltpu.make_async_remote_copy(
-                src_ref=src.at[mb_slice],
-                dst_ref=dst.at[mb_slice],
+                src_ref=src.at[src_slice],
+                dst_ref=dst.at[dst_slice],
                 send_sem=self.phase1_send_sems.at[chip_idx, mb_idx],
                 recv_sem=self.phase1_recv_sems.at[chip_idx, mb_idx],
                 device_id=self.topo.partner_id,
@@ -323,8 +334,12 @@ class DmaManager:
                 neighbor_chunk_idx = self.locator.get_phase2_chunk_idx(
                     neigh_device_id, step_idx, op_idx, hcube_dim_idx)
 
-                mb_slice = self.locator.get_slice(neighbor_chunk_idx,
-                                                  chunk_start, k_size)
+                # src and dst are both PACKED working buffers (bf16:
+                # running_sum -> landing buffer; fp8: fp8_send -> fp8_recv),
+                # and sender and receiver share chunk parity, so one packed
+                # slice serves both ends.
+                mb_slice = self.locator.get_packed_slice(
+                    neighbor_chunk_idx, chunk_start, k_size)
                 data_op = pltpu.make_async_remote_copy(
                     src_ref=src.at[mb_slice],
                     dst_ref=dst.at[mb_slice],
@@ -378,13 +393,19 @@ class DmaManager:
         src1,
         src2,
         dst,
-        in_index_fn,
+        in1_index_fn,
+        in2_index_fn,
         out_index_fn,
         hbm_index_fn,
         block_size,
         mb_idx,
     ):
-        """Orchestrates a D2D accumulation pipeline on a 1D chip grid."""
+        """Orchestrates a D2D accumulation pipeline on a 1D chip grid.
+
+    src1 (recv_buf) and dst (running_sum) are PACKED working buffers; src2 is
+    the FULL input operand. That is why the two inputs take separate index
+    fns -- the only pipeline where packed and full indexing meet.
+    """
 
         def accum_body(s1_ref, s2_ref, d_ref):
             d_ref[...] = s1_ref[...] + s2_ref[...]
@@ -397,9 +418,13 @@ class DmaManager:
             sem = self.phase1_recv_sems.at[chip_idx, mb_idx]
             return hbm_index, sem, size
 
-        in_spec = pl.BlockSpec(
+        in1_spec = pl.BlockSpec(
             block_shape=(self.config.seq_chunk_size, block_size),
-            index_map=in_index_fn,
+            index_map=in1_index_fn,
+        )
+        in2_spec = pl.BlockSpec(
+            block_shape=(self.config.seq_chunk_size, block_size),
+            index_map=in2_index_fn,
         )
         out_spec = pl.BlockSpec(
             block_shape=(self.config.seq_chunk_size, block_size),
@@ -407,18 +432,18 @@ class DmaManager:
         )
 
         s1_bref = RemoteWaitBufferedRef.from_ref(
-            self.recv_bref.with_spec(in_spec),
+            self.recv_bref.with_spec(in1_spec),
             index_fn_with_recv_sem=in_index_fn_with_recv_sem,
         )
         s2_bref = RemoteWaitBufferedRef.from_ref(
-            self.run_bref.with_spec(in_spec))
+            self.run_bref.with_spec(in2_spec))
         d_bref = RemoteWaitBufferedRef.from_ref(
             self.out_bref.with_spec(out_spec))
 
         pltpu.emit_pipeline(
             accum_body,
             grid=grid,
-            in_specs=[in_spec, in_spec],
+            in_specs=[in1_spec, in2_spec],
             out_specs=[out_spec],
         )(src1, src2, dst, allocations=[s1_bref, s2_bref, d_bref])
 
@@ -572,7 +597,8 @@ class DmaManager:
             neigh_chunk_idx = self.locator.get_phase2_chunk_idx(
                 neigh_device_id, step_idx, op_idx, hcube_dim_idx)
             mb_col_idx = mb_idx * self.config.num_hcube_dims + hcube_dim_idx
-            return (neigh_chunk_idx, mb_col_idx)
+            # running_sum (source) and fp8_send (dest) are both packed.
+            return (self.locator.pack(neigh_chunk_idx), mb_col_idx)
 
         def send_scale_index_fn(op_idx, hcube_dim_idx):
             dim = (hcube_dim_idx + step_idx) % self.config.num_hcube_dims
@@ -699,8 +725,9 @@ class DmaManager:
                 self.topo.cur_id, step_idx, op_idx, hcube_dim_idx)
             mb_start = mb_idx * self.locator.mb_stride
             mb_start_idx = mb_start + hcube_dim_idx * self.config.hc_chunk_size
-            chunk_slice = self.locator.get_slice(my_chunk_idx, mb_start_idx,
-                                                 self.config.hc_chunk_size)
+            # fp8_recv is packed.
+            chunk_slice = self.locator.get_packed_slice(
+                my_chunk_idx, mb_start_idx, self.config.hc_chunk_size)
             sem = self.fp8_p2_recv_sems.at[step_idx, mb_idx, hcube_dim_idx,
                                            op_idx]
             return chunk_slice, sem, self.config.hc_chunk_size

--- a/tpu_inference/kernels/collectives/hierrs_tc/kernel.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/kernel.py
@@ -1,0 +1,412 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Pallas kernel body for TensorCore Reduce-Scatter.
+
+`hier_rs_kernel` is the pallas_call body: it sequences phase 1 (intra-chip D2D)
+and phase 2 (inter-chip hypercube) across micro-batches, driving the DmaManager.
+`make_unified_scratch_shapes` declares the scratch/BufferedRef layout the body
+unpacks positionally -- the two MUST be kept in lockstep.
+"""
+
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+from tpu_inference.kernels.collectives.hierrs_tc.config import (
+    SCALE_LANE, Config, next_multiple_of)
+from tpu_inference.kernels.collectives.hierrs_tc.dma_pipeline import (
+    DmaManager, RemoteWaitBufferedRef)
+from tpu_inference.kernels.collectives.hierrs_tc.topology import (ChunkLocator,
+                                                                  Topology)
+
+
+def hier_rs_kernel(
+    input_ref,
+    output_ref,
+    running_sum_ref,
+    recv_buf_ref,
+    *args,
+    config: Config,
+    axis_name: str = "x",
+    fp8_comm: bool = False,
+    fp8_static_scale: float | None = None,
+):
+    p2_recv_buf_ref = None
+    if fp8_comm:
+        (
+            fp8_send_ref,
+            fp8_recv_ref,
+            scale_send_ref,
+            scale_recv_ref,
+            recv_bref,
+            run_bref,
+            out_bref,
+            phase1_send_sems,
+            phase1_recv_sems,
+            phase2_send_sems,
+            phase2_recv_sems,
+            fp8_p2_send_sems,
+            fp8_p2_recv_sems,
+            scale_p2_send_sems,
+            scale_p2_recv_sems,
+            fp8_send_bref,
+            scale_send_bref,
+            fp8_recv_bref,
+            scale_bref,
+        ) = args
+    else:
+        # Phase 2's bf16 wire gets its OWN landing buffer, appended ahead of
+        # the scratch shapes. Without it an incoming phase-2 chunk can
+        # overwrite phase-1 bytes the receiver has not drained yet -- a
+        # cross-device WAR that produced wrong answers in 157/200 runs at
+        # 512 rows / mb=4. Not optional; the fp8 wire has always had its own
+        # landing buffer, which is exactly why it never reproduced that bug.
+        p2_recv_buf_ref, *args = args
+        (
+            recv_bref,
+            run_bref,
+            out_bref,
+            phase1_send_sems,
+            phase1_recv_sems,
+            phase2_send_sems,
+            phase2_recv_sems,
+        ) = args
+        fp8_send_ref = fp8_recv_ref = scale_send_ref = scale_recv_ref = None
+        fp8_p2_send_sems = fp8_p2_recv_sems = None
+        scale_p2_send_sems = scale_p2_recv_sems = None
+        fp8_send_bref = scale_send_bref = None
+        fp8_recv_bref = scale_bref = None
+
+    # Phase-2's bf16 landing zone. This is a
+    # dedicated buffer, so incoming phase-2 chunks cannot land on phase-1 bytes
+    # the receiver has not consumed yet (the cross-device WAR that corrupted
+    # bf16 at num_micro_batches=4). Otherwise it aliases recv_buf_ref, the old
+    # racy behaviour, kept for reproducing the bug.
+    p2_buf = p2_recv_buf_ref if p2_recv_buf_ref is not None else recv_buf_ref
+
+    topo = Topology(axis_name)
+    locator = ChunkLocator(config, topo)
+    dma = DmaManager(
+        config,
+        topo,
+        locator,
+        recv_bref,
+        run_bref,
+        out_bref,
+        phase1_send_sems,
+        phase1_recv_sems,
+        phase2_send_sems,
+        phase2_recv_sems,
+        fp8_send_buf=fp8_send_ref,
+        fp8_recv_buf=fp8_recv_ref,
+        scale_send_buf=scale_send_ref,
+        scale_recv_buf=scale_recv_ref,
+        fp8_p2_send_sems=fp8_p2_send_sems,
+        fp8_p2_recv_sems=fp8_p2_recv_sems,
+        scale_p2_send_sems=scale_p2_send_sems,
+        scale_p2_recv_sems=scale_p2_recv_sems,
+        fp8_send_bref=fp8_send_bref,
+        scale_send_bref=scale_send_bref,
+        fp8_recv_bref=fp8_recv_bref,
+        scale_bref=scale_bref,
+        fp8_static_scale=fp8_static_scale,
+    )
+
+    all_phase1_ops = []
+    all_phase2_ops = []
+
+    # =========================================================================================================
+    #                                  HIERARCHICAL REDUCE-SCATTER TIMELINE (D2D + C2C Step 0)
+    # =========================================================================================================
+    #
+    # Time -------->  t0                  t1                                      t2                                      t3
+    #                 | Global Prologue   |              Loop m=0                 |              Loop m=1                 |
+    #                 |                   |                                       |                                       |
+    # D2D/DMA (P1)    [A]========[B]      |       [D]========[E]                  |       [D]========[E]                  |
+    #                 |   P1 MB0          |       |   P1 MB1                      |       |   P1 MB2                      |
+    #                 |                   |       |                               |       |                               |
+    # C2C (P2)        |                   [C]=====================================[G]                                     |
+    #                 |                   |             P2 MB0                    |                                       |
+    #                 |                   |                                       [F]=====================================[G]
+    #                 |                   |                                       |             P2 MB1                    |
+    #                 |                   |                                       |                                       [F]========> (to t4)
+    #                 |                   |                                       |                                       |  P2 MB2
+    # Accumulate      |          [B]======|                  [E]======|           [G]======|                 [I]======|   [J]======|
+    #                 |            AC P1  |                    AC P1  |           |  AC P2 |                   AC P1  |   |  AC P2 |
+    #                 |            (MB0)  |                    (MB1)  |           |  (MB0) |                   (MB2)  |   |  (MB1) |
+    # =========================================================================================================
+
+    # =========== Global Prologue: PHASE 1 Micro-Batch 0 D2D REDUCTIONS ===========
+    # [Step A]: Start remote D2D copies for micro-batch 0
+    all_phase1_ops.extend(
+        dma.start_phase1_d2d_copies(src=input_ref,
+                                    dst=recv_buf_ref,
+                                    mb_idx=0))
+
+    # [Step B]: Wait for micro-batch 0 copies to finish, and accumulate locally
+    dma.run_phase1_accumulate_pipeline(
+        src1=recv_buf_ref,
+        src2=input_ref,
+        dst=running_sum_ref,
+        in_index_fn=locator.make_phase1_index_fn(mb_idx=0),
+        out_index_fn=locator.make_phase1_index_fn(mb_idx=0),
+        hbm_index_fn=locator.make_phase1_in_index_fn_with_recv_sem(
+            mb_idx=0),
+        block_size=config.mb_size,
+        mb_idx=0,
+    )
+
+    # [Step C]: Start Phase 2 Ring ICI copies for micro-batch 0
+    if fp8_comm:
+        dma.quantize_chunks_to_fp8_staging(running_sum_ref,
+                                           mb_idx=0,
+                                           step_idx=0)
+        mb_ops_0 = dma.start_phase2_c2c_copies_fp8(mb_idx=0, step_idx=0)
+        all_phase2_ops.extend([item[0] for item in mb_ops_0])
+        all_phase2_ops.extend([i[1] for i in mb_ops_0 if i[1] is not None])
+    else:
+        mb_ops_0 = dma.start_phase2_c2c_copies(src=running_sum_ref,
+                                               dst=p2_buf,
+                                               mb_idx=0,
+                                               step_idx=0)
+        all_phase2_ops.extend([item[0] for item in mb_ops_0])
+
+    def _start_phase2_step0(mb):
+        """[Step F] body: start the phase-2 step-0 C2C copies for micro-batch mb."""
+        if fp8_comm:
+            dma.quantize_chunks_to_fp8_staging(running_sum_ref,
+                                               mb,
+                                               step_idx=0)
+            ops = dma.start_phase2_c2c_copies_fp8(mb, step_idx=0)
+            all_phase2_ops.extend([item[0] for item in ops])
+            all_phase2_ops.extend([i[1] for i in ops if i[1] is not None])
+        else:
+            ops = dma.start_phase2_c2c_copies(src=running_sum_ref,
+                                              dst=p2_buf,
+                                              mb_idx=mb,
+                                              step_idx=0)
+            all_phase2_ops.extend([item[0] for item in ops])
+
+    for m in range(config.num_micro_batches):
+
+        if m < config.num_micro_batches - 1:
+            # [Step D]: Start overlap Phase 1 D2D copies for next micro-batch
+            all_phase1_ops.extend(
+                dma.start_phase1_d2d_copies(src=input_ref,
+                                            dst=recv_buf_ref,
+                                            mb_idx=m + 1))
+
+            # [Step E]: Wait and Accumulate Phase 1 for next micro-batch
+            dma.run_phase1_accumulate_pipeline(
+                src1=recv_buf_ref,
+                src2=input_ref,
+                dst=running_sum_ref,
+                in_index_fn=locator.make_phase1_index_fn(m + 1),
+                out_index_fn=locator.make_phase1_index_fn(m + 1),
+                hbm_index_fn=locator.
+                make_phase1_in_index_fn_with_recv_sem(m + 1),
+                block_size=config.mb_size,
+                mb_idx=m + 1,
+            )
+
+            # [Step F]: Pre-start next micro-batch Phase 2 Ring ICI copies
+            #
+            # RACE (suspected, cross-device): start_phase2_c2c_copies issues remote
+            # copies into the NEIGHBOR's recv_buf_ref -- the same buffer [Step D]
+            # fills with phase-1 data and [Step E] consumes. Nothing tells the
+            # neighbor that it has finished draining phase 1 for this micro-batch,
+            # so a device that runs ahead can land phase-2 bytes on top of its
+            # neighbor's unread phase-1 bytes.
+            #
+            # If that is the mechanism, local reordering CANNOT fix it -- it only
+            # moves the window. RS_STEPF_DELAY=1 defers this start until after
+            # [Step G] purely as a diagnostic: if deferring "fixes" mb=4, the fix is
+            # timing, not ordering, and the race is still latent.
+            _start_phase2_step0(m + 1)
+
+        # [Phase 2, Step 1] Pre-start Step 1 MB0 during the last iteration of Step 0
+        #
+        # RACE: this reads running_sum_ref for micro-batch 0, which was produced
+        # by [Step G] of an earlier iteration of this same loop. That producer is
+        # an emit_pipeline whose output lands in HBM asynchronously, so the read
+        # here is not ordered against it. Symptom: non-deterministic corruption of
+        # the last micro-batch's tile -- identical input, identical code,
+        # different answers run to run. Affects the bf16 and fp8 wires both;
+        # num_micro_batches == 1 is always correct because that case does the
+        # start AFTER the loop (see below), which is exactly the ordering the
+        # multi-micro-batch path is missing.
+        #
+        # RS_UNSAFE_STEP1_PRESTART=1 restores the old in-loop start to reproduce
+        # the bug; default is the safe ordering.
+        # [Step G]: Wait and Accumulate Phase 2 Step 0 for current micro-batch
+        if config.num_hcube_dims >= 1:
+            is_last = config.num_hcube_dims == 1
+            if fp8_comm:
+                dma.run_phase2_dequant_accumulate_pipeline(
+                    running_sum_ref,
+                    output_ref,
+                    m,
+                    step_idx=0,
+                    is_last_step=is_last)
+            else:
+                dma.run_phase2_accumulate_pipeline(
+                    src1=p2_buf,
+                    src2=running_sum_ref,
+                    dst=output_ref if is_last else running_sum_ref,
+                    in_index_fn=locator.make_phase2_index_fn(0, m),
+                    out_index_fn=locator.make_phase2_out_index_fn(0, m)
+                    if is_last else locator.make_phase2_index_fn(0, m),
+                    hbm_index_fn=locator.
+                    make_phase2_in_index_fn_with_recv_sem(0, m),
+                    block_size=config.hc_chunk_size,
+                    mb_idx=m,
+                    step_idx=0,
+                )
+
+        # [Step F], deferred variant -- diagnostic only (see the RACE note above).
+    # Start Step 1 MB0 here, after the Step-0 loop has fully drained, so the read
+    # of running_sum_ref is ordered against the [Step G] pipeline that wrote it.
+    # This was previously done only for num_micro_batches == 1 ("we couldn't
+    # pre-start Step 1 MB0 in the loop due to data dependency") -- the same data
+    # dependency exists for every micro-batch count; it was simply hidden by
+    # timing when other micro-batches gave the write time to land.
+    if fp8_comm:
+        dma.quantize_chunks_to_fp8_staging(running_sum_ref, 0, step_idx=1)
+        mb_ops = dma.start_phase2_c2c_copies_fp8(0, step_idx=1)
+        all_phase2_ops.extend([item[0] for item in mb_ops])
+        all_phase2_ops.extend([i[1] for i in mb_ops if i[1] is not None])
+    else:
+        mb_ops = dma.start_phase2_c2c_copies(src=running_sum_ref,
+                                             dst=p2_buf,
+                                             mb_idx=0,
+                                             step_idx=1)
+        all_phase2_ops.extend([item[0] for item in mb_ops])
+
+    # ================= STEP 1 LOOP =================
+    for m in range(config.num_micro_batches):
+
+        if m < config.num_micro_batches - 1:
+            if fp8_comm:
+                dma.quantize_chunks_to_fp8_staging(running_sum_ref,
+                                                   m + 1,
+                                                   step_idx=1)
+                mb_ops = dma.start_phase2_c2c_copies_fp8(m + 1,
+                                                         step_idx=1)
+                all_phase2_ops.extend([item[0] for item in mb_ops])
+                all_phase2_ops.extend(
+                    [i[1] for i in mb_ops if i[1] is not None])
+            else:
+                mb_ops = dma.start_phase2_c2c_copies(
+                    src=running_sum_ref,
+                    dst=p2_buf,
+                    mb_idx=m + 1,
+                    step_idx=1)
+                all_phase2_ops.extend([item[0] for item in mb_ops])
+
+        # Accumulate Step 1
+        if config.num_hcube_dims > 1:
+            if fp8_comm:
+                dma.run_phase2_dequant_accumulate_pipeline(
+                    running_sum_ref,
+                    output_ref,
+                    m,
+                    step_idx=1,
+                    is_last_step=True)
+            else:
+                dma.run_phase2_accumulate_pipeline(
+                    src1=p2_buf,
+                    src2=running_sum_ref,
+                    dst=output_ref,
+                    in_index_fn=locator.make_phase2_index_fn(1, m),
+                    out_index_fn=locator.make_phase2_out_index_fn(1, m),
+                    hbm_index_fn=locator.
+                    make_phase2_in_index_fn_with_recv_sem(1, m),
+                    block_size=config.hc_chunk_size,
+                    mb_idx=m,
+                    step_idx=1,
+                )
+
+    for op in all_phase1_ops:
+        op.wait_send()
+    for op in all_phase2_ops:
+        op.wait_send()
+
+
+def make_unified_scratch_shapes(
+    seq_chunk_size,
+    mb_size,
+    dtype,
+    num_chips,
+    num_hcube_dims,
+    num_micro_batches,
+    fp8_comm: bool = False,
+):
+    block_spec = pl.BlockSpec(block_shape=(seq_chunk_size, mb_size),
+                              index_map=lambda *args: (0, 0))
+    recv_bref = pltpu.BufferedRef.input(block_spec, dtype, buffer_count=2)
+    run_bref = pltpu.BufferedRef.input(block_spec, dtype, buffer_count=2)
+    out_bref = pltpu.BufferedRef.output(block_spec, dtype, buffer_count=2)
+
+    p2_sem_shape = (
+        num_hcube_dims,
+        num_micro_batches,
+        num_hcube_dims,
+        1 << max(0, num_hcube_dims - 1),
+    )
+
+    scratch_shapes = [
+        recv_bref,
+        run_bref,
+        out_bref,
+        pltpu.SemaphoreType.DMA((num_chips, num_micro_batches)),  # p1 send
+        pltpu.SemaphoreType.DMA((num_chips, num_micro_batches)),  # p1 recv
+        pltpu.SemaphoreType.DMA(p2_sem_shape),  # p2 send
+        pltpu.SemaphoreType.DMA(p2_sem_shape),  # p2 recv
+    ]
+
+    if fp8_comm:
+        fp8_block_spec = pl.BlockSpec(block_shape=(seq_chunk_size, mb_size),
+                                      index_map=lambda *a: (0, 0))
+        fp8_recv_bref = pltpu.BufferedRef.input(fp8_block_spec,
+                                                jnp.float8_e4m3fn,
+                                                buffer_count=2)
+        # Send-side staging is now pipelined: emit_pipeline double-buffers these
+        # OUTPUT BufferedRefs (BF16->FP8 quantize) instead of the old serial
+        # load/quantize/store VMEM scratch + DMA-sem chain. The BF16 input reuses
+        # run_bref, so net VMEM is slightly lower than the serial scratch.
+        fp8_send_bref = pltpu.BufferedRef.output(fp8_block_spec,
+                                                 jnp.float8_e4m3fn,
+                                                 buffer_count=2)
+        scale_block_spec = pl.BlockSpec(block_shape=(1, SCALE_LANE),
+                                        index_map=lambda *a: (0, 0))
+        scale_bref = pltpu.BufferedRef.input(scale_block_spec,
+                                             jnp.float32,
+                                             buffer_count=2)
+        scale_send_bref = pltpu.BufferedRef.output(scale_block_spec,
+                                                   jnp.float32,
+                                                   buffer_count=2)
+        scratch_shapes += [
+            pltpu.SemaphoreType.DMA(p2_sem_shape),  # fp8_p2_send
+            pltpu.SemaphoreType.DMA(p2_sem_shape),  # fp8_p2_recv
+            pltpu.SemaphoreType.DMA(p2_sem_shape),  # scale_p2_send
+            pltpu.SemaphoreType.DMA(p2_sem_shape),  # scale_p2_recv
+            fp8_send_bref,  # fp8_send_bref (send-side pipeline output)
+            scale_send_bref,  # scale_send_bref (send-side pipeline output)
+            fp8_recv_bref,  # fp8_recv_bref
+            scale_bref,  # scale_bref
+        ]
+
+        # Appended LAST so the existing positional unpacking in hier_rs_kernel is
+        # undisturbed; the kernel unpacks these two off the tail.
+    return scratch_shapes

--- a/tpu_inference/kernels/collectives/hierrs_tc/kernel.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/kernel.py
@@ -126,6 +126,17 @@ def hier_rs_kernel(
     all_phase1_ops = []
     all_phase2_ops = []
 
+    def _collect_phase2_ops(ops):
+        """Queue a start_phase2_c2c_copies batch for the final wait_send drain.
+
+    Slot 0 is the payload DMA and is always present; slot 1 is the fp8 scale
+    DMA, which is None on the bf16 wire and under fp8 static scaling. Filtering
+    on None rather than branching on the wire is what lets both wires share one
+    call site.
+    """
+        all_phase2_ops.extend([o[0] for o in ops])
+        all_phase2_ops.extend([o[1] for o in ops if o[1] is not None])
+
     # =========================================================================================================
     #                                  HIERARCHICAL REDUCE-SCATTER TIMELINE (D2D + C2C Step 0)
     # =========================================================================================================
@@ -172,15 +183,12 @@ def hier_rs_kernel(
         dma.quantize_chunks_to_fp8_staging(running_sum_ref,
                                            mb_idx=0,
                                            step_idx=0)
-        mb_ops_0 = dma.start_phase2_c2c_copies_fp8(mb_idx=0, step_idx=0)
-        all_phase2_ops.extend([item[0] for item in mb_ops_0])
-        all_phase2_ops.extend([i[1] for i in mb_ops_0 if i[1] is not None])
-    else:
-        mb_ops_0 = dma.start_phase2_c2c_copies(src=running_sum_ref,
-                                               dst=p2_buf,
-                                               mb_idx=0,
-                                               step_idx=0)
-        all_phase2_ops.extend([item[0] for item in mb_ops_0])
+    mb_ops_0 = dma.start_phase2_c2c_copies(mb_idx=0,
+                                           step_idx=0,
+                                           src=running_sum_ref,
+                                           dst=p2_buf,
+                                           fp8=fp8_comm)
+    _collect_phase2_ops(mb_ops_0)
 
     def _start_phase2_step0(mb):
         """[Step F] body: start the phase-2 step-0 C2C copies for micro-batch mb."""
@@ -188,15 +196,12 @@ def hier_rs_kernel(
             dma.quantize_chunks_to_fp8_staging(running_sum_ref,
                                                mb,
                                                step_idx=0)
-            ops = dma.start_phase2_c2c_copies_fp8(mb, step_idx=0)
-            all_phase2_ops.extend([item[0] for item in ops])
-            all_phase2_ops.extend([i[1] for i in ops if i[1] is not None])
-        else:
-            ops = dma.start_phase2_c2c_copies(src=running_sum_ref,
-                                              dst=p2_buf,
-                                              mb_idx=mb,
-                                              step_idx=0)
-            all_phase2_ops.extend([item[0] for item in ops])
+        ops = dma.start_phase2_c2c_copies(mb_idx=mb,
+                                          step_idx=0,
+                                          src=running_sum_ref,
+                                          dst=p2_buf,
+                                          fp8=fp8_comm)
+        _collect_phase2_ops(ops)
 
     for m in range(config.num_micro_batches):
 
@@ -283,15 +288,12 @@ def hier_rs_kernel(
     # timing when other micro-batches gave the write time to land.
     if fp8_comm:
         dma.quantize_chunks_to_fp8_staging(running_sum_ref, 0, step_idx=1)
-        mb_ops = dma.start_phase2_c2c_copies_fp8(0, step_idx=1)
-        all_phase2_ops.extend([item[0] for item in mb_ops])
-        all_phase2_ops.extend([i[1] for i in mb_ops if i[1] is not None])
-    else:
-        mb_ops = dma.start_phase2_c2c_copies(src=running_sum_ref,
-                                             dst=p2_buf,
-                                             mb_idx=0,
-                                             step_idx=1)
-        all_phase2_ops.extend([item[0] for item in mb_ops])
+    mb_ops = dma.start_phase2_c2c_copies(mb_idx=0,
+                                         step_idx=1,
+                                         src=running_sum_ref,
+                                         dst=p2_buf,
+                                         fp8=fp8_comm)
+    _collect_phase2_ops(mb_ops)
 
     # ================= STEP 1 LOOP =================
     for m in range(config.num_micro_batches):
@@ -301,18 +303,12 @@ def hier_rs_kernel(
                 dma.quantize_chunks_to_fp8_staging(running_sum_ref,
                                                    m + 1,
                                                    step_idx=1)
-                mb_ops = dma.start_phase2_c2c_copies_fp8(m + 1,
-                                                         step_idx=1)
-                all_phase2_ops.extend([item[0] for item in mb_ops])
-                all_phase2_ops.extend(
-                    [i[1] for i in mb_ops if i[1] is not None])
-            else:
-                mb_ops = dma.start_phase2_c2c_copies(
-                    src=running_sum_ref,
-                    dst=p2_buf,
-                    mb_idx=m + 1,
-                    step_idx=1)
-                all_phase2_ops.extend([item[0] for item in mb_ops])
+            mb_ops = dma.start_phase2_c2c_copies(mb_idx=m + 1,
+                                                 step_idx=1,
+                                                 src=running_sum_ref,
+                                                 dst=p2_buf,
+                                                 fp8=fp8_comm)
+            _collect_phase2_ops(mb_ops)
 
         # Accumulate Step 1
         if config.num_hcube_dims > 1:

--- a/tpu_inference/kernels/collectives/hierrs_tc/kernel.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/kernel.py
@@ -170,8 +170,10 @@ def hier_rs_kernel(
         src1=recv_buf_ref,
         src2=input_ref,
         dst=running_sum_ref,
-        in_index_fn=locator.make_phase1_index_fn(mb_idx=0),
-        out_index_fn=locator.make_phase1_index_fn(mb_idx=0),
+        # recv_buf and running_sum are packed; the input operand is full-size.
+        in1_index_fn=locator.make_phase1_packed_index_fn(mb_idx=0),
+        in2_index_fn=locator.make_phase1_index_fn(mb_idx=0),
+        out_index_fn=locator.make_phase1_packed_index_fn(mb_idx=0),
         hbm_index_fn=locator.make_phase1_in_index_fn_with_recv_sem(
             mb_idx=0),
         block_size=config.mb_size,
@@ -217,8 +219,9 @@ def hier_rs_kernel(
                 src1=recv_buf_ref,
                 src2=input_ref,
                 dst=running_sum_ref,
-                in_index_fn=locator.make_phase1_index_fn(m + 1),
-                out_index_fn=locator.make_phase1_index_fn(m + 1),
+                in1_index_fn=locator.make_phase1_packed_index_fn(m + 1),
+                in2_index_fn=locator.make_phase1_index_fn(m + 1),
+                out_index_fn=locator.make_phase1_packed_index_fn(m + 1),
                 hbm_index_fn=locator.
                 make_phase1_in_index_fn_with_recv_sem(m + 1),
                 block_size=config.mb_size,

--- a/tpu_inference/kernels/collectives/hierrs_tc/topology.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/topology.py
@@ -1,0 +1,208 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Topology abstraction and layout chunk computations, abstracted from the pipeline."""
+
+import jax
+from jax.experimental import pallas as pl
+
+from tpu_inference.kernels.collectives.hierrs_tc.config import Config
+
+
+class Topology:
+    """Abstracts device indexing logic to find neighbors/partners."""
+
+    def __init__(self, axis_name: str):
+        self.cur_id = jax.lax.axis_index(axis_name)
+        self.cur_chip_id = self.cur_id // 2
+        self.cur_chiplet_bit = self.cur_id % 2
+        self.partner_id = jax.lax.select(self.cur_chiplet_bit == 0,
+                                         self.cur_id + 1, self.cur_id - 1)
+
+    def get_device_id(self, chip_id, chiplet_bit):
+        """Returns the global device ID from physical chip `chip_id` and chiplet coordinate `chiplet_bit` (0 or 1)."""
+        return chip_id * 2 + chiplet_bit
+
+    def get_neighbor_chip_id(self, dim):
+        """Returns the physical chip ID of the logical neighbor in hypercube dimension `dim`.
+
+    For example, on a 2D hypercube of 4 physical chips (IDs: 0, 1, 2, 3):
+    - If current chip is 0 (binary 00):
+      - Neighbor along dimension 0 is: 0 ^ (1 << 0) = 1 (binary 01).
+      - Neighbor along dimension 1 is: 0 ^ (1 << 1) = 2 (binary 10).
+    """
+        return self.cur_chip_id ^ (1 << dim)
+
+    def get_neighbor_device_id(self, dim):
+        """Returns the ID of the neighbor device along hypercube dimension `dim` sharing the same chiplet position.
+
+    For example, on a 2D hypercube of 4 chips (IDs 0-3) containing 8 logical
+    devices (IDs 0-7):
+    - If current device is 0 (physical chip 0, chiplet bit 0):
+      - Neighbor along dimension 0 is: get_device_id(neighbor_chip=1, chiplet=0)
+      = 2.
+      - Neighbor along dimension 1 is: get_device_id(neighbor_chip=2, chiplet=0)
+      = 4.
+    """
+        return self.get_device_id(self.get_neighbor_chip_id(dim),
+                                  self.cur_chiplet_bit)
+
+
+class ChunkLocator:
+    """Encapsulates sequence and HBM indexing math for TensorCore Reduce-Scatter."""
+
+    def __init__(self, config: Config, topo: Topology):
+        self.config = config
+        self.topo = topo
+        self.mb_stride = config.num_hcube_dims * config.hc_chunk_size
+
+    def get_slice(self, chunk_idx, start, size):
+        """Returns a 2D HBM slice for a given chunk index and hidden dimension range."""
+        return (
+            pl.ds(chunk_idx * self.config.seq_chunk_size,
+                  self.config.seq_chunk_size),
+            pl.ds(start, size),
+        )
+
+    def get_phase1_slice(self, chunk_idx, mb_idx):
+        """Returns the 2D HBM slice for Phase 1 (D2D) at `chunk_idx`, `mb_idx`."""
+        return self.get_slice(chunk_idx, mb_idx * self.config.mb_size,
+                              self.config.mb_size)
+
+    def get_phase2_slice(self, chunk_idx, mb_idx, hcube_dim_idx):
+        """Returns the 2D HBM slice for Phase 2 (C2C) at `chunk_idx`, `mb_idx`, `hcube_dim_idx`."""
+        return self.get_slice(
+            chunk_idx,
+            mb_idx * self.mb_stride +
+            hcube_dim_idx * self.config.hc_chunk_size,
+            self.config.hc_chunk_size,
+        )
+
+    def get_phase1_chunk_idx(self, device_id, chip_idx):
+        """Calculates the chunk index processed by `device_id` for `chip_idx`.
+
+    In Phase 1, global token chunks are sharded across the topology. A device
+    processes token chunks corresponding to all physical chips `chip_idx` in
+    the mesh, filtered by its own chiplet position (even/odd device ID).
+    """
+        chiplet_bit = device_id % 2
+        return chip_idx * 2 + chiplet_bit
+
+    def get_phase1_chunk_idxes(self, device_id):
+        """Returns all global chunk indices processed by the chiplet group of device `device_id`."""
+        chiplet_bit = device_id % 2
+        return [
+            chip_idx * 2 + chiplet_bit
+            for chip_idx in range(self.config.num_chips)
+        ]
+
+    def get_phase2_chunk_idx(self, device_id, step_idx, chunk_group_idx,
+                             hcube_dim_idx):
+        """Calculates the chunk index owned by `device_id` for chunk group `chunk_group_idx` during Phase 2 (C2C RS).
+
+    During Phase 2, devices perform a hypercube reduction. At step `step_idx` of
+    the hypercube reduction, the topology is partitioned into independent
+    parallel sub-cubes/groups of devices exchanging along hypercube dimension
+    `hcube_dim_idx`.
+    """
+        dim = (hcube_dim_idx + step_idx) % self.config.num_hcube_dims
+        chip_id = device_id // 2
+        my_dim_bit = (chip_id >> dim) & 1
+
+        prev_dims = [(hcube_dim_idx + j) % self.config.num_hcube_dims
+                     for j in range(step_idx)]
+        future_dims = [(hcube_dim_idx + j) % self.config.num_hcube_dims
+                       for j in range(step_idx + 1, self.config.num_hcube_dims)
+                       ]
+
+        my_base_chunk_idx = self.get_hcube_chunk_idx(device_id,
+                                                     chunk_group_idx,
+                                                     future_dims, prev_dims,
+                                                     dim, my_dim_bit)
+        chiplet_bit = device_id % 2
+        return my_base_chunk_idx * 2 + chiplet_bit
+
+    def get_hcube_chunk_idx(
+        self,
+        device_id,
+        chunk_group_idx,
+        future_dims,
+        prev_dims,
+        target_dim,
+        dim_val,
+    ):
+        """Calculates the mapped HBM chunk index for the hypercube communication ring of device `device_id` at iteration `chunk_group_idx` along active dimension `target_dim` with bit value `dim_val`, given the processed dimensions `prev_dims` and unprocessed dimensions `future_dims`."""
+        chip_id = device_id // 2
+        base = 0
+        for d in prev_dims:
+            bit = (chip_id >> d) & 1
+            base |= bit << d
+        for bit_pos, d in enumerate(future_dims):
+            bit = (chunk_group_idx >> bit_pos) & 1
+            base |= bit << d
+        base |= dim_val << target_dim
+        return base
+
+    def make_phase1_index_fn(self, mb_idx):
+        """Grid index fn for the Phase 1 emit_pipeline (chip_idx -> ref index)."""
+
+        def phase1_index_fn(chip_idx):
+            c_me = self.get_phase1_chunk_idx(self.topo.cur_id, chip_idx)
+            return (c_me, mb_idx)
+
+        return phase1_index_fn
+
+    def make_phase1_in_index_fn_with_recv_sem(self, mb_idx):
+        """Phase 1 input index fn that also reports the slice width for the recv semaphore."""
+
+        def phase1_in_index_fn_with_recv_sem(grid_indices, ref):
+            (chip_idx, ) = grid_indices
+            c_me = self.get_phase1_chunk_idx(self.topo.cur_id, chip_idx)
+            return self.get_phase1_slice(c_me, mb_idx), self.config.mb_size
+
+        return phase1_in_index_fn_with_recv_sem
+
+    def make_phase2_in_index_fn_with_recv_sem(self, step_idx, mb_idx):
+        """Phase 2 input index fn that also reports the slice width for the recv semaphore."""
+
+        def phase2_in_index_fn_with_recv_sem(grid_indices, ref):
+            chunk_group_idx, hcube_dim_idx = grid_indices
+            my_chunk_idx = self.get_phase2_chunk_idx(self.topo.cur_id,
+                                                     step_idx, chunk_group_idx,
+                                                     hcube_dim_idx)
+            chunk_slice = self.get_phase2_slice(my_chunk_idx, mb_idx,
+                                                hcube_dim_idx)
+            return chunk_slice, self.config.hc_chunk_size
+
+        return phase2_in_index_fn_with_recv_sem
+
+    def make_phase2_index_fn(self, step_idx, mb_idx):
+        """Grid index fn for the Phase 2 emit_pipeline."""
+
+        def phase2_index_fn(chunk_group_idx, hcube_dim_idx):
+            my_chunk_idx = self.get_phase2_chunk_idx(self.topo.cur_id,
+                                                     step_idx, chunk_group_idx,
+                                                     hcube_dim_idx)
+            mb_start_idx = mb_idx * self.config.num_hcube_dims + hcube_dim_idx
+            return (my_chunk_idx, mb_start_idx)
+
+        return phase2_index_fn
+
+    def make_phase2_out_index_fn(self, step_idx, mb_idx):
+        """Grid index fn for the Phase 2 output ref on the final step."""
+
+        def phase2_out_index_fn(chunk_group_idx, hcube_dim_idx):
+            mb_start_idx = mb_idx * self.config.num_hcube_dims + hcube_dim_idx
+            return (0, mb_start_idx)
+
+        return phase2_out_index_fn

--- a/tpu_inference/kernels/collectives/hierrs_tc/topology.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/topology.py
@@ -74,19 +74,29 @@ class ChunkLocator:
             pl.ds(start, size),
         )
 
-    def get_phase1_slice(self, chunk_idx, mb_idx):
-        """Returns the 2D HBM slice for Phase 1 (D2D) at `chunk_idx`, `mb_idx`."""
-        return self.get_slice(chunk_idx, mb_idx * self.config.mb_size,
-                              self.config.mb_size)
+    def pack(self, chunk_idx):
+        """Global chunk index -> row-chunk index in a PACKED working buffer.
 
-    def get_phase2_slice(self, chunk_idx, mb_idx, hcube_dim_idx):
-        """Returns the 2D HBM slice for Phase 2 (C2C) at `chunk_idx`, `mb_idx`, `hcube_dim_idx`."""
-        return self.get_slice(
-            chunk_idx,
-            mb_idx * self.mb_stride +
-            hcube_dim_idx * self.config.hc_chunk_size,
-            self.config.hc_chunk_size,
-        )
+    Every chunk index that ever touches a working buffer (recv_buf,
+    running_sum, the bf16 phase-2 landing buffer, fp8_send, fp8_recv) is of
+    the form `k * 2 + chiplet_bit`: phase 1 lands at this device's parity
+    (`get_phase1_chunk_idx`), and phase 2 both reads and receives at it too,
+    because hypercube neighbours share the chiplet position
+    (`get_neighbor_device_id`). The odd/even half of a full-size buffer is
+    therefore dead rows. Packed buffers drop that half -- allocated at
+    (local_seq_len // 2, hidden) -- and this remap, `chunk_idx // 2`, is exact
+    for both parities and agrees between DMA sender and receiver because both
+    compute the same chunk index and share parity.
+
+    The INPUT operand is the one buffer this must never be applied to: its
+    other-parity rows are real data, read by the phase-1 send that pushes
+    them to the partner chiplet.
+    """
+        return chunk_idx // 2
+
+    def get_packed_slice(self, chunk_idx, start, size):
+        """`get_slice` into a PACKED working buffer (see `pack`)."""
+        return self.get_slice(self.pack(chunk_idx), start, size)
 
     def get_phase1_chunk_idx(self, device_id, chip_idx):
         """Calculates the chunk index processed by `device_id` for `chip_idx`.
@@ -154,7 +164,11 @@ class ChunkLocator:
         return base
 
     def make_phase1_index_fn(self, mb_idx):
-        """Grid index fn for the Phase 1 emit_pipeline (chip_idx -> ref index)."""
+        """Grid index fn for the Phase 1 emit_pipeline (chip_idx -> ref index).
+
+    FULL-buffer indexing -- valid only for the input operand. The working
+    buffers are packed; use `make_phase1_packed_index_fn` for those.
+    """
 
         def phase1_index_fn(chip_idx):
             c_me = self.get_phase1_chunk_idx(self.topo.cur_id, chip_idx)
@@ -162,13 +176,26 @@ class ChunkLocator:
 
         return phase1_index_fn
 
+    def make_phase1_packed_index_fn(self, mb_idx):
+        """Phase-1 grid index fn into PACKED working buffers.
+
+    pack(chip_idx * 2 + chiplet_bit) == chip_idx, so the packed row-chunk
+    index is the grid index itself.
+    """
+
+        def phase1_packed_index_fn(chip_idx):
+            return (chip_idx, mb_idx)
+
+        return phase1_packed_index_fn
+
     def make_phase1_in_index_fn_with_recv_sem(self, mb_idx):
         """Phase 1 input index fn that also reports the slice width for the recv semaphore."""
 
         def phase1_in_index_fn_with_recv_sem(grid_indices, ref):
             (chip_idx, ) = grid_indices
-            c_me = self.get_phase1_chunk_idx(self.topo.cur_id, chip_idx)
-            return self.get_phase1_slice(c_me, mb_idx), self.config.mb_size
+            # recv_buf is packed: pack(c_me) == chip_idx.
+            return (self.get_slice(chip_idx, mb_idx * self.config.mb_size,
+                                   self.config.mb_size), self.config.mb_size)
 
         return phase1_in_index_fn_with_recv_sem
 
@@ -180,8 +207,12 @@ class ChunkLocator:
             my_chunk_idx = self.get_phase2_chunk_idx(self.topo.cur_id,
                                                      step_idx, chunk_group_idx,
                                                      hcube_dim_idx)
-            chunk_slice = self.get_phase2_slice(my_chunk_idx, mb_idx,
-                                                hcube_dim_idx)
+            # The landing buffer is packed.
+            chunk_slice = self.get_packed_slice(
+                my_chunk_idx,
+                mb_idx * self.mb_stride +
+                hcube_dim_idx * self.config.hc_chunk_size,
+                self.config.hc_chunk_size)
             return chunk_slice, self.config.hc_chunk_size
 
         return phase2_in_index_fn_with_recv_sem
@@ -190,11 +221,13 @@ class ChunkLocator:
         """Grid index fn for the Phase 2 emit_pipeline."""
 
         def phase2_index_fn(chunk_group_idx, hcube_dim_idx):
+            # All phase-2 refs (fp8_recv, running_sum, the bf16 landing
+            # buffer) are packed working buffers.
             my_chunk_idx = self.get_phase2_chunk_idx(self.topo.cur_id,
                                                      step_idx, chunk_group_idx,
                                                      hcube_dim_idx)
             mb_start_idx = mb_idx * self.config.num_hcube_dims + hcube_dim_idx
-            return (my_chunk_idx, mb_start_idx)
+            return (self.pack(my_chunk_idx), mb_start_idx)
 
         return phase2_index_fn
 

--- a/tpu_inference/kernels/collectives/hierrs_tc/wrapper.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/wrapper.py
@@ -1,0 +1,339 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Top-level dispatcher for TensorCore Reduce-Scatter.
+
+Phase 1 is intra-chip D2D (always BF16). Phase 2 is the inter-chip hypercube
+(recursive doubling) over ICI, optionally FP8 on the wire at a fixed static
+scale. Accumulation stays BF16 throughout; only the phase 2 transfer is FP8.
+"""
+
+import functools
+import math
+import os
+
+import jax
+import jax.numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental import shard_map
+from jax.experimental.pallas import tpu as pltpu
+
+from tpu_inference.kernels.collectives.hierrs_tc.config import (
+    FP8_COMM_MIN_ROWS, SCALE_LANE, Config, next_multiple_of,
+    pick_num_micro_batches)
+from tpu_inference.kernels.collectives.hierrs_tc.kernel import (
+    hier_rs_kernel, make_unified_scratch_shapes)
+
+# RS_VMEM_PIN=0 disables VMEM operand pinning entirely and restores the old
+# behaviour (pl.ANY operands, 0.95 scoped claim). RS_VMEM_FRAC / RS_VMEM_INPUT
+# force a specific plan and exist for sweeps; unset, the plan is chosen by
+# _pick_vmem_plan below.
+_RS_VMEM_PIN = os.environ.get("RS_VMEM_PIN", "1") != "0"
+# EXP-021 probe: also request VMEM for the PRIMARY output (out_shape,
+# seq_chunk x hidden -- 2 MiB at 2048 rows). The other outputs stay pl.ANY:
+# running_sum / recv_buf / the fp8 payloads are ~16 MiB each and exist as
+# outputs only because Pallas cannot allocate HBM scratch, so they cannot move.
+_RS_VMEM_OUT = os.environ.get("RS_VMEM_OUT", "0") == "1"
+_RS_VMEM_INPUT_OVERRIDE = os.environ.get("RS_VMEM_INPUT")
+_RS_VMEM_FRAC_OVERRIDE = os.environ.get("RS_VMEM_FRAC")
+
+# Default scoped claim when we are NOT pinning. Deliberately generous: it is a
+# ceiling, not a reservation (EXP-016 measured 60.80 MiB claimed vs 8.00 MiB
+# used), and shrinking it buys nothing unless we are also pinning.
+_VMEM_FRAC_UNPINNED = 0.95
+# Headroom multiplier on the measured scoped requirement, so a shape whose
+# footprint is slightly off the operand/2 rule still compiles.
+_VMEM_SCOPED_SLACK = 1.30
+# Leave a little of VMEM unclaimed so MSA has somewhere to put small buffers
+# besides our operand.
+_VMEM_TOTAL_SAFETY = 0.92
+
+
+def _pick_vmem_plan(local_seq_len, hidden_dim_size, itemsize,
+                    num_micro_batches):
+    """Decide whether to pin the operand into VMEM, and how much to claim.
+
+  Two facts drive this, both measured in EXP-017:
+
+  1. `pl.ANY` resolves to input color 0 (HBM), so the 16 MiB operand
+     round-trips through HBM. `with_memory_space_constraint` is the ONLY way to
+     get color 1 -- a `BlockSpec(memory_space=VMEM)` leaves the color at 0 and
+     merely stages the operand into scoped VMEM, which is strictly worse.
+  2. The color is useless on its own. XLA reserves a colored operand out of
+     "alternate memory", which is whatever VMEM our scoped claim leaves behind.
+     At the old 0.95 claim that is ~3.2 MiB, and a 16 MiB operand fails to
+     compile outright ("Too many buffers are colored in the alternate memory").
+
+  So pinning needs the operand AND the kernel's own scratch to fit in VMEM
+  together. Measured scratch is almost exactly half the operand (512 rows ->
+  2 MiB of 4, 2048 -> 8 of 16, 4096 -> 16 of 32), so the requirement is ~1.5x
+  the operand. At 8192 rows the operand alone is 64 MiB -- the entire VMEM --
+  and no claim can make it fit, which is why this must be conditional rather
+  than a global constant. Getting that wrong does not merely lose the speedup:
+  an over-small claim raises CompileTimeScopedVmemOom and the server never
+  boots.
+
+  Returns (pin, frac).
+  """
+    capacity = pltpu.get_tpu_info().vmem_capacity_bytes
+    operand = local_seq_len * hidden_dim_size * itemsize
+    # Scratch scales as operand / num_micro_batches: the BufferedRef block is
+    # (seq_chunk_size, hidden/mb), so halving mb doubles every staging buffer.
+    # Verified exactly against measured `used_scoped_memory_configs`:
+    #   512/mb2 -> 2.00 MiB, 2048/mb2 -> 8.00, 4096/mb2 -> 16.00,
+    #   8192/mb2 -> 32.00, and 512/mb1 -> 4.00 MiB.
+    # An earlier version of this used a flat operand/2 -- correct at mb=2 and
+    # 2x too small at mb=1, which crashed a real server at startup with
+    # "Scoped allocation with size 4.00M and limit 3.20M". mb MUST be an input.
+    scoped_need = int(operand / max(1, num_micro_batches) * _VMEM_SCOPED_SLACK)
+
+    if not _RS_VMEM_PIN or operand + scoped_need > capacity * _VMEM_TOTAL_SAFETY:
+        return False, _VMEM_FRAC_UNPINNED
+
+    # Claim enough for our scratch, but never so much that MSA cannot reserve
+    # the operand out of what is left.
+    lo = scoped_need / capacity
+    hi = (capacity - operand) / capacity
+    if lo > hi:
+        return False, _VMEM_FRAC_UNPINNED
+    return True, min(max(lo, 0.05), hi)
+
+
+def hierarchical_reduce_scatter_local(
+    local_x: jax.Array,
+    num_devices: int,
+    num_micro_batches: int | None = None,
+    axis_name: str | tuple[str, ...] = "x",
+    fp8_comm: bool = False,
+    fp8_static_scale: float | None = None,
+    fp8_min_rows: int | None = None,
+) -> jax.Array:
+    # Shape-specialized wire: local_x.shape is a static Python value at trace
+    # time, so each token bucket compiles its own wire format -- plain BF16
+    # kernel for small buckets (zero FP8 overhead), FP8 wire for large ones.
+    # Zero runtime cost; callers and flags are unchanged.
+    #
+    # fp8_static_scale: None -> per-chunk dynamic FP8 scale; a positive float ->
+    #   fixed static scale (skips the send-side max-abs reduction).
+    # fp8_min_rows overrides the env-derived FP8_COMM_MIN_ROWS gate per call.
+    #   FP8_COMM_MIN_ROWS is read from os.environ ONCE at import, so a process
+    #   that imports this module before setting the env freezes the default for
+    #   everyone. A caller that must force the FP8 wire regardless of size (e.g.
+    #   a quality/perf harness comparing fp8 vs bf16 at every tested shape, or a
+    #   unit test) should pass fp8_min_rows=0 rather than rely on the env var.
+    min_rows = FP8_COMM_MIN_ROWS if fp8_min_rows is None else fp8_min_rows
+    if fp8_comm and local_x.shape[0] < min_rows:
+        fp8_comm = False
+    num_chips = num_devices // 2
+    num_hcube_dims = int(math.log2(num_chips))
+    local_seq_len, hidden_dim_size = local_x.shape
+
+    seq_chunk_size_orig = local_seq_len // num_devices
+    # Row-dim (seq) DMA slices and BlockSpec row sizes must be aligned to the TPU
+    # sublane tile. On newer chips (tpu7x) that tile is 16 sublanes for bf16 and
+    # 32 for fp8 (vs 8 on v6e), and seq_chunk_size = local_seq_len // num_devices
+    # is used directly as a block/slice size. Pad each per-device chunk up to a
+    # multiple of 32 (covers fp8's worst case; also satisfies bf16/f32) so the
+    # kernel compiles and stays correct for any seq length, including small
+    # decode batches.
+    _SEQ_TILE = 32
+    seq_chunk_size_padded = next_multiple_of(max(seq_chunk_size_orig, 1),
+                                             _SEQ_TILE)
+    needs_padding = seq_chunk_size_padded != seq_chunk_size_orig
+
+    if needs_padding:
+        # Pad each device's seq chunk up to the tile multiple; trimmed after.
+        reshaped_x = local_x.reshape(num_devices, -1, hidden_dim_size)
+        padded_x = jnp.pad(
+            reshaped_x,
+            ((0, 0), (0, seq_chunk_size_padded - seq_chunk_size_orig), (0, 0)),
+        )
+        local_x = padded_x.reshape(-1, hidden_dim_size)
+        local_seq_len = local_x.shape[0]
+
+    if num_micro_batches is None:
+        # Chosen from bytes per micro-batch, with a different target per wire.
+        # Note `fp8_comm` is the RESOLVED wire: the FP8_COMM_MIN_ROWS downgrade
+        # above may already have turned it off, and a downgraded call must use
+        # the bf16 target (4x smaller stages) or it runs badly mis-tuned. This
+        # is exactly why the choice lives here and not at the call site.
+        num_micro_batches = pick_num_micro_batches(local_seq_len,
+                                                   hidden_dim_size,
+                                                   local_x.dtype.itemsize,
+                                                   fp8_comm)
+
+    vmem_pin, vmem_frac = _pick_vmem_plan(local_seq_len, hidden_dim_size,
+                                          local_x.dtype.itemsize,
+                                          num_micro_batches)
+    if _RS_VMEM_INPUT_OVERRIDE is not None:
+        vmem_pin = int(_RS_VMEM_INPUT_OVERRIDE) == 2
+    if _RS_VMEM_FRAC_OVERRIDE is not None:
+        vmem_frac = float(_RS_VMEM_FRAC_OVERRIDE)
+
+    vector_width = pltpu.get_tpu_info().num_lanes
+    mb_size = next_multiple_of(hidden_dim_size // num_micro_batches,
+                               vector_width)
+    assert (num_micro_batches - 1) * mb_size < hidden_dim_size, (
+        f"Unsupported micro-batches config: num_micro_batches={num_micro_batches}"
+        f" is too large for hidden_dim_size={hidden_dim_size} with"
+        f" mb_size={mb_size} (due to padding).")
+    hc_chunk_size = next_multiple_of(mb_size // max(1, num_hcube_dims),
+                                     vector_width)
+    seq_chunk_size = local_seq_len // num_devices
+
+    num_scale_slots = max(
+        1,
+        num_hcube_dims * num_micro_batches * num_hcube_dims *
+        (1 << max(0, num_hcube_dims - 1)),
+    )
+
+    out_shape = jax.ShapeDtypeStruct((seq_chunk_size, hidden_dim_size),
+                                     local_x.dtype)
+    running_sum_shape = jax.ShapeDtypeStruct((local_seq_len, hidden_dim_size),
+                                             local_x.dtype)
+    recv_buf_shape = jax.ShapeDtypeStruct((local_seq_len, hidden_dim_size),
+                                          local_x.dtype)
+
+    out_shapes = [out_shape, running_sum_shape, recv_buf_shape]
+    _out0_space = pltpu.VMEM if (_RS_VMEM_OUT and vmem_pin) else pl.ANY
+    out_specs = [pl.BlockSpec(memory_space=_out0_space)
+                 ] + [pl.BlockSpec(memory_space=pl.ANY)] * 2
+
+    # Separate phase-2 landing buffer for the bf16 wire. Without it an incoming
+    # phase-2 chunk can overwrite phase-1 bytes the receiver has not drained
+    # yet -- a cross-device WAR that gave wrong answers in 157/200 runs at
+    # 512 rows / mb=4. Not optional.
+    # The fp8 wire already lands phase 2 in fp8_recv_buf, so it needs nothing.
+    if not fp8_comm:
+        out_shapes.append(
+            jax.ShapeDtypeStruct((local_seq_len, hidden_dim_size),
+                                 local_x.dtype))
+        out_specs.append(pl.BlockSpec(memory_space=pl.ANY))
+
+    if fp8_comm:
+        fp8_shape = jax.ShapeDtypeStruct((local_seq_len, hidden_dim_size),
+                                         jnp.float8_e4m3fn)
+        SCALE_LANE = 128
+        scale_shape = jax.ShapeDtypeStruct(
+            (num_devices, num_scale_slots * SCALE_LANE), jnp.float32)
+        out_shapes += [fp8_shape, fp8_shape, scale_shape, scale_shape]
+        out_specs += [pl.BlockSpec(memory_space=pl.ANY)] * 4
+
+    config = Config(
+        num_devices=num_devices,
+        hidden_dim_size=hidden_dim_size,
+        local_seq_len=local_seq_len,
+        dtype=local_x.dtype,
+        fp8_comm=fp8_comm,
+        fp8_static_scale=fp8_static_scale,
+        _num_micro_batches=num_micro_batches,
+    )
+
+    grid_spec = pltpu.PrefetchScalarGridSpec(
+        num_scalar_prefetch=0,
+        # pl.ANY here on purpose. A BlockSpec of pltpu.VMEM does NOT change the
+        # operand color (EXP-017 arm 1: color stayed 0 and scoped usage jumped
+        # 8 -> 24 MiB as the operand was staged into scratch). The color is set
+        # by with_memory_space_constraint at the call site below instead.
+        in_specs=[pl.BlockSpec(memory_space=pl.ANY)],
+        out_specs=tuple(out_specs),
+        scratch_shapes=tuple(
+            make_unified_scratch_shapes(
+                seq_chunk_size,
+                mb_size,
+                local_x.dtype,
+                num_chips,
+                num_hcube_dims,
+                num_micro_batches,
+                fp8_comm=fp8_comm,
+            )),
+        grid=(1, ),
+    )
+
+    hier_rs = pl.pallas_call(
+        jax.tree_util.Partial(
+            hier_rs_kernel,
+            config=config,
+            axis_name=axis_name,
+            fp8_comm=fp8_comm,
+            fp8_static_scale=fp8_static_scale,
+        ),
+        out_shape=tuple(out_shapes),
+        grid_spec=grid_spec,
+        name=
+        f"hier_rs_kernel.mb{num_micro_batches}{'_fp8' if fp8_comm else ''}",
+        compiler_params=pltpu.CompilerParams(
+            # This becomes scoped_memory_configs {"memory_space":1, "size":...} on
+            # the custom-call, i.e. "reserve this much VMEM for me".
+            #
+            # 0.95 claims ~60.8 of 64 MiB and leaves XLA's memory-space
+            # assignment ~3 MiB to work with -- which may be exactly why it never
+            # promotes our 16 MiB operand to S(1) while it promotes the identical
+            # buffer for its own reduce-scatter. `pl.ANY` does not pin us to HBM;
+            # over-claiming scoped VMEM may leave MSA nowhere to put us.
+            #
+            # Actual need is ~8 MiB of BufferedRefs and semaphores, or ~24 MiB
+            # with RS_VMEM_LANDING, so 0.95 over-claims by 3-7x.
+            #
+            # Default unchanged at 0.95 until this is measured.
+            vmem_limit_bytes=int(pltpu.get_tpu_info().vmem_capacity_bytes *
+                                 vmem_frac),
+            disable_bounds_checks=True,
+        ),
+    )
+    # NOTE: no pltpu.with_memory_space_constraint here. It does not survive
+    # shard_map tracing -- the vmem-annotated aval reaches broadcast_in_dim,
+    # which rejects it ("unknown memory_space type"), and that failed all 24
+    # kernel tests. The in_specs BlockSpec above is sufficient on its own:
+    # results/probe_vmem_which_knob.py shows the producer is annotated S(1) with
+    # the BlockSpec alone and the constraint call adds nothing.
+    if vmem_pin:
+        # EXP-017 arm 2. Only `with_memory_space_constraint` sets the memory
+        # space on the INPUT AVAL, which is what _resolve_memory_spaces reads
+        # (jax/_src/pallas/mosaic/pallas_call_registration.py). The BlockSpec
+        # alone does not (arm 1 leaves the color at 0 and merely stages the
+        # operand into scoped VMEM). Historically this broke under shard_map --
+        # the vmem aval reached broadcast_in_dim -- so this arm re-tests that
+        # against the current JAX rather than trusting an old note.
+        local_x = pltpu.with_memory_space_constraint(local_x, pltpu.VMEM)
+    out = hier_rs(local_x)[0]
+    if needs_padding:
+        out = out[:seq_chunk_size_orig, :]
+    return out
+
+
+def hierarchical_reduce_scatter(
+    x: jax.Array,
+    *,
+    mesh: jax.sharding.Mesh,
+    in_specs: jax.sharding.PartitionSpec = jax.sharding.PartitionSpec(
+        "x", None),
+    num_micro_batches: int | None = None,
+    fp8_comm: bool = False,
+    fp8_static_scale: float | None = None,
+    fp8_min_rows: int | None = None,
+) -> jax.Array:
+    return shard_map.shard_map(
+        lambda local_x: hierarchical_reduce_scatter_local(
+            local_x,
+            num_devices=mesh.devices.size,
+            num_micro_batches=num_micro_batches,
+            fp8_comm=fp8_comm,
+            fp8_static_scale=fp8_static_scale,
+            fp8_min_rows=fp8_min_rows,
+        ),
+        mesh=mesh,
+        in_specs=in_specs,
+        out_specs=in_specs,
+        check_rep=False,
+    )(x)

--- a/tpu_inference/kernels/collectives/hierrs_tc/wrapper.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/wrapper.py
@@ -19,6 +19,7 @@ scale. Accumulation stays BF16 throughout; only the phase 2 transfer is FP8.
 """
 
 import functools
+import logging
 import math
 import os
 
@@ -33,19 +34,149 @@ from tpu_inference.kernels.collectives.hierrs_tc.config import (
     pick_num_micro_batches)
 from tpu_inference.kernels.collectives.hierrs_tc.kernel import (
     hier_rs_kernel, make_unified_scratch_shapes)
+# stdlib logging on purpose: every other import in this package stays inside
+# hierrs_tc, which is what lets the kernel be imported (and unit-tested)
+# without dragging in the vLLM graph. tpu_inference.logger imports vllm.
+logger = logging.getLogger(__name__)
 
 # RS_VMEM_PIN=0 disables VMEM operand pinning entirely and restores the old
 # behaviour (pl.ANY operands, 0.95 scoped claim). RS_VMEM_FRAC / RS_VMEM_INPUT
 # force a specific plan and exist for sweeps; unset, the plan is chosen by
 # _pick_vmem_plan below.
 _RS_VMEM_PIN = os.environ.get("RS_VMEM_PIN", "1") != "0"
-# EXP-021 probe: also request VMEM for the PRIMARY output (out_shape,
-# seq_chunk x hidden -- 2 MiB at 2048 rows). The other outputs stay pl.ANY:
-# running_sum / recv_buf / the fp8 payloads are ~16 MiB each and exist as
-# outputs only because Pallas cannot allocate HBM scratch, so they cannot move.
+# Also request VMEM for the PRIMARY output (out_shape, seq_chunk x hidden --
+# 2 MiB at local_seq_len 2048). Takes effect only when the operand is pinned
+# too (see `_out0_space` below). The working buffers are handled separately by
+# RS_VMEM_WORK.
 _RS_VMEM_OUT = os.environ.get("RS_VMEM_OUT", "0") == "1"
 _RS_VMEM_INPUT_OVERRIDE = os.environ.get("RS_VMEM_INPUT")
 _RS_VMEM_FRAC_OVERRIDE = os.environ.get("RS_VMEM_FRAC")
+
+# RS_VMEM_WORK: place the kernel's WORKING buffers (running_sum, recv_buf and
+# the wire's staging buffers) in VMEM scratch instead of HBM.
+#
+# Those buffers are pure scratch -- nothing downstream reads them. They are
+# declared as `pl.ANY` OUTPUTS only because Pallas cannot allocate HBM scratch,
+# so output-ness is the mechanism that forces them into HBM. Declaring them as
+# real VMEM scratch instead removes the HBM round trip that made the kernel's
+# reduce-scatter input and output spill where XLA's psum_scatter keeps both in
+# alternate memory.
+#
+# Note this is NOT the same as `BlockSpec(memory_space=VMEM)` on an output,
+# which was measured to colour nothing and merely add a copy-out.
+#
+# DEFAULT ON, but it is SHAPE-GATED and does not engage everywhere. The working
+# set is O(local_seq_len * hidden_dim) and VMEM is 64 MiB total, so
+# _plan_work_scratch falls back to the pl.ANY/HBM form once it stops fitting.
+#
+# The working set is `local_seq_len * hidden_dim * 6 bytes` on BOTH wires:
+# running_sum and recv_buf are bf16 (2 B/elem each) either way, and the fp8
+# wire replaces the bf16 phase-2 landing buffer with two 1-byte staging
+# buffers. FP8 halves what crosses the wire; it does not shrink this.
+#
+# Measured at hidden 4096 on 8 devices, against 0.92 * 64 = 58.9 MiB usable:
+#
+#   local_seq_len | operand | working set | scoped | total | VMEM scratch?
+#            128  |   1.0   |     3.1     |   1.3  |   5.4 | yes
+#            256  |   2.0   |     6.1     |   2.6  |  10.7 | yes
+#            512  |   4.0   |    12.1     |   5.2  |  21.3 | yes
+#           1024  |   8.0   |    24.1     |  10.4  |  42.5 | yes
+#           2048  |  16.0   |    48.1     |  10.4  |  74.5 | NO -- over 58.9
+#
+# Only 2048 is excluded, and it is excluded by arithmetic rather than by a
+# tuning constant. There the operand and primary output are still VMEM-pinned
+# by _pick_vmem_plan / _RS_VMEM_OUT; it is only the working set that stays in
+# HBM. `RS_VMEM_WORK=1 ignored` is logged whenever that happens, once per
+# shape, so the fallback is never silent.
+#
+# `local_seq_len` here is the PER-DEVICE, PRE-scatter row count, i.e. the
+# operand's first dim -- 8x the post-scatter row count that appears in the HLO.
+# A decode-heavy server sweeps this whole range in one run rather than running
+# a single shape, so both branches of the table are live in production and the
+# large shapes are NOT covered by this optimisation.
+#
+# RS_VMEM_WORK=0 restores the pl.ANY output form unconditionally.
+_RS_VMEM_WORK = os.environ.get("RS_VMEM_WORK", "1") not in ("0", "")
+# Optional hard ceiling on the scoped claim, as a fraction of total VMEM.
+# UNSET BY DEFAULT: _plan_work_scratch claims exactly what the shape needs and
+# refuses the shape outright when that does not leave room for the operand, so
+# a blanket fraction can only reject shapes that genuinely fit.
+# Set it to re-impose a ceiling if a future module hits
+# "Too many buffers are colored in the alternate memory ... size: 67108864" --
+# that failure is what the ceiling was originally guarding against.
+_RS_VMEM_WORK_FRAC = (float(os.environ["RS_VMEM_WORK_FRAC"])
+                      if "RS_VMEM_WORK_FRAC" in os.environ else None)
+
+
+def _work_set_bytes(local_seq_len, hidden_dim_size, itemsize, fp8_comm,
+                    num_devices, num_scale_slots):
+    """Total bytes of the buffers that move from pl.ANY outputs to VMEM scratch."""
+    big = local_seq_len * hidden_dim_size
+    total = 2 * big * itemsize  # running_sum + recv_buf
+    if fp8_comm:
+        total += 2 * big  # fp8_send + fp8_recv, 1 byte/elem
+        total += 2 * num_devices * num_scale_slots * SCALE_LANE * 4
+    else:
+        total += big * itemsize  # the bf16 wire's phase-2 landing buffer
+    return total
+
+
+@functools.lru_cache(maxsize=None)
+def _warn_work_scratch_off(work_bytes: int, capacity: int) -> None:
+    """Log the RS_VMEM_WORK fallback once per distinct shape.
+
+  lru_cache keyed on the sizes, so a server that sweeps many shapes logs one
+  line per shape rather than one per call.
+  """
+    logger.info(
+        "hierrs_tc: RS_VMEM_WORK=1 ignored at this shape -- the working set "
+        "(%.2f MiB) plus the operand does not fit in %.0f MiB of VMEM. "
+        "Falling back to pl.ANY outputs (HBM).", work_bytes / 2**20,
+        capacity / 2**20)
+
+
+def _plan_work_scratch(local_seq_len, hidden_dim_size, itemsize, fp8_comm,
+                       num_devices, num_scale_slots, num_micro_batches,
+                       vmem_frac):
+    """Can the working set live in VMEM scratch, and at what scoped claim?
+
+  Moving these buffers out of `pl.ANY` outputs and into scratch makes them
+  genuinely VMEM-resident -- unlike a `BlockSpec(memory_space=VMEM)` on the
+  output, which colours nothing and merely adds a copy-out.
+  The cost is that they now come out of the SCOPED claim, so `vmem_frac` has to
+  grow to cover them or the kernel dies at compile time with
+  `CompileTimeScopedVmemOom`.
+
+  The operand still has to be colourable out of what the scoped claim leaves
+  behind, so this returns (False, unchanged_frac) whenever the two do not fit
+  together, which is what happens at the largest shapes.
+
+  Returns (enabled, vmem_frac).
+  """
+    if not _RS_VMEM_WORK:
+        return False, vmem_frac
+    capacity = pltpu.get_tpu_info().vmem_capacity_bytes
+    operand = local_seq_len * hidden_dim_size * itemsize
+    work = _work_set_bytes(local_seq_len, hidden_dim_size, itemsize, fp8_comm,
+                           num_devices, num_scale_slots)
+    # Existing BufferedRef/semaphore scratch, same model as _pick_vmem_plan.
+    scoped = int(operand / max(1, num_micro_batches) * _VMEM_SCOPED_SLACK)
+    need = scoped + work
+    # THE decision: the scoped claim and the operand must both fit, with
+    # _VMEM_TOTAL_SAFETY held back for everything else XLA colours. This is a
+    # property of the shape -- no tuning knob can make a shape fit that does
+    # not, and none should reject one that does.
+    if need + operand > capacity * _VMEM_TOTAL_SAFETY:
+        _warn_work_scratch_off(work, capacity)
+        return False, vmem_frac
+    # Claim exactly what this shape needs, not a fixed fraction. Claiming more
+    # steals alternate memory MSA needs to colour the operand; claiming less
+    # raises CompileTimeScopedVmemOom.
+    frac = need / capacity
+    if _RS_VMEM_WORK_FRAC is not None and frac > _RS_VMEM_WORK_FRAC:
+        _warn_work_scratch_off(work, capacity)
+        return False, vmem_frac
+    return True, frac
 
 
 @functools.lru_cache(maxsize=1)
@@ -97,6 +228,7 @@ def _pin_unsupported_once() -> None:
             "unpinned (correct, and the measured cost is ~0.3% on the fp8 wire "
             "and ~2.2% on bf16). Set RS_VMEM_INPUT=2 to force the old path.",
             flush=True)
+
 
 # Default scoped claim when we are NOT pinning. Deliberately generous: it is a
 # ceiling, not a reservation (EXP-016 measured 60.80 MiB claimed vs 8.00 MiB
@@ -263,10 +395,39 @@ def hierarchical_reduce_scatter_local(
     recv_buf_shape = jax.ShapeDtypeStruct((local_seq_len, hidden_dim_size),
                                           local_x.dtype)
 
-    out_shapes = [out_shape, running_sum_shape, recv_buf_shape]
+    work_scratch_on, vmem_frac = _plan_work_scratch(
+        local_seq_len, hidden_dim_size, local_x.dtype.itemsize, fp8_comm,
+        num_devices, num_scale_slots, num_micro_batches, vmem_frac)
+
+    # The working set -- running_sum, recv_buf, and the wire's staging buffers.
+    # These are pure scratch: nothing downstream reads them. They are declared
+    # as `pl.ANY` OUTPUTS only because Pallas cannot allocate HBM scratch, so
+    # output-ness is what forces them into HBM. Where they fit, RS_VMEM_WORK=1
+    # declares them as real VMEM scratch instead and the HBM buffers disappear.
+    # A `BlockSpec(memory_space=VMEM)` on the OUTPUT is not an alternative: it
+    # colours nothing and merely adds a copy-out.
+    #
+    # ORDER IS LOAD-BEARING. Pallas passes the kernel inputs, then outputs, then
+    # scratch. Emitting this group in the same relative order either as trailing
+    # outputs or as leading scratch leaves hier_rs_kernel's positional unpacking
+    # byte-identical, which is why that file needs no change. Never promote a
+    # subset -- that interleaves the two groups and silently permutes the args.
     _out0_space = pltpu.VMEM if (_RS_VMEM_OUT and vmem_pin) else pl.ANY
-    out_specs = [pl.BlockSpec(memory_space=_out0_space)
-                 ] + [pl.BlockSpec(memory_space=pl.ANY)] * 2
+    out_shapes = [out_shape]
+    out_specs = [pl.BlockSpec(memory_space=_out0_space)]
+    work_scratch = []
+
+    def _emit_work(shape_struct, memref):
+        if work_scratch_on:
+            work_scratch.append(memref)
+        else:
+            out_shapes.append(shape_struct)
+            out_specs.append(pl.BlockSpec(memory_space=pl.ANY))
+
+    _emit_work(running_sum_shape,
+               pltpu.VMEM((local_seq_len, hidden_dim_size), local_x.dtype))
+    _emit_work(recv_buf_shape,
+               pltpu.VMEM((local_seq_len, hidden_dim_size), local_x.dtype))
 
     # Separate phase-2 landing buffer for the bf16 wire. Without it an incoming
     # phase-2 chunk can overwrite phase-1 bytes the receiver has not drained
@@ -274,19 +435,28 @@ def hierarchical_reduce_scatter_local(
     # 512 rows / mb=4. Not optional.
     # The fp8 wire already lands phase 2 in fp8_recv_buf, so it needs nothing.
     if not fp8_comm:
-        out_shapes.append(
+        _emit_work(
             jax.ShapeDtypeStruct((local_seq_len, hidden_dim_size),
-                                 local_x.dtype))
-        out_specs.append(pl.BlockSpec(memory_space=pl.ANY))
+                                 local_x.dtype),
+            pltpu.VMEM((local_seq_len, hidden_dim_size), local_x.dtype))
 
     if fp8_comm:
         fp8_shape = jax.ShapeDtypeStruct((local_seq_len, hidden_dim_size),
                                          jnp.float8_e4m3fn)
-        SCALE_LANE = 128
         scale_shape = jax.ShapeDtypeStruct(
             (num_devices, num_scale_slots * SCALE_LANE), jnp.float32)
-        out_shapes += [fp8_shape, fp8_shape, scale_shape, scale_shape]
-        out_specs += [pl.BlockSpec(memory_space=pl.ANY)] * 4
+        # Order must match hier_rs_kernel's unpacking:
+        # fp8_send_ref, fp8_recv_ref, scale_send_ref, scale_recv_ref.
+        for _ in range(2):
+            _emit_work(
+                fp8_shape,
+                pltpu.VMEM((local_seq_len, hidden_dim_size),
+                           jnp.float8_e4m3fn))
+        for _ in range(2):
+            _emit_work(
+                scale_shape,
+                pltpu.VMEM((num_devices, num_scale_slots * SCALE_LANE),
+                           jnp.float32))
 
     config = Config(
         num_devices=num_devices,
@@ -306,7 +476,9 @@ def hierarchical_reduce_scatter_local(
         # by with_memory_space_constraint at the call site below instead.
         in_specs=[pl.BlockSpec(memory_space=pl.ANY)],
         out_specs=tuple(out_specs),
-        scratch_shapes=tuple(
+        # work_scratch FIRST: it occupies exactly the positions these buffers
+        # held as trailing outputs, so the kernel's unpacking is unchanged.
+        scratch_shapes=tuple(work_scratch) + tuple(
             make_unified_scratch_shapes(
                 seq_chunk_size,
                 mb_size,

--- a/tpu_inference/kernels/collectives/hierrs_tc/wrapper.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/wrapper.py
@@ -47,6 +47,57 @@ _RS_VMEM_OUT = os.environ.get("RS_VMEM_OUT", "0") == "1"
 _RS_VMEM_INPUT_OVERRIDE = os.environ.get("RS_VMEM_INPUT")
 _RS_VMEM_FRAC_OVERRIDE = os.environ.get("RS_VMEM_FRAC")
 
+
+@functools.lru_cache(maxsize=1)
+def _memory_space_constraint_survives() -> bool:
+    """Will a with_memory_space_constraint aval survive an ordinary primitive?
+
+    jax 0.11 gave jax.core its own MemorySpace enum and made
+    `check_avals_context_mesh` assert `isinstance(aval.memory_space,
+    MemorySpace)` for every primitive traced under a mesh. The space that
+    `with_memory_space_constraint` attaches is Pallas's MemorySpace -- a
+    different enum -- so once the annotated aval reaches a non-Pallas primitive
+    under shard_map, abstract eval raises
+
+        TypeError: Primitive broadcast_in_dim got aval bfloat16<vmem>[...]
+                   with unknown memory_space type: <enum 'MemorySpace'>
+
+    On jax 0.10 there was no such check and the identical code pinned the
+    operand fine -- every EXP-017/021/024 pinned arm was measured that way.
+
+    This evaluates jax's own predicate rather than tracing a probe function: the
+    check is skipped unless BOTH the context mesh and the aval's mesh are
+    non-empty, which only holds inside shard_map, so a standalone eval_shape
+    probe reports "survives" no matter what and is worse than useless. If a
+    later JAX teaches core about Pallas spaces, pinning switches itself back on
+    with no code change here.
+    """
+    try:
+        from jax._src import core as jax_core
+    except Exception:  # noqa: BLE001 - unknown JAX layout, assume the old one
+        return True
+    core_space = getattr(jax_core, "MemorySpace", None)
+    if core_space is None:
+        # No core-level memory space enum -> no type check to trip over.
+        return True
+    return isinstance(pltpu.VMEM, core_space)
+
+
+_PIN_UNSUPPORTED_WARNED = False
+
+
+def _pin_unsupported_once() -> None:
+    global _PIN_UNSUPPORTED_WARNED
+    if not _PIN_UNSUPPORTED_WARNED:
+        _PIN_UNSUPPORTED_WARNED = True
+        print(
+            "hierrs_tc: VMEM operand pinning disabled -- this JAX "
+            f"({jax.__version__}) rejects a Pallas memory-space annotation on "
+            "an aval that escapes into an ordinary primitive. The kernel runs "
+            "unpinned (correct, and the measured cost is ~0.3% on the fp8 wire "
+            "and ~2.2% on bf16). Set RS_VMEM_INPUT=2 to force the old path.",
+            flush=True)
+
 # Default scoped claim when we are NOT pinning. Deliberately generous: it is a
 # ceiling, not a reservation (EXP-016 measured 60.80 MiB claimed vs 8.00 MiB
 # used), and shrinking it buys nothing unless we are also pinning.
@@ -179,6 +230,14 @@ def hierarchical_reduce_scatter_local(
         vmem_pin = int(_RS_VMEM_INPUT_OVERRIDE) == 2
     if _RS_VMEM_FRAC_OVERRIDE is not None:
         vmem_frac = float(_RS_VMEM_FRAC_OVERRIDE)
+    # Pinning needs a memory-space annotation that survives shard_map tracing.
+    # Where it does not, fall back to the unpinned plan rather than crashing;
+    # an explicit RS_VMEM_INPUT=2 is still honoured so the failure stays
+    # reproducible.
+    if (vmem_pin and _RS_VMEM_INPUT_OVERRIDE is None
+            and not _memory_space_constraint_survives()):
+        _pin_unsupported_once()
+        vmem_pin = False
 
     vector_width = pltpu.get_tpu_info().num_lanes
     mb_size = next_multiple_of(hidden_dim_size // num_micro_batches,

--- a/tpu_inference/kernels/collectives/hierrs_tc/wrapper.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/wrapper.py
@@ -69,31 +69,37 @@ _RS_VMEM_FRAC_OVERRIDE = os.environ.get("RS_VMEM_FRAC")
 # set is O(local_seq_len * hidden_dim) and VMEM is 64 MiB total, so
 # _plan_work_scratch falls back to the pl.ANY/HBM form once it stops fitting.
 #
-# The working set is `local_seq_len * hidden_dim * 6 bytes` on BOTH wires:
-# running_sum and recv_buf are bf16 (2 B/elem each) either way, and the fp8
-# wire replaces the bf16 phase-2 landing buffer with two 1-byte staging
-# buffers. FP8 halves what crosses the wire; it does not shrink this.
+# The working set is `local_seq_len * hidden_dim * 3 bytes` on BOTH wires.
+# The working buffers are PACKED to half the input's rows -- every chunk index
+# that touches them carries this device's chiplet parity (ChunkLocator.pack),
+# so the full-size allocation they used to get was half dead rows. Unpacked
+# the cost was 6 B/elem: running_sum and recv_buf are bf16 (2 B/elem each)
+# either way, and the fp8 wire replaces the bf16 phase-2 landing buffer with
+# two 1-byte staging buffers. FP8 halves what crosses the wire; it never
+# shrank the working set, and packing shrinks both wires equally.
 #
-# Measured at hidden 4096 on 8 devices, against 0.92 * 64 = 58.9 MiB usable:
+# At hidden 4096 on 8 devices, against 0.92 * 64 = 58.9 MiB usable:
 #
 #   local_seq_len | operand | working set | scoped | total | VMEM scratch?
-#            128  |   1.0   |     3.1     |   1.3  |   5.4 | yes
-#            256  |   2.0   |     6.1     |   2.6  |  10.7 | yes
-#            512  |   4.0   |    12.1     |   5.2  |  21.3 | yes
-#           1024  |   8.0   |    24.1     |  10.4  |  42.5 | yes
-#           2048  |  16.0   |    48.1     |  10.4  |  74.5 | NO -- over 58.9
+#            128  |   1.0   |     1.6     |   1.3  |   3.9 | yes
+#            256  |   2.0   |     3.1     |   2.6  |   7.7 | yes
+#            512  |   4.0   |     6.1     |   5.2  |  15.3 | yes
+#           1024  |   8.0   |    12.1     |  10.4  |  30.5 | yes
+#           2048  |  16.0   |    24.3     |  10.4  |  50.7 | yes (was NO unpacked)
+#           4096  |  32.0   |    48.5     |  10.4  |  90.9 | NO -- over 58.9
 #
-# Only 2048 is excluded, and it is excluded by arithmetic rather than by a
-# tuning constant. There the operand and primary output are still VMEM-pinned
-# by _pick_vmem_plan / _RS_VMEM_OUT; it is only the working set that stays in
-# HBM. `RS_VMEM_WORK=1 ignored` is logged whenever that happens, once per
-# shape, so the fallback is never silent.
+# Packing is what brought the production-dominant 2048 shape inside the
+# budget. 4096+ is still excluded by arithmetic rather than by a tuning
+# constant; there the operand and primary output are still VMEM-pinned by
+# _pick_vmem_plan / _RS_VMEM_OUT and only the working set stays in HBM.
+# `RS_VMEM_WORK=1 ignored` is logged whenever that happens, once per shape,
+# so the fallback is never silent.
 #
 # `local_seq_len` here is the PER-DEVICE, PRE-scatter row count, i.e. the
 # operand's first dim -- 8x the post-scatter row count that appears in the HLO.
 # A decode-heavy server sweeps this whole range in one run rather than running
-# a single shape, so both branches of the table are live in production and the
-# large shapes are NOT covered by this optimisation.
+# a single shape, so both branches of the table are live in production; with
+# packing, every shape up to and including 2048 is covered.
 #
 # RS_VMEM_WORK=0 restores the pl.ANY output form unconditionally.
 _RS_VMEM_WORK = os.environ.get("RS_VMEM_WORK", "1") not in ("0", "")
@@ -110,14 +116,22 @@ _RS_VMEM_WORK_FRAC = (float(os.environ["RS_VMEM_WORK_FRAC"])
 
 def _work_set_bytes(local_seq_len, hidden_dim_size, itemsize, fp8_comm,
                     num_devices, num_scale_slots):
-    """Total bytes of the buffers that move from pl.ANY outputs to VMEM scratch."""
-    big = local_seq_len * hidden_dim_size
-    total = 2 * big * itemsize  # running_sum + recv_buf
+    """Total bytes of the buffers that move from pl.ANY outputs to VMEM scratch.
+
+  The working buffers are PACKED to half the input's rows (see
+  ChunkLocator.pack: only this device's chunk parity is ever touched), so the
+  per-element cost against local_seq_len * hidden is 3 bytes on either wire:
+  bf16 = (2 + 2 + 2)/2, fp8 = (2 + 2 + 1 + 1)/2. FP8 halves what crosses the
+  wire; it never shrank the working set, and packing shrinks both wires
+  equally.
+  """
+    packed = (local_seq_len // 2) * hidden_dim_size
+    total = 2 * packed * itemsize  # running_sum + recv_buf
     if fp8_comm:
-        total += 2 * big  # fp8_send + fp8_recv, 1 byte/elem
+        total += 2 * packed  # fp8_send + fp8_recv, 1 byte/elem
         total += 2 * num_devices * num_scale_slots * SCALE_LANE * 4
     else:
-        total += big * itemsize  # the bf16 wire's phase-2 landing buffer
+        total += packed * itemsize  # the bf16 wire's phase-2 landing buffer
     return total
 
 
@@ -390,9 +404,14 @@ def hierarchical_reduce_scatter_local(
 
     out_shape = jax.ShapeDtypeStruct((seq_chunk_size, hidden_dim_size),
                                      local_x.dtype)
-    running_sum_shape = jax.ShapeDtypeStruct((local_seq_len, hidden_dim_size),
+    # Working buffers are PACKED: every chunk index that touches them carries
+    # this device's chiplet parity (see ChunkLocator.pack), so a full
+    # (local_seq_len, hidden) allocation is half dead rows. num_chips chunks
+    # of seq_chunk_size rows each == local_seq_len // 2.
+    packed_seq_len = local_seq_len // 2
+    running_sum_shape = jax.ShapeDtypeStruct((packed_seq_len, hidden_dim_size),
                                              local_x.dtype)
-    recv_buf_shape = jax.ShapeDtypeStruct((local_seq_len, hidden_dim_size),
+    recv_buf_shape = jax.ShapeDtypeStruct((packed_seq_len, hidden_dim_size),
                                           local_x.dtype)
 
     work_scratch_on, vmem_frac = _plan_work_scratch(
@@ -425,9 +444,9 @@ def hierarchical_reduce_scatter_local(
             out_specs.append(pl.BlockSpec(memory_space=pl.ANY))
 
     _emit_work(running_sum_shape,
-               pltpu.VMEM((local_seq_len, hidden_dim_size), local_x.dtype))
+               pltpu.VMEM((packed_seq_len, hidden_dim_size), local_x.dtype))
     _emit_work(recv_buf_shape,
-               pltpu.VMEM((local_seq_len, hidden_dim_size), local_x.dtype))
+               pltpu.VMEM((packed_seq_len, hidden_dim_size), local_x.dtype))
 
     # Separate phase-2 landing buffer for the bf16 wire. Without it an incoming
     # phase-2 chunk can overwrite phase-1 bytes the receiver has not drained
@@ -436,12 +455,12 @@ def hierarchical_reduce_scatter_local(
     # The fp8 wire already lands phase 2 in fp8_recv_buf, so it needs nothing.
     if not fp8_comm:
         _emit_work(
-            jax.ShapeDtypeStruct((local_seq_len, hidden_dim_size),
+            jax.ShapeDtypeStruct((packed_seq_len, hidden_dim_size),
                                  local_x.dtype),
-            pltpu.VMEM((local_seq_len, hidden_dim_size), local_x.dtype))
+            pltpu.VMEM((packed_seq_len, hidden_dim_size), local_x.dtype))
 
     if fp8_comm:
-        fp8_shape = jax.ShapeDtypeStruct((local_seq_len, hidden_dim_size),
+        fp8_shape = jax.ShapeDtypeStruct((packed_seq_len, hidden_dim_size),
                                          jnp.float8_e4m3fn)
         scale_shape = jax.ShapeDtypeStruct(
             (num_devices, num_scale_slots * SCALE_LANE), jnp.float32)
@@ -450,7 +469,7 @@ def hierarchical_reduce_scatter_local(
         for _ in range(2):
             _emit_work(
                 fp8_shape,
-                pltpu.VMEM((local_seq_len, hidden_dim_size),
+                pltpu.VMEM((packed_seq_len, hidden_dim_size),
                            jnp.float8_e4m3fn))
         for _ in range(2):
             _emit_work(

--- a/tpu_inference/kernels/collectives/hierrs_tc/wrapper.py
+++ b/tpu_inference/kernels/collectives/hierrs_tc/wrapper.py
@@ -182,7 +182,18 @@ def _plan_work_scratch(local_seq_len, hidden_dim_size, itemsize, fp8_comm,
     # not, and none should reject one that does.
     if need + operand > capacity * _VMEM_TOTAL_SAFETY:
         _warn_work_scratch_off(work, capacity)
-        return False, vmem_frac
+        # HBM fallback for the WORK SET -- but do not inherit the fat 0.95
+        # claim for the scoped scratch that remains. The claim is what starves
+        # XLA's memory-space assignment: with 0.95 (60.8 of 64 MiB) MSA has
+        # ~3 MiB and colours nothing (the fusion-barrier 0/240), while a
+        # need-sized claim leaves it room to promote the operand and output to
+        # S(1) on its own -- measured: S(1) copies appear at every shape whose
+        # claim stays small, vanish at the 0.95 claim, and no annotation API
+        # is involved (with_memory_space_constraint compiles to identical HLO).
+        # 1.5x headroom on the scoped estimate; an underestimate fails loudly
+        # at compile time (CompileTimeScopedVmemOom), never silently.
+        scoped_frac = min(vmem_frac, (scoped * 1.5) / capacity)
+        return False, scoped_frac
     # Claim exactly what this shape needs, not a fixed fraction. Claiming more
     # steals alternate memory MSA needs to colour the operand; claiming less
     # raises CompileTimeScopedVmemOom.
@@ -236,11 +247,13 @@ def _pin_unsupported_once() -> None:
     if not _PIN_UNSUPPORTED_WARNED:
         _PIN_UNSUPPORTED_WARNED = True
         print(
-            "hierrs_tc: VMEM operand pinning disabled -- this JAX "
-            f"({jax.__version__}) rejects a Pallas memory-space annotation on "
-            "an aval that escapes into an ordinary primitive. The kernel runs "
-            "unpinned (correct, and the measured cost is ~0.3% on the fp8 wire "
-            "and ~2.2% on bf16). Set RS_VMEM_INPUT=2 to force the old path.",
+            "hierrs_tc: explicit VMEM operand annotation disabled (and known "
+            f"to be a no-op on this JAX ({jax.__version__}): "
+            "with_memory_space_constraint compiles to byte-identical HLO). "
+            "Operand/output colouring is done by XLA's memory-space assignment "
+            "instead, whenever the scoped-VMEM claim leaves it room -- see the "
+            "need-sized claims in _plan_work_scratch. "
+            "Set RS_VMEM_INPUT=2 to force the old annotation path.",
             flush=True)
 
 

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import functools
+import os
 from typing import Literal
 
 import jax
@@ -23,6 +24,8 @@ from tokamax._src.ops.experimental.gmm_v2.gmm_v2 import gmm_v2
 
 import tpu_inference.envs as envs
 from tpu_inference.kernels.collectives.hierrs_sc import wrapper as hier_rs_sc
+from tpu_inference.kernels.collectives.hierrs_tc import \
+    wrapper as hier_rs_tc
 from tpu_inference.kernels.sparse_core.dense_gather_reduce import \
     dense_gather_reduce
 from tpu_inference.kernels.sparse_core.ragged_gather_reduce_v2 import \
@@ -35,6 +38,26 @@ from tpu_inference.logger import init_logger
 from tpu_inference.utils import get_mesh_shape_product
 
 logger = init_logger(__name__)
+
+# EXP-012 diagnostic, off by default and read once at import. Set
+# RS_NAN_PROBE=1 to print a per-call NaN census around the MoE unpermute.
+# Costs a device sync per chunk per layer, so it is a correctness-run knob,
+# never a perf-run one.
+_RS_NAN_PROBE = os.environ.get("RS_NAN_PROBE", "0") == "1"
+
+# Pipelining probe. Everything the MoE-chunking gate depends on --
+# num_tokens, scatter_axis_size, moe_chunk_size, is_onehot -- is a static
+# Python value at trace time, so a plain print() is enough and costs nothing
+# at run time. Set RS_PIPE_PROBE=1 to report every DISTINCT gate outcome
+# once. This is what turned "chunking cannot have engaged at
+# --max-num-batched-tokens=1024" from an inference into an observation.
+_RS_PIPE_PROBE = os.environ.get("RS_PIPE_PROBE", "0") == "1"
+_RS_PIPE_SEEN = set()
+
+# Below this many LOCAL rows the hierrs_tc Mosaic kernel will not compile
+# (its seq tile is 8), so that branch falls back to psum_scatter. hierrs_sc
+# has no such limit, which is why the guard is scoped to the tc backend.
+_RS_TC_MIN_LOCAL_ROWS = int(os.environ.get("RS_ROUTER_MIN_ROWS", "8"))
 
 # Target chunk size of 2048 slots was found empirically to be optimal
 # for MoE workloads (e.g., Qwen) to hide ICI/DMA latency during AllReduce.
@@ -249,6 +272,17 @@ def moe_gmm_local(x: jax.Array,
         actual_chunk_size = num_tokens
 
     is_pipelined = actual_chunk_size < num_tokens
+    if _RS_PIPE_PROBE:
+        _k = (num_tokens, topk, scatter_axis_size, moe_chunk_size,
+              actual_chunk_size, is_onehot, is_pipelined)
+        if _k not in _RS_PIPE_SEEN:
+            _RS_PIPE_SEEN.add(_k)
+            print(f"PIPEPROBE num_tokens={num_tokens} topk={topk} "
+                  f"scatter_axis={scatter_axis_size} "
+                  f"chunk={moe_chunk_size} "
+                  f"gate={moe_chunk_size * scatter_axis_size} "
+                  f"actual_chunk={actual_chunk_size} onehot={is_onehot} "
+                  f"pipelined={is_pipelined}", flush=True)
     if is_pipelined and scatter_axis_size > 1:
         num_chunks = num_tokens // actual_chunk_size
         topk_weights = _permute_tokens_for_chunked_rs(topk_weights,
@@ -303,12 +337,54 @@ def moe_gmm_local(x: jax.Array,
                 topk_weights,
                 topk,
             )
+        if _RS_NAN_PROBE:
+            # EXP-012. Counts NaN where it is BORN, not where it is observed.
+            # The fp8 wire's quant_body does `where(isfinite(x), x, 0.0)`,
+            # which sits downstream of this point, so a NaN produced by the
+            # one-hot unpermute is silently rewritten to 0 before anything
+            # downstream -- including the API response -- can see it. Probing
+            # here is the only way to tell "no NaN was produced" apart from "a
+            # NaN was produced and then hidden".
+            jax.debug.print(
+                "NANPROBE src={s} out={o} rows={r} onehot={h}",
+                s=jnp.isnan(gmm2_res.astype(jnp.float32)).sum(),
+                o=jnp.isnan(chunk_hidden.astype(jnp.float32)).sum(),
+                r=chunk_hidden.shape[0],
+                h=int(onehot_moe_permute_threshold > 0
+                      and batch_size <= onehot_moe_permute_threshold),
+            )
+
         if enable_rs_kernel:
-            rs_out = hier_rs_sc.hierarchical_reduce_scatter_local(
-                chunk_hidden,
-                num_devices=scatter_axis_size,
-                axis_name=reduction_axis)
-            out = rs_out.astype(x.dtype)
+            if envs.RS_KERNEL_BACKEND == "tc":
+                local_rows = chunk_hidden.shape[0] // scatter_axis_size
+                if local_rows < _RS_TC_MIN_LOCAL_ROWS:
+                    out = jax.lax.psum_scatter(chunk_hidden,
+                                               axis_name=reduction_axis,
+                                               scatter_dimension=0,
+                                               tiled=True).astype(x.dtype)
+                else:
+                    # num_micro_batches is deliberately NOT passed: the kernel
+                    # picks it from bytes per micro-batch with a per-wire target
+                    # (config.pick_num_micro_batches).
+                    #
+                    # It has to be decided there, not here. This site only knows
+                    # the REQUESTED wire (VLLM_TPU_FP8_REDUCE_SCATTER); the
+                    # kernel downgrades FP8 to BF16 below FP8_COMM_MIN_ROWS, and
+                    # the two wires want stage sizes 4x apart, so choosing here
+                    # would mis-tune every downgraded call. See EXP-007.
+                    rs_out = hier_rs_tc.hierarchical_reduce_scatter_local(
+                        chunk_hidden,
+                        num_devices=scatter_axis_size,
+                        axis_name=reduction_axis,
+                        fp8_comm=envs.VLLM_TPU_FP8_REDUCE_SCATTER,
+                        fp8_static_scale=envs.VLLM_TPU_FP8_RS_STATIC_SCALE)
+                    out = rs_out.astype(x.dtype)
+            else:
+                rs_out = hier_rs_sc.hierarchical_reduce_scatter_local(
+                    chunk_hidden,
+                    num_devices=scatter_axis_size,
+                    axis_name=reduction_axis)
+                out = rs_out.astype(x.dtype)
         elif scatter_results:
             if reduce_axes:
                 chunk_hidden = jax.lax.psum(chunk_hidden,


### PR DESCRIPTION
This change adds a hierarchical reduce-scatter kernel that runs on the **TensorCore**, with an optional FP8 inter-chip wire. It sits alongside the existing SparseCore kernel (`hierrs_sc`) rather than replacing it; `RS_KERNEL_BACKEND` selects between them and the default is unchanged.

- Two-phase reduce-scatter: phase 1 is intra-chip D2D, phase 2 is an inter-chip hypercube (recursive doubling) over ICI. Accumulation stays BF16 throughout.
- Optional FP8 wire for phase 2 only (`VLLM_TPU_FP8_REDUCE_SCATTER`), dequantizing and accumulating in BF16 on arrival, with per-chunk dynamic scaling or a fixed static scale (`VLLM_TPU_FP8_RS_STATIC_SCALE`). Halves inter-chip bytes; the payload below its row threshold falls back to the BF16 wire.
- Micro-batched so phase-1 D2D on one micro-batch overlaps phase-2 ICI on the previous one, with the depth chosen from bytes per micro-batch and a per-wire target.
- Working set (`running_sum`, `recv_buf`, wire staging) placed in VMEM scratch where the shape allows, so the reduce-scatter input and output do not round-trip through HBM.
- Routed from the MoE combine in `fused_moe_gmm.py`, gated on `ENABLE_RS_KERNEL` + `RS_KERNEL_BACKEND=tc`, falling back to `jax.lax.psum_scatter` below a minimum row count.

**Correctness fixes included in this series** (last two commits, separated for review):

- `num_micro_batches=1` returned the *previous* call's result: [Step C] reads the accumulator on the line after the `emit_pipeline` that writes it, with nothing ordering the two. Floored at `mb>=2` on the BF16 wire; the FP8 wire is exempt because its quantize/staging step already separates the write from the wire read.
- The working set moved from `pl.ANY` outputs into real VMEM scratch, with the claim sized from the shape and a logged fallback to HBM when it does not fit.

**Commits**
1. `Hier-RS TensorCore kernel (hierrs_tc) + FP8 reduce-scatter wire`
2. `hierrs_tc: disable VMEM pinning where JAX rejects the Pallas memory space`
3. `Floor hierarchical RS micro-batching at mb>=2 on the BF16 wire`
4. `Move the hierarchical RS working set into VMEM scratch`

**Flags**

Three vLLM env vars are added in `envs.py`: `RS_KERNEL_BACKEND` (`"sc"` default / `"tc"`), `VLLM_TPU_FP8_REDUCE_SCATTER` (default off), and `VLLM_TPU_FP8_RS_STATIC_SCALE` (unset -> per-chunk dynamic). With defaults unchanged, `ENABLE_RS_KERNEL` still selects the SparseCore kernel and nothing in this PR is reachable.

The kernel also reads three variables of its own directly from the environment, at import.

Flag | Default | Effect
-- | -- | --
`RS_VMEM_WORK` | `1` (on) | Place the working set (`running_sum`, `recv_buf`, wire staging) in VMEM scratch. Shape-gated: falls back to the `pl.ANY`/HBM form and logs `RS_VMEM_WORK=1 ignored` when the set does not fit. `0` restores the previous behaviour unconditionally.
`RS_VMEM_WORK_FRAC` | unset | Optional hard ceiling on the scoped VMEM claim, as a fraction of total VMEM. Unset, the claim is sized from the shape. Set it only to re-impose a ceiling if a module hits `Too many buffers are colored in the alternate memory`.
`RS_ALLOW_UNSAFE_MB1` | `0` | Lifts the `mb>=2` correctness floor so the underlying defect can be reproduced. Not a tuning knob -- with this set, the BF16 wire returns wrong answers at small shapes.

The working-set decision at hidden 4096 on 8 devices, against 0.92 x 64 = 58.9 MiB usable VMEM. `local_seq_len` is the per-device, pre-scatter row count (8x the post-scatter row count in the HLO); a decode-heavy server sweeps this whole range in one run.

local_seq_len | operand | working set | scoped | total | VMEM scratch?
-- | -- | -- | -- | -- | --
128 | 1.0 | 3.1 | 1.3 | 5.4 | yes
256 | 2.0 | 6.1 | 2.6 | 10.7 | yes
512 | 4.0 | 12.1 | 5.2 | 21.3 | yes
1024 | 8.0 | 24.1 | 10.4 | 42.5 | yes
2048 | 16.0 | 48.1 | 10.4 | 74.5 | no, over 58.9

The working set is `local_seq_len * hidden_dim * 6 bytes` on both wires: `running_sum` and `recv_buf` are BF16 either way, and the FP8 wire swaps the BF16 phase-2 landing buffer for two 1-byte staging buffers. FP8 halves what crosses the wire; it does not shrink this.

Existing flags this change interacts with, unchanged: `RS_VMEM_PIN`, `RS_VMEM_INPUT`, `RS_VMEM_OUT`, `RS_VMEM_FRAC` (operand and primary-output pinning) and `VLLM_TPU_FP8_RS_MIN_TOKENS` (the FP8-to-BF16 wire downgrade, default 2048 pre-scatter rows). Note the results below were taken with `VLLM_TPU_FP8_RS_MIN_TOKENS=0` so the FP8 wire runs at every shape; at the default, shapes below 2048 rows take the BF16 wire instead.

**Testing environment**
- rebased onto tpu-inference@5f999f098
- vllm@58302b459198eec60fad49af3c506ec10d6af821 (0.26.1rc1.dev952)
- jax 0.11.0, jaxlib 0.11.0, libtpu 0.0.44, tokamax 0.0.13
- Qwen3.5-397B-A17B-FP8, TP8 + expert parallel + DP attention, MNBT 1024, MoE chunk 256, one-hot permute disabled
- Baseline is `jax.lax.psum_scatter` (XLA). All four arms measured on the same tree, one boot per arm, one run per cell.

**Results**

Total token throughput (tok/s) and delta vs the XLA baseline. `fp8_default` and `bf16_default` set no `RS_VMEM_*` variables at all -- the out-of-the-box configuration. `fp8_pin` adds `RS_VMEM_INPUT=2 RS_VMEM_OUT=1`.

8192-in / 1024-out:

Concurrency | Baseline TPS | Baseline TPS/chip | fp8_default | bf16_default | fp8_pin
-- | -- | -- | -- | -- | --
64 | 13359.62 | 3339.91 | 13849.68 (+3.67%) | 13002.82 (-2.67%) | 13914.11 (+4.15%)
128 | 20818.03 | 5204.51 | 20521.76 (-1.42%) | 20083.83 (-3.53%) | 20553.56 (-1.27%)
256 | 27266.20 | 6816.55 | 27058.62 (-0.76%) | 26339.43 (-3.40%) | 27073.12 (-0.71%)
512 | 31678.33 | 7919.58 | 32099.86 (+1.33%) | 30513.63 (-3.68%) | 32131.84 (+1.43%)
**mean** | | | **+0.70%** | **-3.32%** | **+0.90%**

1024-in / 8192-out:

Concurrency | Baseline TPS | Baseline TPS/chip | fp8_default | bf16_default | fp8_pin
-- | -- | -- | -- | -- | --
64 | 2300.92 | 575.23 | 2384.92 (+3.65%) | 2238.46 (-2.71%) | 2257.54 (-1.89%)
128 | 3591.83 | 897.96 | 3536.27 (-1.55%) | 3758.25 (+4.63%) | 3530.77 (-1.70%)
256 | 5835.00 | 1458.75 | 5948.58 (+1.95%) | 5817.92 (-0.29%) | 5766.78 (-1.17%)
512 | 8785.23 | 2196.31 | 8806.25 (+0.24%) | 8673.28 (-1.27%) | 8845.59 (+0.69%)
**mean** | | | **+1.07%** | **+0.09%** | **-1.02%**
**overall (16 cells)** | | | **+0.89%** | **-1.62%** | **-0.06%**

**How much of this is measurable.** `fp8_default` and `fp8_pin` differ only by the operand pin, and the 8k/1k rows show that pin doing nothing (per-cell gaps +0.48 / +0.15 / +0.05 / +0.10). Their 8-cell means nonetheless differ by 0.95 points. Treat ~1 point on an 8-cell mean as the noise floor of this setup; per-cell, two boots of the *identical* baseline config differed by up to 4.5%.

**FP8 at shipping defaults is at parity with XLA `psum_scatter`** -- +0.89% and -0.06% for the two fp8 arms, both inside that floor, on both workloads. This is not a speedup claim; it is a "costs nothing" claim, which is what the kernel needs to be worth taking on correctness grounds.

**BF16 is ~3.3% behind at 8k/1k, and that is the price of correctness.** That row is the only tight one in the matrix: -2.67 / -3.53 / -3.40 / -3.68 across an 8x concurrency range, sd 0.45. The BF16 wire pays the `mb>=2` floor at every shape and the FP8 wire does not, so this is a direct end-to-end measurement of what the floor costs. It is the strongest argument for keeping `VLLM_TPU_FP8_RS_MIN_TOKENS` low enough that production reaches the FP8 path.

**One unexplained result.** BF16 at 1k/8k c128 is +4.63%, and it reproduces: 3760.73 before the rebase, 3758.25 after (0.07% apart), against a baseline measured five times (3550-3623, sd 0.8%). No other cell in either workload behaves like this, and it is not a shape effect -- `_SEQ_TILE=32` padding compiles c64, c128 and c256 to the same `local_seq_len` of 256. Flagged rather than claimed; an xprof capture at c64 vs c128 is the obvious next step.

**Quality.** mmlu_pro exact_match `0.8229 +/- 0.0071` (online, lm_eval local-chat-completions, limit 200, seed 42, one-hot permute disabled). **Measured before the rebase**, on the FP8 wire with the operand pinned; not re-run on the rebased tree.

There is no XLA `psum_scatter` quality run at the identical configuration to compare against: the nearest stock measurement is `0.8232 +/- 0.0071` but was taken with the one-hot permute threshold at 32768, and an earlier 0.8250 figure was measured on the `mb=1` path this PR fixes, so it does not represent correct output. All three sit within a third of one standard error of each other, which supports "no quality regression" but is not a controlled A/B.

**Correctness gating.** Every cell scored against an independent `psum` + `dynamic_slice` reference with a fresh input per run, which is required -- with a fixed input a stale buffer is indistinguishable from a correct answer. Before the floor: 26/30, 24/30 and 11/30 runs below 40 dB SNR at 128, 256 and 512 local rows. After: 0/30 at every shape on both wires and both memory paths.

The FP8 mb=1 exemption is gated at `local_seq_len` 256, 512 and 1024, which is every shape a server reaches at mb=1: each device's chunk is padded up to `_SEQ_TILE=32` before the micro-batch heuristic runs, so any request under 256 rows arrives as 256, and 2048 picks mb=2.

**Tests.** `tests/kernels/collectives/hierrs_tc_test.py` is new in this PR, 27 tests, all green:

- 24 on-device tests (~16 min): BF16 correctness at each micro-batch depth, repeat-run agreement, FP8 wire SNR across shapes for both the dynamic and static-scale paths, no-NaN, zero-input, and static-vs-dynamic agreement.
- 3 CPU-only planning tests (~6 s) covering the micro-batch floor and the VMEM sizing model. Each was checked to FAIL when its invariant is broken (`RS_ALLOW_UNSAFE_MB1=1` trips the floor test; `RS_VMEM_WORK_FRAC=0.35` trips the fallback test), so they are not vacuous.

`test_correctness_bf16` at mb=1 fails without the micro-batch floor; it passes with it.

Note the suite cannot detect the mb=1 defect on its own -- that needs a fresh input per run scored against an independent `psum` + `dynamic_slice` reference, which is how the counts above were produced.

**Defaults were verified.** The `fp8_pin` arm forces the operand pin past a capability guard that jax 0.11 otherwise trips (`with_memory_space_constraint` attaches Pallas's `MemorySpace`; `check_avals_context_mesh` only accepts `jax.core.MemorySpace`). Measured against `fp8_default`, that pin is worth nothing: 8k/1k per-cell gaps of +0.48 / +0.15 / +0.05 / +0.10 points. The numbers above are the shipping configuration.

**Known gaps**
- The `mb>=2` floor masks the underlying ordering hazard by timing rather than fixing it. The [Step B] -> [Step C] and [Step G] -> post-loop ordering in `kernel.py` still needs a real fix. Until then the FP8 exemption rests on the quantize/staging step happening to separate the write from the read, which is why the code comment says to re-validate it with fresh inputs if that step is ever moved.
- One run per cell. The noise floor above (~1 point on an 8-cell mean, up to 4.5% per cell) is measured, not assumed, but individual cells should not be read as signed results.
- Quality was measured pre-rebase and against no exactly-matched XLA baseline (see above).
- `VLLM_TPU_FP8_RS_MIN_TOKENS` defaults to 2048 pre-scatter rows, and the results above set it to 0. At the default, a decode-heavy server takes the BF16 wire for most shapes -- i.e. the -3.32% row, not the parity row. Whether that default should move is a separate question this PR does not settle.
- The BF16 1k/8k c128 result (+4.63%) is reproducible and unexplained.
