### PR TITLE
[CI] Report disk usage around the Docker cleanup hooks

### DIFF
--- a/.buildkite/scripts/run_multihost.sh
+++ b/.buildkite/scripts/run_multihost.sh
@@ -218,6 +218,12 @@ docker system prune -a --volumes -f || true
 # Source the environment setup script
 # shellcheck disable=SC1091
 source "$SCRIPT_DIR/setup_docker_env.sh"
+# The prune above runs before this file is sourced, so report_disk is not
+# available to bracket it. Reporting once here still answers the question that
+# matters at this point: how much room the head has left before it builds and
+# pulls the image.
+report_disk "head node, after prune"
+
 # setup_environment traces a long tail of docker tag/build/push plumbing and
 # one line per variable it sources from /etc/environment. It echoes its own
 # progress, so the trace adds nothing; xtrace is on for this whole script, so
@@ -386,7 +392,12 @@ for worker_ip in "${WORKER_IPS_ARRAY[@]}"; do
 
     # Prune Worker Node BEFORE it tries to pull the new giant image
     echo "   -> Pruning Docker on worker to free disk space..."
-    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "docker system prune -a --volumes -f" || true
+    # Report the reclaimed total and the space left, so a worker that is still
+    # short says so here rather than only surfacing as a pull failure further
+    # down. Workers are boot-disk only -- no /mnt/disks/persist to check.
+    # shellcheck disable=SC2029
+    ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" \
+      "docker system prune -a --volumes -f | tail -1; df -h /var/lib/docker" || true
     
     ssh "${SSH_OPTS[@]}" "${SSH_USER}@${worker_ip}" "mkdir -p ~/tpu-inference/scripts/multihost" || true
     # shellcheck disable=SC2002

--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -17,7 +17,39 @@
 # Exit on error, exit on unset variable, fail on pipe errors.
 set -euo pipefail
 
+# Report free space either side of the cleanup. A job that dies with "No space
+# left on device" names a path inside the container, not the host filesystem
+# that actually filled, so without this there is nothing in the log to tell the
+# candidate disks apart. The docker root is wherever the daemon is configured to
+# live, not necessarily /var/lib/docker, and /mnt/disks/persist only exists on
+# agents that have a data disk attached.
+#
+# The model cache gets a per-entry breakdown rather than a single total. It is
+# shared with every other pipeline scheduled on this agent pool and nothing
+# evicts from it, so it holds the union of every model ever run here -- the
+# useful question is which snapshots are still worth their space, and that
+# needs the list, not the sum.
+report_disk() {
+  local when="$1" docker_root
+  echo "=== Disk usage (${when}) ==="
+  docker_root=$(docker info --format '{{.DockerRootDir}}' 2>/dev/null || true)
+  df -h "${docker_root:-/var/lib/docker}" 2>/dev/null || true
+
+  if [[ -d /mnt/disks/persist ]]; then
+    df -h /mnt/disks/persist 2>/dev/null || true
+    # du only stats, it does not read file contents, and model repos are a
+    # handful of large shards rather than many small files -- so this is cheap
+    # despite the size of the tree. Bounded anyway: a cold or unusually
+    # fragmented cache should slow the report down, not the build.
+    echo "--- Largest entries in /mnt/disks/persist/models ---"
+    timeout 120 du -sh /mnt/disks/persist/models/* 2>/dev/null | sort -rh | head -15 || true
+    timeout 60 du -sh /mnt/disks/persist/models 2>/dev/null || true
+  fi
+}
+
 cleanup_docker_resource() {
+  report_disk "before cleanup"
+
   # Define defaults and get the parameter
   DEFAULT_IMAGES=("vllm-tpu")
   IMAGE_NAME="${1:-}"
@@ -74,6 +106,8 @@ cleanup_docker_resource() {
 
   echo "Pruning old Docker build cache..."
   docker builder prune -f
+
+  report_disk "after cleanup"
 
   echo "Cleanup complete."
 }


### PR DESCRIPTION
# Description

Jobs on the tpu7x agents fail with "No space left on device" and the log gives no way to tell which filesystem filled. The error names a path inside the container -- a pytest artifact write, a compile cache save, a `docker pull` temp file -- while the host has two candidates: the boot disk and the data disk at /mnt/disks/persist. No step prints `df`, so after the fact the two are indistinguishable.

Add report_disk() next to cleanup_docker_resource() in setup_docker_env.sh and call it either side of that function. It prints `df` for the docker root, resolved from the daemon rather than assumed to be /var/lib/docker, and for /mnt/disks/persist where a data disk is attached.

The model cache gets a per-entry breakdown rather than a single total. /mnt/disks/persist/models is mounted as HF_HOME by run_in_docker.sh and is shared with every other pipeline scheduled on this agent pool. Nothing evicts from it, so it accumulates the union of every model ever run on the agent, including snapshots no longer referenced by any case file. A total says the disk is full; the list says which entries to drop.

run_multihost.sh has its own cleanup path and never calls cleanup_docker_resource, so it would report nothing. Report once on the head after its prune -- the prune runs before this file is sourced, so report_disk cannot bracket it, but the remaining space is the number that matters before the image build and pull. Workers get the reclaimed total and remaining space appended to the prune they already run, so a worker that is still short says so there instead of only surfacing later as a pull failure.

# Tests

Reporting only. No cleanup behaviour changes.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
