### PR TITLE
[torchax] Accept vLLM canonical-layout weights for in-place weight sync (RL)

### DIFF
--- a/tests/models/vllm/test_weight_sync.py
+++ b/tests/models/vllm/test_weight_sync.py
@@ -1,0 +1,63 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the tpu-inference project
+"""Unit tests for the canonical-layout weight-sync helpers of the torchax path.
+
+The end-to-end check (MaxText Qwen3.5-35B-A3B -> Tunix `VllmSampler.update_params`
+-> torchax model, compared against the HF-loaded model) lives with the MaxText
+mapping; these tests cover the layout helpers that do not need a TPU model.
+"""
+from types import SimpleNamespace
+
+import jax.numpy as jnp
+import numpy as np
+
+from tpu_inference.models.vllm import weight_sync
+
+
+def test_strip_prefix():
+    assert weight_sync._strip_prefix("vllm_model.model.layers.0.x") == \
+        "model.layers.0.x"
+    assert weight_sync._strip_prefix("model.layers.0.x") == "model.layers.0.x"
+
+
+def _fake_qkv(total_heads, total_kv, head_size, replicas):
+    return SimpleNamespace(total_num_heads=total_heads,
+                           total_num_kv_heads=total_kv,
+                           head_size=head_size,
+                           num_kv_head_replicas=replicas)
+
+
+def test_replicate_kv_heads_repeats_each_kv_head_consecutively():
+    # 4 q heads, 2 kv heads, head_size 3, tp=8 -> each kv head 4 times in a row,
+    # matching vLLM's per-rank `qkv_proj` layout (rank r owns kv head r // 4).
+    hs, in_dim = 3, 5
+    q = np.arange(4 * hs * in_dim, dtype=np.float32).reshape(4 * hs, in_dim)
+    k = 100 + np.arange(2 * hs * in_dim, dtype=np.float32).reshape(2 * hs, in_dim)
+    v = 200 + np.arange(2 * hs * in_dim, dtype=np.float32).reshape(2 * hs, in_dim)
+    canon = jnp.asarray(np.concatenate([q, k, v], 0))
+    out = np.asarray(
+        weight_sync._replicate_kv_heads(_fake_qkv(4, 2, hs, 4), canon))
+    assert out.shape == ((4 + 2 * 4 + 2 * 4) * hs, in_dim)
+    np.testing.assert_array_equal(out[:4 * hs], q)
+    k_rep = out[4 * hs:4 * hs + 8 * hs].reshape(8, hs, in_dim)
+    v_rep = out[4 * hs + 8 * hs:].reshape(8, hs, in_dim)
+    for r in range(8):
+        np.testing.assert_array_equal(k_rep[r], k.reshape(2, hs, in_dim)[r // 4])
+        np.testing.assert_array_equal(v_rep[r], v.reshape(2, hs, in_dim)[r // 4])
+
+
+def test_replicate_kv_heads_is_identity_without_replicas():
+    canon = jnp.arange(24, dtype=jnp.float32).reshape(6, 4)
+    out = weight_sync._replicate_kv_heads(_fake_qkv(2, 2, 1, 1), canon)
+    np.testing.assert_array_equal(np.asarray(out), np.asarray(canon))
+
+
+def test_replicate_kv_heads_handles_1d_bias():
+    hs = 2
+    canon = jnp.asarray(np.arange((4 + 2 + 2) * hs, dtype=np.float32))
+    out = np.asarray(
+        weight_sync._replicate_kv_heads(_fake_qkv(4, 2, hs, 2), canon))
+    assert out.shape == ((4 + 4 + 4) * hs, )
+    k = np.asarray(canon)[4 * hs:6 * hs].reshape(2, hs)
+    np.testing.assert_array_equal(out[4 * hs:8 * hs].reshape(4, hs),
+                                  np.repeat(k, 2, axis=0))

--- a/tpu_inference/layers/vllm/quantization/base.py
+++ b/tpu_inference/layers/vllm/quantization/base.py
@@ -70,3 +70,16 @@ class VllmQuantizationMethod(ABC):
     @abstractmethod
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         raise NotImplementedError
+
+    def process_weights(self, layer: torch.nn.Module, *args, **kwargs):
+        """Turns canonical-layout (vLLM Parameter layout) jax arrays into this
+        method's processed, sharded on-device weights.
+
+        `process_weights_after_loading` is the loading shell around it; the
+        in-place weight update path (`tpu_inference.models.vllm.weight_sync`)
+        calls it directly with arrays that are already on device, so the two
+        paths share one implementation. Methods that do not implement it do
+        not support in-place weight updates.
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not support in-place weight updates")

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import functools
 from typing import Any, Callable, Optional
 
 import jax
@@ -161,40 +162,95 @@ class VllmUnquantizedConfig(QuantizationConfig, VllmQuantConfig):
                 return None
 
 
+@functools.partial(jax.jit,
+                   static_argnames=("fused", "output_sizes", "reorder_size"))
+def _process_unquantized_linear_weights(
+    weight: jax.Array,
+    bias: jax.Array | None,
+    *,
+    fused: bool,
+    output_sizes: tuple[int, ...],
+    reorder_size: int,
+) -> LinearWeights:
+    """Module-level jit so the trace is shared by every layer with the same
+    shapes/config (both at load time and during in-place weight updates)."""
+    return process_linear_weights(
+        LinearWeights(weight=weight,
+                      weight_scale=None,
+                      zero_point=None,
+                      bias=bias),
+        fused=fused,
+        output_sizes=list(output_sizes),
+        reorder_size=reorder_size,
+    )
+
+
+def _record_canonical_shape(layer: torch.nn.Module, param_name: str) -> None:
+    """Remembers the vLLM Parameter (canonical) shape before it is replaced by
+    the processed on-device weight, for `weight_sync.canonical_weight_specs`."""
+    shapes = layer.__dict__.setdefault("_canonical_shapes", {})
+    shapes[param_name] = tuple(getattr(layer, param_name).shape)
+
+
 class VllmUnquantizedEmbeddingMethod(UnquantizedEmbeddingMethod):
 
     def __init__(self, mesh):
         self.mesh = mesh
 
+    def process_weights(self,
+                        layer: torch.nn.Module,
+                        weight: jax.Array,
+                        bias: jax.Array | None = None) -> LinearWeights:
+        """Canonical `[vocab, hidden]` arrays -> sharded on-device weights."""
+        del layer
+        weight_sharding = NamedSharding(self.mesh,
+                                        P(ShardingAxisName.MLP_TENSOR, None))
+        weight = general_device_put(weight, weight_sharding)
+        if bias is not None:
+            bias_sharding = NamedSharding(self.mesh,
+                                          P(ShardingAxisName.MLP_TENSOR))
+            bias = general_device_put(bias, bias_sharding)
+        return LinearWeights(weight=weight,
+                             weight_scale=None,
+                             zero_point=None,
+                             bias=bias)
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         weight_sharding = NamedSharding(self.mesh,
                                         P(ShardingAxisName.MLP_TENSOR, None))
         weight = _load_weight_for_layer(layer, "weight", weight_sharding)
+        _record_canonical_shape(layer, "weight")
         delattr(layer, 'weight')
-        weight = general_device_put(weight, weight_sharding)
+        bias = None
+        if isinstance(layer, ParallelLMHead) and layer.bias is not None:
+            bias_sharding = NamedSharding(self.mesh,
+                                          P(ShardingAxisName.MLP_TENSOR))
+            bias = _load_weight_for_layer(layer, "bias", bias_sharding)
+            _record_canonical_shape(layer, "bias")
+            delattr(layer, 'bias')
+
+        weights = self.process_weights(layer, weight, bias)
         is_pooling = get_current_vllm_config(
         ).model_config.runner_type == "pooling"
 
         if is_pooling:
             layer.__dict__.pop("weight", None)
-            layer._parameters["weight"] = Parameter(torch_view(weight),
+            layer._parameters["weight"] = Parameter(torch_view(
+                weights.weight),
                                                     requires_grad=False)
         else:
-            layer.weight = Parameter(torch_view(weight), requires_grad=False)
+            layer.weight = Parameter(torch_view(weights.weight),
+                                     requires_grad=False)
 
-        if isinstance(layer, ParallelLMHead) and layer.bias is not None:
-            bias_sharding = NamedSharding(self.mesh,
-                                          P(ShardingAxisName.MLP_TENSOR))
-            bias = _load_weight_for_layer(layer, "bias", bias_sharding)
-            delattr(layer, 'bias')
-            bias = general_device_put(bias, bias_sharding)
-
+        if weights.bias is not None:
             if is_pooling:
                 layer.__dict__.pop("bias", None)
-                layer._parameters["bias"] = Parameter(torch_view(bias),
+                layer._parameters["bias"] = Parameter(torch_view(
+                    weights.bias),
                                                       requires_grad=False)
             else:
-                layer.bias = Parameter(torch_view(bias), requires_grad=False)
+                layer.bias = Parameter(torch_view(weights.bias),
+                                       requires_grad=False)
 
 
 class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
@@ -215,6 +271,28 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
         self.maybe_process_linear_weights(layer, param_name, args, kwargs,
                                           self.linear_config.num_proj)
 
+    def process_weights(self,
+                        layer: torch.nn.Module,
+                        weight: jax.Array,
+                        bias: jax.Array | None = None) -> LinearWeights:
+        """Canonical `[out, in]` arrays (vLLM Parameter layout, KV heads
+        already replicated for QKV) -> processed, sharded on-device weights."""
+        del layer
+        weight = jnp.transpose(weight)
+        weights = _process_unquantized_linear_weights(
+            weight,
+            bias,
+            fused=self.linear_config.fuse_matmuls,
+            output_sizes=tuple(self.linear_config.output_sizes),
+            reorder_size=self.linear_config.n_shards,
+        )
+        return shard_linear_weights(
+            weights,
+            mesh=self.linear_config.mesh,
+            weight_p_spec=self.linear_config.weight_sharding,
+            bias_p_spec=self.linear_config.bias_sharding,
+        )
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if not _tensor_is_in_cpu(layer.weight):
             # Already processed and sharded.
@@ -225,7 +303,7 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
             self.linear_config.mesh,
             PartitionSpec(*self.linear_config.weight_sharding[::-1]))
         weight = _load_weight_for_layer(layer, "weight", loading_sharding)
-        weight = jnp.transpose(weight)
+        _record_canonical_shape(layer, "weight")
 
         # Free CPU memory immediately
         layer.weight.untyped_storage().resize_(0)
@@ -236,36 +314,13 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
             bias_sharding = NamedSharding(self.linear_config.mesh,
                                           self.linear_config.bias_sharding)
             bias = _load_weight_for_layer(layer, "bias", bias_sharding)
+            _record_canonical_shape(layer, "bias")
             layer.bias.untyped_storage().resize_(0)
             delattr(layer, 'bias')
         else:
             bias = None
 
-        @jax.jit
-        def process_unquantized_linear_weights(
-            weight: jax.Array,
-            bias: jax.Array | None,
-        ) -> LinearWeights:
-            return process_linear_weights(
-                LinearWeights(
-                    weight=weight,
-                    weight_scale=None,
-                    zero_point=None,
-                    bias=bias,
-                ),
-                fused=self.linear_config.fuse_matmuls,
-                output_sizes=self.linear_config.output_sizes,
-                reorder_size=self.linear_config.n_shards,
-            )
-
-        weights = process_unquantized_linear_weights(weight, bias)
-        weights = torch_view(
-            shard_linear_weights(
-                weights,
-                mesh=self.linear_config.mesh,
-                weight_p_spec=self.linear_config.weight_sharding,
-                bias_p_spec=self.linear_config.bias_sharding,
-            ))
+        weights = torch_view(self.process_weights(layer, weight, bias))
         if self.linear_config.fuse_matmuls:
             layer.weight = Parameter(weights.weight, requires_grad=False)
             if bias is not None:
@@ -347,6 +402,23 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod,
             self.process_weights_after_loading(layer)
             logger.debug(f"Complete sharding weights for layer {type(layer)}")
 
+    def process_weights(self,
+                        layer: torch.nn.Module,
+                        w13_weight: jax.Array,
+                        w2_weight: jax.Array,
+                        w13_bias: jax.Array | None = None,
+                        w2_bias: jax.Array | None = None) -> FusedMoEWeights:
+        """Canonical `w13 = [E, 2F, D]` (gate first) / `w2 = [E, D, F]` arrays
+        -> processed (backend layout), sharded on-device weights."""
+        weights = process_unquantized_moe_weights(mesh=self.mesh,
+                                                  moe_backend=self.moe_backend,
+                                                  activation=layer.activation,
+                                                  w13_weight=w13_weight,
+                                                  w13_bias=w13_bias,
+                                                  w2_weight=w2_weight,
+                                                  w2_bias=w2_bias)
+        return shard_moe_weights(weights, self.moe_backend, self.mesh)
+
     def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
         if not _tensor_is_in_cpu(layer.w13_weight):
             # Already processed and sharded.
@@ -358,6 +430,8 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod,
         ep_sharding = NamedSharding(self.mesh, P(ShardingAxisName.EXPERT))
         w13_weight = _load_weight_for_layer(layer, "w13_weight", ep_sharding)
         w2_weight = _load_weight_for_layer(layer, "w2_weight", ep_sharding)
+        _record_canonical_shape(layer, "w13_weight")
+        _record_canonical_shape(layer, "w2_weight")
         # Free CPU memory immediately
         layer.w13_weight.untyped_storage().resize_(0)
         layer.w2_weight.untyped_storage().resize_(0)
@@ -367,6 +441,8 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod,
         if self.moe.has_bias:
             w13_bias = _load_weight_for_layer(layer, "w13_bias", ep_sharding)
             w2_bias = _load_weight_for_layer(layer, "w2_bias", ep_sharding)
+            _record_canonical_shape(layer, "w13_bias")
+            _record_canonical_shape(layer, "w2_bias")
             layer.w13_bias.untyped_storage().resize_(0)
             layer.w2_bias.untyped_storage().resize_(0)
             delattr(layer, 'w13_bias')
@@ -374,18 +450,11 @@ class VllmUnquantizedFusedMoEMethod(UnquantizedFusedMoEMethod,
         else:
             w13_bias = w2_bias = None
 
-        weights = process_unquantized_moe_weights(mesh=self.mesh,
-                                                  moe_backend=self.moe_backend,
-                                                  activation=layer.activation,
-                                                  w13_weight=w13_weight,
-                                                  w13_bias=w13_bias,
-                                                  w2_weight=w2_weight,
-                                                  w2_bias=w2_bias)
-
+        weights = self.process_weights(layer, w13_weight, w2_weight, w13_bias,
+                                       w2_bias)
         del w13_weight, w2_weight, w13_bias, w2_bias
 
-        weights = torch_view(
-            shard_moe_weights(weights, self.moe_backend, self.mesh))
+        weights = torch_view(weights)
         layer.w13_weight = Parameter(weights.w13_weight, requires_grad=False)
         layer.w2_weight = Parameter(weights.w2_weight, requires_grad=False)
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -347,6 +347,31 @@ class VllmModelWrapper:
         )
         return params, lora_manager
 
+    # ------------------------------------------------------------------
+    # Weight sync (RL): canonical vLLM layout -> internal torchax layout.
+    # ------------------------------------------------------------------
+    def canonical_weight_specs(
+            self, state: dict[str, Any]) -> dict[str, jax.ShapeDtypeStruct]:
+        """Trainer-facing weight contract: vLLM TP=1 parameter names/shapes.
+
+        `state` is the runner's flat params dict (`model_runner.state`).
+        See `tpu_inference.models.vllm.weight_sync`.
+        """
+        from tpu_inference.models.vllm import weight_sync
+        return weight_sync.canonical_weight_specs(self.model.vllm_model, state)
+
+    def load_canonical_weights(self,
+                               weights: dict[str, jax.Array],
+                               state: dict[str, Any],
+                               strict: bool = False) -> list[str]:
+        """Write canonical-layout arrays into `state` (the runner's flat params
+        dict) in place, re-running this path's weight processing/sharding."""
+        from tpu_inference.models.vllm import weight_sync
+        return weight_sync.load_canonical_weights(self.model.vllm_model,
+                                                  weights,
+                                                  state,
+                                                  strict=strict)
+
     def jit_step_func(self):
 
         def step_fun_impl(

--- a/tpu_inference/models/vllm/weight_sync.py
+++ b/tpu_inference/models/vllm/weight_sync.py
@@ -1,0 +1,402 @@
+# SPDX-License-Identifier: Apache-2.0
+# SPDX-FileCopyrightText: Copyright contributors to the tpu-inference project
+"""In-place weight updates for the vLLM (torchax) model path.
+
+The torchax model runner keeps its weights in a flat ``{name: jax.Array}``
+state dict whose layout is an internal detail of tpu-inference: linear
+kernels are stored transposed (``[in, out]``) with fused projections
+reordered per tensor-parallel shard (`process_linear_weights`), fused MoE
+kernels go through the backend-specific `process_moe_weights` (transposes,
+per-shard padding), and KV heads are replicated when ``tp_size`` exceeds the
+number of KV heads.  None of that should leak to a trainer that wants to push
+new weights (RL weight sync).
+
+This module defines the trainer-facing contract as vLLM's *canonical*
+parameter layout -- what ``model.named_parameters()`` holds on a single GPU
+at TP=1 (``[out, in]`` linears, ``qkv_proj`` = ``[q | k | v]`` with
+unreplicated KV heads, ``w13_weight`` = ``[E, 2F, D]`` gate-first,
+``w2_weight`` = ``[E, D, F]``) -- and re-runs tpu-inference's own weight
+processing to turn canonical arrays into the internal layout:
+
+    specs = wrapper.canonical_weight_specs()      # name -> ShapeDtypeStruct
+    wrapper.load_canonical_weights(new_weights, state)
+
+Names are vLLM module paths (``language_model.model.layers.0.self_attn.
+qkv_proj.weight``); the ``vllm_model.`` prefix of the runner state is
+accepted but optional.
+"""
+from __future__ import annotations
+
+from typing import Any, Mapping
+
+import jax
+import jax.numpy as jnp
+import torch
+from jax.sharding import NamedSharding, PartitionSpec
+from torchax.interop import jax_view, torch_view
+from vllm.model_executor.layers.fused_moe.routed_experts import RoutedExperts
+from vllm.model_executor.layers.linear import LinearBase, QKVParallelLinear
+from vllm.model_executor.layers.vocab_parallel_embedding import \
+    VocabParallelEmbedding
+
+from tpu_inference.layers.common.process_weights.linear_weights import (
+    LinearWeights, process_linear_weights, shard_linear_weights)
+from tpu_inference.layers.common.process_weights.moe_weights import (
+    process_unquantized_moe_weights, shard_moe_weights)
+from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.common.utils import general_device_put
+from tpu_inference.layers.vllm.quantization.unquantized import (
+    VllmUnquantizedEmbeddingMethod, VllmUnquantizedFusedMoEMethod,
+    VllmUnquantizedLinearMethod)
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+STATE_PREFIX = "vllm_model."
+
+P = PartitionSpec
+
+
+def _strip_prefix(name: str) -> str:
+    return name[len(STATE_PREFIX):] if name.startswith(STATE_PREFIX) else name
+
+
+def _state_entry(state: Mapping[str, Any], name: str) -> jax.Array:
+    key = STATE_PREFIX + _strip_prefix(name)
+    if key not in state:
+        raise KeyError(f"{key} is not a parameter of the torchax model state")
+    return jax_view(state[key])
+
+
+def _linear_canonical_out(layer: LinearBase) -> int:
+    if isinstance(layer, QKVParallelLinear):
+        # `output_sizes` already contain the tp-replicated KV heads; the
+        # canonical layout carries each KV head once.
+        return (layer.total_num_heads +
+                2 * layer.total_num_kv_heads) * layer.head_size
+    return layer.output_size
+
+
+def _replicate_kv_heads(layer: QKVParallelLinear,
+                        weight: jax.Array) -> jax.Array:
+    """[q | k | v] with unique KV heads -> [q | k*r | v*r] as vLLM lays out
+    ``qkv_proj`` when tp_size > num_kv_heads (each KV head repeated
+    `num_kv_head_replicas` times consecutively, one copy per TP rank)."""
+    r = layer.num_kv_head_replicas
+    if r == 1:
+        return weight
+    hs = layer.head_size
+    q_size = layer.total_num_heads * hs
+    kv_size = layer.total_num_kv_heads * hs
+    q = weight[:q_size]
+    k = weight[q_size:q_size + kv_size]
+    v = weight[q_size + kv_size:q_size + 2 * kv_size]
+
+    def rep(x):
+        x = x.reshape(layer.total_num_kv_heads, hs, *x.shape[1:])
+        x = jnp.repeat(x, r, axis=0)
+        return x.reshape(layer.total_num_kv_heads * r * hs, *x.shape[2:])
+
+    return jnp.concatenate([q, rep(k), rep(v)], axis=0)
+
+
+def _on_runner_devices(arr: jax.Array, target: jax.sharding.Sharding,
+                       name: str) -> jax.Array:
+    """Make sure `arr` can be resharded onto the runner mesh with device_put.
+
+    Single-host `jax.device_put` reshards between two meshes only when they
+    list the same devices in the same order. The runner builds its mesh from
+    the physical topology, so a trainer mesh over the same chips may well
+    order them differently. In that case: replicate on the source mesh
+    (same-mesh reshard), re-express the per-device buffers on the runner mesh
+    (no copy), and let the caller shard from there. Transient cost: one
+    replicated copy of the tensor.
+    """
+    src = getattr(arr, "sharding", None)
+    src_mesh = getattr(src, "mesh", None)
+    tgt_mesh = getattr(target, "mesh", None)
+    if src_mesh is None or tgt_mesh is None:
+        return arr
+    src_ids = [d.id for d in src_mesh.devices.flat]
+    tgt_ids = [d.id for d in tgt_mesh.devices.flat]
+    if src_ids == tgt_ids or len(src_ids) == 1:
+        return arr
+    if sorted(src_ids) != sorted(tgt_ids):
+        raise ValueError(
+            f"{name}: source array lives on devices {src_ids}, the runner "
+            f"mesh uses {tgt_ids}; cross-device-set weight sync needs a "
+            "transport (Pathways reshard / Raiden) before load_canonical_weights.")
+    if not arr.is_fully_addressable:
+        raise ValueError(
+            f"{name}: source mesh order {src_ids} differs from the runner "
+            f"mesh {tgt_ids} and the array is not fully addressable; reshard "
+            "it onto the runner mesh before load_canonical_weights.")
+    logger.info_once(
+        f"Source mesh device order {src_ids} differs from the runner mesh "
+        f"{tgt_ids}; re-expressing arrays on the runner mesh via replication.")
+    # A jitted identity keeps the all-gather on device (plain device_put may
+    # take the host slow path for sharded -> replicated).
+    replicated = jax.jit(lambda x: x,
+                         out_shardings=NamedSharding(src_mesh, P()))(arr)
+    replicated.block_until_ready()
+    by_device = {s.device.id: s.data for s in replicated.addressable_shards}
+    return jax.make_array_from_single_device_arrays(
+        replicated.shape, NamedSharding(tgt_mesh, P()),
+        [by_device[d.id] for d in tgt_mesh.devices.flat])
+
+
+def canonical_weight_specs(
+        vllm_model: torch.nn.Module,
+        state: Mapping[str, Any]) -> dict[str, jax.ShapeDtypeStruct]:
+    """Canonical (vLLM TP=1) shape/dtype for every parameter in `state`."""
+    specs: dict[str, jax.ShapeDtypeStruct] = {}
+    modules = dict(vllm_model.named_modules())
+    for key in state:
+        name = _strip_prefix(key)
+        mod_path, _, pname = name.rpartition(".")
+        layer = modules.get(mod_path)
+        arr = jax_view(state[key])
+        shape = tuple(arr.shape)
+        qm = getattr(layer, "quant_method", None)
+        if isinstance(layer, LinearBase) and isinstance(
+                qm, VllmUnquantizedLinearMethod):
+            out = _linear_canonical_out(layer)
+            if pname == "weight":
+                shape = (out, layer.input_size)
+            elif pname == "bias":
+                shape = (out, )
+            else:
+                continue
+        elif isinstance(layer, RoutedExperts) and isinstance(
+                qm, VllmUnquantizedFusedMoEMethod):
+            e = layer.global_num_experts
+            d = layer.hidden_size
+            f = layer.moe_config.intermediate_size
+            if pname == "w13_weight":
+                shape = (e, 2 * f, d)
+            elif pname == "w2_weight":
+                shape = (e, d, f)
+            elif pname == "w13_bias":
+                shape = (e, 2 * f)
+            elif pname == "w2_bias":
+                shape = (e, d)
+            else:
+                continue
+        # Embeddings, replicated linears (vLLM's default method), norms,
+        # conv1d, A_log, ...: the internal layout is the canonical one.
+        specs[name] = jax.ShapeDtypeStruct(shape, arr.dtype)
+    return specs
+
+
+def _process_linear(layer: LinearBase, qm: VllmUnquantizedLinearMethod,
+                    weight: jax.Array | None,
+                    bias: jax.Array | None) -> LinearWeights:
+    cfg = qm.linear_config
+    if not cfg.fuse_matmuls:
+        raise NotImplementedError(
+            f"{layer}: weight sync into unfused (split) linear weights is not "
+            "supported yet; the layer keeps one processed tensor per "
+            "projection.")
+    if isinstance(layer, QKVParallelLinear):
+        if weight is not None:
+            weight = _replicate_kv_heads(layer, weight)
+        if bias is not None:
+            bias = _replicate_kv_heads(layer, bias)
+    if weight is not None:
+        weight = jnp.transpose(weight)  # [out, in] -> [in, out]
+    weights = process_linear_weights(
+        LinearWeights(weight=weight,
+                      weight_scale=None,
+                      zero_point=None,
+                      bias=bias),
+        fused=True,
+        output_sizes=cfg.output_sizes,
+        reorder_size=cfg.n_shards,
+    )
+    return shard_linear_weights(weights,
+                                mesh=cfg.mesh,
+                                weight_p_spec=cfg.weight_sharding,
+                                bias_p_spec=cfg.bias_sharding)
+
+
+def _process_moe(layer: RoutedExperts, qm: VllmUnquantizedFusedMoEMethod,
+                 w13: jax.Array, w2: jax.Array, w13_bias: jax.Array | None,
+                 w2_bias: jax.Array | None):
+    weights = process_unquantized_moe_weights(mesh=qm.mesh,
+                                              moe_backend=qm.moe_backend,
+                                              activation=layer.activation,
+                                              w13_weight=w13,
+                                              w13_bias=w13_bias,
+                                              w2_weight=w2,
+                                              w2_bias=w2_bias)
+    return shard_moe_weights(weights, qm.moe_backend, qm.mesh)
+
+
+def _flush_moe(vllm_model: torch.nn.Module,
+               modules: dict[str, torch.nn.Module], state: dict[str, Any],
+               mod_path: str, layer: RoutedExperts,
+               qm: VllmUnquantizedFusedMoEMethod,
+               parts: dict[str, jax.Array]) -> list[str]:
+    """Re-expresses, processes and installs one MoE layer's expert weights."""
+    ready = {}
+    for pname, arr in parts.items():
+        name = f"{mod_path}.{pname}"
+        old = jax_view(state[STATE_PREFIX + name])
+        ready[pname] = _on_runner_devices(jnp.asarray(arr), old.sharding,
+                                          name).astype(old.dtype)
+    processed = _process_moe(layer, qm, ready["w13_weight"],
+                             ready["w2_weight"], ready.get("w13_bias"),
+                             ready.get("w2_bias"))
+    del ready
+    updated = []
+    for pname in ("w13_weight", "w2_weight", "w13_bias", "w2_bias"):
+        if pname in parts:
+            name = f"{mod_path}.{pname}"
+            _install(vllm_model, modules, state, name,
+                     getattr(processed, pname))
+            updated.append(STATE_PREFIX + name)
+    jax.effects_barrier()
+    return updated
+
+
+def _install(vllm_model: torch.nn.Module, modules: dict[str, torch.nn.Module],
+             state: dict[str, Any], name: str, new: jax.Array) -> None:
+    key = STATE_PREFIX + name
+    old = jax_view(state[key])
+    if tuple(new.shape) != tuple(old.shape) or new.dtype != old.dtype:
+        raise ValueError(
+            f"{name}: processed weight has shape {new.shape}/{new.dtype}, "
+            f"model state expects {old.shape}/{old.dtype}")
+    if getattr(new, "sharding", None) != old.sharding:
+        # Same spec on the same mesh is what the compiled step expects; a
+        # different placement would trigger a recompile (or fail).
+        new = general_device_put(new, old.sharding)
+    # Bound the transient HBM: without this, async dispatch keeps enqueueing
+    # per-tensor intermediates (replicated / pre-shard copies) for the whole
+    # model before any of them is freed.
+    new.block_until_ready()
+    # The runner state holds plain jax arrays (`jax_view(params_and_buffers)`).
+    state[key] = new
+    # Re-point the module parameter too, so the old buffer is released and
+    # anything reading `layer.<param>` directly (the GDN op reads conv1d /
+    # A_log / dt_bias off the module) sees the new array.
+    mod_path, _, pname = name.rpartition(".")
+    layer = modules.get(mod_path)
+    if layer is not None and pname in layer._parameters:
+        # `.data = ...` is rejected across the torchax tensor type; replace the
+        # Parameter object like the loading path does.
+        layer._parameters[pname] = torch.nn.Parameter(torch_view(new),
+                                                      requires_grad=False)
+
+
+def load_canonical_weights(vllm_model: torch.nn.Module,
+                           weights: Mapping[str, jax.Array],
+                           state: dict[str, Any],
+                           strict: bool = False) -> list[str]:
+    """Convert canonical-layout arrays to the internal layout and write them
+    into `state` (the runner's flat params dict) in place.
+
+    Args:
+        vllm_model: the wrapped ``torch.nn.Module`` (``wrapper.model.vllm_model``).
+        weights: canonical name -> jax.Array (any sharding / mesh; cast to the
+            state dtype here).  Names may carry the ``vllm_model.`` prefix.
+        state: the runner's ``{name: array}`` state dict, updated in place.
+        strict: raise if a parameter of the model is not covered by `weights`
+            (attention scale scalars are always exempt).
+
+    Returns:
+        The list of state names that were updated.
+    """
+    modules = dict(vllm_model.named_modules())
+    pending_moe: dict[str, dict[str, jax.Array]] = {}
+    updated: list[str] = []
+
+    def _hbm_gib() -> str:
+        try:
+            return " ".join(
+                f"{d.memory_stats()['bytes_in_use'] / 2**30:.1f}"
+                for d in jax.local_devices())
+        except Exception:  # pragma: no cover - stats are best effort
+            return "n/a"
+
+    logger.info("load_canonical_weights: %d incoming tensors; HBM in use "
+                "per device (GiB): %s", len(weights), _hbm_gib())
+
+    for raw_name, arr in weights.items():
+        name = _strip_prefix(raw_name)
+        key = STATE_PREFIX + name
+        if key not in state:
+            msg = f"{name} is not a parameter of the torchax model state"
+            if strict:
+                raise KeyError(msg)
+            logger.warning(msg)
+            continue
+        mod_path, _, pname = name.rpartition(".")
+        layer = modules.get(mod_path)
+        qm = getattr(layer, "quant_method", None)
+        old = jax_view(state[key])
+
+        if isinstance(layer, RoutedExperts) and isinstance(
+                qm, VllmUnquantizedFusedMoEMethod):
+            # Keep the caller's array as is until the layer's w13/w2 pair is
+            # complete, then process the layer right away: the per-tensor
+            # re-expression below may hold a replicated copy, and parking
+            # those for every MoE layer does not fit in HBM.
+            parts = pending_moe.setdefault(mod_path, {})
+            parts[pname] = arr
+            needed = {"w13_weight", "w2_weight"}
+            if qm.moe.has_bias:
+                needed |= {"w13_bias", "w2_bias"}
+            if needed <= set(parts):
+                updated.extend(
+                    _flush_moe(vllm_model, modules, state, mod_path, layer,
+                               qm, pending_moe.pop(mod_path)))
+            continue
+
+        arr = _on_runner_devices(jnp.asarray(arr), old.sharding, name)
+        arr = arr.astype(old.dtype)
+
+        if isinstance(layer, LinearBase) and isinstance(
+                qm, VllmUnquantizedLinearMethod) and pname in ("weight",
+                                                               "bias"):
+            processed = _process_linear(layer, qm,
+                                        arr if pname == "weight" else None,
+                                        arr if pname == "bias" else None)
+            new = processed.weight if pname == "weight" else processed.bias
+            _install(vllm_model, modules, state, name, new)
+            updated.append(key)
+        elif isinstance(layer, VocabParallelEmbedding) and isinstance(
+                qm, VllmUnquantizedEmbeddingMethod):
+            sharding = NamedSharding(qm.mesh, P(ShardingAxisName.MLP_TENSOR,
+                                                None))
+            _install(vllm_model, modules, state, name,
+                     general_device_put(arr, sharding))
+            updated.append(key)
+        else:
+            # Layout-preserving parameters: keep the state's own placement.
+            old = jax_view(state[key])
+            _install(vllm_model, modules, state, name,
+                     general_device_put(arr, old.sharding))
+            updated.append(key)
+
+    if pending_moe:
+        incomplete = {k: sorted(v) for k, v in pending_moe.items()}
+        raise ValueError(
+            "fused MoE layers need w13_weight and w2_weight (and the biases "
+            f"when present) in the same update; incomplete: {incomplete}")
+
+    updated_set = set(updated)
+    missing = [
+        k for k in state if k not in updated_set
+        and not k.rsplit(".", 1)[-1].startswith("_")  # attn _k_scale etc.
+    ]
+    if missing:
+        msg = (f"{len(missing)} model parameters were not updated, e.g. "
+               f"{missing[:5]}")
+        if strict:
+            raise ValueError(msg)
+        logger.warning(msg)
+    logger.info(
+        "Updated %d/%d torchax model parameters in place; HBM in use per "
+        "device (GiB): %s", len(updated), len(state), _hbm_gib())
+    return updated

--- a/tpu_inference/models/vllm/weight_sync.py
+++ b/tpu_inference/models/vllm/weight_sync.py
@@ -15,8 +15,9 @@ This module defines the trainer-facing contract as vLLM's *canonical*
 parameter layout -- what ``model.named_parameters()`` holds on a single GPU
 at TP=1 (``[out, in]`` linears, ``qkv_proj`` = ``[q | k | v]`` with
 unreplicated KV heads, ``w13_weight`` = ``[E, 2F, D]`` gate-first,
-``w2_weight`` = ``[E, D, F]``) -- and re-runs tpu-inference's own weight
-processing to turn canonical arrays into the internal layout:
+``w2_weight`` = ``[E, D, F]``) -- and turns canonical arrays into the internal
+layout by calling each layer's own ``quant_method.process_weights``, the same
+function the checkpoint loader runs, so the two paths cannot drift:
 
     specs = wrapper.canonical_weight_specs()      # name -> ShapeDtypeStruct
     wrapper.load_canonical_weights(new_weights, state)
@@ -39,11 +40,6 @@ from vllm.model_executor.layers.linear import LinearBase, QKVParallelLinear
 from vllm.model_executor.layers.vocab_parallel_embedding import \
     VocabParallelEmbedding
 
-from tpu_inference.layers.common.process_weights.linear_weights import (
-    LinearWeights, process_linear_weights, shard_linear_weights)
-from tpu_inference.layers.common.process_weights.moe_weights import (
-    process_unquantized_moe_weights, shard_moe_weights)
-from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.common.utils import general_device_put
 from tpu_inference.layers.vllm.quantization.unquantized import (
     VllmUnquantizedEmbeddingMethod, VllmUnquantizedFusedMoEMethod,
@@ -156,80 +152,73 @@ def canonical_weight_specs(
         mod_path, _, pname = name.rpartition(".")
         layer = modules.get(mod_path)
         arr = jax_view(state[key])
-        shape = tuple(arr.shape)
-        qm = getattr(layer, "quant_method", None)
-        if isinstance(layer, LinearBase) and isinstance(
-                qm, VllmUnquantizedLinearMethod):
-            out = _linear_canonical_out(layer)
-            if pname == "weight":
-                shape = (out, layer.input_size)
-            elif pname == "bias":
-                shape = (out, )
-            else:
-                continue
-        elif isinstance(layer, RoutedExperts) and isinstance(
-                qm, VllmUnquantizedFusedMoEMethod):
-            e = layer.global_num_experts
-            d = layer.hidden_size
-            f = layer.moe_config.intermediate_size
-            if pname == "w13_weight":
-                shape = (e, 2 * f, d)
-            elif pname == "w2_weight":
-                shape = (e, d, f)
-            elif pname == "w13_bias":
-                shape = (e, 2 * f)
-            elif pname == "w2_bias":
-                shape = (e, d)
-            else:
-                continue
-        # Embeddings, replicated linears (vLLM's default method), norms,
-        # conv1d, A_log, ...: the internal layout is the canonical one.
+        # The quant methods record the vLLM Parameter shape at load time
+        # (`_record_canonical_shape`); everything else keeps its layout.
+        shape = tuple(
+            getattr(layer, "_canonical_shapes", {}).get(pname, arr.shape))
+        if isinstance(layer, QKVParallelLinear) and pname in ("weight",
+                                                             "bias"):
+            # The vLLM Parameter carries the tp-replicated KV heads; the sync
+            # contract carries each KV head once.
+            shape = (_linear_canonical_out(layer), ) + shape[1:]
         specs[name] = jax.ShapeDtypeStruct(shape, arr.dtype)
     return specs
 
 
 def _process_linear(layer: LinearBase, qm: VllmUnquantizedLinearMethod,
-                    weight: jax.Array | None,
-                    bias: jax.Array | None) -> LinearWeights:
-    cfg = qm.linear_config
-    if not cfg.fuse_matmuls:
+                    weight: jax.Array | None, bias: jax.Array | None):
+    """Runs the quant method's own `process_weights` (the same code the
+    loading path uses) on canonical `[out, in]` arrays."""
+    if not qm.linear_config.fuse_matmuls:
         raise NotImplementedError(
             f"{layer}: weight sync into unfused (split) linear weights is not "
             "supported yet; the layer keeps one processed tensor per "
             "projection.")
     if isinstance(layer, QKVParallelLinear):
+        # The sync contract carries each KV head once; vLLM's Parameter (and
+        # therefore `process_weights`) expects them replicated per TP rank.
         if weight is not None:
             weight = _replicate_kv_heads(layer, weight)
         if bias is not None:
             bias = _replicate_kv_heads(layer, bias)
-    if weight is not None:
-        weight = jnp.transpose(weight)  # [out, in] -> [in, out]
-    weights = process_linear_weights(
-        LinearWeights(weight=weight,
-                      weight_scale=None,
-                      zero_point=None,
-                      bias=bias),
-        fused=True,
-        output_sizes=cfg.output_sizes,
-        reorder_size=cfg.n_shards,
-    )
-    return shard_linear_weights(weights,
-                                mesh=cfg.mesh,
-                                weight_p_spec=cfg.weight_sharding,
-                                bias_p_spec=cfg.bias_sharding)
+    if weight is None:
+        # Bias-only update: process_weights needs the weight too, so reuse the
+        # current processed one untouched is not possible; require both.
+        raise NotImplementedError(
+            f"{layer}: bias-only updates are not supported; update weight "
+            "and bias together.")
+    return qm.process_weights(layer, weight, bias)
 
 
 def _process_moe(layer: RoutedExperts, qm: VllmUnquantizedFusedMoEMethod,
                  w13: jax.Array, w2: jax.Array, w13_bias: jax.Array | None,
                  w2_bias: jax.Array | None):
-    weights = process_unquantized_moe_weights(mesh=qm.mesh,
-                                              moe_backend=qm.moe_backend,
-                                              activation=layer.activation,
-                                              w13_weight=w13,
-                                              w13_bias=w13_bias,
-                                              w2_weight=w2,
-                                              w2_bias=w2_bias)
-    return shard_moe_weights(weights, qm.moe_backend, qm.mesh)
+    return qm.process_weights(layer, w13, w2, w13_bias, w2_bias)
+
+
+def _flush_linear(vllm_model: torch.nn.Module,
+                  modules: dict[str, torch.nn.Module], state: dict[str, Any],
+                  mod_path: str, layer: LinearBase,
+                  qm: VllmUnquantizedLinearMethod,
+                  parts: dict[str, jax.Array]) -> list[str]:
+    """Re-expresses, processes and installs one linear layer's weight/bias."""
+    ready = {}
+    for pname, arr in parts.items():
+        name = f"{mod_path}.{pname}"
+        old = jax_view(state[STATE_PREFIX + name])
+        ready[pname] = _on_runner_devices(jnp.asarray(arr), old.sharding,
+                                          name).astype(old.dtype)
+    processed = _process_linear(layer, qm, ready["weight"],
+                                ready.get("bias"))
+    del ready
+    updated = []
+    for pname in ("weight", "bias"):
+        if pname in parts:
+            name = f"{mod_path}.{pname}"
+            _install(vllm_model, modules, state, name,
+                     getattr(processed, pname))
+            updated.append(STATE_PREFIX + name)
+    return updated
 
 
 def _flush_moe(vllm_model: torch.nn.Module,
@@ -309,6 +298,7 @@ def load_canonical_weights(vllm_model: torch.nn.Module,
     """
     modules = dict(vllm_model.named_modules())
     pending_moe: dict[str, dict[str, jax.Array]] = {}
+    pending_linear: dict[str, dict[str, jax.Array]] = {}
     updated: list[str] = []
 
     def _hbm_gib() -> str:
@@ -353,24 +343,29 @@ def load_canonical_weights(vllm_model: torch.nn.Module,
                                qm, pending_moe.pop(mod_path)))
             continue
 
-        arr = _on_runner_devices(jnp.asarray(arr), old.sharding, name)
-        arr = arr.astype(old.dtype)
-
         if isinstance(layer, LinearBase) and isinstance(
                 qm, VllmUnquantizedLinearMethod) and pname in ("weight",
                                                                "bias"):
-            processed = _process_linear(layer, qm,
-                                        arr if pname == "weight" else None,
-                                        arr if pname == "bias" else None)
-            new = processed.weight if pname == "weight" else processed.bias
-            _install(vllm_model, modules, state, name, new)
-            updated.append(key)
-        elif isinstance(layer, VocabParallelEmbedding) and isinstance(
-                qm, VllmUnquantizedEmbeddingMethod):
-            sharding = NamedSharding(qm.mesh, P(ShardingAxisName.MLP_TENSOR,
-                                                None))
+            # weight and bias are processed together (one process_weights
+            # call, as at load time); wait until both parts of the layer are in.
+            parts = pending_linear.setdefault(mod_path, {})
+            parts[pname] = arr
+            needed = {"weight"}
+            if STATE_PREFIX + mod_path + ".bias" in state:
+                needed.add("bias")
+            if needed <= set(parts):
+                updated.extend(
+                    _flush_linear(vllm_model, modules, state, mod_path, layer,
+                                  qm, pending_linear.pop(mod_path)))
+            continue
+
+        arr = _on_runner_devices(jnp.asarray(arr), old.sharding, name)
+        arr = arr.astype(old.dtype)
+
+        if isinstance(layer, VocabParallelEmbedding) and isinstance(
+                qm, VllmUnquantizedEmbeddingMethod) and pname == "weight":
             _install(vllm_model, modules, state, name,
-                     general_device_put(arr, sharding))
+                     qm.process_weights(layer, arr).weight)
             updated.append(key)
         else:
             # Layout-preserving parameters: keep the state's own placement.
@@ -379,11 +374,15 @@ def load_canonical_weights(vllm_model: torch.nn.Module,
                      general_device_put(arr, old.sharding))
             updated.append(key)
 
-    if pending_moe:
-        incomplete = {k: sorted(v) for k, v in pending_moe.items()}
+    if pending_moe or pending_linear:
+        incomplete = {
+            k: sorted(v)
+            for k, v in {**pending_moe, **pending_linear}.items()
+        }
         raise ValueError(
-            "fused MoE layers need w13_weight and w2_weight (and the biases "
-            f"when present) in the same update; incomplete: {incomplete}")
+            "layers must receive all of their parameters in the same update "
+            "(weight and bias; w13_weight and w2_weight and the biases when "
+            f"present); incomplete: {incomplete}")
 
     updated_set = set(updated)
     missing = [


### PR DESCRIPTION
## Summary

Adds an in-place weight-sync entry point for the vLLM (torchax) model path, for RL rollouts (Tunix/MaxText):

- `tpu_inference/models/vllm/weight_sync.py`
- `VllmModelWrapper.canonical_weight_specs(state)` / `VllmModelWrapper.load_canonical_weights(weights, state)`

The torchax runner keeps its weights in a flat `{name: jax.Array}` dict whose layout is an internal detail: linears are transposed (`[in, out]`) with fused projections reordered per TP shard (`process_linear_weights`), KV heads are replicated into `qkv_proj` when `tp_size > num_kv_heads`, and fused MoE kernels go through the backend-specific `process_moe_weights` (transposes, per-shard padding). A trainer pushing new weights should not have to reproduce any of that.

The contract exposed here is vLLM's **canonical parameter layout** (what `model.named_parameters()` holds on one GPU at TP=1): `[out, in]` linears, `qkv_proj = [q | k | v]` with each KV head once, `w13_weight = [E, 2F, D]` (gate first), `w2_weight = [E, D, F]`, module-path names such as `language_model.model.layers.0.self_attn.qkv_proj.weight`. `load_canonical_weights` turns canonical arrays into the internal layout by calling each layer's own `quant_method.process_weights(layer, ...)` and replaces state entries and module `Parameter`s in place, asserting shape/dtype/sharding are unchanged so the compiled step keeps working.

**One implementation for load and sync.** Each unquantized quant method's `process_weights_after_loading(layer)` is split into a loading shell (fetch the CPU tensor, record the vLLM Parameter shape, install the result) and `process_weights(layer, ...)`, which takes canonical-layout jax arrays and returns the processed, sharded weights (transpose, per-shard reorder, MoE backend layout/padding, sharding). The loader and `weight_sync` both call `process_weights`, so the two paths cannot drift; quant methods without it (fp8, awq, …) raise `NotImplementedError` on sync instead of silently taking a fallback. `canonical_weight_specs` reads the shapes recorded at load time (KV heads are still carried once for QKV). The per-layer linear jit is hoisted to module level with static config args, which also speeds up model load (58 s → 49 s for 35B-A3B on v7x-8).

Details:
- Source arrays may live on a differently ordered mesh (a trainer FSDP mesh orders the same chips `[0,1,2,3,6,7,4,5]`, the runner mesh `[0..7]`; single-host `jax.device_put` refuses that reshard). They are replicated on the source mesh with a jitted identity and re-expressed on the runner mesh without a copy.
- Transient HBM is bounded: per-tensor `block_until_ready`, and MoE layers are processed as soon as their `w13`/`w2` pair is complete instead of parking replicated copies for every layer.
- Not covered: unfused (`fuse_matmuls=False`) linears and quantized layers (`NotImplementedError` / left untouched). FP8 checkpoints would need an online bf16→fp8 quantization step here (`quantize_moe_weights` and the fp8 linear quantizer exist to build on).

Consumers: google/tunix `VllmSampler.update_params` (torchax branch) and the MaxText Qwen3.5 mapping (PR links below).

## Testing

- `tests/models/vllm/test_weight_sync.py` (KV-head replication, prefix handling).
- End to end on v7x-8, Qwen3.5-35B-A3B bf16, TP=8: MaxText checkpoint (`gs://maxtext-model-checkpoints/qwen3.5-35b-a3b/unscanned/0/items`) → Tunix `update_params` → torchax model whose weights had been overwritten with random values. All 613 weight tensors bit-identical to the model loaded from the HF checkpoint by vLLM's loader (the only differing state entry is the sampler-computed `rotary_emb.cos_sin_cache` buffer); greedy generations identical (4/4) to the in-process HF-weight reference. `update_params` 149 s on the first call (JIT), HBM back to 28.6 GiB/device.
- Same check with the production Qwen3.5 serving configuration (TP=8, `--enable-expert-parallel`, `enable_dp_attention` + `attn_dp_size=4`, prefix caching, async scheduling, chunked prefill, block size 256, the production env vars and LIBTPU flags): generations 4/4 identical to the in-process HF-weight reference after the sync (MoE weights take the EP layout there), `update_params` 156 s.
- The torchax layout assumptions were checked numerically against the HF safetensors before implementation (`in_proj_qkvz` output_sizes `[q,k,v,z]`, consecutive KV replication, GMM_TP `w13` per-shard `[gate pad128 | up pad128]`).
- Not covered by this PR: FP8 checkpoints (the receiver needs an online bf16→fp8 quantization step; `quantize_moe_weights` and the fp8 linear quantizer exist to build on) and 397B-scale syncs, where the trainer is disaggregated and the transport (Pathways reshard / Raiden) must land arrays on the sampler mesh first; the sync also needs per-layer streaming at that size instead of materializing the whole canonical copy.

Companion PRs: AI-Hypercomputer/maxtext#5034 (Qwen3.5 mapping), google/tunix#2014 (VllmSampler torchax branch).
