### PR TITLE
[PCP] Add benchmark script

### DIFF
--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -380,8 +380,10 @@ def _variants(mp, n, pcp_sizes):
         if p <= 1 or n % p:
             continue
         tp = n // p
-        if p % 2 or mp.num_q_heads % tp:
-            continue  # PCP needs an even pcp size and whole Q heads per shard
+        if p % 2 or mp.num_q_heads % tp or mp.num_kv_heads % tp:
+            # PCP needs an even pcp size and shards Q and KV heads over tp
+            # (TP replicates KV heads when tp > num_kv_heads, PCP does not).
+            continue
         out.append(f"pcp{p}xtp{tp}")
     return out
 
@@ -389,6 +391,8 @@ def _variants(mp, n, pcp_sizes):
 def _cell(v, base):
     if v is None:
         return "n/a"
+    if isinstance(v, str):
+        return v
     r = v / base
     if abs(r - 1) < 0.005:
         return f"{v:.2f} (=)"
@@ -461,10 +465,17 @@ def main():
 
     if args.worker:
         model, n, variant = args.worker
-        res = _run_variant(MODEL_CONFIGS[model], variant, args.chunk_size,
-                           args.max_context, args.kv_dtype, args.page_size,
-                           args.cache_slack, args.warmup, args.iters,
-                           not args.no_layer_all_reduce)
+        try:
+            res = _run_variant(MODEL_CONFIGS[model], variant, args.chunk_size,
+                               args.max_context, args.kv_dtype, args.page_size,
+                               args.cache_slack, args.warmup, args.iters,
+                               not args.no_layer_all_reduce)
+        except Exception as e:  # noqa: BLE001
+            if "vmem" not in str(e):
+                raise
+            # The kernel's default tiles do not fit VMEM for this head
+            # config on one device; report it instead of failing the sweep.
+            res = {"error": "vmem OOM"}
         with open(args.json, "w") as f:
             json.dump(res, f)
         return
