### PR TITLE
[Bugfix] Support IPv6 only environment

### DIFF
--- a/tests/distributed/test_distributed_utils.py
+++ b/tests/distributed/test_distributed_utils.py
@@ -16,7 +16,8 @@ from collections import namedtuple
 
 import pytest
 
-from tpu_inference.distributed.utils import get_device_topology_order_id
+from tpu_inference.distributed.utils import (format_host_port,
+                                             get_device_topology_order_id)
 
 # Mock TpuDevice object to simulate the real one.
 TpuDevice = namedtuple('TpuDevice',
@@ -118,3 +119,21 @@ def test_get_device_topology_order_id_not_in_global():
     ]
     with pytest.raises(ValueError, match="do not exist in the global device:"):
         get_device_topology_order_id(local_devices, global_devices)
+
+
+def test_format_host_port():
+    """Tests that format_host_port correctly formats IPv4, hostnames, and IPv6 addresses."""
+    # IPv4 tests
+    assert format_host_port("127.0.0.1", 8080) == "127.0.0.1:8080"
+    assert format_host_port("10.0.0.1", "9100") == "10.0.0.1:9100"
+    assert format_host_port("localhost", 5000) == "localhost:5000"
+
+    # IPv6 tests
+    assert format_host_port("2001:db8::1", 9100) == "[2001:db8::1]:9100"
+    assert format_host_port("::1", 0) == "[::1]:0"
+    assert format_host_port("fd99:0:0:2a::ac6",
+                            "9100") == "[fd99:0:0:2a::ac6]:9100"
+
+    # Already bracketed IPv6 tests
+    assert format_host_port("[2001:db8::1]", 9100) == "[2001:db8::1]:9100"
+    assert format_host_port("[::1]", 0) == "[::1]:0"

--- a/tests/distributed/test_jax_parallel_state.py
+++ b/tests/distributed/test_jax_parallel_state.py
@@ -1,0 +1,93 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest
+from unittest.mock import MagicMock, patch
+
+from tpu_inference.distributed import jax_parallel_state
+
+
+class TestJaxParallelState(unittest.TestCase):
+
+    def setUp(self):
+        jax_parallel_state._PP = jax_parallel_state.GroupCoordinator(0, 2)
+
+    @patch("tpu_inference.distributed.jax_parallel_state.transfer")
+    def test_init_pp_distributed_environment_ipv4(self, mock_transfer):
+        mock_device = MagicMock()
+        mock_transfer_server = MagicMock()
+        mock_transfer.start_transfer_server.return_value = mock_transfer_server
+
+        jax_parallel_state.init_pp_distributed_environment(ip="127.0.0.1",
+                                                           rank=0,
+                                                           world_size=2,
+                                                           device=mock_device,
+                                                           need_pp=True)
+
+        mock_transfer.start_transfer_server.assert_called_once_with(
+            mock_device.client, "127.0.0.1:5000",
+            ["127.0.0.1:0", "127.0.0.1:0"])
+        pp_group = jax_parallel_state.get_pp_group()
+        self.assertEqual(pp_group.transfer_server, mock_transfer_server)
+
+    @patch("tpu_inference.distributed.jax_parallel_state.transfer")
+    def test_init_pp_distributed_environment_ipv6(self, mock_transfer):
+        mock_device = MagicMock()
+        mock_transfer_server = MagicMock()
+        mock_transfer.start_transfer_server.return_value = mock_transfer_server
+
+        jax_parallel_state.init_pp_distributed_environment(ip="2001:db8::1",
+                                                           rank=1,
+                                                           world_size=2,
+                                                           device=mock_device,
+                                                           need_pp=True)
+
+        mock_transfer.start_transfer_server.assert_called_once_with(
+            mock_device.client,
+            "[2001:db8::1]:5001",
+            ["[2001:db8::1]:0", "[2001:db8::1]:0"],
+        )
+        pp_group = jax_parallel_state.get_pp_group()
+        self.assertEqual(pp_group.transfer_server, mock_transfer_server)
+
+    def test_connect_ipv4(self):
+        mock_transfer_server = MagicMock()
+        mock_conn = MagicMock()
+        mock_transfer_server.connect.return_value = mock_conn
+
+        pp_group = jax_parallel_state.get_pp_group()
+        pp_group.transfer_server = mock_transfer_server
+
+        jax_parallel_state.connect(prev_ip="127.0.0.1", prev_rank=0)
+
+        mock_transfer_server.connect.assert_called_once_with("127.0.0.1:5000")
+        self.assertEqual(pp_group.connection, mock_conn)
+
+    def test_connect_ipv6(self):
+        mock_transfer_server = MagicMock()
+        mock_conn = MagicMock()
+        mock_transfer_server.connect.return_value = mock_conn
+
+        pp_group = jax_parallel_state.get_pp_group()
+        pp_group.transfer_server = mock_transfer_server
+
+        jax_parallel_state.connect(prev_ip="2001:db8::1", prev_rank=0)
+
+        mock_transfer_server.connect.assert_called_once_with(
+            "[2001:db8::1]:5000")
+        self.assertEqual(pp_group.connection, mock_conn)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/distributed/test_tpu_connector.py
+++ b/tests/distributed/test_tpu_connector.py
@@ -509,6 +509,50 @@ class TestTPUConnectorWorker(unittest.TestCase):
         self.assertEqual(done_recving, set())
         self.assertNotIn('req1', worker.reqs_wait_pull)
 
