### PR TITLE
[Runner] Never pad a step past max_num_batched_tokens

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -16,7 +16,8 @@ from jax._src.pallas.utils import next_power_of_2
 from tpu_inference.runner.utils import (
     MAX_TRACED_REQUEST_IDS, PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR,
     AggregatedStatsLogger, ForbidCompile, InferencePhase, LatencyTracker,
-    PhasedBasedProfiler, determine_phase_from_batch_composition_stats,
+    PhasedBasedProfiler, build_token_paddings,
+    determine_phase_from_batch_composition_stats,
     extract_request_ids_for_tracing, get_batch_composition_stats,
     get_padded_num_reqs_with_upper_limit, get_padded_token_len,
     get_req_paddings, get_token_paddings)
@@ -99,6 +100,32 @@ def test_get_paddings():
     actual_paddings = get_token_paddings(min_token_size, max_token_size,
                                          padding_gap)
     assert actual_paddings == expected_paddings
+
+
+def test_build_token_paddings_caps_at_budget():
+    # Budget 16640 with the exponential gap: the stock list ends ..., 16384,
+    # 32768; the runner list ends at the budget itself.
+    assert build_token_paddings(
+        256, 16640, 0) == [256, 512, 1024, 2048, 4096, 8192, 16384, 16640]
+    # A budget that is already a bucket yields the stock list.
+    assert build_token_paddings(16, 512, 0) == get_token_paddings(16, 512, 0)
+    # Bucketed gap: the last bucket is the budget, not the overshoot.
+    assert build_token_paddings(16, 317,
+                                64) == [16, 32, 64, 128, 192, 256, 320]
+    # The budget is rounded up to a multiple of min_token_size.
+    assert build_token_paddings(32, 16640 * 16, 0)[-1] == 266240
+
+
+def test_build_token_paddings_keeps_compilation_sizes():
+    # User-supplied sizes are merged as given (even above the budget) and
+    # deduplicated against the generated buckets.
+    assert build_token_paddings(256,
+                                16640,
+                                0,
+                                additional_sizes=[4096, 12288, 32768]) == [
+                                    256, 512, 1024, 2048, 4096, 8192, 12288,
+                                    16384, 16640, 32768
+                                ]
 
 
 def _tracing_batch(num_reqs):

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1062,12 +1062,6 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             cache_dtype = self.dtype
         kv_cache_dtype = to_jax_dtype(cache_dtype)
         kv_packing = common_utils.get_dtype_packing(kv_cache_dtype)
-        self.num_tokens_paddings = runner_utils.get_token_paddings(
-            min_token_size=max(envs.MIN_TOKEN_BUCKET,
-                               next_power_of_2(self.dp_size * kv_packing)),
-            max_token_size=scheduler_config.max_num_batched_tokens *
-            self.dp_size,
-            padding_gap=envs.VLLM_TPU_BUCKET_PADDING_GAP)
         # PCP rounds every request's chunk size up independently, so the token
         # buffer the layout needs can exceed max_num_batched_tokens by up to
         # 2 * pcp_size * max_num_seqs; add a bucket with exactly that headroom.
@@ -1078,8 +1072,20 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             additional_sizes = list(additional_sizes) + [
                 common_utils.align_to(_worst * self.dp_size, 128)
             ]
-        self.num_tokens_paddings = sorted(self.num_tokens_paddings +
-                                          additional_sizes)
+        # Never pad a step past the scheduler's own token budget: a full
+        # chunked-prefill step must not jump to the next exponential bucket
+        # (which can be ~2x the budget and, on some shapes, compiles into a
+        # program that returns wrong last-position logits). The budget joins
+        # the bucket list through the same merge as `compilation_sizes` (and
+        # the PCP headroom bucket above), and unreachable generated buckets
+        # above it are dropped.
+        self.num_tokens_paddings = runner_utils.build_token_paddings(
+            min_token_size=max(envs.MIN_TOKEN_BUCKET,
+                               next_power_of_2(self.dp_size * kv_packing)),
+            max_token_size=scheduler_config.max_num_batched_tokens *
+            self.dp_size,
+            padding_gap=envs.VLLM_TPU_BUCKET_PADDING_GAP,
+            additional_sizes=additional_sizes)
         self.num_tokens_paddings_per_dp = [
             padding // self.dp_size for padding in self.num_tokens_paddings
         ]

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -14,7 +14,7 @@ import threading
 import time
 from dataclasses import dataclass, field
 from enum import Enum
-from typing import Any, Optional
+from typing import Any, Optional, Sequence
 
 import jax
 import jax.numpy as jnp