@@ -515,7 +526,8 @@ def main():
                 if key not in base:
                     continue
                 rows.append([_human(ctx), f"{base[key]:.2f}"] + [
-                    _cell(results[v].get(key), base[key]) for v in variants[1:]
+                    _cell(results[v].get("error") or results[v].get(key),
+                          base[key]) for v in variants[1:]
                 ])
             header = ["Context", f"{variants[0]} ({n} dev)"] + [
                 f"{v} ({n // 2} dev)" if v == f"tp{n // 2}" else v

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -184,7 +184,10 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
         nkv2 = align_to(2 * nkv, kvp)
         npages = max(cdiv(max_ctx, page), 1) * slack
         mesh = Mesh(np.array(jax.devices()[:tp]).reshape(tp), ("x", ))
-        put = lambda x: jax.device_put(x, NamedSharding(mesh, P("x")))
+
+        def put(x):
+            return jax.device_put(x, NamedSharding(mesh, P("x")))
+
         q = put(jnp.broadcast_to(rand((chunk, nq, HD)), (tp, chunk, nq, HD)))
         k = put(
             jnp.broadcast_to(
@@ -236,7 +239,10 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
         nkv2 = tp * align_to(2 * max(1, NKV // tp), kvp)
         cache_spec = P(ShardingAxisName.BATCH, ShardingAxisName.KV_CONTEXT,
                        ShardingAxisName.KV_HEAD, None, None)
-        put = lambda x, s: jax.device_put(x, NamedSharding(mesh, s))
+
+        def put(x, s):
+            return jax.device_put(x, NamedSharding(mesh, s))
+
         q = put(
             rand((chunk, NQ, HD)),
             P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None))
@@ -363,8 +369,8 @@ def _cell(v, base):
 def _box_table(header, rows):
     widths = [max(len(str(x)) for x in col) + 2 for col in zip(header, *rows)]
 
-    def line(l, m, r):
-        return l + m.join("─" * w for w in widths) + r
+    def line(left, mid, right):
+        return left + mid.join("─" * w for w in widths) + right
 
     def fmt(cells, center=False):
         parts = []
@@ -441,13 +447,17 @@ def main():
                     ]
                     t0 = time.time()
                     rc = subprocess.call(cmd)
+                    # The worker writes its results before exiting; trust
+                    # them even if the runtime's teardown returns non-zero.
+                    try:
+                        results[variant] = json.load(open(tf.name))
+                    except (OSError, ValueError):
+                        results[variant] = {}
+                    status = "ok" if results[variant] else f"FAILED rc={rc}"
                     print(
-                        f"  {model} {n} dev {variant}: "
-                        f"{'ok' if rc == 0 else f'FAILED rc={rc}'} "
+                        f"  {model} {n} dev {variant}: {status} "
                         f"({time.time() - t0:.0f}s)",
                         flush=True)
-                    results[variant] = json.load(open(
-                        tf.name)) if rc == 0 else {}
             base = results[variants[0]]
             rows = []
             for ctx in _ladder(args.max_context):

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -28,10 +28,10 @@ parallelism layouts, each cell relative to the all-device TP baseline.
                          cache phase.
 
 Attention alone understates the difference between the layouts: under TP a
-layer also all-reduces the o_proj and down_proj outputs of the whole chunk
-over all N devices, while under pcp{P}xtp{N/P} those all-reduces cover 1/P of
-the tokens over N/P devices. By default every step therefore also performs the
-two [tokens_per_device, hidden] bf16 all-reduces over the model axis (data
+layer also all-reduces the o_proj output of the whole chunk over all N
+devices, while under pcp{P}xtp{N/P} that all-reduce covers 1/P of the tokens
+over N/P devices. By default every step therefore also performs the
+[tokens_per_device, hidden] bf16 all-reduce over the model axis (data
 dependent on the attention output); ``--no-layer-all-reduce`` times attention
 only. Matmuls are not modelled (they cost the same per device in both).
 
@@ -69,7 +69,7 @@ class ModelParams:
     num_kv_heads: int
     head_dim: int
     num_devices: list[int]
-    hidden_size: int  # width of the all-reduced o_proj / down_proj outputs
+    hidden_size: int  # width of the all-reduced o_proj output
 
 
 MODEL_CONFIGS = {
@@ -163,11 +163,11 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
     def rand(shape):
         return jnp.asarray(rng.random(shape, np.float32)).astype(dtype)
 
-    def layer_all_reduces(o, axis):
-        """The two per-layer all-reduces that follow attention (o_proj and
-        down_proj outputs, [tokens, hidden] bf16) over the model axis `axis`,
-        made data dependent on the attention output `o` so they are timed
-        after it. Returns `o` unchanged when disabled."""
+    def layer_all_reduce_fn(o, axis):
+        """The per-layer all-reduce that follows attention (o_proj output,
+        [tokens, hidden] bf16) over the model axis `axis`, made data
+        dependent on the attention output `o` so it is timed after it.
+        Returns `o` unchanged when disabled."""
         if not layer_all_reduce:
             return o
         tokens = o.shape[0]
@@ -175,7 +175,6 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
             o.reshape(tokens, -1)[:, :1].astype(dtype),
             (tokens, mp.hidden_size))
         act = jax.lax.psum(act, axis)
-        act = jax.lax.psum(act * act, axis)
         return o + act[:, :1].astype(o.dtype).reshape((tokens, ) + (1, ) *
                                                       (o.ndim - 1))
 
@@ -231,7 +230,7 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
                                                 sm_scale=sm_scale,
                                                 use_causal_mask=True,
                                                 update_kv_cache=True)
-            return layer_all_reduces(out, "x")[None], cache
+            return layer_all_reduce_fn(out, "x")[None], cache
 
         @functools.partial(jax.jit, donate_argnums=(0, ))
         def fn(cache, q, k, v, ctx):
@@ -324,7 +323,7 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
                                              use_causal_mask=True)
                     # Heads are sharded over the model axis; all-reduce there.
                     out = jax.shard_map(functools.partial(
-                        layer_all_reduces, axis=ShardingAxisName.ATTN_HEAD),
+                        layer_all_reduce_fn, axis=ShardingAxisName.ATTN_HEAD),
                                         mesh=mesh,
                                         in_specs=q_spec,
                                         out_specs=q_spec,
@@ -478,8 +477,8 @@ def main():
                     help="KV cache pages allocated = slack x request pages")
     ap.add_argument("--no-layer-all-reduce",
                     action="store_true",
-                    help="time attention only (skip the two per-layer "
-                    "all-reduces of [tokens, hidden] over the model axis)")
+                    help="time attention only (skip the per-layer "
+                    "all-reduce of [tokens, hidden] over the model axis)")
     ap.add_argument("--profile-dir",
                     default=None,
                     help="also record xprof traces per layout here (local "
@@ -577,7 +576,7 @@ def main():
                 for v in variants[1:]
             ]
             what = ("attention only" if args.no_layer_all_reduce else
-                    f"attention + 2 layer all-reduces "
+                    f"attention + layer all-reduce "
                     f"(hidden={mp.hidden_size})")
             title = (f"{model}: NQ={mp.num_q_heads} NKV={mp.num_kv_heads} "
                      f"HD={mp.head_dim}, {n} devices, "

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -65,15 +65,6 @@ class ModelParams:
 
 
 MODEL_CONFIGS = {
-    # https://huggingface.co/Qwen/Qwen3-32B/raw/main/config.json
-    'Qwen3-32B':
-    ModelParams(
-        num_q_heads=64,
-        num_kv_heads=8,
-        head_dim=128,
-        num_devices=[2],
-        hidden_size=5120,
-    ),
     # google3/third_party/py/tpu_kernel_testbench/qwen35_config_defaults.json
     'Qwen3.5':
     ModelParams(

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -1,0 +1,477 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Prefill TTFT benchmark: PCP (rpa_v3_cp) vs TP (rpa_v3) attention.
+
+For every model config and device count, measures the attention latency of
+each prefill chunk (queries [i*CH, (i+1)*CH) attending KV [0, (i+1)*CH)) and
+reports cumulative TTFT(N) = sum over chunks, as a table of context lengths x
+parallelism layouts, each cell relative to the all-device TP baseline.
+
+  * ``tp{N}``          - rpa_v3 (ragged_paged_attention) with heads sharded
+                         over all N devices. The baseline.
+  * ``tp{N/2}``        - same on half the devices.
+  * ``pcp{P}xtp{N/P}`` - rpa_v3_cp through the production PCP wrapper
+                         (``cp_attention.pcp_forward``): a (pcp, model) mesh,
+                         Q/K/V head-tail sharded over pcp, heads over model,
+                         KV cache page-striped over pcp. In-kernel ring for the
+                         cache phase.
+
+TP attention has no in-op collective, so it is measured on a shard_map over
+the tp devices and blocked on all of them: it pays the same cross-device
+dispatch/sync the PCP columns do. Meshes over different device subsets cannot
+coexist in one TPU process, so every variant runs in its own subprocess.
+
+Usage:
+  python pcp_vs_tp_benchmark.py                       # all models, all layouts
+  python pcp_vs_tp_benchmark.py --models Qwen3.5 --max-context 262144
+  python pcp_vs_tp_benchmark.py --kv-dtype float8_e4m3fn --pcp-sizes 8
+"""
+import argparse
+import dataclasses
+import functools
+import json
+import subprocess
+import sys
+import tempfile
+import time
+
+
+@dataclasses.dataclass(frozen=True)
+class ModelParams:
+    num_q_heads: int
+    num_kv_heads: int
+    head_dim: int
+    num_devices: list[int]
+
+
+MODEL_CONFIGS = {
+    # https://huggingface.co/Qwen/Qwen3-32B/raw/main/config.json
+    'Qwen3-32B':
+    ModelParams(
+        num_q_heads=64,
+        num_kv_heads=8,
+        head_dim=128,
+        num_devices=[2],
+    ),
+    # google3/third_party/py/tpu_kernel_testbench/qwen35_config_defaults.json
+    'Qwen3.5':
+    ModelParams(
+        num_q_heads=32,
+        num_kv_heads=2,
+        head_dim=256,
+        num_devices=[8],
+    ),
+    # https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/config.json
+    'Qwen3-Coder-480B':
+    ModelParams(
+        num_q_heads=96,
+        num_kv_heads=8,
+        head_dim=128,
+        num_devices=[8],
+    ),
+    # https://huggingface.co/google/gemma-4-31b-it/raw/main/config.json
+    'Gemma4-31B':
+    ModelParams(
+        num_q_heads=32,
+        num_kv_heads=16,
+        head_dim=256,
+        num_devices=[8],
+    ),
+}
+
+MAX_SEQ = 4
+
+
+def _human(n):
+    return f"{n // 1024}k" if n < 1024 * 1024 else f"{n // (1024 * 1024)}M"
+
+
+def _boundaries(n, ch):
+    """Chunk end-points for a prompt of n tokens: ch, 2ch, ..., n."""
+    out, cur = [], 0
+    while cur < n:
+        cur = min(cur + ch, n)
+        out.append(cur)
+    return out
+
+
+def _ladder(max_ctx):
+    return [c for c in (1 << i for i in range(10, 31)) if c <= max_ctx]
+
+
+# --------------------------------------------------------------------------
+# Worker: one variant, one process (jax is imported here only).
+# --------------------------------------------------------------------------
+def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
+                 warmup, iters):
+    # tpu_inference must be imported before jax (its __init__ loads the
+    # engine first).
+    import jax
+    import jax.numpy as jnp
+    import numpy as np
+    from jax.sharding import Mesh, NamedSharding
+    from jax.sharding import PartitionSpec as P
+
+    import tpu_inference  # noqa: F401
+    from tpu_inference.kernels.ragged_paged_attention.v3.util import (
+        align_to, cdiv, get_dtype_packing)
+    from tpu_inference.layers.common import sharding as sharding_mod
+    from tpu_inference.layers.common.attention_interface import \
+        ragged_paged_attention
+    from tpu_inference.layers.common.attention_metadata import (
+        AttentionMetadata, PCPMetadata)
+    from tpu_inference.layers.common.cp_attention import pcp_forward
+    from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
+                                                      ShardingAxisName,
+                                                      ShardingAxisNameBase)
+
+    # The N-D axis names carry `pcp`; select them regardless of
+    # NEW_MODEL_DESIGN so the benchmark does not depend on the env.
+    sharding_mod.ShardingAxisName._cls = ShardingAxisNameBase
+
+    NQ, NKV, HD = mp.num_q_heads, mp.num_kv_heads, mp.head_dim
+    dtype = jnp.bfloat16
+    kv_dtype = getattr(jnp, kv_dtype_name)
+    sm_scale = HD**-0.5
+    kvp = get_dtype_packing(kv_dtype)
+    rng = np.random.default_rng(0)
+
+    def rand(shape):
+        return jnp.asarray(rng.random(shape, np.float32)).astype(dtype)
+
+    def bench(fn, *args):
+        # Queue every iteration and block once: per-step time reflects device
+        # work, not `iters` host<->device round trips.
+        jax.block_until_ready(fn(*args))
+        for _ in range(warmup):
+            jax.block_until_ready(fn(*args))
+        t0 = time.perf_counter()
+        out = None
+        for _ in range(iters):
+            out = fn(*args)
+        jax.block_until_ready(out)
+        return (time.perf_counter() - t0) / iters * 1e3
+
+    def bench_cache(fn, cache, *args):
+        # fn(cache, *args) -> (out, cache), cache donated and threaded so the
+        # in-place cache write is timed too.
+        out, cache = fn(cache, *args)
+        jax.block_until_ready(out)
+        for _ in range(warmup):
+            out, cache = fn(cache, *args)
+            jax.block_until_ready(out)
+        t0 = time.perf_counter()
+        for _ in range(iters):
+            out, cache = fn(cache, *args)
+        jax.block_until_ready(out)
+        return (time.perf_counter() - t0) / iters * 1e3
+
+    def make_tp(tp):
+        """rpa_v3 with heads sharded over `tp` devices (KV heads replicated
+        when tp > num_kv_heads, as the model does)."""
+        nq, nkv = NQ // tp, max(1, NKV // tp)
+        nkv2 = align_to(2 * nkv, kvp)
+        npages = max(cdiv(max_ctx, page), 1) * slack
+        mesh = Mesh(np.array(jax.devices()[:tp]).reshape(tp), ("x", ))
+        put = lambda x: jax.device_put(x, NamedSharding(mesh, P("x")))
+        q = put(jnp.broadcast_to(rand((chunk, nq, HD)), (tp, chunk, nq, HD)))
+        k = put(
+            jnp.broadcast_to(
+                rand((chunk, nkv, HD)).astype(kv_dtype), (tp, chunk, nkv, HD)))
+        v = put(
+            jnp.broadcast_to(
+                rand((chunk, nkv, HD)).astype(kv_dtype), (tp, chunk, nkv, HD)))
+        pi = jnp.arange(npages, dtype=jnp.int32)
+        cu = jnp.array([0, chunk], jnp.int32)
+        dist = jnp.array([0, 0, 1], jnp.int32)
+
+        def per_device(q1, k1, v1, ctx1):
+            cache = jnp.zeros((npages, page, nkv2 // kvp, kvp, HD), kv_dtype)
+            out, _ = ragged_paged_attention(q1[0],
+                                            k1[0],
+                                            v1[0],
+                                            cache,
+                                            ctx1.reshape(1),
+                                            pi,
+                                            cu,
+                                            dist,
+                                            sm_scale=sm_scale,
+                                            use_causal_mask=True,
+                                            update_kv_cache=True)
+            return out[None]
+
+        @jax.jit
+        def fn(q, k, v, ctx):
+            return jax.shard_map(per_device,
+                                 mesh=mesh,
+                                 in_specs=(P("x"), P("x"), P("x"), P()),
+                                 out_specs=P("x"),
+                                 check_vma=False)(q, k, v, ctx)
+
+        return lambda ctx: bench(fn, q, k, v, jnp.array(ctx, jnp.int32))
+
+    def make_pcp(pcp, tp):
+        """rpa_v3_cp through cp_attention.pcp_forward on a (pcp, model) mesh."""
+        shape = tuple(pcp if a == "pcp" else tp if a == "model" else 1
+                      for a in MESH_AXIS_NAMES)
+        mesh = Mesh(
+            np.array(jax.devices()[:pcp * tp]).reshape(shape), MESH_AXIS_NAMES)
+        two_p, C = 2 * pcp, chunk // (2 * pcp)
+        # KV_CONTEXT shards the page dim: a global page holds page*pcp tokens.
+        gpage = page * pcp
+        pages_per_seq = max(cdiv(max_ctx, gpage), 1)
+        npages = pages_per_seq * slack
+        # Packed KV planes are laid out per TP shard.
+        nkv2 = tp * align_to(2 * max(1, NKV // tp), kvp)
+        cache_spec = P(ShardingAxisName.BATCH, ShardingAxisName.KV_CONTEXT,
+                       ShardingAxisName.KV_HEAD, None, None)
+        put = lambda x, s: jax.device_put(x, NamedSharding(mesh, s))
+        q = put(
+            rand((chunk, NQ, HD)),
+            P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None))
+        kv_spec = P(ShardingAxisName.ATTN_DATA, ShardingAxisName.KV_HEAD, None)
+        k = put(rand((chunk, NKV, HD)).astype(kv_dtype), kv_spec)
+        v = put(rand((chunk, NKV, HD)).astype(kv_dtype), kv_spec)
+        # Head and tail chunks of the request are two "sequences" of the same
+        # request; both index the same pages.
+        pg = jnp.arange(pages_per_seq, dtype=jnp.int32)
+        pi = jnp.zeros(
+            (MAX_SEQ * pages_per_seq, ),
+            jnp.int32).at[:2 * pages_per_seq].set(jnp.concatenate([pg, pg]))
+        dist = jnp.array([0, 0, 2], jnp.int32)
+        pcp_cu = np.zeros((pcp, MAX_SEQ + 1), np.int32)
+        pcp_qp = np.zeros((pcp, MAX_SEQ), np.int32)
+        for r in range(pcp):
+            toff = (two_p - 1 - r) * C
+            treal = int(np.clip(chunk - toff, 0, C))
+            pcp_cu[r, 1] = C
+            pcp_cu[r, 2:] = C + treal
+            pcp_qp[r, 0] = r * C
+            pcp_qp[r, 1] = toff
+        pcp_spec = P(ShardingAxisName.PREFILL_CONTEXT, None)
+        pcp_cu = put(jnp.asarray(pcp_cu), pcp_spec)
+        pcp_qp = put(jnp.asarray(pcp_qp), pcp_spec)
+        fns = {}
+
+        def fn_for(cache_pages):
+            # `cache_pages` is static metadata (one program per bucket), as in
+            # the runner.
+            if cache_pages not in fns:
+
+                @functools.partial(jax.jit, donate_argnums=(0, ))
+                def fn(cache, q, k, v, kvl, kvcl, _cp=cache_pages):
+                    md = AttentionMetadata(
+                        input_positions=jnp.zeros(1, jnp.int32),
+                        seq_lens=kvl,
+                        block_tables=pi,
+                        request_distribution=dist,
+                        pcp=PCPMetadata(query_start_loc=pcp_cu,
+                                        kv_cache_lens=kvcl,
+                                        q_pos_offsets=pcp_qp,
+                                        cache_pages=_cp),
+                    )
+                    cache, out = pcp_forward(mesh,
+                                             q,
+                                             k,
+                                             v,
+                                             cache,
+                                             md,
+                                             sm_scale=sm_scale,
+                                             update_kv_cache=True,
+                                             use_causal_mask=True)
+                    return out, cache
+
+                fns[cache_pages] = fn
+            return fns[cache_pages]
+
+        def cache_pages_for(ctx):
+            # Mirror the runner: live page count rounded up to a power of two.
+            computed = ctx - chunk
+            if computed <= 0:
+                return 0
+            live = cdiv(computed, gpage)
+            return min(1 << max(live - 1, 0).bit_length(), npages)
+
+        def measure(ctx):
+            kvl = jnp.zeros((MAX_SEQ, ), jnp.int32).at[:2].set(ctx)
+            kvcl = jnp.zeros((MAX_SEQ, ),
+                             jnp.int32).at[:2].set(max(ctx - chunk, 0))
+            cache = jax.device_put(
+                jnp.zeros((npages, gpage, nkv2 // kvp, kvp, HD), kv_dtype),
+                NamedSharding(mesh, cache_spec))
+            return bench_cache(fn_for(cache_pages_for(ctx)), cache, q, k, v,
+                               kvl, kvcl)
+
+        return measure
+
+    if variant.startswith("pcp"):
+        pcp, tp = (int(x) for x in variant[3:].split("xtp"))
+        measure = make_pcp(pcp, tp)
+    else:
+        measure = make_tp(int(variant[2:]))
+
+    ladder = _ladder(max_ctx)
+    needed = sorted({b for n in ladder for b in _boundaries(n, chunk)})
+    step = {c: measure(c) for c in needed}
+    return {
+        str(n): sum(step[b] for b in _boundaries(n, chunk))
+        for n in ladder
+    }
+
+
+# --------------------------------------------------------------------------
+# Driver
+# --------------------------------------------------------------------------
+def _variants(mp, n, pcp_sizes):
+    out = [f"tp{n}"]
+    if n >= 2 and mp.num_q_heads % (n // 2) == 0:
+        out.append(f"tp{n // 2}")
+    for p in pcp_sizes:
+        if p <= 1 or n % p:
+            continue
+        tp = n // p
+        if p % 2 or mp.num_q_heads % tp:
+            continue  # PCP needs an even pcp size and whole Q heads per shard
+        out.append(f"pcp{p}xtp{tp}")
+    return out
+
+
+def _cell(v, base):
+    if v is None:
+        return "n/a"
+    r = v / base
+    if abs(r - 1) < 0.005:
+        return f"{v:.2f} (=)"
+    if r >= 1.5:
+        return f"{v:.2f} ({r:.2f}x slower)"
+    if r > 1:
+        return f"{v:.2f} ({(r - 1) * 100:.1f}% slower)"
+    return f"{v:.2f} ({(1 - r) * 100:.1f}% faster)"
+
+
+def _box_table(header, rows):
+    widths = [max(len(str(x)) for x in col) + 2 for col in zip(header, *rows)]
+
+    def line(l, m, r):
+        return l + m.join("─" * w for w in widths) + r
+
+    def fmt(cells, center=False):
+        parts = []
+        for c, w in zip(cells, widths):
+            c = str(c)
+            parts.append(c.center(w) if center else " " + c.ljust(w - 1))
+        return "│" + "│".join(parts) + "│"
+
+    out = [line("┌", "┬", "┐"), fmt(header, center=True)]
+    for i, row in enumerate(rows):
+        out.append(line("├", "┼", "┤"))
+        out.append(fmt(row))
+    out.append(line("└", "┴", "┘"))
+    return "\n".join(out)
+
+
+def main():
+    ap = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    ap.add_argument("--models",
+                    nargs="*",
+                    default=list(MODEL_CONFIGS),
+                    choices=list(MODEL_CONFIGS))
+    ap.add_argument("--chunk-size", type=int, default=4096)
+    ap.add_argument("--max-context", type=int, default=1024 * 1024)
+    ap.add_argument("--kv-dtype",
+                    default="bfloat16",
+                    choices=["bfloat16", "float8_e4m3fn"])
+    ap.add_argument("--pcp-sizes",
+                    nargs="*",
+                    type=int,
+                    default=[2, 4, 8],
+                    help="pcp sizes to try (those dividing num_devices)")
+    ap.add_argument("--page-size", type=int, default=256)
+    ap.add_argument("--cache-slack",
+                    type=int,
+                    default=1,
+                    help="KV cache pages allocated = slack x request pages")
+    ap.add_argument("--warmup", type=int, default=2)
+    ap.add_argument("--iters", type=int, default=10)
+    ap.add_argument("--worker",
+                    nargs=3,
+                    metavar=("MODEL", "NUM_DEVICES", "VARIANT"),
+                    help=argparse.SUPPRESS)
+    ap.add_argument("--json", help=argparse.SUPPRESS)
+    args = ap.parse_args()
+
+    if args.worker:
+        model, n, variant = args.worker
+        res = _run_variant(MODEL_CONFIGS[model], variant, args.chunk_size,
+                           args.max_context, args.kv_dtype, args.page_size,
+                           args.cache_slack, args.warmup, args.iters)
+        with open(args.json, "w") as f:
+            json.dump(res, f)
+        return
+
+    tables = []
+    for model in args.models:
+        mp = MODEL_CONFIGS[model]
+        for n in mp.num_devices:
+            variants = _variants(mp, n, args.pcp_sizes)
+            results = {}
+            for variant in variants:
+                with tempfile.NamedTemporaryFile(suffix=".json") as tf:
+                    cmd = [
+                        sys.executable, __file__, "--worker", model,
+                        str(n), variant, "--json", tf.name, "--chunk-size",
+                        str(args.chunk_size), "--max-context",
+                        str(args.max_context), "--kv-dtype", args.kv_dtype,
+                        "--page-size",
+                        str(args.page_size), "--cache-slack",
+                        str(args.cache_slack), "--warmup",
+                        str(args.warmup), "--iters",
+                        str(args.iters)
+                    ]
+                    t0 = time.time()
+                    rc = subprocess.call(cmd)
+                    print(
+                        f"  {model} {n} dev {variant}: "
+                        f"{'ok' if rc == 0 else f'FAILED rc={rc}'} "
+                        f"({time.time() - t0:.0f}s)",
+                        flush=True)
+                    results[variant] = json.load(open(
+                        tf.name)) if rc == 0 else {}
+            base = results[variants[0]]
+            rows = []
+            for ctx in _ladder(args.max_context):
+                key = str(ctx)
+                if key not in base:
+                    continue
+                rows.append([_human(ctx), f"{base[key]:.2f}"] + [
+                    _cell(results[v].get(key), base[key]) for v in variants[1:]
+                ])
+            header = ["Context", f"{variants[0]} ({n} dev)"] + [
+                f"{v} ({n // 2} dev)" if v == f"tp{n // 2}" else v
+                for v in variants[1:]
+            ]
+            title = (
+                f"{model}: NQ={mp.num_q_heads} NKV={mp.num_kv_heads} "
+                f"HD={mp.head_dim}, {n} devices, CH={_human(args.chunk_size)}, "
+                f"KV {args.kv_dtype} -- cumulative TTFT (ms), baseline "
+                f"{variants[0]}")
+            tables.append(title + "\n\n" + _box_table(header, rows))
+            print("\n" + tables[-1] + "\n", flush=True)
+
+    if len(tables) > 1:
+        print("\n\n".join(tables))
+
+
+if __name__ == "__main__":
+    main()

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -35,10 +35,17 @@ covers 1/P of the tokens over N/P devices -- but PCP then all-gathers the
 token-sharded activation over the pcp axis into the MLP's replicated layout
 (``activation_ffw_td``). The MLP itself is tensor-sharded over every axis
 (``MLP_TENSOR``), so its all-reduce is identical in both layouts and left out.
-By default every step therefore also performs that o_proj all-reduce (and, for
-PCP, the pcp all-gather), data dependent on the attention output;
-``--no-layer-all-reduce`` times attention only. Matmuls are not modelled (they
-cost the same per device in both).
+``--no-collectives`` selects which of the two things a step measures:
+
+  * default: attention + the layer collectives around it (the o_proj
+    all-reduce over the model axis and, for PCP, the all-gather over the pcp
+    axis between the token-sharded attention layout and the replicated MLP
+    layout), data dependent on the attention output;
+  * ``--no-collectives``: pure attention, no collective outside the kernel
+    (the PCP kernel's own ring DMAs and current-KV all-gather stay, they are
+    the attention).
+
+Matmuls are not modelled (they cost the same per device in every layout).
 
 TP attention has no in-op collective, so it is measured on a shard_map over
 the tp devices and blocked on all of them: it pays the same cross-device
@@ -49,6 +56,7 @@ Usage:
   python pcp_vs_tp_benchmark.py                       # all models, all layouts
   python pcp_vs_tp_benchmark.py --models Qwen3.5 --max-context 262144
   python pcp_vs_tp_benchmark.py --kv-dtype float8_e4m3fn --pcp-sizes 8
+  python pcp_vs_tp_benchmark.py --no-collectives                # pure attention
   python pcp_vs_tp_benchmark.py --profile-dir gs://bucket/path   # + xprof traces
 
 With ``--profile-dir`` every layout also records an xprof trace of the step at
@@ -131,8 +139,7 @@ def _ladder(max_ctx):
 # Worker: one variant, one process (jax is imported here only).
 # --------------------------------------------------------------------------
 def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
-                 warmup, iters, layer_all_reduce, profile_dir,
-                 profile_contexts, n):
+                 warmup, iters, collectives, profile_dir, profile_contexts, n):
     # tpu_inference must be imported before jax (its __init__ loads the
     # engine first).
     import jax
@@ -168,14 +175,14 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
     def rand(shape):
         return jnp.asarray(rng.random(shape, np.float32)).astype(dtype)
 
-    def layer_all_reduce_fn(o, axis, gather_axis=None):
-        """The per-layer collectives that follow attention: the o_proj
-        output ([tokens, hidden] bf16) all-reduced over the model axis `axis`
-        and, when `gather_axis` is given (PCP), all-gathered over it into the
-        MLP's token-replicated layout. Made data dependent on the attention
-        output `o` so they are timed after it. Returns `o` unchanged when
-        disabled."""
-        if not layer_all_reduce:
+    def layer_collectives(o, axis, gather_axis=None):
+        """The layer collectives around attention: the o_proj output
+        ([tokens, hidden] bf16) all-reduced over the model axis `axis` and,
+        when `gather_axis` is given (PCP), all-gathered over it between the
+        token-sharded attention layout and the replicated MLP layout. Made
+        data dependent on the attention output `o` so they are timed after
+        it. Returns `o` unchanged with --no-collectives."""
+        if not collectives:
             return o
         tokens = o.shape[0]
         act = jnp.broadcast_to(
@@ -240,7 +247,7 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
                                                 sm_scale=sm_scale,
                                                 use_causal_mask=True,
                                                 update_kv_cache=True)
-            return layer_all_reduce_fn(out, "x")[None], cache
+            return layer_collectives(out, "x")[None], cache
 
         @functools.partial(jax.jit, donate_argnums=(0, ))
         def fn(cache, q, k, v, ctx):
@@ -333,7 +340,7 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
                                              use_causal_mask=True)
                     # Heads are sharded over the model axis; all-reduce there.
                     out = jax.shard_map(functools.partial(
-                        layer_all_reduce_fn,
+                        layer_collectives,
                         axis=ShardingAxisName.ATTN_HEAD,
                         gather_axis=ShardingAxisName.PREFILL_CONTEXT),
                                         mesh=mesh,
@@ -487,11 +494,11 @@ def main():
                     type=int,
                     default=1,
                     help="KV cache pages allocated = slack x request pages")
-    ap.add_argument("--no-layer-all-reduce",
+    ap.add_argument("--no-collectives",
                     action="store_true",
-                    help="time attention only (skip the o_proj all-reduce "
-                    "over the model axis and, for PCP, the pcp all-gather "
-                    "into the MLP layout)")
+                    help="pure attention: skip the layer collectives (o_proj "
+                    "all-reduce over the model axis and, for PCP, the "
+                    "all-gather over the pcp axis into the MLP layout)")
     ap.add_argument("--profile-dir",
                     default=None,
                     help="also record xprof traces per layout here (local "
@@ -520,7 +527,7 @@ def main():
                 MODEL_CONFIGS[model], variant, args.chunk_size,
                 args.max_context, args.kv_dtype, args.page_size,
                 args.cache_slack, args.warmup, args.iters,
-                not args.no_layer_all_reduce, args.profile_dir,
+                not args.no_collectives, args.profile_dir,
                 [int(c) for c in args.profile_contexts.split(",")], int(n))
         except Exception as e:  # noqa: BLE001
             if "vmem" not in str(e):
@@ -550,8 +557,8 @@ def main():
                         str(args.cache_slack), "--warmup",
                         str(args.warmup), "--iters",
                         str(args.iters)
-                    ] + (["--no-layer-all-reduce"]
-                         if args.no_layer_all_reduce else []) + ([
+                    ] + (["--no-collectives"]
+                         if args.no_collectives else []) + ([
                              "--profile-dir", args.profile_dir,
                              "--profile-contexts", args.profile_contexts
                          ] if args.profile_dir else [])
@@ -588,9 +595,9 @@ def main():
                 f"{v} ({n // 2} dev)" if v == f"tp{n // 2}" else v
                 for v in variants[1:]
             ]
-            what = ("attention only" if args.no_layer_all_reduce else
-                    f"attention + o_proj all-reduce (+ pcp all-gather) "
-                    f"(hidden={mp.hidden_size})")
+            what = ("pure attention" if args.no_collectives else
+                    f"attention + collectives: o_proj all-reduce, pcp "
+                    f"all-gather (hidden={mp.hidden_size})")
             title = (f"{model}: NQ={mp.num_q_heads} NKV={mp.num_kv_heads} "
                      f"HD={mp.head_dim}, {n} devices, "
                      f"CH={_human(args.chunk_size)}, KV {args.kv_dtype}, "

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -27,6 +27,14 @@ parallelism layouts, each cell relative to the all-device TP baseline.
                          KV cache page-striped over pcp. In-kernel ring for the
                          cache phase.
 
+Attention alone understates the difference between the layouts: under TP a
+layer also all-reduces the o_proj and down_proj outputs of the whole chunk
+over all N devices, while under pcp{P}xtp{N/P} those all-reduces cover 1/P of
+the tokens over N/P devices. By default every step therefore also performs the
+two [tokens_per_device, hidden] bf16 all-reduces over the model axis (data
+dependent on the attention output); ``--no-layer-all-reduce`` times attention
+only. Matmuls are not modelled (they cost the same per device in both).
+
 TP attention has no in-op collective, so it is measured on a shard_map over
 the tp devices and blocked on all of them: it pays the same cross-device
 dispatch/sync the PCP columns do. Meshes over different device subsets cannot
@@ -53,6 +61,7 @@ class ModelParams:
     num_kv_heads: int
     head_dim: int
     num_devices: list[int]
+    hidden_size: int  # width of the all-reduced o_proj / down_proj outputs
 
 
 MODEL_CONFIGS = {
@@ -63,6 +72,7 @@ MODEL_CONFIGS = {
         num_kv_heads=8,
         head_dim=128,
         num_devices=[2],
+        hidden_size=5120,
     ),
     # google3/third_party/py/tpu_kernel_testbench/qwen35_config_defaults.json
     'Qwen3.5':
@@ -71,6 +81,7 @@ MODEL_CONFIGS = {
         num_kv_heads=2,
         head_dim=256,
         num_devices=[8],
+        hidden_size=4096,
     ),
     # https://huggingface.co/Qwen/Qwen3-Coder-480B-A35B-Instruct/blob/main/config.json
     'Qwen3-Coder-480B':
@@ -79,6 +90,7 @@ MODEL_CONFIGS = {
         num_kv_heads=8,
         head_dim=128,
         num_devices=[8],
+        hidden_size=6144,
     ),
     # https://huggingface.co/google/gemma-4-31b-it/raw/main/config.json
     'Gemma4-31B':
@@ -87,6 +99,7 @@ MODEL_CONFIGS = {
         num_kv_heads=16,
         head_dim=256,
         num_devices=[8],
+        hidden_size=5376,
     ),
 }
 
@@ -114,7 +127,7 @@ def _ladder(max_ctx):
 # Worker: one variant, one process (jax is imported here only).
 # --------------------------------------------------------------------------
 def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
-                 warmup, iters):
+                 warmup, iters, layer_all_reduce):
     # tpu_inference must be imported before jax (its __init__ loads the
     # engine first).
     import jax
@@ -149,6 +162,22 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
 
     def rand(shape):
         return jnp.asarray(rng.random(shape, np.float32)).astype(dtype)
+
+    def layer_all_reduces(o, axis):
+        """The two per-layer all-reduces that follow attention (o_proj and
+        down_proj outputs, [tokens, hidden] bf16) over the model axis `axis`,
+        made data dependent on the attention output `o` so they are timed
+        after it. Returns `o` unchanged when disabled."""
+        if not layer_all_reduce:
+            return o
+        tokens = o.shape[0]
+        act = jnp.broadcast_to(
+            o.reshape(tokens, -1)[:, :1].astype(dtype),
+            (tokens, mp.hidden_size))
+        act = jax.lax.psum(act, axis)
+        act = jax.lax.psum(act * act, axis)
+        return o + act[:, :1].astype(o.dtype).reshape((tokens, ) + (1, ) *
+                                                      (o.ndim - 1))
 
     def bench_cache(fn, cache, *args):
         # fn(cache, *args) -> (out, cache), cache donated and threaded so the
@@ -202,7 +231,7 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
                                                 sm_scale=sm_scale,
                                                 use_causal_mask=True,
                                                 update_kv_cache=True)
-            return out[None], cache
+            return layer_all_reduces(out, "x")[None], cache
 
         @functools.partial(jax.jit, donate_argnums=(0, ))
         def fn(cache, q, k, v, ctx):
@@ -240,9 +269,9 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
         def put(x, s):
             return jax.device_put(x, NamedSharding(mesh, s))
 
-        q = put(
-            rand((chunk, NQ, HD)),
-            P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None))
+        q_spec = P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD,
+                   None)
+        q = put(rand((chunk, NQ, HD)), q_spec)
         kv_spec = P(ShardingAxisName.ATTN_DATA, ShardingAxisName.KV_HEAD, None)
         k = put(rand((chunk, NKV, HD)).astype(kv_dtype), kv_spec)
         v = put(rand((chunk, NKV, HD)).astype(kv_dtype), kv_spec)
@@ -293,6 +322,13 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
                                              sm_scale=sm_scale,
                                              update_kv_cache=True,
                                              use_causal_mask=True)
+                    # Heads are sharded over the model axis; all-reduce there.
+                    out = jax.shard_map(functools.partial(
+                        layer_all_reduces, axis=ShardingAxisName.ATTN_HEAD),
+                                        mesh=mesh,
+                                        in_specs=q_spec,
+                                        out_specs=q_spec,
+                                        check_vma=False)(out)
                     return out, cache
 
                 fns[cache_pages] = fn
@@ -405,6 +441,10 @@ def main():
                     type=int,
                     default=1,
                     help="KV cache pages allocated = slack x request pages")
+    ap.add_argument("--no-layer-all-reduce",
+                    action="store_true",
+                    help="time attention only (skip the two per-layer "
+                    "all-reduces of [tokens, hidden] over the model axis)")
     ap.add_argument("--warmup", type=int, default=2)
     ap.add_argument("--iters", type=int, default=10)
     ap.add_argument("--worker",
@@ -418,7 +458,8 @@ def main():
         model, n, variant = args.worker
         res = _run_variant(MODEL_CONFIGS[model], variant, args.chunk_size,
                            args.max_context, args.kv_dtype, args.page_size,
-                           args.cache_slack, args.warmup, args.iters)
+                           args.cache_slack, args.warmup, args.iters,
+                           not args.no_layer_all_reduce)
         with open(args.json, "w") as f:
             json.dump(res, f)
         return
@@ -441,7 +482,8 @@ def main():
                         str(args.cache_slack), "--warmup",
                         str(args.warmup), "--iters",
                         str(args.iters)
-                    ]
+                    ] + (["--no-layer-all-reduce"]
+                         if args.no_layer_all_reduce else [])
                     t0 = time.time()
                     rc = subprocess.call(cmd)
                     # The worker writes its results before exiting; trust
@@ -468,11 +510,14 @@ def main():
                 f"{v} ({n // 2} dev)" if v == f"tp{n // 2}" else v
                 for v in variants[1:]
             ]
-            title = (
-                f"{model}: NQ={mp.num_q_heads} NKV={mp.num_kv_heads} "
-                f"HD={mp.head_dim}, {n} devices, CH={_human(args.chunk_size)}, "
-                f"KV {args.kv_dtype} -- cumulative TTFT (ms), baseline "
-                f"{variants[0]}")
+            what = ("attention only" if args.no_layer_all_reduce else
+                    f"attention + 2 layer all-reduces "
+                    f"(hidden={mp.hidden_size})")
+            title = (f"{model}: NQ={mp.num_q_heads} NKV={mp.num_kv_heads} "
+                     f"HD={mp.head_dim}, {n} devices, "
+                     f"CH={_human(args.chunk_size)}, KV {args.kv_dtype}, "
+                     f"{what} -- cumulative TTFT (ms), baseline "
+                     f"{variants[0]}")
             tables.append(title + "\n\n" + _box_table(header, rows))
             print("\n" + tables[-1] + "\n", flush=True)
 

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -150,22 +150,11 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
     def rand(shape):
         return jnp.asarray(rng.random(shape, np.float32)).astype(dtype)
 
-    def bench(fn, *args):
-        # Queue every iteration and block once: per-step time reflects device
-        # work, not `iters` host<->device round trips.
-        jax.block_until_ready(fn(*args))
-        for _ in range(warmup):
-            jax.block_until_ready(fn(*args))
-        t0 = time.perf_counter()
-        out = None
-        for _ in range(iters):
-            out = fn(*args)
-        jax.block_until_ready(out)
-        return (time.perf_counter() - t0) / iters * 1e3
-
     def bench_cache(fn, cache, *args):
         # fn(cache, *args) -> (out, cache), cache donated and threaded so the
-        # in-place cache write is timed too.
+        # in-place cache write is timed and nothing is re-materialized per
+        # step. Every iteration is queued and the host blocks once, so the
+        # per-step time reflects device work, not `iters` host round trips.
         out, cache = fn(cache, *args)
         jax.block_until_ready(out)
         for _ in range(warmup):
@@ -184,9 +173,10 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
         nkv2 = align_to(2 * nkv, kvp)
         npages = max(cdiv(max_ctx, page), 1) * slack
         mesh = Mesh(np.array(jax.devices()[:tp]).reshape(tp), ("x", ))
+        sharding = NamedSharding(mesh, P("x"))
 
         def put(x):
-            return jax.device_put(x, NamedSharding(mesh, P("x")))
+            return jax.device_put(x, sharding)
 
         q = put(jnp.broadcast_to(rand((chunk, nq, HD)), (tp, chunk, nq, HD)))
         k = put(
@@ -195,34 +185,41 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
         v = put(
             jnp.broadcast_to(
                 rand((chunk, nkv, HD)).astype(kv_dtype), (tp, chunk, nkv, HD)))
+        cache_shape = (tp * npages, page, nkv2 // kvp, kvp, HD)
         pi = jnp.arange(npages, dtype=jnp.int32)
         cu = jnp.array([0, chunk], jnp.int32)
         dist = jnp.array([0, 0, 1], jnp.int32)
 
-        def per_device(q1, k1, v1, ctx1):
-            cache = jnp.zeros((npages, page, nkv2 // kvp, kvp, HD), kv_dtype)
-            out, _ = ragged_paged_attention(q1[0],
-                                            k1[0],
-                                            v1[0],
-                                            cache,
-                                            ctx1.reshape(1),
-                                            pi,
-                                            cu,
-                                            dist,
-                                            sm_scale=sm_scale,
-                                            use_causal_mask=True,
-                                            update_kv_cache=True)
-            return out[None]
+        def per_device(cache, q1, k1, v1, ctx1):
+            out, cache = ragged_paged_attention(q1[0],
+                                                k1[0],
+                                                v1[0],
+                                                cache,
+                                                ctx1.reshape(1),
+                                                pi,
+                                                cu,
+                                                dist,
+                                                sm_scale=sm_scale,
+                                                use_causal_mask=True,
+                                                update_kv_cache=True)
+            return out[None], cache
 
-        @jax.jit
-        def fn(q, k, v, ctx):
+        @functools.partial(jax.jit, donate_argnums=(0, ))
+        def fn(cache, q, k, v, ctx):
             return jax.shard_map(per_device,
                                  mesh=mesh,
-                                 in_specs=(P("x"), P("x"), P("x"), P()),
-                                 out_specs=P("x"),
-                                 check_vma=False)(q, k, v, ctx)
+                                 in_specs=(P("x"), P("x"), P("x"), P("x"),
+                                           P()),
+                                 out_specs=(P("x"), P("x")),
+                                 check_vma=False)(cache, q, k, v, ctx)
 
-        return lambda ctx: bench(fn, q, k, v, jnp.array(ctx, jnp.int32))
+        def measure(ctx):
+            # Donated and threaded, like the PCP path, so the cache write is
+            # timed and no per-step cache materialization is.
+            cache = jax.device_put(jnp.zeros(cache_shape, kv_dtype), sharding)
+            return bench_cache(fn, cache, q, k, v, jnp.array(ctx, jnp.int32))
+
+        return measure
 
     def make_pcp(pcp, tp):
         """rpa_v3_cp through cp_attention.pcp_forward on a (pcp, model) mesh."""

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -55,7 +55,7 @@ coexist in one TPU process, so every variant runs in its own subprocess.
 Usage:
   python pcp_vs_tp_benchmark.py                       # all models, all layouts
   python pcp_vs_tp_benchmark.py --models Qwen3.5 --max-context 262144
-  python pcp_vs_tp_benchmark.py --kv-dtype float8_e4m3fn --pcp-sizes 8
+  python pcp_vs_tp_benchmark.py --kv-dtype bfloat16 --pcp-sizes 8
   python pcp_vs_tp_benchmark.py --no-collectives                # pure attention
   python pcp_vs_tp_benchmark.py --profile-dir gs://bucket/path   # + xprof traces
 
@@ -149,8 +149,11 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
     from jax.sharding import PartitionSpec as P
 
     import tpu_inference  # noqa: F401
-    from tpu_inference.kernels.ragged_paged_attention.v3.util import (
-        align_to, cdiv, get_dtype_packing)
+    from tpu_inference.kernels.experimental.rpa_v3_cp import \
+        kernel as rpa_v3_cp
+    from tpu_inference.kernels.ragged_paged_attention.v3 import \
+        kernel as rpa_v3
+    from tpu_inference.kernels.ragged_paged_attention.v3.util import cdiv
     from tpu_inference.layers.common import sharding as sharding_mod
     from tpu_inference.layers.common.attention_interface import \
         ragged_paged_attention
@@ -169,7 +172,6 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
     dtype = jnp.bfloat16
     kv_dtype = getattr(jnp, kv_dtype_name)
     sm_scale = HD**-0.5
-    kvp = get_dtype_packing(kv_dtype)
     rng = np.random.default_rng(0)
 
     def rand(shape):
@@ -215,7 +217,6 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
         """rpa_v3 with heads sharded over `tp` devices (KV heads replicated
         when tp > num_kv_heads, as the model does)."""
         nq, nkv = NQ // tp, max(1, NKV // tp)
-        nkv2 = align_to(2 * nkv, kvp)
         npages = max(cdiv(max_ctx, page), 1) * slack
         mesh = Mesh(np.array(jax.devices()[:tp]).reshape(tp), ("x", ))
         sharding = NamedSharding(mesh, P("x"))
@@ -230,7 +231,10 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
         v = put(
             jnp.broadcast_to(
                 rand((chunk, nkv, HD)).astype(kv_dtype), (tp, chunk, nkv, HD)))
-        cache_shape = (tp * npages, page, nkv2 // kvp, kvp, HD)
+        # Per-device layout (packing of K/V heads per 32-bit word for the KV
+        # dtype) is the kernel's own; the leading page dim is stacked over tp.
+        per_dev = rpa_v3.get_kv_cache_shape(npages, page, nkv, HD, kv_dtype)
+        cache_shape = (tp * per_dev[0], ) + tuple(per_dev[1:])
         pi = jnp.arange(npages, dtype=jnp.int32)
         cu = jnp.array([0, chunk], jnp.int32)
         dist = jnp.array([0, 0, 1], jnp.int32)
@@ -277,8 +281,12 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
         gpage = page * pcp
         pages_per_seq = max(cdiv(max_ctx, gpage), 1)
         npages = pages_per_seq * slack
-        # Packed KV planes are laid out per TP shard.
-        nkv2 = tp * align_to(2 * max(1, NKV // tp), kvp)
+        # Each rank holds `page` tokens of every global page (KV_CONTEXT shards
+        # the page dim over pcp) and its own KV heads (KV_HEAD shards the
+        # packed planes over tp); the per-rank layout is the CP kernel's own.
+        per_rank = rpa_v3_cp.get_kv_cache_shape(npages, page, NKV // tp, HD,
+                                                kv_dtype)
+        cache_shape = (npages, gpage, per_rank[2] * tp) + tuple(per_rank[3:])
         cache_spec = P(ShardingAxisName.BATCH, ShardingAxisName.KV_CONTEXT,
                        ShardingAxisName.KV_HEAD, None, None)
 
@@ -364,9 +372,8 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
             kvl = jnp.zeros((MAX_SEQ, ), jnp.int32).at[:2].set(ctx)
             kvcl = jnp.zeros((MAX_SEQ, ),
                              jnp.int32).at[:2].set(max(ctx - chunk, 0))
-            cache = jax.device_put(
-                jnp.zeros((npages, gpage, nkv2 // kvp, kvp, HD), kv_dtype),
-                NamedSharding(mesh, cache_spec))
+            cache = jax.device_put(jnp.zeros(cache_shape, kv_dtype),
+                                   NamedSharding(mesh, cache_spec))
             return bench_cache(fn_for(cache_pages_for(ctx)), cache, q, k, v,
                                kvl, kvcl)
 
@@ -482,8 +489,9 @@ def main():
     ap.add_argument("--chunk-size", type=int, default=4096)
     ap.add_argument("--max-context", type=int, default=1024 * 1024)
     ap.add_argument("--kv-dtype",
-                    default="bfloat16",
-                    choices=["bfloat16", "float8_e4m3fn"])
+                    default="float8_e4m3fn",
+                    choices=["bfloat16", "float8_e4m3fn"],
+                    help="KV cache dtype (Q/K/V activations stay bf16)")
     ap.add_argument("--pcp-sizes",
                     nargs="*",
                     type=int,

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -27,13 +27,18 @@ parallelism layouts, each cell relative to the all-device TP baseline.
                          KV cache page-striped over pcp. In-kernel ring for the
                          cache phase.
 
-Attention alone understates the difference between the layouts: under TP a
-layer also all-reduces the o_proj output of the whole chunk over all N
-devices, while under pcp{P}xtp{N/P} that all-reduce covers 1/P of the tokens
-over N/P devices. By default every step therefore also performs the
-[tokens_per_device, hidden] bf16 all-reduce over the model axis (data
-dependent on the attention output); ``--no-layer-all-reduce`` times attention
-only. Matmuls are not modelled (they cost the same per device in both).
+Attention alone understates the difference between the layouts. Per the
+sharding rules (``ShardingAxisName``): o_proj is row-parallel over the model
+axis, so under TP a layer all-reduces the whole chunk's [tokens, hidden]
+o_proj output over all N devices, while under pcp{P}xtp{N/P} that all-reduce
+covers 1/P of the tokens over N/P devices -- but PCP then all-gathers the
+token-sharded activation over the pcp axis into the MLP's replicated layout
+(``activation_ffw_td``). The MLP itself is tensor-sharded over every axis
+(``MLP_TENSOR``), so its all-reduce is identical in both layouts and left out.
+By default every step therefore also performs that o_proj all-reduce (and, for
+PCP, the pcp all-gather), data dependent on the attention output;
+``--no-layer-all-reduce`` times attention only. Matmuls are not modelled (they
+cost the same per device in both).
 
 TP attention has no in-op collective, so it is measured on a shard_map over
 the tp devices and blocked on all of them: it pays the same cross-device
@@ -163,11 +168,13 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
     def rand(shape):
         return jnp.asarray(rng.random(shape, np.float32)).astype(dtype)
 
-    def layer_all_reduce_fn(o, axis):
-        """The per-layer all-reduce that follows attention (o_proj output,
-        [tokens, hidden] bf16) over the model axis `axis`, made data
-        dependent on the attention output `o` so it is timed after it.
-        Returns `o` unchanged when disabled."""
+    def layer_all_reduce_fn(o, axis, gather_axis=None):
+        """The per-layer collectives that follow attention: the o_proj
+        output ([tokens, hidden] bf16) all-reduced over the model axis `axis`
+        and, when `gather_axis` is given (PCP), all-gathered over it into the
+        MLP's token-replicated layout. Made data dependent on the attention
+        output `o` so they are timed after it. Returns `o` unchanged when
+        disabled."""
         if not layer_all_reduce:
             return o
         tokens = o.shape[0]
@@ -175,8 +182,11 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
             o.reshape(tokens, -1)[:, :1].astype(dtype),
             (tokens, mp.hidden_size))
         act = jax.lax.psum(act, axis)
-        return o + act[:, :1].astype(o.dtype).reshape((tokens, ) + (1, ) *
-                                                      (o.ndim - 1))
+        if gather_axis is not None:
+            act = jax.lax.all_gather(act, gather_axis, axis=0, tiled=True)
+        return o + act[:tokens, :1].astype(o.dtype).reshape((tokens, ) +
+                                                            (1, ) *
+                                                            (o.ndim - 1))
 
     def bench_cache(fn, cache, *args):
         # fn(cache, *args) -> (out, cache), cache donated and threaded so the
@@ -323,7 +333,9 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
                                              use_causal_mask=True)
                     # Heads are sharded over the model axis; all-reduce there.
                     out = jax.shard_map(functools.partial(
-                        layer_all_reduce_fn, axis=ShardingAxisName.ATTN_HEAD),
+                        layer_all_reduce_fn,
+                        axis=ShardingAxisName.ATTN_HEAD,
+                        gather_axis=ShardingAxisName.PREFILL_CONTEXT),
                                         mesh=mesh,
                                         in_specs=q_spec,
                                         out_specs=q_spec,
@@ -477,8 +489,9 @@ def main():
                     help="KV cache pages allocated = slack x request pages")
     ap.add_argument("--no-layer-all-reduce",
                     action="store_true",
-                    help="time attention only (skip the per-layer "
-                    "all-reduce of [tokens, hidden] over the model axis)")
+                    help="time attention only (skip the o_proj all-reduce "
+                    "over the model axis and, for PCP, the pcp all-gather "
+                    "into the MLP layout)")
     ap.add_argument("--profile-dir",
                     default=None,
                     help="also record xprof traces per layout here (local "
@@ -576,7 +589,7 @@ def main():
                 for v in variants[1:]
             ]
             what = ("attention only" if args.no_layer_all_reduce else
-                    f"attention + layer all-reduce "
+                    f"attention + o_proj all-reduce (+ pcp all-gather) "
                     f"(hidden={mp.hidden_size})")
             title = (f"{model}: NQ={mp.num_q_heads} NKV={mp.num_kv_heads} "
                      f"HD={mp.head_dim}, {n} devices, "

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -445,6 +445,11 @@ def main():
                     action="store_true",
                     help="time attention only (skip the two per-layer "
                     "all-reduces of [tokens, hidden] over the model axis)")
+    ap.add_argument("--retries",
+                    type=int,
+                    default=3,
+                    help="re-run a layout whose worker failed (e.g. the TPU "
+                    "was held by another process), 60s apart")
     ap.add_argument("--warmup", type=int, default=2)
     ap.add_argument("--iters", type=int, default=10)
     ap.add_argument("--worker",
@@ -485,17 +490,23 @@ def main():
                     ] + (["--no-layer-all-reduce"]
                          if args.no_layer_all_reduce else [])
                     t0 = time.time()
-                    rc = subprocess.call(cmd)
-                    # The worker writes its results before exiting; trust
-                    # them even if the runtime's teardown returns non-zero.
-                    try:
-                        results[variant] = json.load(open(tf.name))
-                    except (OSError, ValueError):
-                        results[variant] = {}
+                    for attempt in range(args.retries + 1):
+                        if attempt:
+                            time.sleep(60)
+                        rc = subprocess.call(cmd)
+                        # The worker writes its results before exiting; trust
+                        # them even if the runtime's teardown returns non-zero.
+                        try:
+                            results[variant] = json.load(open(tf.name))
+                        except (OSError, ValueError):
+                            results[variant] = {}
+                        if results[variant]:
+                            break
                     status = "ok" if results[variant] else f"FAILED rc={rc}"
                     print(
                         f"  {model} {n} dev {variant}: {status} "
-                        f"({time.time() - t0:.0f}s)",
+                        f"({time.time() - t0:.0f}s, {attempt + 1} attempt"
+                        f"{'s' if attempt else ''})",
                         flush=True)
             base = results[variants[0]]
             rows = []

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -44,11 +44,19 @@ Usage:
   python pcp_vs_tp_benchmark.py                       # all models, all layouts
   python pcp_vs_tp_benchmark.py --models Qwen3.5 --max-context 262144
   python pcp_vs_tp_benchmark.py --kv-dtype float8_e4m3fn --pcp-sizes 8
+  python pcp_vs_tp_benchmark.py --profile-dir gs://bucket/path   # + xprof traces
+
+With ``--profile-dir`` every layout also records an xprof trace of the step at
+each ``--profile-contexts`` length (warm-up and timed iterations included)
+under ``<profile-dir>/<model>_<N>dev_<layout>/ctx<len>/``; a ``gs://`` path
+is uploaded with gsutil.
 """
 import argparse
 import dataclasses
 import functools
 import json
+import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -118,7 +126,8 @@ def _ladder(max_ctx):
 # Worker: one variant, one process (jax is imported here only).
 # --------------------------------------------------------------------------
 def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
-                 warmup, iters, layer_all_reduce):
+                 warmup, iters, layer_all_reduce, profile_dir,
+                 profile_contexts, n):
     # tpu_inference must be imported before jax (its __init__ loads the
     # engine first).
     import jax
@@ -352,12 +361,43 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
         measure = make_tp(int(variant[2:]))
 
     ladder = _ladder(max_ctx)
-    needed = sorted({b for n in ladder for b in _boundaries(n, chunk)})
+    needed = sorted({b for m in ladder for b in _boundaries(m, chunk)})
     step = {c: measure(c) for c in needed}
+    if profile_dir:
+        _profile(measure, profile_dir, f"{mp_name(mp)}_{n}dev_{variant}",
+                 [c for c in profile_contexts if c <= max_ctx])
     return {
-        str(n): sum(step[b] for b in _boundaries(n, chunk))
-        for n in ladder
+        str(m): sum(step[b] for b in _boundaries(m, chunk))
+        for m in ladder
     }
+
+
+def mp_name(mp):
+    return next(k for k, v in MODEL_CONFIGS.items() if v is mp)
+
+
+def _profile(measure, profile_dir, name, contexts):
+    """Record an xprof trace of `measure(ctx)` for each context under
+    <profile_dir>/<name>/ctx<len>/ (uploaded with gsutil for gs:// paths)."""
+    import jax
+    local = tempfile.mkdtemp(prefix="pcp_vs_tp_prof_")
+    for ctx in contexts:
+        d = os.path.join(local, name, f"ctx{_human(ctx)}")
+        os.makedirs(d, exist_ok=True)
+        with jax.profiler.trace(d):
+            measure(ctx)
+    if profile_dir.startswith("gs://"):
+        subprocess.check_call([
+            "gsutil", "-q", "-m", "cp", "-r",
+            os.path.join(local, name),
+            profile_dir.rstrip("/") + "/"
+        ])
+        shutil.rmtree(local, ignore_errors=True)
+    else:
+        os.makedirs(profile_dir, exist_ok=True)
+        dst = os.path.join(profile_dir, name)
+        shutil.rmtree(dst, ignore_errors=True)
+        shutil.move(os.path.join(local, name), dst)
 
 
 # --------------------------------------------------------------------------
@@ -440,6 +480,13 @@ def main():
                     action="store_true",
                     help="time attention only (skip the two per-layer "
                     "all-reduces of [tokens, hidden] over the model axis)")
