### PR TITLE
Fix HMA connector base initialization

### DIFF
--- a/tests/distributed/test_tpu_connector.py
+++ b/tests/distributed/test_tpu_connector.py
@@ -23,7 +23,7 @@ from vllm.distributed.kv_transfer.kv_connector.v1.base import KVConnectorRole
 from vllm.v1.kv_cache_interface import KVCacheConfig
 from vllm.v1.request import RequestStatus
 
-from tpu_inference.distributed import tpu_connector
+from tpu_inference.distributed import tpu_connector, tpu_connector_hma
 from tpu_inference.distributed.tpu_connector_stats import (
     TpuKVConnectorPromMetrics, TpuKVConnectorStats)
 
@@ -124,6 +124,44 @@ class TestTPUConnector(unittest.TestCase):
 
         connector.get_finished(set())
         mock_worker_instance.get_finished.assert_called_once_with()
+
+
+@patch("tpu_inference.distributed.tpu_connector_hma.TPUConnectorHMAWorker")
+@patch("tpu_inference.distributed.tpu_connector_hma.TPUConnectorHMAScheduler")
+class TestTPUConnectorHMA(unittest.TestCase):
+
+    def setUp(self):
+        self.vllm_config = MockVllmConfig()
+
+    def test_init_scheduler_role(self, mock_scheduler_cls, mock_worker_cls):
+        connector = tpu_connector_hma.TPUConnectorHMA(
+            self.vllm_config, KVConnectorRole.SCHEDULER,
+            _make_test_kv_cache_config())
+
+        mock_scheduler_cls.assert_called_once_with(self.vllm_config)
+        mock_worker_cls.assert_not_called()
+        self.assertIs(connector._vllm_config, self.vllm_config)
+        self.assertIs(connector._kv_transfer_config,
+                      self.vllm_config.kv_transfer_config)
+        self.assertEqual(connector.role, KVConnectorRole.SCHEDULER)
+        self.assertTrue(connector.requires_kv_delivery)
+        self.assertIsNotNone(connector.connector_scheduler)
+        self.assertIsNone(connector.connector_worker)
+
+    def test_init_worker_role(self, mock_scheduler_cls, mock_worker_cls):
+        connector = tpu_connector_hma.TPUConnectorHMA(
+            self.vllm_config, KVConnectorRole.WORKER,
+            _make_test_kv_cache_config())
+
+        mock_worker_cls.assert_called_once_with(self.vllm_config)
+        mock_scheduler_cls.assert_not_called()
+        self.assertIs(connector._vllm_config, self.vllm_config)
+        self.assertIs(connector._kv_transfer_config,
+                      self.vllm_config.kv_transfer_config)
+        self.assertEqual(connector.role, KVConnectorRole.WORKER)
+        self.assertTrue(connector.requires_kv_delivery)
+        self.assertIsNone(connector.connector_scheduler)
+        self.assertIsNotNone(connector.connector_worker)
 
 
 class TestTPUConnectorScheduler(unittest.TestCase):

--- a/tpu_inference/distributed/tpu_connector_hma.py
+++ b/tpu_inference/distributed/tpu_connector_hma.py
@@ -20,8 +20,8 @@ from typing import TYPE_CHECKING, Any, Optional
 import jax
 import jax.numpy as jnp
 from vllm.config import VllmConfig
-from vllm.distributed.kv_transfer.kv_connector.v1.base import (KVConnectorRole,
-                                                               SupportsHMA)
+from vllm.distributed.kv_transfer.kv_connector.v1.base import (
+    KVConnectorBase_V1, KVConnectorRole, SupportsHMA)
 from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.request import RequestStatus
 
@@ -52,7 +52,9 @@ class TPUConnectorHMA(TPUConnector, SupportsHMA):
                  vllm_config: VllmConfig,
                  role: KVConnectorRole,
                  kv_cache_config: "KVCacheConfig | None" = None):
-        self._connector_metadata = None
+        # TPUConnector.__init__ creates the non-HMA scheduler/worker, so call
+        # the shared base directly before creating the HMA implementation.
+        KVConnectorBase_V1.__init__(self, vllm_config, role, kv_cache_config)
 
         if role == KVConnectorRole.SCHEDULER:
             self.connector_scheduler = TPUConnectorHMAScheduler(vllm_config)


### PR DESCRIPTION
# Description

Initialize `TPUConnectorHMA`'s inherited `KVConnectorBase_V1` state before creating its HMA scheduler or worker delegate. This restores inherited properties such as `requires_kv_delivery`, `role`, and the vLLM/KV-cache configuration fields.

The shared base is initialized directly because calling `TPUConnector.__init__` would also create a non-HMA scheduler or worker (including worker executors, sockets, and a listener thread) only to overwrite it immediately.

Adds scheduler- and worker-role regression coverage for the inherited state and HMA delegate selection.

FIXES: #3468

# Tests

- `ruff check tpu_inference/distributed/tpu_connector_hma.py tests/distributed/test_tpu_connector.py`
- `isort --check-only --diff tpu_inference/distributed/tpu_connector_hma.py tests/distributed/test_tpu_connector.py`
- `yapf --diff tpu_inference/distributed/tpu_connector_hma.py tests/distributed/test_tpu_connector.py`
- `python3 -m py_compile tpu_inference/distributed/tpu_connector_hma.py tests/distributed/test_tpu_connector.py`
- `git diff --check` and `git show --check HEAD`

The focused pytest tests were not run locally because this checkout does not have the vLLM/JAX/TPU development runtime installed; project CI is expected to exercise them.

# Checklist

- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation. (No documentation change is needed for this initialization bug.)

> This change was prepared with AI assistance and reviewed by the issue reporter before being marked ready.