@@ -223,6 +223,33 @@ def get_token_paddings(min_token_size: int, max_token_size: int,
             paddings.append(num)
     logger.info(f"Prepared token paddings: {paddings}")
     return paddings
+
+
+def build_token_paddings(
+    min_token_size: int,
+    max_token_size: int,
+    padding_gap: int,
+    additional_sizes: Sequence[int] = ()) -> list[int]:
+    """Token buckets for the runner: never pad a step past the budget.
+
+    `get_token_paddings` grows buckets until one covers `max_token_size`, so
+    a budget that is not itself a bucket (e.g. 16640 with the default
+    exponential gap) lands a full chunked-prefill step on the next bucket,
+    up to ~2x the scheduler's own limit (16640 -> 32768 tokens per rank).
+    The scheduler never schedules more than the budget, so buckets above it
+    are unreachable: they only cost a compile each and size the runner's
+    preallocated token buffers.
+
+    This returns the generated buckets capped at the budget (rounded up to a
+    multiple of `min_token_size`), the budget itself, and any user-supplied
+    `compilation_sizes`, which are kept as given even when above the budget.
+    A budget that is already a bucket yields the stock list.
+    """
+    budget = -(-max_token_size // min_token_size) * min_token_size
+    generated = get_token_paddings(min_token_size, max_token_size, padding_gap)
+    sizes = {p for p in generated if p <= budget} | {budget}
+    sizes.update(int(x) for x in additional_sizes)
+    return sorted(sizes)
 
 
 def get_padded_token_len(paddings: list[int], x: int) -> int:


### PR DESCRIPTION
# [Runner] Never pad a step past `max_num_batched_tokens`

## Problem
`TPUModelRunner` builds `num_tokens_paddings` with `get_token_paddings(min, max_num_batched_tokens * dp_size, gap)`.
With the default `VLLM_TPU_BUCKET_PADDING_GAP=0` the buckets double until they cover the budget, so a **full
chunked-prefill step is padded to the next power of two** whenever the budget is not one itself. Example
(Qwen3-0.6B, TP8 x DP16, `max_num_batched_tokens=16640`): a 16640-token prefill chunk runs at the **32768**-token
shape per rank — 97% padding.

On that shape we also observe a silent correctness problem: the last-position logits of the padded prefill step
are wrong, so the *first sampled token* of ~90% of requests is garbage (` tắc`, ` iquement`, ` 人力`, ...) before
the model recovers on the next decode step. Reproduced on TPU7x with page_size 128, 1 KV head/device
(tpu-inference @ be9cdf04): first token correct for 0/2048 requests at the 32768 shape, 2048/2048 when the
same chunk is padded to 18432 (`VLLM_TPU_BUCKET_PADDING_GAP=32768`), 16384 (`max_num_batched_tokens=12544`),
or 4096. The kernel-level cause at the 32768 shape is not localized here; this PR removes the trigger
and the padding waste.

## Change
- `runner/utils.py::build_token_paddings(min, max, gap, additional_sizes)`: the runner's bucket list is now the generated
  buckets **capped at the budget** (rounded up to a multiple of `min_token_size`), the budget itself, and the user's
  `additional_config.compilation_sizes`, merged and deduplicated in one place. The budget enters through the same merge
  that already handled `compilation_sizes`; no new flag on `get_token_paddings`, which is unchanged.
- Buckets above the budget are dropped: the scheduler never schedules more than `max_num_batched_tokens` per rank, so
  they are unreachable and only cost a compile each and oversize the preallocated token buffers (`max_num_tokens` is
  derived from the last bucket). With a 16640 budget the list ends `..., 8192, 16384, 16640` instead of
  `..., 8192, 16384, 32768`. User-supplied `compilation_sizes` are kept as given, even above the budget.
- `runner/tpu_runner.py`: builds the list through the helper. A budget that is already a bucket (e.g. 8192, 16384)
  yields the stock list, so those configurations see no change.
- `tests/runner/test_utils.py`: capped list for the exponential and bucketed gaps, stock list for a power-of-two budget,
  rounding of the budget, and `compilation_sizes` preserved and deduplicated.

## Validation
- Unit tests for `get_token_paddings`.
- End-to-end (MaxText/tunix GRPO, Qwen3-0.6B, TP8xDP16, budget 16640): with the patch and **no** env override,
  first token correct for 2048/2048 requests (LENDIST census), generation distribution identical to the
  `VLLM_TPU_BUCKET_PADDING_GAP=32768` workaround; without it 0-256/2048. Run 51 (this patch, no env): first token correct 2048/2048 at steps 0 and 1; 29.3% / osl 4477 at step 0 (workaround run: 27.5% / 4391 — same distribution, different samples); step-1 engine_generate 84.5 s vs 88.5 s with the 18432 workaround and 82.9 s on the corrupted 32768 shape, i.e. the exact-budget bucket also pads less than the gap workaround.
- No behaviour change when the budget is already a bucket (e.g. 8192, 16384).

