### PR TITLE
Add opt-out for structured decoding precompile

### DIFF
--- a/tests/runner/test_compilation_manager.py
+++ b/tests/runner/test_compilation_manager.py
@@ -1,0 +1,18 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the tpu-inference project
+
+from unittest.mock import MagicMock, patch
+
+from tpu_inference.runner.compilation_manager import CompilationManager
+
+
+def test_skip_structured_decoding_precompile():
+    manager = CompilationManager.__new__(CompilationManager)
+    manager.runner = MagicMock()
+
+    with patch(
+            "tpu_inference.runner.compilation_manager.envs."
+            "SKIP_STRUCTURED_DECODING_PRECOMPILE", True):
+        manager._precompile_structured_decoding()
+
+    assert manager.runner.mock_calls == []

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -58,6 +58,7 @@ def test_getattr_with_cache(monkeypatch: pytest.MonkeyPatch):
 def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     # Ensure clean environment for boolean vars by setting to default "0"
     monkeypatch.setenv("SKIP_JAX_PRECOMPILE", "0")
+    monkeypatch.setenv("SKIP_STRUCTURED_DECODING_PRECOMPILE", "0")
     monkeypatch.setenv("VLLM_XLA_CHECK_RECOMPILATION", "0")
     monkeypatch.setenv("NEW_MODEL_DESIGN", "0")
     monkeypatch.setenv("ENABLE_QUANTIZED_MATMUL_KERNEL", "0")
@@ -72,6 +73,13 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     assert envs.SKIP_JAX_PRECOMPILE is True
     monkeypatch.setenv("SKIP_JAX_PRECOMPILE", "0")
     assert envs.SKIP_JAX_PRECOMPILE is False
+
+    # Test SKIP_STRUCTURED_DECODING_PRECOMPILE (default False)
+    assert envs.SKIP_STRUCTURED_DECODING_PRECOMPILE is False
+    monkeypatch.setenv("SKIP_STRUCTURED_DECODING_PRECOMPILE", "1")
+    assert envs.SKIP_STRUCTURED_DECODING_PRECOMPILE is True
+    monkeypatch.setenv("SKIP_STRUCTURED_DECODING_PRECOMPILE", "0")
+    assert envs.SKIP_STRUCTURED_DECODING_PRECOMPILE is False
 
     # Test DISABLE_WEIGHT_REQUANTIZATION (default False)
     assert envs.DISABLE_WEIGHT_REQUANTIZATION is False

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
     PREFILL_SLICES: str = ""
     DECODE_SLICES: str = ""
     SKIP_JAX_PRECOMPILE: bool = False
+    SKIP_STRUCTURED_DECODING_PRECOMPILE: bool = False
     VLLM_XLA_CHECK_RECOMPILATION: bool = False
     MODEL_IMPL_TYPE: str = "auto"
     DRAFT_MODEL_IMPL_TYPE: str = "auto"
@@ -247,6 +248,9 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Skip JAX precompilation step during initialization
     "SKIP_JAX_PRECOMPILE":
     env_bool("SKIP_JAX_PRECOMPILE", default=False),
+    # Skip only structured-decoding precompilation during initialization.
+    "SKIP_STRUCTURED_DECODING_PRECOMPILE":
+    env_bool("SKIP_STRUCTURED_DECODING_PRECOMPILE", default=False),
     # Check for XLA recompilation during execution
     "VLLM_XLA_CHECK_RECOMPILATION":
     env_bool("VLLM_XLA_CHECK_RECOMPILATION", default=False),

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -1886,6 +1886,10 @@ class CompilationManager:
                 )
 
     def _precompile_structured_decoding(self) -> None:
+        if envs.SKIP_STRUCTURED_DECODING_PRECOMPILE:
+            logger.info(
+                "Structured decoding precompilation skipped by configuration.")
+            return
         logger.info(
             "Compiling structured_decoding with different input shapes.")
         if self.runner.vllm_config.sharding_config.total_dp_size > 1:


### PR DESCRIPTION
# Description

Add a `SKIP_STRUCTURED_DECODING_PRECOMPILE` boolean environment variable for deployments that know they will not serve structured-output requests. When enabled, TPU startup skips only the structured-decoding JAX precompile; all other precompilation and the runtime structured-decoding path are unchanged.

This avoids reserving the large `[num_reqs, vocab_size]` structured-decoding program during startup without requiring the all-or-nothing `SKIP_JAX_PRECOMPILE` setting.

FIXES: #3360

# Tests

- Exact-source environment parsing checks for unset, enabled, and disabled values
- Exact-source guard checks for the opt-out and the existing DP skip path
- `python3 -m ruff check` on all changed Python files
- `python3 -m isort --check-only --diff` on all changed Python files
- YAPF 0.43.0 diff check on all changed Python files
- `python3 -m py_compile` on all changed Python files
- `git diff --check` and `git show --check HEAD`

Limitation: focused pytest collection was not available locally because this checkout does not have the vLLM/JAX/TPU development runtime. The committed regression tests are included for project CI.

# Checklist

- [x] I have performed a self-review of the change.
- [x] The behavior is narrowly scoped and has focused regression coverage.
- [x] No separate documentation page exists for these internal TPU environment switches; the variable is documented alongside the existing precompile setting.

AI-assisted contribution: this draft has not yet been human-reviewed. Please keep it in draft until that review is complete.
