### PR TITLE
[CI] Fall back to GCS mirror for MMLU dataset download

### DIFF
--- a/tests/e2e/benchmarking/mmlu.sh
+++ b/tests/e2e/benchmarking/mmlu.sh
@@ -132,9 +132,15 @@ if [ -z "$dataset_path" ]; then
     dataset_path="$root_dir"/mmlu/
     mkdir -p "$dataset_path"
     cd "$dataset_path" || exit
+    fetchDataset() {
+        rm -f data.tar
+        "$@" && tar -xf data.tar
+    }
     if [ ! -d "$dataset_path/data/test" ]; then
-        wget https://people.eecs.berkeley.edu/~hendrycks/data.tar -P .
-        tar -xvf data.tar
+        # The Berkeley host has recurring outages; fall back to the GCS mirror.
+        fetchDataset wget --tries=2 --timeout=60 https://people.eecs.berkeley.edu/~hendrycks/data.tar -P . \
+            || fetchDataset gsutil cp "${MMLU_GCS_URI:-gs://tpu-commons-ci/datasets/mmlu/data.tar}" . \
+            || { echo "ERROR: failed to download the MMLU dataset." >&2; exit 1; }
     fi
     dataset_path=$dataset_path/data/test/
 fi


### PR DESCRIPTION
# Description

`mmlu.sh` downloads the MMLU dataset from `people.eecs.berkeley.edu`, which has recurring outages (down today: requests redirect to an EECS storage-incident page and 404). The script ignored the failed download and later crashed with a confusing `FileNotFoundError: '/workspace/mmlu//data/test/'`.

This change keeps Berkeley as the primary source (with `--tries=2 --timeout=60` so an unresponsive host can't stall the step), falls back to a GCS mirror (`gs://tpu-commons-ci/datasets/mmlu/data.tar`, overridable via `MMLU_GCS_URI`), and exits with a clear error if both fail. The mirror is identical to the official copy at https://huggingface.co/datasets/cais/mmlu (sha256 `bec563ba...`).

# Tests

Ran the download block standalone during the live Berkeley outage: wget times out, GCS fallback downloads and extracts `data/test/` with all 57 subject CSVs, exit 0. With both sources forced to fail, it exits 1 with the error message. `bash -n` passes.