### PR TITLE
bench: port the bm-infra v6e sonnet workloads to daily Buildkite cases

### DIFF
--- a/.buildkite/benchmark/cases/daily/bm_v6e_sonnet_jax.json
+++ b/.buildkite/benchmark/cases/daily/bm_v6e_sonnet_jax.json
@@ -1,0 +1,318 @@
+{
+  "global_env": {
+    "GCP_PROJECT_ID": "cloud-tpu-inference-test",
+    "GCS_BUCKET": "vllm-cb-storage2",
+    "GCP_INSTANCE_ID": "vllm-bm-inst",
+    "GCP_DATABASE_ID": "vllm-bm-bk-runs"
+  },
+  "benchmark_cases": [
+    {
+      "case_name": "Llama-3.1-8B-v6e-1-dataset_sonnet-inlen_1800-outlen_128-jax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax"
+        },
+        "args": {
+          "model": "meta-llama/Llama-3.1-8B-Instruct",
+          "seed": 42,
+          "max-num-seqs": 256,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "meta-llama/Llama-3.1-8B-Instruct",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-4B-v6e-1-dataset_sonnet-inlen_1800-outlen_128-jax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-4B",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-4B",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-8B-v6e-1-dataset_sonnet-inlen_1800-outlen_128-jax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-8B",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 512,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-8B",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen2.5-1.5B-v6e-1-dataset_sonnet-inlen_1800-outlen_128-jax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax"
+        },
+        "args": {
+          "model": "Qwen/Qwen2.5-1.5B-Instruct",
+          "seed": 42,
+          "max-num-seqs": 512,
+          "max-num-batched-tokens": 4096,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen2.5-1.5B-Instruct",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-32B-v6e-8-dataset_sonnet-inlen_1800-outlen_128-jax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-32B",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-32B",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Llama-3.1-70B-v6e-8-dataset_sonnet-inlen_1800-outlen_128-jax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax"
+        },
+        "args": {
+          "model": "meta-llama/Llama-3.1-70B-Instruct",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "meta-llama/Llama-3.1-70B-Instruct",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Llama-3.3-70B-v6e-8-dataset_sonnet-inlen_1800-outlen_128-jax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax"
+        },
+        "args": {
+          "model": "meta-llama/Llama-3.3-70B-Instruct",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "meta-llama/Llama-3.3-70B-Instruct",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    }
+  ]
+}

--- a/.buildkite/benchmark/cases/daily/bm_v6e_sonnet_jax_new_model_design.json
+++ b/.buildkite/benchmark/cases/daily/bm_v6e_sonnet_jax_new_model_design.json
@@ -1,0 +1,56 @@
+{
+  "global_env": {
+    "GCP_PROJECT_ID": "cloud-tpu-inference-test",
+    "GCS_BUCKET": "vllm-cb-storage2",
+    "GCP_INSTANCE_ID": "vllm-bm-inst",
+    "GCP_DATABASE_ID": "vllm-bm-bk-runs"
+  },
+  "benchmark_cases": [
+    {
+      "case_name": "Llama-3.1-8B-v6e-1-dataset_sonnet-inlen_1800-outlen_128-jax-nmd",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90,
+        "MODELTAG": "NEW"
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "NEW_MODEL_DESIGN": "True"
+        },
+        "args": {
+          "model": "meta-llama/Llama-3.1-8B-Instruct",
+          "seed": 42,
+          "max-num-seqs": 256,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "meta-llama/Llama-3.1-8B-Instruct",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    }
+  ]
+}