+    def test_maybe_start_p2p_server_ipv6(self):
+        """Tests that _maybe_start_p2p_server formats IPv6 addresses with brackets."""
+        self.vllm_config.kv_transfer_config.is_kv_producer = False
+        worker = tpu_connector.TPUConnectorWorker(self.vllm_config)
+        worker.host_ip = "2001:db8::1"
+        worker.kv_transfer_port = 9100
+
+        worker._maybe_start_p2p_server()
+
+        self.all_mocks["start_transfer_server"].assert_called_once()
+        call_args, _ = self.all_mocks["start_transfer_server"].call_args
+        server_addr = call_args[1]
+        transport_addrs = call_args[2]
+
+        self.assertEqual(server_addr, "[2001:db8::1]:9100")
+        for addr in transport_addrs:
+            self.assertEqual(addr, "[2001:db8::1]:0")
+
+    def test_maybe_build_kv_connection_ipv6(self):
+        """Tests that _maybe_build_kv_connection formats IPv6 addresses with brackets."""
+        self.vllm_config.kv_transfer_config.is_kv_producer = False
+        worker = tpu_connector.TPUConnectorWorker(self.vllm_config)
+        mock_server = MagicMock()
+        worker.kv_transfer_server = mock_server
+
+        # Single string host/port
+        load_meta_single = tpu_connector.LoadMeta(uuid=1,
+                                                  local_block_ids=[1],
+                                                  remote_block_ids=[10],
+                                                  remote_host="2001:db8::1",
+                                                  remote_port=9100)
+        worker._maybe_build_kv_connection(load_meta_single)
+        mock_server.connect.assert_called_with("[2001:db8::1]:9100")
+
+        # List host/port
+        load_meta_list = tpu_connector.LoadMeta(
+            uuid=2,
+            local_block_ids=[1],
+            remote_block_ids=[10],
+            remote_host=["2001:db8::2", "2001:db8::3"],
+            remote_port=[9101, 9102])
+        worker._maybe_build_kv_connection(load_meta_list)
+        mock_server.connect.assert_called_with("[2001:db8::2]:9101")
+
 
 class TestTPUConnectorUtils(unittest.TestCase):
 

--- a/tests/distributed/test_tpu_connector.py
+++ b/tests/distributed/test_tpu_connector.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import threading
 import unittest
 from functools import partial
 from unittest.mock import MagicMock, patch
@@ -552,6 +553,58 @@ class TestTPUConnectorWorker(unittest.TestCase):
             remote_port=[9101, 9102])
         worker._maybe_build_kv_connection(load_meta_list)
         mock_server.connect.assert_called_with("[2001:db8::2]:9101")
