### PR TITLE
Honor language-model-only multimodal configurations

### DIFF
--- a/tests/models/vllm/test_vllm_model_wrapper.py
+++ b/tests/models/vllm/test_vllm_model_wrapper.py
@@ -1,0 +1,50 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from tpu_inference.models.vllm.vllm_model_wrapper import VllmModelWrapper
+
+
+@pytest.mark.parametrize(
+    "is_multimodal_model, multimodal_config, expected",
+    [
+        (False, None, False),
+        (True, None, True),
+        (True, MagicMock(language_model_only=False), True),
+        (True, MagicMock(language_model_only=True), False),
+    ],
+)
+def test_is_multimodal_enabled(is_multimodal_model, multimodal_config,
+                               expected):
+    wrapper = object.__new__(VllmModelWrapper)
+    wrapper.vllm_config = MagicMock()
+    wrapper.vllm_config.model_config.is_multimodal_model = is_multimodal_model
+    wrapper.vllm_config.model_config.multimodal_config = multimodal_config
+
+    assert wrapper._is_multimodal_enabled() is expected
+
+
+def test_language_model_only_disables_multimodal_wrappers():
+    wrapper = object.__new__(VllmModelWrapper)
+    wrapper.vllm_config = MagicMock()
+    wrapper.vllm_config.model_config.is_multimodal_model = True
+    wrapper.vllm_config.model_config.multimodal_config.language_model_only = True
+    wrapper._mm_encoder_jit_manager = None
+
+    assert wrapper.wrap_precompile_vision_encoder_fn(MagicMock()) is None
+    assert wrapper.wrap_embed_multimodal_func() is None
+    assert wrapper.wrap_embed_input_ids_func() is None

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -153,6 +153,15 @@ class VllmModelWrapper:
             self.vllm_config, self.mesh)
         self._apply_pp_patch()
 
+    def _is_multimodal_enabled(self) -> bool:
+        """Return whether multimodal model paths should be active."""
+        model_config = self.vllm_config.model_config
+        if not model_config.is_multimodal_model:
+            return False
+        multimodal_config = model_config.multimodal_config
+        return not (multimodal_config is not None and getattr(
+            multimodal_config, "language_model_only", False))
+
     def _apply_pp_patch(self):
         # patch `get_pp_group` in vLLM to jax's get_pp_group.
         import sys
@@ -314,7 +323,7 @@ class VllmModelWrapper:
 
         self._pooler: Pooler | None = self.model.pooler
 
-        if self.vllm_config.model_config.is_multimodal_model:
+        if self._is_multimodal_enabled():
             # NOTE: It patch mm models to be JITtable within some submodule.
             # Caution: the submodule params_and_buffers would be put into
             # the wrapper directly. params_and_buffers should be sharded to tpu
@@ -527,7 +536,7 @@ class VllmModelWrapper:
         Registers budget-capture tasks against the existing manager so
         compile_manager can AOT-prime the XLA cache at startup.
         """
-        if not self.vllm_config.model_config.is_multimodal_model:
+        if not self._is_multimodal_enabled():
             return None
         if self._mm_encoder_jit_manager is not None:
             return self._mm_encoder_jit_manager.precompile_vision_encoder
@@ -538,7 +547,7 @@ class VllmModelWrapper:
                                                   self.vllm_config)
 
     def wrap_embed_multimodal_func(self):
-        if not self.vllm_config.model_config.is_multimodal_model:
+        if not self._is_multimodal_enabled():
             return None
 
         def embed_multimodal_func_jax(
@@ -601,7 +610,7 @@ class VllmModelWrapper:
         return embed_multimodal_func_torch
 
     def wrap_embed_input_ids_func(self):
-        if not self.vllm_config.model_config.is_multimodal_model:
+        if not self._is_multimodal_enabled():
             return None
 
         # The function cannot be JITted directly due to its dynamic implementation


### PR DESCRIPTION
# Description

Fixes #3469.

Multimodal architectures can be configured with `language_model_only=True`, while `ModelConfig.is_multimodal_model` remains true. The vLLM wrapper was therefore still patching multimodal modules and exposing vision/embed functions for a text-only deployment.

This change centralizes the active-multimodal check and applies it when patching the loaded model and when building the precompile, multimodal embedding, and input embedding wrappers. It preserves existing behavior for ordinary text and multimodal configurations.

Focused tests cover model capability versus deployment configuration and verify that language-model-only configurations expose no multimodal wrapper functions.

# Tests

- Four isolated activation cases using the exact helper implementation: passed
- `python3 -m ruff check` on both changed files: passed
- `python3 -m isort --check-only --diff` on both changed files: passed
- YAPF 0.43.0 diff check on both changed files: passed
- `python3 -m py_compile` on both changed files: passed
- `git diff --check` and `git show --check HEAD`: passed

The focused pytest test was not run locally because this checkout does not have the vLLM, JAX, and TPU development runtime installed; project CI should exercise it.

# Checklist

- [x] I performed a focused self-review of the code and tests.
- [x] No documentation change is needed for this internal correctness fix.
- [x] The issue reporter reviewed the focused fix; the PR is ready for maintainer review.

This change was prepared with AI assistance and reviewed by the issue reporter before being marked ready.