--- a/.buildkite/benchmark/cases/daily/bm_v6e_sonnet_torchax_jax.json
+++ b/.buildkite/benchmark/cases/daily/bm_v6e_sonnet_torchax_jax.json
@@ -1,0 +1,968 @@
+{
+  "global_env": {
+    "GCP_PROJECT_ID": "cloud-tpu-inference-test",
+    "GCS_BUCKET": "vllm-cb-storage2",
+    "GCP_INSTANCE_ID": "vllm-bm-inst",
+    "GCP_DATABASE_ID": "vllm-bm-bk-runs"
+  },
+  "benchmark_cases": [
+    {
+      "case_name": "Qwen3-8B-v6e-1-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-8B",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 512,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-8B",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-4B-v6e-1-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-4B",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-4B",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen2.5-1.5B-AWQ-v6e-1-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+          "seed": 42,
+          "max-num-seqs": 512,
+          "max-num-batched-tokens": 4096,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true,
+          "dtype": "bfloat16"
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen2.5-1.5B-Instruct-AWQ",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen2.5-7B-v6e-1-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen2.5-7B-Instruct",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen2.5-7B-Instruct",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen2.5-1.5B-v6e-1-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen2.5-1.5B-Instruct",
+          "seed": 42,
+          "max-num-seqs": 512,
+          "max-num-batched-tokens": 4096,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen2.5-1.5B-Instruct",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Meta-Llama-3.1-8B-quantized.w8a8-v6e-1-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm"
+        },
+        "args": {
+          "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-quantized.w8a8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Meta-Llama-3.1-8B-FP8-v6e-1-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm"
+        },
+        "args": {
+          "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Meta-Llama-3.1-8B-FP8-dynamic-v6e-1-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm"
+        },
+        "args": {
+          "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "RedHatAI/Meta-Llama-3.1-8B-Instruct-FP8-dynamic",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Llama-3.1-8B-v6e-1-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 90
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm"
+        },
+        "args": {
+          "model": "meta-llama/Llama-3.1-8B-Instruct",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 1,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "meta-llama/Llama-3.1-8B-Instruct",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen2.5-14B-v6e-8-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen2.5-14B-Instruct",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen2.5-14B-Instruct",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen2.5-32B-v6e-8-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen2.5-32B",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen2.5-32B",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-32B-AWQ-v6e-8-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-32B-AWQ",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true,
+          "dtype": "bfloat16"
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-32B-AWQ",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-32B-v6e-8-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-32B",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-32B",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-30B-A3B-v6e-8-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-30B-A3B",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 4,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-30B-A3B",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Meta-Llama-3.1-70B-quantized.w8a8-v6e-8-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm"
+        },
+        "args": {
+          "model": "RedHatAI/Meta-Llama-3.1-70B-Instruct-quantized.w8a8",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "RedHatAI/Meta-Llama-3.1-70B-Instruct-quantized.w8a8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Meta-Llama-3.1-70B-FP8-v6e-8-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm"
+        },
+        "args": {
+          "model": "RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Meta-Llama-3.1-70B-FP8-dynamic-v6e-8-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm"
+        },
+        "args": {
+          "model": "RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8-dynamic",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "RedHatAI/Meta-Llama-3.1-70B-Instruct-FP8-dynamic",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Llama-3.1-70B-v6e-8-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm"
+        },
+        "args": {
+          "model": "meta-llama/Llama-3.1-70B-Instruct",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "meta-llama/Llama-3.1-70B-Instruct",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "gemma-3-27b-it-v6e-8-dataset_sonnet-inlen_1000-outlen_100-torchax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1000,
+        "OUTPUT_LEN": 100,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm"
+        },
+        "args": {
+          "model": "google/gemma-3-27b-it",
+          "seed": 42,
+          "max-num-seqs": 512,
+          "max-num-batched-tokens": 2048,
+          "tensor-parallel-size": 8,
+          "max-model-len": 1280,
+          "no-enable-prefix-caching": true,
+          "limit-mm-per-prompt": "{\"image\":0}"
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "google/gemma-3-27b-it",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1000,
+          "sonnet-output-len": 100,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Llama-3.3-70B-v6e-8-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm"
+        },
+        "args": {
+          "model": "meta-llama/Llama-3.3-70B-Instruct",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 1024,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "meta-llama/Llama-3.3-70B-Instruct",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Mixtral-8x7B-v0.1-v6e-8-dataset_sonnet-inlen_1800-outlen_128-torchax",
+      "ci_queue": [
+        "tpu_v6e_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1800,
+        "OUTPUT_LEN": 128,
+        "BK_TIMEOUT_IN_MINUTES": 180
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm"
+        },
+        "args": {
+          "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+          "seed": 42,
+          "max-num-seqs": 512,
+          "max-num-batched-tokens": 4096,
+          "tensor-parallel-size": 8,
+          "max-model-len": 2048,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1800,
+          "sonnet-output-len": 128,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    }
+  ]
+}

--- a/.buildkite/benchmark/cases/daily/bm_v7x_random_480b_torchax_jax.json
+++ b/.buildkite/benchmark/cases/daily/bm_v7x_random_480b_torchax_jax.json
@@ -1,0 +1,343 @@
+{
+  "global_env": {
+    "GCP_PROJECT_ID": "cloud-tpu-inference-test",
+    "GCS_BUCKET": "vllm-cb-storage2",
+    "GCP_INSTANCE_ID": "vllm-bm-inst",
+    "GCP_DATABASE_ID": "vllm-bm-bk-runs"
+  },
+  "benchmark_cases": [
+    {
+      "case_name": "Qwen3-Coder-480B-A35B-FP8-tpu7x-8-dataset_random-inlen_1024-outlen_1024-torchax",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 43200000,
+        "INPUT_LEN": 1024,
+        "OUTPUT_LEN": 1024,
+        "PREFIX_LEN": 0,
+        "SERVER_WAIT_MINS": 180,
+        "BENCHMARK_TIMEOUT": "4h",
+        "BK_TIMEOUT_IN_MINUTES": 360
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+          "seed": 42,
+          "max-num-seqs": 512,
+          "max-num-batched-tokens": 8192,
+          "tensor-parallel-size": {
+            "v7x-8": 8
+          },
+          "max-model-len": 9216,
+          "no-enable-prefix-caching": true,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.8,
+          "block-size": 256,
+          "enable-expert-parallel": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 1024,
+          "random-output-len": 1024,
+          "num-prompts": 320,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-Coder-480B-A35B-FP8-tpu7x-8-dataset_random-inlen_1024-outlen_8192-torchax",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 43200000,
+        "INPUT_LEN": 1024,
+        "OUTPUT_LEN": 8192,
+        "PREFIX_LEN": 0,
+        "SERVER_WAIT_MINS": 180,
+        "BENCHMARK_TIMEOUT": "4h",
+        "BK_TIMEOUT_IN_MINUTES": 360
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+          "seed": 42,
+          "max-num-seqs": 512,
+          "max-num-batched-tokens": 8192,
+          "tensor-parallel-size": {
+            "v7x-8": 8
+          },
+          "max-model-len": 9216,
+          "no-enable-prefix-caching": true,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.8,
+          "block-size": 256,
+          "enable-expert-parallel": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 1024,
+          "random-output-len": 8192,
+          "num-prompts": 320,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-Coder-480B-A35B-FP8-tpu7x-8-dataset_random-inlen_8192-outlen_1024-torchax",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 43200000,
+        "INPUT_LEN": 8192,
+        "OUTPUT_LEN": 1024,
+        "PREFIX_LEN": 0,
+        "SERVER_WAIT_MINS": 180,
+        "BENCHMARK_TIMEOUT": "4h",
+        "BK_TIMEOUT_IN_MINUTES": 360
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+          "seed": 42,
+          "max-num-seqs": 512,
+          "max-num-batched-tokens": 8192,
+          "tensor-parallel-size": {
+            "v7x-8": 8
+          },
+          "max-model-len": 9216,
+          "no-enable-prefix-caching": true,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.8,
+          "block-size": 256,
+          "enable-expert-parallel": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 8192,
+          "random-output-len": 1024,
+          "num-prompts": 320,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-Coder-480B-A35B-FP8-tpu7x-8-dataset_random-inlen_1024-outlen_1024-torchax-libtpuopt",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 43200000,
+        "INPUT_LEN": 1024,
+        "OUTPUT_LEN": 1024,
+        "PREFIX_LEN": 0,
+        "SERVER_WAIT_MINS": 180,
+        "BENCHMARK_TIMEOUT": "4h",
+        "BK_TIMEOUT_IN_MINUTES": 360
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1",
+          "LIBTPU_INIT_ARGS": "--xla_tpu_enable_sparse_core_collective_offload_all_reduce=false --xla_tpu_all_gather_collective_matmul_mode=post_spmd_conservative --xla_tpu_reduce_scatter_collective_matmul_mode=post_spmd_conservative --xla_jf_crs_combiner_threshold_in_bytes=0 --xla_tpu_scheduler_percent_shared_memory_limit=1000 --xla_jf_enable_producer_consumer_multi_output_fusion=false --xla_tpu_enable_domain_passes=true --xla_collective_optimize_constant_table=ENABLED --xla_jf_fusion_max_instruction_count_for_window_config=65536"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+          "seed": 42,
+          "max-num-seqs": 512,
+          "max-num-batched-tokens": 8192,
+          "tensor-parallel-size": {
+            "v7x-8": 8
+          },
+          "max-model-len": 9216,
+          "no-enable-prefix-caching": true,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.8,
+          "block-size": 256,
+          "enable-expert-parallel": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 1024,
+          "random-output-len": 1024,
+          "num-prompts": 320,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-Coder-480B-A35B-FP8-tpu7x-8-dataset_random-inlen_1024-outlen_8192-torchax-libtpuopt",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 43200000,
+        "INPUT_LEN": 1024,
+        "OUTPUT_LEN": 8192,
+        "PREFIX_LEN": 0,
+        "SERVER_WAIT_MINS": 180,
+        "BENCHMARK_TIMEOUT": "4h",
+        "BK_TIMEOUT_IN_MINUTES": 360
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1",
+          "LIBTPU_INIT_ARGS": "--xla_tpu_enable_sparse_core_collective_offload_all_reduce=false --xla_tpu_all_gather_collective_matmul_mode=post_spmd_conservative --xla_tpu_reduce_scatter_collective_matmul_mode=post_spmd_conservative --xla_jf_crs_combiner_threshold_in_bytes=0 --xla_tpu_scheduler_percent_shared_memory_limit=1000 --xla_jf_enable_producer_consumer_multi_output_fusion=false --xla_tpu_enable_domain_passes=true --xla_collective_optimize_constant_table=ENABLED --xla_jf_fusion_max_instruction_count_for_window_config=65536"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+          "seed": 42,
+          "max-num-seqs": 512,
+          "max-num-batched-tokens": 8192,
+          "tensor-parallel-size": {
+            "v7x-8": 8
+          },
+          "max-model-len": 9216,
+          "no-enable-prefix-caching": true,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.8,
+          "block-size": 256,
+          "enable-expert-parallel": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 1024,
+          "random-output-len": 8192,
+          "num-prompts": 320,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-Coder-480B-A35B-FP8-tpu7x-8-dataset_random-inlen_8192-outlen_1024-torchax-libtpuopt",
+      "ci_queue": [
+        "tpu_v7x_8_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 43200000,
+        "INPUT_LEN": 8192,
+        "OUTPUT_LEN": 1024,
+        "PREFIX_LEN": 0,
+        "SERVER_WAIT_MINS": 180,
+        "BENCHMARK_TIMEOUT": "4h",
+        "BK_TIMEOUT_IN_MINUTES": 360
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1",
+          "LIBTPU_INIT_ARGS": "--xla_tpu_enable_sparse_core_collective_offload_all_reduce=false --xla_tpu_all_gather_collective_matmul_mode=post_spmd_conservative --xla_tpu_reduce_scatter_collective_matmul_mode=post_spmd_conservative --xla_jf_crs_combiner_threshold_in_bytes=0 --xla_tpu_scheduler_percent_shared_memory_limit=1000 --xla_jf_enable_producer_consumer_multi_output_fusion=false --xla_tpu_enable_domain_passes=true --xla_collective_optimize_constant_table=ENABLED --xla_jf_fusion_max_instruction_count_for_window_config=65536"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+          "seed": 42,
+          "max-num-seqs": 512,
+          "max-num-batched-tokens": 8192,
+          "tensor-parallel-size": {
+            "v7x-8": 8
+          },
+          "max-model-len": 9216,
+          "no-enable-prefix-caching": true,
+          "kv-cache-dtype": "fp8",
+          "gpu-memory-utilization": 0.8,
+          "block-size": 256,
+          "enable-expert-parallel": true,
+          "async-scheduling": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-Coder-480B-A35B-Instruct-FP8",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "random",
+          "random-input-len": 8192,
+          "random-output-len": 1024,
+          "num-prompts": 320,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    }
+  ]
+}

--- a/.buildkite/benchmark/cases/daily/bm_v7x_sonnet_torchax_jax.json
+++ b/.buildkite/benchmark/cases/daily/bm_v7x_sonnet_torchax_jax.json
@@ -1,0 +1,153 @@
+{
+  "global_env": {
+    "GCP_PROJECT_ID": "cloud-tpu-inference-test",
+    "GCS_BUCKET": "vllm-cb-storage2",
+    "GCP_INSTANCE_ID": "vllm-bm-inst",
+    "GCP_DATABASE_ID": "vllm-bm-bk-runs"
+  },
+  "benchmark_cases": [
+    {
+      "case_name": "Qwen3-Coder-30B-A3B-tpu7x-2-dataset_sonnet-inlen_1024-outlen_1024-torchax",
+      "ci_queue": [
+        "tpu_v7x_2_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1024,
+        "OUTPUT_LEN": 1024,
+        "BK_TIMEOUT_IN_MINUTES": 120
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 10275,
+          "tensor-parallel-size": {
+            "v7x-2": 1
+          },
+          "max-model-len": 10275,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-Coder-30B-A3B-Instruct",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1024,
+          "sonnet-output-len": 1024,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "Qwen3-0.6B-tpu7x-2-dataset_sonnet-inlen_1024-outlen_1024-torchax",
+      "ci_queue": [
+        "tpu_v7x_2_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1024,
+        "OUTPUT_LEN": 1024,
+        "BK_TIMEOUT_IN_MINUTES": 120
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm",
+          "USE_BATCHED_RPA_KERNEL": "1"
+        },
+        "args": {
+          "model": "Qwen/Qwen3-0.6B",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 10275,
+          "tensor-parallel-size": {
+            "v7x-2": 1
+          },
+          "max-model-len": 10275,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "Qwen/Qwen3-0.6B",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1024,
+          "sonnet-output-len": 1024,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    },
+    {
+      "case_name": "gpt-oss-20b-tpu7x-2-dataset_sonnet-inlen_1024-outlen_1024-torchax",
+      "ci_queue": [
+        "tpu_v7x_2_queue"
+      ],
+      "env": {
+        "RUN_TYPE": "DAILY_AX_JAX",
+        "EXPECTED_ETEL": 3600000,
+        "INPUT_LEN": 1024,
+        "OUTPUT_LEN": 1024,
+        "BK_TIMEOUT_IN_MINUTES": 120
+      },
+      "server_command_options": {
+        "command_type": "vllm_serve",
+        "env": {
+          "VLLM_USE_V1": "1",
+          "TPU_BACKEND_TYPE": "jax",
+          "MODEL_IMPL_TYPE": "vllm"
+        },
+        "args": {
+          "model": "openai/gpt-oss-20b",
+          "seed": 42,
+          "max-num-seqs": 128,
+          "max-num-batched-tokens": 10275,
+          "tensor-parallel-size": {
+            "v7x-2": 1
+          },
+          "max-model-len": 10275,
+          "no-enable-prefix-caching": true
+        }
+      },
+      "client_command_options": {
+        "command_type": "vllm_bench_serve",
+        "args": {
+          "model": "openai/gpt-oss-20b",
+          "backend": "vllm",
+          "request-rate": "inf",
+          "dataset-name": "sonnet",
+          "dataset-path": "/workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt",
+          "sonnet-input-len": 1024,
+          "sonnet-output-len": 1024,
+          "num-prompts": 1000,
+          "percentile-metrics": "ttft,tpot,itl,e2el",
+          "ignore-eos": true
+        }
+      }
+    }
+  ]
+}

--- a/.buildkite/benchmark/scripts/run_bm.sh
+++ b/.buildkite/benchmark/scripts/run_bm.sh
@@ -410,6 +410,26 @@ if contains_element "$DATASET" "${DATASETS[@]}"; then
   fi
 fi
 
+# sonnet ships inside the vLLM checkout rather than the GCS bucket, so it is
+# built here instead of being synced above. `vllm bench serve` samples each
+# prompt from a distinct slice of the file, and one copy of sonnet.txt is too
+# short to fill 1800-token inputs at 1000 prompts -- concatenating it four times
+# is what bm-infra did, and the recorded throughput history these cases continue
+# was measured against that same 4x file.
+if [[ "$DATASET" == "sonnet" ]]; then
+  SONNET_SRC="/workspace/vllm/benchmarks/sonnet.txt"
+  SONNET_4X="$DATASET_DIR/sonnet_4x.txt"
+  if [[ ! -f "$SONNET_SRC" ]]; then
+    echo "[ERROR] $SONNET_SRC not found; cannot build the sonnet dataset."
+    report_and_exit 1
+  fi
+  echo "Building $SONNET_4X from $SONNET_SRC"
+  : > "$SONNET_4X"
+  for _ in 1 2 3 4; do
+    cat "$SONNET_SRC" >> "$SONNET_4X"
+  done
+fi
+
 # Prep specialized configurations (DeepSeek)
 if [[ "$MODEL" == "deepseek-ai/DeepSeek-R1" && "${IS_MULTI_HOST_BENCH:-false}" == "false" ]]; then
   if [[ -n "${GCS_GEN_CONFIG:-}" ]]; then
@@ -435,16 +455,6 @@ if [ "$COMMAND_TYPE" = "lm_eval" ]; then
   } >> "$BM_LOG"
   echo "Finished running $DATASET benchmark."
   report_and_exit 0
-fi
-
-# For Sonnet
-if [ "$DATASET" = "sonnet" ]; then
-  echo "Create sonnet_4x.txt"
-  echo "" > benchmarks/sonnet_4x.txt
-  for _ in {1..4}
-    do
-     cat benchmarks/sonnet.txt >> benchmarks/sonnet_4x.txt
-  done
 fi
 
 #


### PR DESCRIPTION
## Why

The bm-infra fleet that fed the v6e benchmark dashboards has been stopped, so the `RunRecord` series behind them are about to go flat. This ports the workloads bm-infra was actually completing over to the Buildkite benchmark framework so the dashboards keep getting points.

## What

29 cases across three files under `.buildkite/benchmark/cases/daily/`, reproducing the productive rows of bm-infra's `hourly_jax.csv`, `hourly_torchax_jax.csv` and `hourly_jax_new.csv`:

| File | Cases | `RUN_TYPE` | Backend env |
|---|---|---|---|
| `bm_v6e_sonnet_jax.json` | 7 | `DAILY_JAX` | `TPU_BACKEND_TYPE=jax` |
| `bm_v6e_sonnet_torchax_jax.json` | 21 | `DAILY_AX_JAX` | `+ MODEL_IMPL_TYPE=vllm` |
| `bm_v6e_sonnet_jax_new_model_design.json` | 1 | `DAILY_JAX`, `MODELTAG=NEW` | `+ NEW_MODEL_DESIGN=True` |

Queue split: 14 on `tpu_v6e_queue`, 15 on `tpu_v6e_8_queue`. Both exist in the CI cluster today.

## Decisions worth reviewing

**Daily, not hourly.** bm-infra ran these every hour, but the v6e reservation consolidation leaves no headroom. The dashboards care about config coverage, not cadence, so these land in `cases/daily/`.

**`RUN_TYPE` is `DAILY_*`, not bm-infra's `HOURLY_*`.** Keeping the old spelling would only have been worth it to avoid touching the dashboard queries, and those have to be repointed at `vllm-bm-bk-runs` regardless. The `_JAX` / `_AX_JAX` split is kept because it's the backend A/B the charts plot — collapsing both to the bare `DAILY` the other rows use would leave that distinction recoverable only by string-matching `MODEL_IMPL_TYPE` out of `ExtraEnvs`.

**Dead cases dropped.** Anything with zero completed runs in bm-infra's last 30 days is not carried over: `Qwen2.5-VL-3B`, `Qwen3-Coder-30B-A3B`, `Qwen3-0.6B`, `gpt-oss-20b`, `Codestral-22B`, `Mistral-Small-24B`, and the `Qwen2.5` jax variants on v6e-8.

**customer1 `gemma-3-12b` is not ported.** It needs a v6e-4 queue the CI cluster doesn't have.

**Results go to `vllm-bm-bk-runs`, not the old `vllm-bm-runs`.** `report_result.sh` emits `CaseName` and `Config` unconditionally and needs `RunBy` wide enough for 36-char v6e-8 agent names (`v6e-8-ci-5-test-southamerica-west1-a`). `vllm-bm-bk-runs` already has all three; `vllm-bm-runs` has none of them. **So this needs no production schema change.**

Stitching pre-cutover bm-infra history onto these rows is a query-time concat, verified to reproduce all 29 `case_name`s exactly against real historical rows:

```sql
CONCAT(
  REPLACE(REGEXP_EXTRACT(Model, r'[^/]+$'), '-Instruct', ''), '-', Device,
  '-dataset_', Dataset,
  '-inlen_',  CAST(InputLen  AS STRING),
  '-outlen_', CAST(OutputLen AS STRING), '-',
  CASE
    WHEN RunType LIKE '%AX_JAX'                    THEN 'torchax'
    WHEN RunType LIKE '%JAX' AND ModelTag = 'NEW'  THEN 'jax-nmd'
    WHEN RunType LIKE '%JAX'                       THEN 'jax'
  END)
```

## `run_bm.sh`

**Adds** a `sonnet` branch to dataset prep. `sonnet.txt` ships inside the vLLM checkout rather than the GCS bucket the other datasets sync from, and a single copy is too short to fill 1800-token prompts at 1000 prompts. bm-infra concatenated it 4x, and the throughput history these cases continue was measured against that same file.

**Removes** the pre-existing sonnet block further down the same script. It wrote to a relative `benchmarks/sonnet_4x.txt` while cwd is the repo root inside the container, so the redirect always failed. It was dead code — no case file on `main` sets `dataset-name: sonnet`, so nothing had ever reached it. These cases are the first, and build 24801 crashed on exactly that:

```
Building /workspace/tpu_inference/artifacts/dataset/sonnet_4x.txt from ...   <- new block, worked
Create sonnet_4x.txt                                                          <- old block
run_bm.sh: line 463: benchmarks/sonnet_4x.txt: No such file or directory      <- crash
```

The new block supersedes it and writes to `$DATASET_DIR`, the path the case files pass to `--dataset-path`.

## Validation

Static:
- `validate_case_names.py` — 100 case_names globally unique across 19 files
- `bash -n run_bm.sh` — clean
- `generate_bk_pipeline.py` — 7 / 21 / 1 steps, correct queues and env
- `parser_case.py` reproduces the bm-infra command shape on `Qwen3-30B-A3B-v6e-8`, including `TENSOR_PARALLEL_SIZE=4` on a v6e-8 host and `USE_BATCHED_RPA_KERNEL=1`

Live, on [build 24803](https://buildkite.com/tpu-commons/tpu-inference-ci/builds/24803) with a temporarily trimmed 3-case subset (since restored to the full 29) chosen to cover both queues, both backends, the new sonnet_4x prep, the RPA kernel, and the TP≠chip-count config:

| Case | Queue | Result |
|---|---|---|
| `Llama-3.1-8B-v6e-1-...-jax` | `tpu_v6e_queue` | ✅ passed |
| `Qwen3-4B-v6e-1-...-torchax` | `tpu_v6e_queue` | ✅ passed |
| `Qwen3-30B-A3B-v6e-8-...-torchax` | `tpu_v6e_8_queue` | ✅ passed |

⚠️ **PR builds set `UPLOAD_DB=false`** (`bootstrap.sh:219`), so the Spanner write to `vllm-bm-bk-runs` is *not* covered by the above. That path only exercises on a real daily build, so the first post-merge run is worth watching.