+
+    def test_pull_notify_listener_ipv6(self):
+        """Tests that _pull_notify_listener binds to :: when host_ip is IPv6."""
+        self.vllm_config.kv_transfer_config.is_kv_producer = False
+        worker = tpu_connector.TPUConnectorWorker(self.vllm_config)
+        worker.host_ip = "2001:db8::1"
+        worker.side_channel_port = 9600
+
+        mock_sock = MagicMock()
+        mock_sock.recv_multipart.side_effect = KeyboardInterrupt
+        self.all_mocks["make_zmq_socket"].return_value = mock_sock
+
+        ready_event = threading.Event()
+        try:
+            worker._pull_notify_listener(ready_event)
+        except KeyboardInterrupt:
+            pass
+
+        self.assertTrue(ready_event.is_set())
+        self.all_mocks["make_zmq_path"].assert_called_with("tcp", "::", 9600)
+        self.all_mocks["make_zmq_socket"].assert_called_with(
+            ctx=worker.zmq_cxt,
+            path=self.all_mocks["make_zmq_path"].return_value,
+            socket_type=self.all_mocks["zmq"].ROUTER,
+            bind=True,
+        )
+
+    def test_pull_notify_listener_ipv4(self):
+        """Tests that _pull_notify_listener binds to * when host_ip is IPv4."""
+        self.vllm_config.kv_transfer_config.is_kv_producer = False
+        worker = tpu_connector.TPUConnectorWorker(self.vllm_config)
+        worker.host_ip = "127.0.0.1"
+        worker.side_channel_port = 9600
+
+        mock_sock = MagicMock()
+        mock_sock.recv_multipart.side_effect = KeyboardInterrupt
+        self.all_mocks["make_zmq_socket"].return_value = mock_sock
+
+        ready_event = threading.Event()
+        try:
+            worker._pull_notify_listener(ready_event)
+        except KeyboardInterrupt:
+            pass
+
+        self.assertTrue(ready_event.is_set())
+        self.all_mocks["make_zmq_path"].assert_called_with("tcp", "*", 9600)
+        self.all_mocks["make_zmq_socket"].assert_called_with(
+            ctx=worker.zmq_cxt,
+            path=self.all_mocks["make_zmq_path"].return_value,
+            socket_type=self.all_mocks["zmq"].ROUTER,
+            bind=True,
+        )
 
 
 class TestTPUConnectorUtils(unittest.TestCase):

--- a/tpu_inference/distributed/jax_parallel_state.py
+++ b/tpu_inference/distributed/jax_parallel_state.py
@@ -17,6 +17,8 @@ from typing import Any, Optional
 import jax
 from jax.experimental import transfer
 
+from tpu_inference.distributed.utils import format_host_port
+
 BASE_JAX_PORT = 5000
 
 
@@ -64,15 +66,18 @@ def init_pp_distributed_environment(ip: str, rank: int, world_size: int,
 
     if need_pp:
         port_number = BASE_JAX_PORT + rank
-        server_address = f"{ip}:{port_number}"
+        server_address = format_host_port(ip, port_number)
         transfer_server = transfer.start_transfer_server(
-            device.client, server_address, [f"{ip}:0", f"{ip}:0"])
+            device.client, server_address,
+            [format_host_port(ip, 0),
+             format_host_port(ip, 0)])
         _PP.transfer_server = transfer_server
 
 
 def connect(prev_ip: str, prev_rank: int):
     prev_port_number = BASE_JAX_PORT + prev_rank
-    connection = _PP.transfer_server.connect(f'{prev_ip}:{prev_port_number}')
+    connection = _PP.transfer_server.connect(
+        format_host_port(prev_ip, prev_port_number))
     _PP.connection = connection
 
 

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -570,8 +570,9 @@ class TPUConnectorWorker:
     def _maybe_start_p2p_server(self):
         if self.kv_transfer_server is not None:
             return
-        server_addr = f"{self.host_ip}:{self.kv_transfer_port}"
-        transport_addr = f'{self.host_ip}:0'
+        server_addr = dist_utils.format_host_port(self.host_ip,
+                                                  self.kv_transfer_port)
+        transport_addr = dist_utils.format_host_port(self.host_ip, 0)
         self.kv_transfer_server = start_transfer_server(
             jax.local_devices()[0].client,
             server_addr,
@@ -795,9 +796,12 @@ class TPUConnectorWorker:
     def _maybe_build_kv_connection(self, req_meta: LoadMeta) -> Any:
         if isinstance(req_meta.remote_host, list):
             assert len(req_meta.remote_host) == len(req_meta.remote_port)
-            remote_addr = f"{req_meta.remote_host[self.node_id]}:{req_meta.remote_port[self.node_id]}"
+            remote_addr = dist_utils.format_host_port(
+                req_meta.remote_host[self.node_id],
+                req_meta.remote_port[self.node_id])
         else:
-            remote_addr = f"{req_meta.remote_host}:{req_meta.remote_port}"
+            remote_addr = dist_utils.format_host_port(req_meta.remote_host,
+                                                      req_meta.remote_port)
 
         if remote_addr in self.pull_conns:
             conn = self.pull_conns[remote_addr]
@@ -831,7 +835,8 @@ class TPUConnectorWorker:
                     request_id=trim_request_id_suffix(req_id),
                     bytes=expected_bytes,
                     dimensions=dims_str,
-                    source=f"{req_meta.remote_host}:{req_meta.remote_port}"):
+                    source=dist_utils.format_host_port(req_meta.remote_host,
+                                                       req_meta.remote_port)):
                 kv = conn.pull(req_meta.uuid, kv_spec)
         else:
             kv = conn.pull(req_meta.uuid, kv_spec)