+    ap.add_argument("--profile-dir",
+                    default=None,
+                    help="also record xprof traces per layout here (local "
+                    "dir or gs:// path)")
+    ap.add_argument("--profile-contexts",
+                    default="8192,65536,1048576",
+                    help="comma-separated context lengths to profile")
     ap.add_argument("--retries",
                     type=int,
                     default=3,
@@ -457,10 +504,12 @@ def main():
     if args.worker:
         model, n, variant = args.worker
         try:
-            res = _run_variant(MODEL_CONFIGS[model], variant, args.chunk_size,
-                               args.max_context, args.kv_dtype, args.page_size,
-                               args.cache_slack, args.warmup, args.iters,
-                               not args.no_layer_all_reduce)
+            res = _run_variant(
+                MODEL_CONFIGS[model], variant, args.chunk_size,
+                args.max_context, args.kv_dtype, args.page_size,
+                args.cache_slack, args.warmup, args.iters,
+                not args.no_layer_all_reduce, args.profile_dir,
+                [int(c) for c in args.profile_contexts.split(",")], int(n))
         except Exception as e:  # noqa: BLE001
             if "vmem" not in str(e):
                 raise
@@ -490,7 +539,10 @@ def main():
                         str(args.warmup), "--iters",
                         str(args.iters)
                     ] + (["--no-layer-all-reduce"]
-                         if args.no_layer_all_reduce else [])
+                         if args.no_layer_all_reduce else []) + ([
+                             "--profile-dir", args.profile_dir,
+                             "--profile-contexts", args.profile_contexts
+                         ] if args.profile_dir else [])
                     t0 = time.time()
                     for attempt in range(args.retries + 1):
                         if attempt:


### PR DESCRIPTION
## Summary

Adds `tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py`: a prefill TTFT benchmark that compares PCP attention against TP attention for a set of model head configurations (`MODEL_CONFIGS`: Qwen3.5, Qwen3-Coder-480B, Gemma4-31B).

Flags: 

* `--no-collectives` selects what a step measures. Default: pure attention (the PCP kernel's own ring DMAs and current-KV all-gather) without the input or output collectives (i.e. no all-gather before attention or all-reduce after attention). if False, then we also measure the layer collectives around PCP and TP. TP all-reduces the output, and PCP all-gathers the input. 

Usage: 

```
python tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py                 # all models
python tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py --models Qwen3.5 --kv-dtype float8_e4m3fn
python tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py --no-collectives --max-context 262144   # pure attention
python tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py --profile-dir gs://bucket/path   # + xprof traces at --profile-contexts
```

## Example Results  

### Default: attention + collectives (o_proj all-reduce over the model axis; pcp all-gather for PCP)

```
Qwen3.5: NQ=32 NKV=2 HD=256, 8 devices, CH=4k, KV bfloat16, attention + o_proj all-reduce (+ pcp all-gather) (hidden=4096) -- cumulative TTFT (ms), baseline tp8

┌─────────┬─────────────┬────────────────────────┬────────────────────────┬────────────────────────┐
│ Context │ tp8 (8 dev) │      tp4 (4 dev)       │        pcp4xtp2        │        pcp8xtp1        │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 1k      │ 0.56        │ 0.81 (43.2% slower)    │ 0.70 (24.7% slower)    │ 0.65 (15.4% slower)    │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 2k      │ 0.59        │ 0.84 (43.0% slower)    │ 0.70 (19.9% slower)    │ 0.63 (7.4% slower)     │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 4k      │ 0.65        │ 0.96 (47.4% slower)    │ 0.73 (12.4% slower)    │ 0.62 (4.8% faster)     │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 8k      │ 1.44        │ 2.22 (1.54x slower)    │ 1.70 (17.4% slower)    │ 1.64 (13.4% slower)    │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 16k     │ 3.71        │ 5.60 (1.51x slower)    │ 3.96 (6.8% slower)     │ 4.24 (14.2% slower)    │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 32k     │ 9.72        │ 15.85 (1.63x slower)   │ 9.94 (2.3% slower)     │ 12.80 (31.8% slower)   │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 64k     │ 28.29       │ 50.42 (1.78x slower)   │ 28.07 (0.8% faster)    │ 43.34 (1.53x slower)   │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 128k    │ 93.56       │ 175.46 (1.88x slower)  │ 87.21 (6.8% faster)    │ 158.67 (1.70x slower)  │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 256k    │ 336.38      │ 651.77 (1.94x slower)  │ 299.70 (10.9% faster)  │ 606.65 (1.80x slower)  │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 512k    │ 1274.16     │ 2500.41 (1.96x slower) │ 1106.64 (13.1% faster) │ 2364.06 (1.86x slower) │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 1M      │ 4941.30     │ 9774.33 (1.98x slower) │ 4224.14 (14.5% faster) │ 9315.83 (1.89x slower) │
└─────────┴─────────────┴────────────────────────┴────────────────────────┴────────────────────────┘

Qwen3-Coder-480B: NQ=96 NKV=8 HD=128, 8 devices, CH=4k, KV bfloat16, attention + o_proj all-reduce (+ pcp all-gather) (hidden=6144) -- cumulative TTFT (ms), baseline tp8

┌─────────┬─────────────┬─────────────────────────┬──────────┬─────────────────────────┬─────────────────────────┐
│ Context │ tp8 (8 dev) │       tp4 (4 dev)       │ pcp2xtp4 │         pcp4xtp2        │         pcp8xtp1        │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼─────────────────────────┤
│ 1k      │ 0.78        │ 1.17 (1.50x slower)     │ vmem OOM │ 1.00 (28.4% slower)     │ 0.67 (14.3% faster)     │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼─────────────────────────┤
│ 2k      │ 0.83        │ 1.23 (48.5% slower)     │ vmem OOM │ 1.08 (29.5% slower)     │ 0.68 (18.5% faster)     │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼─────────────────────────┤
│ 4k      │ 1.01        │ 1.56 (1.55x slower)     │ vmem OOM │ 1.15 (14.0% slower)     │ 0.68 (32.5% faster)     │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼─────────────────────────┤
│ 8k      │ 2.44        │ 3.93 (1.61x slower)     │ vmem OOM │ 3.17 (29.7% slower)     │ 3.03 (23.8% slower)     │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼─────────────────────────┤
│ 16k     │ 6.63        │ 11.09 (1.67x slower)    │ vmem OOM │ 9.49 (43.1% slower)     │ 11.95 (1.80x slower)    │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼─────────────────────────┤
│ 32k     │ 20.22       │ 35.07 (1.73x slower)    │ vmem OOM │ 31.18 (1.54x slower)    │ 48.17 (2.38x slower)    │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼─────────────────────────┤
│ 64k     │ 68.15       │ 122.15 (1.79x slower)   │ vmem OOM │ 111.48 (1.64x slower)   │ 192.88 (2.83x slower)   │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼─────────────────────────┤
│ 128k    │ 248.81      │ 451.10 (1.81x slower)   │ vmem OOM │ 418.34 (1.68x slower)   │ 770.88 (3.10x slower)   │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼─────────────────────────┤
│ 256k    │ 943.75      │ 1726.98 (1.83x slower)  │ vmem OOM │ 1616.14 (1.71x slower)  │ 3078.63 (3.26x slower)  │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼─────────────────────────┤
│ 512k    │ 3667.06     │ 6747.23 (1.84x slower)  │ vmem OOM │ 6344.28 (1.73x slower)  │ 12301.37 (3.35x slower) │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼─────────────────────────┤
│ 1M      │ 14433.48    │ 26660.65 (1.85x slower) │ vmem OOM │ 25125.84 (1.74x slower) │ 49174.16 (3.41x slower) │
└─────────┴─────────────┴─────────────────────────┴──────────┴─────────────────────────┴─────────────────────────┘

Gemma4-31B: NQ=32 NKV=16 HD=256, 8 devices, CH=4k, KV bfloat16, attention + o_proj all-reduce (+ pcp all-gather) (hidden=5376) -- cumulative TTFT (ms), baseline tp8

┌─────────┬─────────────┬────────────────────────┬───────────────────────┬─────────────────────────┬──────────────────────────┐
│ Context │ tp8 (8 dev) │      tp4 (4 dev)       │        pcp2xtp4       │         pcp4xtp2        │         pcp8xtp1         │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 1k      │ 0.78        │ 1.12 (43.4% slower)    │ 0.78 (1.0% faster)    │ 1.03 (31.3% slower)     │ 0.75 (4.8% faster)       │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 2k      │ 0.79        │ 1.18 (48.7% slower)    │ 0.77 (2.4% faster)    │ 1.05 (33.0% slower)     │ 0.84 (5.5% slower)       │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 4k      │ 0.86        │ 1.27 (48.1% slower)    │ 0.82 (4.3% faster)    │ 1.31 (1.52x slower)     │ 0.82 (4.8% faster)       │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 8k      │ 1.86        │ 2.84 (1.53x slower)    │ 1.92 (3.4% slower)    │ 3.17 (1.71x slower)     │ 3.11 (1.67x slower)      │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 16k     │ 4.26        │ 6.67 (1.57x slower)    │ 4.50 (5.6% slower)    │ 9.04 (2.12x slower)     │ 12.14 (2.85x slower)     │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 32k     │ 10.72       │ 17.41 (1.62x slower)   │ 11.13 (3.8% slower)   │ 29.44 (2.75x slower)    │ 48.27 (4.50x slower)     │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 64k     │ 30.28       │ 51.07 (1.69x slower)   │ 30.38 (=)             │ 105.51 (3.48x slower)   │ 191.28 (6.32x slower)    │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 128k    │ 95.89       │ 167.21 (1.74x slower)  │ 93.16 (2.9% faster)   │ 397.38 (4.14x slower)   │ 760.14 (7.93x slower)    │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 256k    │ 333.57      │ 597.59 (1.79x slower)  │ 313.79 (5.9% faster)  │ 1537.87 (4.61x slower)  │ 3029.19 (9.08x slower)   │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 512k    │ 1240.83     │ 2239.59 (1.80x slower) │ 1143.69 (7.8% faster) │ 6043.19 (4.87x slower)  │ 12083.08 (9.74x slower)  │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 1M      │ 4752.05     │ 8648.68 (1.82x slower) │ 4330.09 (8.9% faster) │ 23950.40 (5.04x slower) │ 48265.44 (10.16x slower) │
└─────────┴─────────────┴────────────────────────┴───────────────────────┴─────────────────────────┴──────────────────────────┘
```

### `--no-collectives`: pure attention

```
Qwen3.5: NQ=32 NKV=2 HD=256, 8 devices, CH=4k, KV bfloat16, pure attention -- cumulative TTFT (ms), baseline tp8

┌─────────┬─────────────┬────────────────────────┬────────────────────────┬────────────────────────┐
│ Context │ tp8 (8 dev) │      tp4 (4 dev)       │        pcp4xtp2        │        pcp8xtp1        │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 1k      │ 0.47        │ 0.32 (30.9% faster)    │ 0.64 (35.9% slower)    │ 0.79 (1.70x slower)    │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 2k      │ 0.47        │ 0.31 (33.6% faster)    │ 0.64 (37.5% slower)    │ 0.65 (39.4% slower)    │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 4k      │ 0.47        │ 0.37 (21.8% faster)    │ 0.62 (32.0% slower)    │ 0.66 (39.8% slower)    │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 8k      │ 0.95        │ 0.99 (4.7% slower)     │ 1.37 (44.5% slower)    │ 1.65 (1.74x slower)    │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 16k     │ 2.13        │ 3.11 (45.7% slower)    │ 3.10 (45.5% slower)    │ 4.33 (2.03x slower)    │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 32k     │ 6.28        │ 10.83 (1.72x slower)   │ 7.58 (20.7% slower)    │ 12.79 (2.04x slower)   │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 64k     │ 21.58       │ 40.23 (1.86x slower)   │ 22.09 (2.4% slower)    │ 43.26 (2.00x slower)   │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 128k    │ 80.56       │ 155.26 (1.93x slower)  │ 74.63 (7.4% faster)    │ 157.95 (1.96x slower)  │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 256k    │ 309.90      │ 611.37 (1.97x slower)  │ 273.78 (11.7% faster)  │ 605.50 (1.95x slower)  │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 512k    │ 1223.03     │ 2419.82 (1.98x slower) │ 1054.00 (13.8% faster) │ 2362.78 (1.93x slower) │
├─────────┼─────────────┼────────────────────────┼────────────────────────┼────────────────────────┤
│ 1M      │ 4839.28     │ 9612.66 (1.99x slower) │ 4118.72 (14.9% faster) │ 9313.26 (1.92x slower) │
└─────────┴─────────────┴────────────────────────┴────────────────────────┴────────────────────────┘

Qwen3-Coder-480B: NQ=96 NKV=8 HD=128, 8 devices, CH=4k, KV bfloat16, pure attention -- cumulative TTFT (ms), baseline tp8

┌─────────┬─────────────┬─────────────────────────┬──────────┬─────────────────────────┬──────────┐
│ Context │ tp8 (8 dev) │       tp4 (4 dev)       │ pcp2xtp4 │         pcp4xtp2        │ pcp8xtp1 │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼──────────┤
│ 1k      │ 0.50        │ 0.34 (32.0% faster)     │ vmem OOM │ 0.71 (41.3% slower)     │ n/a      │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼──────────┤
│ 2k      │ 0.47        │ 0.35 (24.7% faster)     │ vmem OOM │ 0.66 (42.1% slower)     │ n/a      │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼──────────┤
│ 4k      │ 0.49        │ 0.67 (37.5% slower)     │ vmem OOM │ 0.69 (43.1% slower)     │ n/a      │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼──────────┤
│ 8k      │ 1.38        │ 2.14 (1.56x slower)     │ vmem OOM │ 2.13 (1.55x slower)     │ n/a      │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼──────────┤
│ 16k     │ 4.47        │ 7.50 (1.68x slower)     │ vmem OOM │ 7.27 (1.63x slower)     │ n/a      │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼──────────┤
│ 32k     │ 15.90       │ 27.96 (1.76x slower)    │ vmem OOM │ 26.62 (1.67x slower)    │ n/a      │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼──────────┤
│ 64k     │ 59.54       │ 107.78 (1.81x slower)   │ vmem OOM │ 101.94 (1.71x slower)   │ n/a      │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼──────────┤
│ 128k    │ 231.65      │ 422.08 (1.82x slower)   │ vmem OOM │ 399.65 (1.73x slower)   │ n/a      │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼──────────┤
│ 256k    │ 908.89      │ 1669.13 (1.84x slower)  │ vmem OOM │ 1579.42 (1.74x slower)  │ n/a      │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼──────────┤
│ 512k    │ 3597.05     │ 6630.67 (1.84x slower)  │ vmem OOM │ 6271.08 (1.74x slower)  │ n/a      │
├─────────┼─────────────┼─────────────────────────┼──────────┼─────────────────────────┼──────────┤
│ 1M      │ 14293.13    │ 26428.65 (1.85x slower) │ vmem OOM │ 24980.77 (1.75x slower) │ n/a      │
└─────────┴─────────────┴─────────────────────────┴──────────┴─────────────────────────┴──────────┘

Gemma4-31B: NQ=32 NKV=16 HD=256, 8 devices, CH=4k, KV bfloat16, pure attention -- cumulative TTFT (ms), baseline tp8

┌─────────┬─────────────┬────────────────────────┬───────────────────────┬─────────────────────────┬──────────────────────────┐
│ Context │ tp8 (8 dev) │      tp4 (4 dev)       │        pcp2xtp4       │         pcp4xtp2        │         pcp8xtp1         │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 1k      │ 0.49        │ 0.36 (27.1% faster)    │ 0.88 (1.80x slower)   │ 0.68 (39.3% slower)     │ 0.78 (1.59x slower)      │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 2k      │ 0.46        │ 0.39 (13.6% faster)    │ 0.70 (1.54x slower)   │ 0.72 (1.57x slower)     │ 0.74 (1.61x slower)      │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 4k      │ 0.49        │ 0.51 (4.6% slower)     │ 0.68 (39.9% slower)   │ 0.69 (42.4% slower)     │ 1.00 (2.06x slower)      │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 8k      │ 0.99        │ 1.27 (28.7% slower)    │ 1.35 (36.9% slower)   │ 2.03 (2.06x slower)     │ 3.29 (3.33x slower)      │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 16k     │ 2.32        │ 3.56 (1.54x slower)    │ 3.02 (30.2% slower)   │ 6.89 (2.97x slower)     │ 12.25 (5.28x slower)     │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 32k     │ 6.68        │ 11.22 (1.68x slower)   │ 8.34 (24.8% slower)   │ 25.26 (3.78x slower)    │ 48.04 (7.19x slower)     │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 64k     │ 22.02       │ 38.76 (1.76x slower)   │ 23.99 (8.9% slower)   │ 97.20 (4.41x slower)    │ 190.84 (8.67x slower)    │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 128k    │ 79.33       │ 143.08 (1.80x slower)  │ 79.11 (=)             │ 380.71 (4.80x slower)   │ 759.50 (9.57x slower)    │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 256k    │ 300.22      │ 549.78 (1.83x slower)  │ 284.60 (5.2% faster)  │ 1505.22 (5.01x slower)  │ 3026.04 (10.08x slower)  │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 512k    │ 1172.29     │ 2143.36 (1.83x slower) │ 1084.32 (7.5% faster) │ 5979.48 (5.10x slower)  │ 12077.03 (10.30x slower) │
├─────────┼─────────────┼────────────────────────┼───────────────────────┼─────────────────────────┼──────────────────────────┤
│ 1M      │ 4617.22     │ 8454.22 (1.83x slower) │ 4210.77 (8.8% faster) │ 23822.96 (5.16x slower) │ 48254.90 (10.45x slower) │
└─────────┴─────────────┴────────────────────────┴───────────────────────┴─────────────────────────┴──────────────────────────┘
```