--- a/tpu_inference/distributed/tpu_connector.py
+++ b/tpu_inference/distributed/tpu_connector.py
@@ -78,7 +78,8 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import (
 from vllm.distributed.kv_transfer.kv_connector.v1.metrics import (
     KVConnectorPromMetrics, KVConnectorStats, PromMetric, PromMetricT)
 from vllm.utils.math_utils import round_down
-from vllm.utils.network_utils import make_zmq_path, make_zmq_socket
+from vllm.utils.network_utils import (is_valid_ipv6_address, make_zmq_path,
+                                      make_zmq_socket)
 from vllm.v1.core.sched.output import SchedulerOutput
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.request import RequestStatus
@@ -586,7 +587,8 @@ class TPUConnectorWorker:
         )
 
     def _pull_notify_listener(self, ready_event: threading.Event):
-        sock_path = make_zmq_path("tcp", "*", self.side_channel_port)
+        bind_host = "::" if is_valid_ipv6_address(self.host_ip) else "*"
+        sock_path = make_zmq_path("tcp", bind_host, self.side_channel_port)
         sock = make_zmq_socket(ctx=self.zmq_cxt,
                                path=sock_path,
                                socket_type=zmq.ROUTER,

--- a/tpu_inference/distributed/tpu_raiden_connector.py
+++ b/tpu_inference/distributed/tpu_raiden_connector.py
@@ -567,9 +567,9 @@ class TPUConnectorWorker:
         base = int(port)
         local_eps = self.kv_manager.get_local_endpoints()
         if len(local_eps) <= 1:
-            return f"{host}:{base}"
+            return dist_utils.format_host_port(host, base)
         return [{
-            "endpoint": f"{host}:{base + i}",
+            "endpoint": dist_utils.format_host_port(host, base + i),
             "shards": list(ep["shards"])
         } for i, ep in enumerate(local_eps)]
 

--- a/tpu_inference/distributed/utils.py
+++ b/tpu_inference/distributed/utils.py
@@ -58,6 +58,17 @@ def get_host_ip() -> str:
     return get_ip()
 
 
+def format_host_port(host: str, port: int | str) -> str:
+    """Format host and port into a valid endpoint address string.
+
+    Encloses IPv6 addresses in square brackets if not already bracketed.
+    """
+    host_str = str(host)
+    if ":" in host_str and not host_str.startswith("["):
+        return f"[{host_str}]:{port}"
+    return f"{host_str}:{port}"
+
+
 def get_kv_transfer_port() -> str:
     port = os.getenv("TPU_KV_TRANSFER_PORT", "9100")
     return port


### PR DESCRIPTION
Support IPv6 only environment (#3467)

* Add format_host_port utility in tpu_inference.distributed.utils to correctly enclose unbracketed IPv6 addresses as [ip]:port while preserving IPv4 and hostnames.
* Use format_host_port in TPUConnectorWorker._maybe_start_p2p_server, _maybe_build_kv_connection, and _pull_kv for server and remote endpoint addressing.
* Use format_host_port in jax_parallel_state for PP transfer server creation and connection endpoints.
* Use format_host_port in TPUConnectorWorker._get_remote_endpoint in tpu_raiden_connector.
* Add unit tests for format_host_port and IPv6 handling across distributed utils, tpu_connector, and jax_parallel_state.
* Support IPv6 wildcard binding in TPUConnector side channel listener

# Description

FIXES: #3467

# Tests

pytest tests/distributed/test_distributed_utils.py tests/distributed/test_jax_parallel_state.py tests/distributed/test_tpu_connector.py

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
