### PR TITLE
kernels: add exact V3.2 sparse-attention primitives

### DIFF
--- a/scripts/benchmarking/kernels/benchmark_glm_dsa.py
+++ b/scripts/benchmarking/kernels/benchmark_glm_dsa.py
@@ -17,9 +17,9 @@ The default shape is one live decode row at 256K context with DSA top-k 2048.
 Each sample is individually synchronized, so the reported distribution is
 steady host wall latency rather than queued dispatch time.
 
-Run on a TPU host:
+Run from the repository root on a TPU host:
 
-    python scripts/benchmarking/kernels/benchmark_glm_dsa.py --mode all
+    PYTHONPATH=. python scripts/benchmarking/kernels/benchmark_glm_dsa.py --mode all
 """
 
 from __future__ import annotations

--- a/scripts/benchmarking/kernels/benchmark_glm_dsa.py
+++ b/scripts/benchmarking/kernels/benchmark_glm_dsa.py
@@ -1,0 +1,342 @@
+# Copyright 2026 Gianluigi Vitale
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Profiler-free TPU microbenchmarks for the GLM-5.x DSA decode path.
+
+The default shape is one live decode row at 256K context with DSA top-k 2048.
+Each sample is individually synchronized, so the reported distribution is
+steady host wall latency rather than queued dispatch time.
+
+Run on a TPU host:
+
+    python scripts/benchmarking/kernels/benchmark_glm_dsa.py --mode all
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import platform
+import statistics
+import time
+from collections.abc import Callable
+from dataclasses import asdict, dataclass
+from typing import Any
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from tpu_inference.kernels.experimental.deepseek_v4.indexer.streamindex_topk import \
+    streamindex_topk
+from tpu_inference.kernels.experimental.deepseek_v32.indexer_cache import \
+    insert_indexer_k_cache
+from tpu_inference.kernels.experimental.deepseek_v32.sparse_mla import (
+    gather_paged_kv, sparse_mla_decode)
+
+_PAGE_SIZE = 128
+_PACKING = 32
+_INDEX_RECORD_WIDTH = 256
+_LATENT_WIDTH = 640
+
+
+@dataclass(frozen=True)
+class BenchmarkConfig:
+    """Static GLM DSA benchmark geometry and sampling controls."""
+
+    seq_len: int = 262_144
+    topk: int = 2_048
+    pages_per_block: int = 4
+    mla_block_size: int = 512
+    warmup: int = 5
+    samples: int = 20
+
+
+def _percentile(values_ms: list[float], q: float) -> float:
+    return float(np.percentile(np.asarray(values_ms), q))
+
+
+def _checksum(output: Any) -> int:
+    array = np.asarray(output)
+    return int(array.view(np.uint8).sum(dtype=np.uint64))
+
+
+def _measure(
+    name: str,
+    fn: Callable[[], Any],
+    config: BenchmarkConfig,
+    *,
+    checksum_fn: Callable[[Any], Any] = lambda output: output,
+) -> dict[str, object]:
+    for _ in range(config.warmup):
+        jax.block_until_ready(fn())
+
+    values_ms: list[float] = []
+    checksum = 0
+    for _ in range(config.samples):
+        start_ns = time.perf_counter_ns()
+        output = fn()
+        jax.block_until_ready(output)
+        values_ms.append((time.perf_counter_ns() - start_ns) / 1e6)
+        checksum = _checksum(checksum_fn(output))
+
+    return {
+        "name": name,
+        "warmup": config.warmup,
+        "samples": config.samples,
+        "min_ms": min(values_ms),
+        "mean_ms": statistics.fmean(values_ms),
+        "p50_ms": _percentile(values_ms, 50),
+        "p90_ms": _percentile(values_ms, 90),
+        "p95_ms": _percentile(values_ms, 95),
+        "p99_ms": _percentile(values_ms, 99),
+        "max_ms": max(values_ms),
+        "checksum": checksum,
+        "samples_ms": values_ms,
+    }
+
+
+def _index_cache(config: BenchmarkConfig) -> jax.Array:
+    num_pages = (config.seq_len + _PAGE_SIZE - 1) // _PAGE_SIZE
+    host_cache = np.zeros(
+        (num_pages, _PAGE_SIZE // _PACKING, _PACKING, _INDEX_RECORD_WIDTH),
+        dtype=np.uint8,
+    )
+    host_cache[..., 128:132] = np.asarray([1.0], np.float32).view(np.uint8)
+    return jnp.asarray(host_cache)
+
+
+def _latent_cache(config: BenchmarkConfig) -> jax.Array:
+    num_pages = (config.seq_len + _PAGE_SIZE - 1) // _PAGE_SIZE
+    return jnp.ones(
+        (num_pages, _PAGE_SIZE // _PACKING, _PACKING, _LATENT_WIDTH),
+        dtype=jnp.bfloat16,
+    )
+
+
+def _block_table(config: BenchmarkConfig) -> jax.Array:
+    num_pages = (config.seq_len + _PAGE_SIZE - 1) // _PAGE_SIZE
+    return jnp.roll(jnp.arange(num_pages, dtype=jnp.int32), 17)[None, :]
+
+
+def _streamindex(
+    config: BenchmarkConfig,
+    index_cache: jax.Array,
+    block_table: jax.Array,
+) -> jax.Array:
+    return streamindex_topk(
+        q=jnp.zeros((1, 32, 128), dtype=jnp.float8_e4m3fn),
+        indexer_weights=jnp.ones((1, 32), dtype=jnp.float32),
+        cache_kv=index_cache,
+        seq_lens=jnp.asarray([config.seq_len], dtype=jnp.int32),
+        page_indices=block_table.reshape(-1),
+        cu_q_lens=jnp.asarray([0, 1], dtype=jnp.int32),
+        distribution=jnp.asarray([1, 1, 1], dtype=jnp.int32),
+        k=config.topk,
+        compression_ratio=1,
+        scale_storage="float32",
+        exact_topk=True,
+        num_kv_pages_per_block=config.pages_per_block,
+        num_queries_per_block=1,
+        decode_req_batch_size=1,
+    )
+
+
+def benchmark_topk(config: BenchmarkConfig) -> dict[str, object]:
+    """Measure the JAX top-k baseline at the protected decode shape."""
+    scores = jnp.zeros((1, config.seq_len), dtype=jnp.float32)
+
+    @jax.jit
+    def run() -> jax.Array:
+        return jax.lax.top_k(scores, config.topk)[1]
+
+    return _measure(f"lax_top_k_n{config.seq_len}_k{config.topk}", run, config)
+
+
+def benchmark_scorer(config: BenchmarkConfig) -> dict[str, object]:
+    """Measure exact StreamIndex scoring and selection."""
+    index_cache = _index_cache(config)
+    block_table = _block_table(config)
+
+    @jax.jit
+    def run() -> jax.Array:
+        return _streamindex(config, index_cache, block_table)
+
+    return _measure(
+        f"streamindex_n{config.seq_len}_k{config.topk}_"
+        f"bkvp{config.pages_per_block}",
+        run,
+        config,
+    )
+
+
+def benchmark_index_cache_insert(
+    config: BenchmarkConfig, ) -> dict[str, object]:
+    """Measure one indexer-key insertion into the 256K paged cache."""
+    cache = _index_cache(config)
+    key = jnp.ones((1, 128), dtype=jnp.bfloat16)
+    slot = jnp.asarray([config.seq_len - 1], dtype=jnp.int32)
+
+    @jax.jit
+    def run(cache: jax.Array, key: jax.Array, slot: jax.Array) -> jax.Array:
+        return insert_indexer_k_cache(cache, key, slot)
+
+    return _measure(
+        f"index_cache_insert_n{config.seq_len}",
+        lambda: run(cache, key, slot),
+        config,
+        checksum_fn=lambda output: output.reshape(-1, output.shape[-1])[
+            config.seq_len - 1],
+    )
+
+
+def benchmark_sparse_mla(config: BenchmarkConfig) -> dict[str, object]:
+    """Measure sparse MLA compute after selected KV is resident."""
+    q_nope = jnp.ones((1, 32, 512), dtype=jnp.bfloat16)
+    q_pe = jnp.ones((1, 32, 64), dtype=jnp.bfloat16)
+    selected = jnp.ones((1, config.topk, _LATENT_WIDTH), dtype=jnp.bfloat16)
+    selected_lens = jnp.asarray([config.topk], dtype=jnp.int32)
+
+    @jax.jit
+    def run() -> jax.Array:
+        return sparse_mla_decode(
+            q_nope,
+            q_pe,
+            selected,
+            selected_lens,
+            sm_scale=576**-0.5,
+            block_size=config.mla_block_size,
+        )
+
+    return _measure(f"sparse_mla_k{config.topk}_block{config.mla_block_size}",
+                    run, config)
+
+
+def benchmark_gather_sparse_mla(
+    config: BenchmarkConfig, ) -> dict[str, object]:
+    """Measure selected-KV gather followed by sparse MLA."""
+    latent_cache = _latent_cache(config)
+    block_table = _block_table(config)
+    topk_indices = jnp.linspace(0,
+                                config.seq_len - 1,
+                                config.topk,
+                                dtype=jnp.int32)[None, :]
+    q_nope = jnp.ones((1, 32, 512), dtype=jnp.bfloat16)
+    q_pe = jnp.ones((1, 32, 64), dtype=jnp.bfloat16)
+
+    @jax.jit
+    def run(
+        latent_cache: jax.Array,
+        block_table: jax.Array,
+        topk_indices: jax.Array,
+        q_nope: jax.Array,
+        q_pe: jax.Array,
+    ) -> jax.Array:
+        selected, selected_lens = gather_paged_kv(latent_cache, block_table,
+                                                  topk_indices)
+        return sparse_mla_decode(
+            q_nope,
+            q_pe,
+            selected,
+            selected_lens,
+            sm_scale=576**-0.5,
+            block_size=config.mla_block_size,
+        )
+
+    return _measure(
+        f"gather_sparse_mla_n{config.seq_len}_k{config.topk}",
+        lambda: run(latent_cache, block_table, topk_indices, q_nope, q_pe),
+        config,
+    )
+
+
+def benchmark_decode_chain(config: BenchmarkConfig) -> dict[str, object]:
+    """Measure exact scorer, selected-KV gather, and sparse MLA as one JIT."""
+    index_cache = _index_cache(config)
+    latent_cache = _latent_cache(config)
+    block_table = _block_table(config)
+    q_nope = jnp.ones((1, 32, 512), dtype=jnp.bfloat16)
+    q_pe = jnp.ones((1, 32, 64), dtype=jnp.bfloat16)
+
+    @jax.jit
+    def run(
+        index_cache: jax.Array,
+        latent_cache: jax.Array,
+        block_table: jax.Array,
+        q_nope: jax.Array,
+        q_pe: jax.Array,
+    ) -> jax.Array:
+        topk_indices = _streamindex(config, index_cache, block_table)
+        selected, selected_lens = gather_paged_kv(latent_cache, block_table,
+                                                  topk_indices)
+        return sparse_mla_decode(
+            q_nope,
+            q_pe,
+            selected,
+            selected_lens,
+            sm_scale=576**-0.5,
+            block_size=config.mla_block_size,
+        )
+
+    return _measure(
+        f"dsa_decode_chain_n{config.seq_len}_k{config.topk}",
+        lambda: run(index_cache, latent_cache, block_table, q_nope, q_pe),
+        config,
+    )
+
+
+_BENCHMARKS: dict[str, Callable[[BenchmarkConfig], dict[str, object]]] = {
+    "topk": benchmark_topk,
+    "scorer": benchmark_scorer,
+    "index_cache_insert": benchmark_index_cache_insert,
+    "sparse_mla": benchmark_sparse_mla,
+    "gather_sparse_mla": benchmark_gather_sparse_mla,
+    "decode_chain": benchmark_decode_chain,
+}
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--mode", choices=("all", *_BENCHMARKS), default="all")
+    parser.add_argument("--seq-len", type=int, default=262_144)
+    parser.add_argument("--topk", type=int, default=2_048)
+    parser.add_argument("--pages-per-block", type=int, default=4)
+    parser.add_argument("--mla-block-size", type=int, default=512)
+    parser.add_argument("--warmup", type=int, default=5)
+    parser.add_argument("--samples", type=int, default=20)
+    args = parser.parse_args()
+    config = BenchmarkConfig(
+        seq_len=args.seq_len,
+        topk=args.topk,
+        pages_per_block=args.pages_per_block,
+        mla_block_size=args.mla_block_size,
+        warmup=args.warmup,
+        samples=args.samples,
+    )
+    if jax.default_backend() != "tpu":
+        parser.error("this performance benchmark requires a TPU backend")
+
+    names = list(_BENCHMARKS) if args.mode == "all" else [args.mode]
+    result = {
+        "platform": platform.platform(),
+        "jax_version": jax.__version__,
+        "jax_backend": jax.default_backend(),
+        "devices": [str(device) for device in jax.devices()],
+        "config": asdict(config),
+        "measurements": [_BENCHMARKS[name](config) for name in names],
+    }
+    print(json.dumps(result, indent=2, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/kernels/deepseek_v32/test_indexer_cache.py
+++ b/tests/kernels/deepseek_v32/test_indexer_cache.py
@@ -1,0 +1,126 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax.numpy as jnp
+import numpy as np
+
+from tpu_inference.kernels.experimental.deepseek_v4.indexer.streamindex_topk import \
+    streamindex_topk
+from tpu_inference.kernels.experimental.deepseek_v32.indexer_cache import (
+    insert_indexer_k_cache, pack_indexer_k_records, quantize_indexer_k)
+
+
+def _reference_quantize(k: np.ndarray) -> tuple[np.ndarray, np.ndarray]:
+    amax = np.maximum(np.max(np.abs(k), axis=-1, keepdims=True), 1e-4)
+    scales = np.exp2(np.ceil(np.log2(amax / 448.0))).astype(np.float32)
+    quantized = np.asarray(jnp.asarray(k / scales).astype(jnp.float8_e4m3fn))
+    return quantized, scales
+
+
+def test_quantize_indexer_k_matches_v32_contract():
+    values = np.linspace(-511.0, 509.0, 3 * 128,
+                         dtype=np.float32).reshape(3, 128)
+    values[0] = 0
+    expected_q, expected_scale = _reference_quantize(values)
+    actual_q, actual_scale = quantize_indexer_k(jnp.asarray(values))
+    np.testing.assert_array_equal(np.asarray(actual_q), expected_q)
+    np.testing.assert_array_equal(np.asarray(actual_scale), expected_scale)
+
+
+def test_pack_indexer_k_records_has_exact_bytes_and_zero_padding():
+    values = np.linspace(-3.0, 5.0, 256, dtype=np.float32).reshape(2, 128)
+    expected_q, expected_scale = _reference_quantize(values)
+    expected = np.zeros((2, 256), dtype=np.uint8)
+    expected[:, :128] = expected_q.view(np.uint8)
+    expected[:, 128:132] = expected_scale.view(np.uint8).reshape(2, 4)
+
+    actual = pack_indexer_k_records(jnp.asarray(values), record_width=256)
+    np.testing.assert_array_equal(np.asarray(actual), expected)
+
+
+def test_insert_indexer_k_cache_fragmented_slots_and_padding():
+    page_size = 64
+    packing = 32
+    cache = jnp.full((4, page_size // packing, packing, 256),
+                     0xA5,
+                     dtype=jnp.uint8)
+    values = np.stack([
+        np.full(128, 1.0, np.float32),
+        np.full(128, 2.0, np.float32),
+        np.full(128, 3.0, np.float32),
+        np.full(128, 4.0, np.float32),
+    ])
+    slots = jnp.asarray([2 * page_size + 7, page_size - 1, -1, 3 * page_size],
+                        dtype=jnp.int32)
+    actual = insert_indexer_k_cache(cache, jnp.asarray(values), slots)
+    actual_flat = np.asarray(actual).reshape(-1, 256)
+    expected_records = np.asarray(
+        pack_indexer_k_records(jnp.asarray(values), record_width=256))
+
+    np.testing.assert_array_equal(actual_flat[2 * page_size + 7],
+                                  expected_records[0])
+    np.testing.assert_array_equal(actual_flat[page_size - 1],
+                                  expected_records[1])
+    np.testing.assert_array_equal(actual_flat[3 * page_size],
+                                  expected_records[3])
+    assert not np.any(np.all(actual_flat == expected_records[2], axis=-1))
+    untouched = np.delete(actual_flat,
+                          [2 * page_size + 7, page_size - 1, 3 * page_size],
+                          axis=0)
+    np.testing.assert_array_equal(untouched, np.full_like(untouched, 0xA5))
+
+
+def test_insert_indexer_k_cache_supports_unpadded_vllm_layout():
+    cache = jnp.zeros((2, 16, 132), dtype=jnp.uint8)
+    key = jnp.arange(128, dtype=jnp.float32)[None, :]
+    actual = insert_indexer_k_cache(
+        cache,
+        key,
+        jnp.asarray([19], dtype=jnp.int32),
+    )
+    expected = pack_indexer_k_records(key, record_width=132)
+    np.testing.assert_array_equal(
+        np.asarray(actual).reshape(-1, 132)[19], np.asarray(expected[0]))
+
+
+def test_inserted_cache_composes_with_exact_streamindex_topk():
+    page_size = 128
+    packing = 32
+    head_dim = 128
+    keys = np.zeros((page_size, head_dim), dtype=np.float32)
+    for token in range(page_size):
+        keys[token, :token + 1] = 1.0
+    cache = insert_indexer_k_cache(
+        jnp.zeros((1, page_size // packing, packing, 256), dtype=jnp.uint8),
+        jnp.asarray(keys),
+        jnp.arange(page_size, dtype=jnp.int32),
+    )
+    topk = streamindex_topk(
+        q=jnp.ones((1, 4, head_dim), dtype=jnp.float8_e4m3fn),
+        indexer_weights=jnp.ones((1, 4), dtype=jnp.float32),
+        cache_kv=cache,
+        seq_lens=jnp.asarray([page_size], dtype=jnp.int32),
+        page_indices=jnp.asarray([0], dtype=jnp.int32),
+        cu_q_lens=jnp.asarray([0, 1], dtype=jnp.int32),
+        distribution=jnp.asarray([1, 1, 1], dtype=jnp.int32),
+        k=8,
+        compression_ratio=1,
+        scale_storage="float32",
+        exact_topk=True,
+        num_kv_pages_per_block=1,
+        num_queries_per_block=1,
+        decode_req_batch_size=1,
+    )
+    np.testing.assert_array_equal(np.asarray(topk),
+                                  np.arange(127, 119, -1)[None, :])

--- a/tests/kernels/deepseek_v32/test_indexer_cache.py
+++ b/tests/kernels/deepseek_v32/test_indexer_cache.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import jax
 import jax.numpy as jnp
 import numpy as np
 
@@ -124,3 +125,14 @@ def test_inserted_cache_composes_with_exact_streamindex_topk():
     )
     np.testing.assert_array_equal(np.asarray(topk),
                                   np.arange(127, 119, -1)[None, :])
+
+
+def test_insert_indexer_k_cache_stablehlo_contract():
+    cache = jax.ShapeDtypeStruct((2048, 4, 32, 256), jnp.uint8)
+    key = jax.ShapeDtypeStruct((1, 128), jnp.bfloat16)
+    slot = jax.ShapeDtypeStruct((1, ), jnp.int32)
+    lowered = jax.jit(insert_indexer_k_cache).lower(cache, key, slot)
+    stablehlo = str(lowered.compiler_ir(dialect="stablehlo"))
+
+    assert "stablehlo.scatter" in stablehlo
+    assert "stablehlo.while" not in stablehlo

--- a/tests/kernels/deepseek_v32/test_sparse_mla.py
+++ b/tests/kernels/deepseek_v32/test_sparse_mla.py
@@ -1,0 +1,185 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from tpu_inference.kernels.experimental.deepseek_v4.indexer.streamindex_topk import \
+    streamindex_topk
+from tpu_inference.kernels.experimental.deepseek_v32.sparse_mla import (
+    gather_paged_kv, sparse_mla_decode, sparse_mla_reference)
+
+
+def test_gather_paged_kv_fragmented_and_padded():
+    page_size = 128
+    packing = 32
+    width = 640
+    cache = np.zeros((4, page_size // packing, packing, width), np.float32)
+    for page in range(4):
+        for offset in range(page_size):
+            cache[page, offset // packing, offset % packing,
+                  0] = (page * page_size + offset)
+    block_tables = jnp.asarray([[2, 0, 3, 1]], dtype=jnp.int32)
+    indices = jnp.asarray([[0, 127, 128, 255, 256, 383, -1, -1]],
+                          dtype=jnp.int32)
+    selected, selected_lens = gather_paged_kv(jnp.asarray(cache), block_tables,
+                                              indices)
+    np.testing.assert_array_equal(
+        np.asarray(selected[0, :, 0]),
+        np.asarray([256, 383, 0, 127, 384, 511, 256, 256], np.float32),
+    )
+    np.testing.assert_array_equal(np.asarray(selected_lens), [6])
+
+
+def test_sparse_mla_v4_matches_reference():
+    rng = np.random.default_rng(11)
+    batch = 1
+    num_heads = 32
+    latent_dim = 512
+    rope_dim = 64
+    width = 640
+    selected_len = 2048
+    q_nope = jnp.asarray(
+        rng.normal(size=(batch, num_heads, latent_dim)).astype(np.float32),
+        dtype=jnp.bfloat16,
+    )
+    q_pe = jnp.asarray(
+        rng.normal(size=(batch, num_heads, rope_dim)).astype(np.float32),
+        dtype=jnp.bfloat16,
+    )
+    selected = jnp.asarray(
+        rng.normal(size=(batch, selected_len, width)).astype(np.float32),
+        dtype=jnp.bfloat16,
+    )
+    selected_lens = jnp.asarray([2035], dtype=jnp.int32)
+    scale = (latent_dim + rope_dim)**-0.5
+    expected = sparse_mla_reference(q_nope,
+                                    q_pe,
+                                    selected,
+                                    selected_lens,
+                                    sm_scale=scale)
+    actual = sparse_mla_decode(
+        q_nope,
+        q_pe,
+        selected,
+        selected_lens,
+        sm_scale=scale,
+        block_size=512,
+    )
+    np.testing.assert_allclose(
+        np.asarray(actual, dtype=np.float32),
+        np.asarray(expected, dtype=np.float32),
+        atol=4e-3,
+        rtol=4e-3,
+    )
+
+
+def test_sparse_mla_fully_masked_row_is_zero():
+    q_nope = jnp.ones((1, 4, 128), dtype=jnp.bfloat16)
+    q_pe = jnp.ones((1, 4, 64), dtype=jnp.bfloat16)
+    selected = jnp.ones((1, 128, 256), dtype=jnp.bfloat16)
+    actual = sparse_mla_decode(
+        q_nope,
+        q_pe,
+        selected,
+        jnp.asarray([0], dtype=jnp.int32),
+        sm_scale=192**-0.5,
+        block_size=128,
+    )
+    np.testing.assert_array_equal(np.asarray(actual), 0)
+
+
+@pytest.mark.parametrize("seq_len", [2047, 2048, 2049])
+def test_streamindex_to_sparse_mla_boundary(seq_len):
+    """Selected positions flow directly into paged sparse MLA at the boundary."""
+    rng = np.random.default_rng(23)
+    page_size = 128
+    packing = 32
+    max_seq_len = 2049
+    num_pages = (max_seq_len + page_size - 1) // page_size
+    topk = 2048
+    width = 640
+
+    # A zero scorer makes every valid key tie, so exact semantics select the
+    # lowest absolute positions and append -1 only when the sequence is short.
+    index_cache = np.zeros((num_pages, page_size // packing, packing, 256),
+                           dtype=np.uint8)
+    index_cache[..., 128:132] = np.asarray([1.0], np.float32).view(np.uint8)
+    block_table = np.roll(np.arange(num_pages, dtype=np.int32), 5)[None, :]
+    topk_indices = streamindex_topk(
+        q=jnp.zeros((1, 4, 128), dtype=jnp.float8_e4m3fn),
+        indexer_weights=jnp.ones((1, 4), dtype=jnp.float32),
+        cache_kv=jnp.asarray(index_cache),
+        seq_lens=jnp.asarray([seq_len], dtype=jnp.int32),
+        page_indices=jnp.asarray(block_table.reshape(-1)),
+        cu_q_lens=jnp.asarray([0, 1], dtype=jnp.int32),
+        distribution=jnp.asarray([1, 1, 1], dtype=jnp.int32),
+        k=topk,
+        compression_ratio=1,
+        scale_storage="float32",
+        exact_topk=True,
+        num_kv_pages_per_block=1,
+        num_queries_per_block=1,
+        decode_req_batch_size=1,
+    )
+    valid = min(seq_len, topk)
+    expected_indices = np.full((1, topk), -1, dtype=np.int32)
+    expected_indices[0, :valid] = np.arange(valid, dtype=np.int32)
+    np.testing.assert_array_equal(np.asarray(topk_indices), expected_indices)
+
+    logical_cache = rng.normal(size=(num_pages * page_size,
+                                     width)).astype(np.float32)
+    physical_cache = np.zeros(
+        (num_pages, page_size // packing, packing, width), np.float32)
+    for logical_page, physical_page in enumerate(block_table[0]):
+        page = logical_cache[logical_page * page_size:(logical_page + 1) *
+                             page_size]
+        physical_cache[physical_page] = page.reshape(page_size // packing,
+                                                     packing, width)
+    selected, selected_lens = gather_paged_kv(
+        jnp.asarray(physical_cache, dtype=jnp.bfloat16),
+        jnp.asarray(block_table),
+        topk_indices,
+    )
+    np.testing.assert_array_equal(np.asarray(selected_lens), [valid])
+
+    q_nope = jnp.asarray(rng.normal(size=(1, 32, 512)).astype(np.float32),
+                         dtype=jnp.bfloat16)
+    q_pe = jnp.asarray(rng.normal(size=(1, 32, 64)).astype(np.float32),
+                       dtype=jnp.bfloat16)
+    sm_scale = 576**-0.5
+    actual = sparse_mla_decode(
+        q_nope,
+        q_pe,
+        selected,
+        selected_lens,
+        sm_scale=sm_scale,
+        block_size=512,
+    )
+    expected_selected = np.zeros((1, topk, width), np.float32)
+    expected_selected[0, :valid] = logical_cache[:valid]
+    expected = sparse_mla_reference(
+        q_nope,
+        q_pe,
+        jnp.asarray(expected_selected, dtype=jnp.bfloat16),
+        selected_lens,
+        sm_scale=sm_scale,
+    )
+    np.testing.assert_allclose(
+        np.asarray(actual, dtype=np.float32),
+        np.asarray(expected, dtype=np.float32),
+        atol=4e-3,
+        rtol=4e-3,
+    )

--- a/tests/kernels/deepseek_v4/test_streamindex_topk.py
+++ b/tests/kernels/deepseek_v4/test_streamindex_topk.py
@@ -46,6 +46,40 @@ def quantize_fp8_ue8m0(x: jax.Array, block_size: int):
     return q, scale
 
 
+def quantize_fp8_fp32_scale(x: jax.Array, block_size: int):
+    """Current vLLM V3.2/GLM cache quantization and scale storage."""
+    fp8_max = float(jnp.finfo(jnp.float8_e4m3fn).max)
+    *lead, dim = x.shape
+    blocked = x.reshape(*lead, dim // block_size, block_size)
+    amax = jnp.clip(jnp.max(jnp.abs(blocked), axis=-1, keepdims=True), 1e-4,
+                    None)
+    scale = jnp.exp2(jnp.ceil(jnp.log2(amax / fp8_max)))
+    q = (blocked / scale).astype(jnp.float8_e4m3fn).reshape(x.shape)
+    return q, jnp.squeeze(scale, -1).astype(jnp.float32)
+
+
+def pack_v32_indexer_cache(float32_kv, page_size, *, packing=32):
+    """Pack ``[pages, page, 1, 128]`` as TPU-native V3.2 records."""
+    num_pages, _, num_kv_heads, head_dim = float32_kv.shape
+    assert num_kv_heads == 1
+    assert head_dim == 128
+    cache = np.zeros((num_pages, page_size // packing, packing, 256),
+                     dtype=np.uint8)
+    dequantized = np.zeros_like(float32_kv)
+    for page in range(num_pages):
+        for offset in range(page_size):
+            q, scale = quantize_fp8_fp32_scale(
+                jnp.asarray(float32_kv[page, offset, 0]), head_dim)
+            q_bytes = np.asarray(_to_byte_lane(q))
+            scale_bytes = np.asarray(_to_byte_lane(scale)).reshape(-1)
+            record = np.concatenate([q_bytes, scale_bytes])
+            cache[page, offset // packing,
+                  offset % packing, :record.size] = record
+            dequantized[page, offset,
+                        0] = np.asarray(q).astype(np.float32) * float(scale[0])
+    return cache, dequantized
+
+
 def _verify_padding_at_end(actual_topk_np):
     """Verifies that -1 is only at the end of the innermost dimension."""
     is_minus_one = (actual_topk_np == -1).astype(np.int32)
@@ -511,6 +545,87 @@ def test_streamindex_topk_quantized():
         np.sort(actual_topk_np, axis=-1),
         np.sort(expected_topk, axis=-1),
     )
+
+
+def test_streamindex_v32_fp32_scale_numerical():
+    """Current FP8+FP32-scale records match exact dequantized DSA math."""
+    rng = np.random.default_rng(7)
+    page_size = 128
+    seq_len = 257
+    num_pages = 3
+    num_heads = 4
+    head_dim = 128
+    topk = 64
+
+    q_source = rng.normal(size=(1, num_heads, head_dim)).astype(np.float32)
+    q_quant, q_scale_groups = quantize_fp8_fp32_scale(jnp.asarray(q_source),
+                                                      head_dim)
+    q_scale = q_scale_groups[..., 0]
+    raw_weights = rng.uniform(-1.0, 1.0,
+                              size=(1, num_heads)).astype(np.float32)
+    kernel_weights = raw_weights * np.asarray(q_scale)
+    float32_kv = rng.normal(size=(num_pages, page_size, 1,
+                                  head_dim)).astype(np.float32)
+    cache, dequantized_kv = pack_v32_indexer_cache(float32_kv, page_size)
+
+    q_dequantized = np.asarray(q_quant).astype(
+        np.float32) * np.asarray(q_scale)[..., None]
+    keys = dequantized_kv.reshape(-1, head_dim)[:seq_len]
+    per_head = np.einsum("hd,sd->hs", q_dequantized[0], keys)
+    scores = (np.maximum(per_head, 0.0) * raw_weights[0, :, None]).sum(0)
+    expected = np.argsort(-scores, kind="stable")[:topk]
+
+    actual = streamindex_topk(
+        q=q_quant,
+        indexer_weights=jnp.asarray(kernel_weights),
+        cache_kv=jnp.asarray(cache),
+        seq_lens=jnp.asarray([seq_len], dtype=jnp.int32),
+        page_indices=jnp.arange(num_pages, dtype=jnp.int32),
+        cu_q_lens=jnp.asarray([0, 1], dtype=jnp.int32),
+        distribution=jnp.asarray([1, 1, 1], dtype=jnp.int32),
+        k=topk,
+        compression_ratio=1,
+        scale_storage="float32",
+        exact_topk=True,
+        num_kv_pages_per_block=1,
+        num_queries_per_block=1,
+        decode_req_batch_size=1,
+    )
+    np.testing.assert_array_equal(np.asarray(actual)[0], expected)
+
+
+@pytest.mark.parametrize("seq_len", [2047, 2048, 2049])
+def test_streamindex_v32_exact_topk_boundary_ties(seq_len):
+    """Exact ties preserve low-index order and ``-1`` only pads the tail."""
+    page_size = 128
+    max_seq_len = 2049
+    num_pages = (max_seq_len + page_size - 1) // page_size
+    topk = 2048
+    float32_kv = np.ones((num_pages, page_size, 1, 128), dtype=np.float32)
+    cache, _ = pack_v32_indexer_cache(float32_kv, page_size)
+    q = jnp.zeros((1, 4, 128), dtype=jnp.float8_e4m3fn)
+
+    actual = streamindex_topk(
+        q=q,
+        indexer_weights=jnp.ones((1, 4), dtype=jnp.float32),
+        cache_kv=jnp.asarray(cache),
+        seq_lens=jnp.asarray([seq_len], dtype=jnp.int32),
+        page_indices=jnp.arange(num_pages, dtype=jnp.int32),
+        cu_q_lens=jnp.asarray([0, 1], dtype=jnp.int32),
+        distribution=jnp.asarray([1, 1, 1], dtype=jnp.int32),
+        k=topk,
+        compression_ratio=1,
+        scale_storage="float32",
+        exact_topk=True,
+        num_kv_pages_per_block=1,
+        num_queries_per_block=1,
+        decode_req_batch_size=1,
+    )
+    n_valid = min(seq_len, topk)
+    expected = np.full(topk, -1, dtype=np.int32)
+    expected[:n_valid] = np.arange(n_valid, dtype=np.int32)
+    np.testing.assert_array_equal(np.asarray(actual)[0], expected)
+    _verify_padding_at_end(np.asarray(actual))
 
 
 def main(argv):

--- a/tpu_inference/kernels/experimental/deepseek_v32/__init__.py
+++ b/tpu_inference/kernels/experimental/deepseek_v32/__init__.py
@@ -1,0 +1,13 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.

--- a/tpu_inference/kernels/experimental/deepseek_v32/indexer_cache.py
+++ b/tpu_inference/kernels/experimental/deepseek_v32/indexer_cache.py
@@ -1,0 +1,111 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""DeepSeek V3.2 indexer K-cache quantization and insertion."""
+
+import jax
+import jax.numpy as jnp
+
+
+def _to_byte_lane(x: jax.Array) -> jax.Array:
+    """Reinterpret each element of ``x``'s trailing dimension as bytes."""
+    byte_view = jax.lax.bitcast_convert_type(x, jnp.uint8)
+    if byte_view.ndim > x.ndim:
+        byte_view = byte_view.reshape(*x.shape[:-1], -1)
+    return byte_view
+
+
+def quantize_indexer_k(
+    k: jax.Array,
+    *,
+    quant_block_size: int = 128,
+) -> tuple[jax.Array, jax.Array]:
+    """Quantize indexer keys using V3.2's FP8/UE8M0-scale contract.
+
+    The returned scales are the power-of-two values used for quantization,
+    stored as float32 by the V3.2 cache format.
+    """
+    if k.ndim != 2:
+        raise ValueError(
+            f"k must have shape [num_tokens, head_dim], got {k.shape}")
+    if quant_block_size <= 0 or k.shape[-1] % quant_block_size:
+        raise ValueError(
+            f"head_dim {k.shape[-1]} must be divisible by quant_block_size "
+            f"{quant_block_size}")
+
+    blocked = k.astype(jnp.float32).reshape(k.shape[0], -1, quant_block_size)
+    amax = jnp.maximum(jnp.max(jnp.abs(blocked), axis=-1, keepdims=True), 1e-4)
+    fp8_max = float(jnp.finfo(jnp.float8_e4m3fn).max)
+    scales = jnp.exp2(jnp.ceil(jnp.log2(amax / fp8_max)))
+    quantized = (blocked / scales).astype(jnp.float8_e4m3fn).reshape(k.shape)
+    return quantized, jnp.squeeze(scales, axis=-1).astype(jnp.float32)
+
+
+def pack_indexer_k_records(
+    k: jax.Array,
+    *,
+    record_width: int,
+    quant_block_size: int = 128,
+) -> jax.Array:
+    """Pack V3.2 indexer keys as FP8 values followed by float32 scales."""
+    quantized, scales = quantize_indexer_k(k,
+                                           quant_block_size=quant_block_size)
+    num_scale_bytes = scales.shape[-1] * 4
+    packed_width = k.shape[-1] + num_scale_bytes
+    if record_width < packed_width:
+        raise ValueError(
+            f"record_width {record_width} cannot hold {k.shape[-1]} FP8 "
+            f"values and {num_scale_bytes} scale bytes")
+
+    value_bytes = _to_byte_lane(quantized)
+    scale_bytes = _to_byte_lane(scales)
+    packed = jnp.concatenate((value_bytes, scale_bytes), axis=-1)
+    records = jnp.zeros((k.shape[0], record_width), dtype=jnp.uint8)
+    return records.at[:, :packed_width].set(packed)
+
+
+def insert_indexer_k_cache(
+    cache: jax.Array,
+    k: jax.Array,
+    slot_mapping: jax.Array,
+    *,
+    quant_block_size: int = 128,
+) -> jax.Array:
+    """Quantize and scatter indexer keys into a paged V3.2 cache.
+
+    ``cache`` may be either ``[pages, page_size, width]`` or TPU-packed
+    ``[pages, page_size / packing, packing, width]``. ``slot_mapping`` uses
+    physical flattened token slots; negative or out-of-range slots are
+    ignored, matching vLLM's padding sentinel behavior.
+    """
+    if cache.dtype != jnp.uint8 or cache.ndim not in (3, 4):
+        raise ValueError(
+            "cache must be a rank-3 or rank-4 uint8 paged cache, got "
+            f"shape={cache.shape}, dtype={cache.dtype}")
+    if slot_mapping.ndim != 1 or slot_mapping.shape[0] != k.shape[0]:
+        raise ValueError("slot_mapping must have one entry per key token, got "
+                         f"slot_mapping={slot_mapping.shape}, k={k.shape}")
+
+    record_width = cache.shape[-1]
+    records = pack_indexer_k_records(
+        k,
+        record_width=record_width,
+        quant_block_size=quant_block_size,
+    )
+    flat_cache = cache.reshape(-1, record_width)
+    flat_cache = flat_cache.at[slot_mapping].set(
+        records,
+        mode="drop",
+        wrap_negative_indices=False,
+    )
+    return flat_cache.reshape(cache.shape)

--- a/tpu_inference/kernels/experimental/deepseek_v32/sparse_mla.py
+++ b/tpu_inference/kernels/experimental/deepseek_v32/sparse_mla.py
@@ -1,0 +1,292 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Decode-only sparse MLA over selected DeepSeek-V3.2/GLM latent rows."""
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import tpu as pltpu
+
+_MASK_VALUE = -0.7 * float(jnp.finfo(jnp.float32).max)
+
+
+def _online_update(m_prev, l_prev, acc_prev, scores, values, precision):
+    m_curr = jnp.max(scores, axis=1, keepdims=True)
+    m_new = jnp.maximum(m_prev, m_curr)
+    correction = jnp.exp(m_prev - m_new)
+    probabilities = jnp.exp(scores - m_new)
+    l_new = l_prev * correction + jnp.sum(probabilities, axis=1, keepdims=True)
+    pv = lax.dot_general(
+        probabilities.astype(values.dtype),
+        values,
+        (((1, ), (0, )), ((), ())),
+        preferred_element_type=jnp.float32,
+        precision=precision,
+    )
+    return m_new, l_new, acc_prev * correction + pv
+
+
+def _finalize(m, denominator, acc):
+    # A fully masked row never raises m above _MASK_VALUE. Select it to zero
+    # explicitly; otherwise masked garbage would be averaged into the result.
+    normalized = acc / (denominator + jnp.exp(_MASK_VALUE - m))
+    return jnp.where(m > _MASK_VALUE, normalized, 0.0)
+
+
+def _sparse_decode_kernel(
+    selected_lens_ref,
+    query_ref,
+    selected_kv_ref,
+    output_ref,
+    m_scratch,
+    l_scratch,
+    acc_scratch,
+    *,
+    sm_scale,
+    num_blocks,
+    block_size,
+    latent_dim,
+    precision,
+):
+    block = pl.program_id(1)
+
+    @pl.when(block == 0)
+    def initialize():
+        m_scratch[...] = jnp.full(m_scratch.shape, _MASK_VALUE, jnp.float32)
+        l_scratch[...] = jnp.zeros(l_scratch.shape, jnp.float32)
+        acc_scratch[...] = jnp.zeros(acc_scratch.shape, jnp.float32)
+
+    query = query_ref[0]
+    kv = selected_kv_ref[0, 0]
+    selected_len = selected_lens_ref[pl.program_id(0)]
+    offsets = block * block_size + lax.broadcasted_iota(
+        jnp.int32, (1, block_size), 1)
+    scores = lax.dot_general(
+        query,
+        kv,
+        (((1, ), (1, )), ((), ())),
+        preferred_element_type=jnp.float32,
+        precision=precision,
+    ) * sm_scale
+    scores = jnp.where(offsets < selected_len, scores, _MASK_VALUE)
+    m, denominator, acc = _online_update(
+        m_scratch[...],
+        l_scratch[...],
+        acc_scratch[...],
+        scores,
+        kv[:, :latent_dim],
+        precision,
+    )
+    m_scratch[...] = m
+    l_scratch[...] = denominator
+    acc_scratch[...] = acc
+
+    @pl.when(block == num_blocks - 1)
+    def store():
+        output_ref[0] = _finalize(m, denominator, acc).astype(output_ref.dtype)
+
+
+@functools.partial(
+    jax.jit,
+    static_argnames=("sm_scale", "block_size", "vmem_limit_bytes",
+                     "interpret"),
+)
+def sparse_mla_decode(
+    q_nope: jax.Array,
+    q_pe: jax.Array,
+    selected_kv: jax.Array,
+    selected_lens: jax.Array,
+    *,
+    sm_scale: float,
+    block_size: int = 512,
+    vmem_limit_bytes: int | None = None,
+    interpret: bool = False,
+) -> jax.Array:
+    """Attend to a fixed selected segment and return its normalized latent.
+
+    ``q_nope`` is ``[batch, heads, latent_dim]`` and ``q_pe`` is the roped
+    positional query. ``selected_kv`` stores ``[latent | rope | padding]``.
+    ``selected_lens`` masks the tail, including the ``-1`` top-k sentinel
+    entries gathered by :func:`gather_paged_kv`.
+    """
+    if q_nope.ndim != 3 or q_pe.ndim != 3 or selected_kv.ndim != 3:
+        raise ValueError(
+            "q_nope, q_pe, and selected_kv must all be rank-3 arrays")
+    batch, num_heads, latent_dim = q_nope.shape
+    rope_dim = q_pe.shape[-1]
+    selected_len, kv_width = selected_kv.shape[1:]
+    if q_pe.shape != (batch, num_heads, rope_dim):
+        raise ValueError(f"q_pe has incompatible shape {q_pe.shape}")
+    if selected_kv.shape != (batch, selected_len, kv_width):
+        raise ValueError(
+            f"selected_kv has incompatible shape {selected_kv.shape}")
+    if selected_lens.shape != (batch, ):
+        raise ValueError(
+            f"selected_lens has incompatible shape {selected_lens.shape}")
+    if latent_dim % 128:
+        raise ValueError(
+            f"latent_dim must be a multiple of 128, got {latent_dim}")
+    if latent_dim + rope_dim > kv_width:
+        raise ValueError((latent_dim, rope_dim, kv_width))
+    if q_nope.dtype != q_pe.dtype or q_nope.dtype != selected_kv.dtype:
+        raise ValueError((q_nope.dtype, q_pe.dtype, selected_kv.dtype))
+    if block_size <= 0 or block_size % 128:
+        raise ValueError(
+            f"block_size must be a positive multiple of 128, got {block_size}")
+    if selected_len == 0:
+        raise ValueError("selected_kv must contain at least one row")
+
+    padding = kv_width - latent_dim - rope_dim
+    query = jnp.concatenate(
+        (
+            q_nope,
+            q_pe,
+            jnp.zeros((batch, num_heads, padding), q_nope.dtype),
+        ),
+        axis=-1,
+    )
+    effective_block = min(block_size, selected_len)
+    if not interpret and effective_block % 128:
+        raise ValueError(
+            f"effective block size {effective_block} must be a multiple of 128"
+        )
+    num_blocks = (selected_len + effective_block - 1) // effective_block
+    tail = num_blocks * effective_block - selected_len
+    if tail:
+        selected_kv = jnp.pad(selected_kv, ((0, 0), (0, tail), (0, 0)))
+    selected_kv = selected_kv.reshape(batch, num_blocks, effective_block,
+                                      kv_width)
+    precision = (lax.Precision.HIGHEST
+                 if q_nope.dtype == jnp.float32 else lax.Precision.DEFAULT)
+
+    def query_map(row, block, selected_lens):
+        del block, selected_lens
+        return (row, 0, 0)
+
+    def kv_map(row, block, selected_lens):
+        del selected_lens
+        return (row, block, 0, 0)
+
+    kernel = functools.partial(
+        _sparse_decode_kernel,
+        sm_scale=sm_scale,
+        num_blocks=num_blocks,
+        block_size=effective_block,
+        latent_dim=latent_dim,
+        precision=precision,
+    )
+    call = pl.pallas_call(
+        kernel,
+        grid_spec=pltpu.PrefetchScalarGridSpec(
+            num_scalar_prefetch=1,
+            grid=(batch, num_blocks),
+            in_specs=(
+                pl.BlockSpec((1, num_heads, kv_width), query_map),
+                pl.BlockSpec((1, 1, effective_block, kv_width), kv_map),
+            ),
+            out_specs=pl.BlockSpec((1, num_heads, latent_dim), query_map),
+            scratch_shapes=(
+                pltpu.VMEM((num_heads, 1), jnp.float32),
+                pltpu.VMEM((num_heads, 1), jnp.float32),
+                pltpu.VMEM((num_heads, latent_dim), jnp.float32),
+            ),
+        ),
+        out_shape=jax.ShapeDtypeStruct((batch, num_heads, latent_dim),
+                                       q_nope.dtype),
+        compiler_params=pltpu.CompilerParams(
+            dimension_semantics=("arbitrary", "arbitrary"),
+            vmem_limit_bytes=vmem_limit_bytes,
+        ),
+        interpret=interpret,
+    )
+    return call(selected_lens.astype(jnp.int32), query, selected_kv)
+
+
+def sparse_mla_reference(
+    q_nope: jax.Array,
+    q_pe: jax.Array,
+    selected_kv: jax.Array,
+    selected_lens: jax.Array,
+    *,
+    sm_scale: float,
+) -> jax.Array:
+    """Pure-JAX reference for :func:`sparse_mla_decode`."""
+    latent_dim = q_nope.shape[-1]
+    rope_dim = q_pe.shape[-1]
+    precision = (lax.Precision.HIGHEST
+                 if q_nope.dtype == jnp.float32 else lax.Precision.DEFAULT)
+    scores = jnp.einsum(
+        "bhd,bnd->bhn",
+        q_nope,
+        selected_kv[..., :latent_dim],
+        preferred_element_type=jnp.float32,
+        precision=precision,
+    )
+    scores += jnp.einsum(
+        "bhd,bnd->bhn",
+        q_pe,
+        selected_kv[..., latent_dim:latent_dim + rope_dim],
+        preferred_element_type=jnp.float32,
+        precision=precision,
+    )
+    scores *= sm_scale
+    offsets = jnp.arange(selected_kv.shape[1], dtype=jnp.int32)
+    valid = offsets[None, None, :] < selected_lens[:, None, None]
+    scores = jnp.where(valid, scores, _MASK_VALUE)
+    maximum = jnp.max(scores, axis=-1, keepdims=True)
+    probabilities = jnp.exp(scores - maximum)
+    denominator = jnp.sum(probabilities, axis=-1, keepdims=True)
+    output = jnp.einsum(
+        "bhn,bnd->bhd",
+        probabilities.astype(selected_kv.dtype),
+        selected_kv[..., :latent_dim],
+        preferred_element_type=jnp.float32,
+        precision=precision,
+    ) / denominator
+    output = jnp.where(maximum > _MASK_VALUE, output, 0.0)
+    return output.astype(q_nope.dtype)
+
+
+def gather_paged_kv(
+    cache: jax.Array,
+    block_tables: jax.Array,
+    topk_indices: jax.Array,
+) -> tuple[jax.Array, jax.Array]:
+    """Gather absolute top-k positions from a token-major paged latent cache."""
+    if cache.ndim not in (3, 4):
+        raise ValueError(f"cache must be rank 3 or 4, got shape {cache.shape}")
+    if block_tables.ndim != 2 or topk_indices.ndim != 2:
+        raise ValueError((block_tables.shape, topk_indices.shape))
+    num_pages = cache.shape[0]
+    kv_width = cache.shape[-1]
+    page_size = 1
+    for size in cache.shape[1:-1]:
+        page_size *= size
+    batch, topk = topk_indices.shape
+    if block_tables.shape[0] != batch:
+        raise ValueError((block_tables.shape, topk_indices.shape))
+    indices = topk_indices.astype(jnp.int32)
+    valid = indices >= 0
+    selected_lens = jnp.sum(valid, axis=-1).astype(jnp.int32)
+    safe = jnp.where(valid, indices, 0)
+    pages = jnp.take_along_axis(block_tables.astype(jnp.int32),
+                                safe // page_size,
+                                axis=1)
+    rows = pages * page_size + safe % page_size
+    flat = cache.reshape(num_pages * page_size, kv_width)
+    gathered = jnp.take(flat, rows.reshape(-1), axis=0)
+    return gathered.reshape(batch, topk, kv_width), selected_lens

--- a/tpu_inference/kernels/experimental/deepseek_v4/indexer/streamindex_topk.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/indexer/streamindex_topk.py
@@ -88,6 +88,7 @@ def _scores_kernel(
     sems,  # [4, 2]
     *,
     compression_ratio: int,
+    scale_storage: str,
     static_q_len: int,
     bkv_p: int,
     bq_sz: int,
@@ -107,7 +108,7 @@ def _scores_kernel(
 
     # Validate against the KV dtype.
     kv_dtype = cache_kv_hbm_ref.dtype
-    assert get_dtype_packing(kv_dtype) == kv_packing
+    assert kv_dtype == jnp.uint8
     assert head_dim % 128 == 0
 
     bkv_sz_per_kv_packing = bkv_p * page_size_per_kv_packing
@@ -269,12 +270,25 @@ def _scores_kernel(
             bkv = bkv_x2_ref.at[bkv_sem_idx,
                                 batch_idx, :bkv_sz_per_kv_packing][...]
 
-            # Unpack quantized values and scales from the DSv4 FP8 cache format.
+            # Unpack quantized values and scales from the FP8 cache record.
+            # DeepSeek-v4's original TPU compressor stores one E8M0 byte;
+            # current vLLM V3.2/GLM stores the (power-of-two) scale as four
+            # raw FP32 bytes.  Both layouts pad each token record to the same
+            # cache width, so only this decode differs.
             flat_bkv = bkv.reshape(-1, bkv.shape[-1])
             fp8_val = flat_bkv[:, :head_dim]
             fp8_val = pltpu.bitcast(fp8_val, jnp.float8_e4m3fn)
-            scale_val = pltpu.bitcast(flat_bkv[:, head_dim:head_dim + 1].T,
-                                      jnp.float8_e8m0fnu).astype(jnp.bfloat16)
+            if scale_storage == "e8m0":
+                scale_val = pltpu.bitcast(flat_bkv[:, head_dim:head_dim + 1].T,
+                                          jnp.float8_e8m0fnu).astype(
+                                              jnp.bfloat16)
+            else:
+                scale_val = pltpu.bitcast(flat_bkv[:, head_dim:head_dim + 4].T,
+                                          jnp.float32)
+                # TPU v4 cannot consume FP8 as an MXU RHS. FP8 E4M3 values
+                # are exactly representable in BF16, so widening in VMEM
+                # preserves the quantized math without expanding the cache.
+                fp8_val = fp8_val.astype(jnp.bfloat16)
 
             # NOTE: Do NOT multiply the scales here. Return them separately.
             bkvs.append(fp8_val.reshape(bkv_sz, head_dim))
@@ -330,6 +344,8 @@ def _scores_kernel(
             for batch_idx in range(seq_batch_size):
                 bq = bq_vec[batch_idx].reshape(-1, head_dim)
                 bkv = bkv_vec[batch_idx]
+                if scale_storage == "float32":
+                    bq = bq.astype(jnp.bfloat16)
                 scale_val = scale_val_vec[batch_idx]
                 bq_weights = bq_weights_vec[batch_idx]
                 bq_pos_compressed = bq_pos_compressed_vec[batch_idx]
@@ -485,6 +501,8 @@ def prepare_outputs(out):
     static_argnames=(
         "k",
         "compression_ratio",
+        "scale_storage",
+        "exact_topk",
         "num_kv_pages_per_block",
         "num_queries_per_block",
         "vmem_limit_bytes",
@@ -503,6 +521,8 @@ def streamindex_topk(
     *,
     k: int,
     compression_ratio: int,
+    scale_storage: str = "e8m0",
+    exact_topk: bool = False,
     num_kv_pages_per_block: tuple[int, int, int] | int | None = None,
     num_queries_per_block: tuple[int, int, int] | int | None = None,
     vmem_limit_bytes: int = DEFAULT_VMEM_LIMIT_BYTES,
@@ -523,6 +543,11 @@ def streamindex_topk(
       k is also the total number of sequences.
     k: Number of top-K elements to retrieve.
     compression_ratio: KV cache compression ratio.
+    scale_storage: Encoding of the per-token scale bytes in ``cache_kv``:
+      ``"e8m0"`` for the original one-byte DeepSeek-v4 TPU record or
+      ``"float32"`` for current vLLM V3.2/GLM's four-byte record.
+    exact_topk: Use ``lax.top_k`` instead of approximate top-k. Required for
+      model contracts that preserve exact selected-set and tie ordering.
     num_kv_pages_per_block: number of kv pages to be processed in one block in
       the pallas kernel. This is a tuple of (decode, prefill, mixed) cases.
     num_queries_per_block: number of queries to be processed in one block in the
@@ -534,6 +559,10 @@ def streamindex_topk(
   """
     # Scale factors for the FP8 index cache format are packed directly inside
     # `cache_kv` along the width dimension, keeping HBM transactions fused.
+    if scale_storage not in ("e8m0", "float32"):
+        raise ValueError(
+            f"scale_storage must be 'e8m0' or 'float32', got {scale_storage!r}"
+        )
 
     if num_kv_pages_per_block is None or num_queries_per_block is None:
         raise ValueError(
@@ -558,6 +587,14 @@ def streamindex_topk(
                                                      original_dtype)
     q = prepare_q_inputs(q)
     lkv_dim = cache_kv.shape[-1]
+    if cache_kv.dtype != jnp.uint8:
+        raise ValueError(
+            f"cache_kv must use raw uint8 records, got {cache_kv.dtype}")
+    scale_bytes = 1 if scale_storage == "e8m0" else 4
+    if lkv_dim < q.shape[-1] + scale_bytes:
+        raise ValueError(
+            f"cache record width {lkv_dim} cannot hold {q.shape[-1]} FP8 "
+            f"values and {scale_bytes} scale bytes")
     _, page_size_per_kv_packing, kv_packing, _ = cache_kv.shape
     page_size = page_size_per_kv_packing * kv_packing
     pages_per_seq = page_indices.shape[0] // max_num_seqs
@@ -672,6 +709,7 @@ def streamindex_topk(
             functools.partial(
                 _scores_kernel,
                 compression_ratio=compression_ratio,
+                scale_storage=scale_storage,
                 static_q_len=static_q_len,
                 bq_sz=bq_sz,
                 bkv_p=bkv_p,
@@ -782,11 +820,14 @@ def streamindex_topk(
     # Currently, jax.lax.approx_max_k wins due to the HBM read/write tax, but
     # direct VMEM streaming will allow SC to beat TensorCore performance.
 
-    # jax.lax.approx_max_k(recall_target=1.0) is equivalent to jax.lax.top_k
-    # but faster.
-    top_vals, top_idxs = jax.lax.approx_max_k(scores,
-                                              k,
-                                              reduction_dimension=-1,
-                                              recall_target=1.0)
+    if exact_topk:
+        top_vals, top_idxs = jax.lax.top_k(scores, k)
+    else:
+        top_vals, top_idxs = jax.lax.approx_max_k(
+            scores,
+            k,
+            reduction_dimension=-1,
+            recall_target=1.0,
+        )
     topk_idxs = jnp.where(top_vals == -jnp.inf, -1, top_idxs)
     return topk_idxs[:q.shape[0], :k]

--- a/tpu_inference/kernels/experimental/deepseek_v4/indexer/streamindex_topk.py
+++ b/tpu_inference/kernels/experimental/deepseek_v4/indexer/streamindex_topk.py
@@ -279,16 +279,19 @@ def _scores_kernel(
             fp8_val = flat_bkv[:, :head_dim]
             fp8_val = pltpu.bitcast(fp8_val, jnp.float8_e4m3fn)
             if scale_storage == "e8m0":
-                scale_val = pltpu.bitcast(flat_bkv[:, head_dim:head_dim + 1].T,
-                                          jnp.float8_e8m0fnu).astype(
-                                              jnp.bfloat16)
+                # E8M0 stores the unbiased power-of-two scale in the same
+                # exponent byte used by IEEE/BF16. Rebuild BF16 bits directly:
+                # Mosaic on TPU v4 cannot lower an E8M0-to-float conversion.
+                scale_bits = flat_bkv[:, head_dim:head_dim + 1].T.astype(
+                    jnp.uint16) * jnp.uint16(128)
+                scale_val = pltpu.bitcast(scale_bits, jnp.bfloat16)
             else:
                 scale_val = pltpu.bitcast(flat_bkv[:, head_dim:head_dim + 4].T,
                                           jnp.float32)
-                # TPU v4 cannot consume FP8 as an MXU RHS. FP8 E4M3 values
-                # are exactly representable in BF16, so widening in VMEM
-                # preserves the quantized math without expanding the cache.
-                fp8_val = fp8_val.astype(jnp.bfloat16)
+            # TPU v4 cannot consume FP8 as an MXU RHS. FP8 E4M3 values are
+            # exactly representable in BF16, so widening in VMEM preserves the
+            # quantized math without expanding either cache format.
+            fp8_val = fp8_val.astype(jnp.bfloat16)
 
             # NOTE: Do NOT multiply the scales here. Return them separately.
             bkvs.append(fp8_val.reshape(bkv_sz, head_dim))


### PR DESCRIPTION

### Description

Current vLLM DeepSeek-V3.2/GLM sparse attention stores each index-cache record
as 128 FP8 E4M3 bytes followed by a power-of-two scale encoded in four raw FP32
bytes. TPU Inference's experimental StreamIndex path currently handles the
older one-byte E8M0 scale record and uses approximate selection.

The DeepSeek-named paths here follow current upstream ownership rather than
mixing model implementations: vLLM registers `GlmMoeDsaForCausalLM` from its
`deepseek_v32` model module, and TPU Inference's reusable StreamIndex primitive
currently lives under `deepseek_v4/indexer`. This patch generalizes only that
primitive and does not add or call a DeepSeek model-execution path for GLM.

This patch adds the isolated primitives needed for the current contract:

- exact FP8+FP32-scale record decoding and deterministic top-k selection;
- UE8M0-compatible key quantization, record packing, and physical paged-cache
  insertion;
- selected-position paged MLA gather and one-row sparse attention; and
- a bounded, synchronized real-TPU benchmark for the complete scorer-to-
  consumer chain.

Existing DeepSeek-v4 callers keep the E8M0/approximate defaults. New V3.2 APIs
remain under `kernels/experimental`; this PR contains no TorchAX bridge, model
registration, scheduler change, or CI enablement. It is the dependency-free
foundation of a three-PR series and is independently useful/testable.

This contributes toward #1699 without closing it.

### Tests

Exact review range:

```text
e08b64c14208cb5efc34cc3b41eeaa3402346911..650b5fccb890b5a872871af489b50fc4c584e8ad
```

Real TPU v4 correctness/HLO run:

```bash
pytest -q \
  tests/kernels/deepseek_v4/test_streamindex_topk.py \
  tests/kernels/deepseek_v32/test_indexer_cache.py \
  tests/kernels/deepseek_v32/test_sparse_mla.py
```

Result: 30/30 passed in 60.16 seconds at the exact head above. Coverage includes
exact cache bytes, fragmented physical slots, numerical scorer equivalence,
low-position tie order, `-1` suffixes at 2047/2048/2049, fully masked rows,
legacy compatibility, K=2048, and scorer -> selected gather -> sparse MLA.

Profiler-free benchmark:

```bash
PYTHONPATH=. python scripts/benchmarking/kernels/benchmark_glm_dsa.py \
  --mode all --warmup 5 --samples 20 --seq-len 262144 --topk 2048
```

Four local TPU v4 devices, five warmups and 20 individually synchronized
samples at the same exact head:

| Operation | p50 ms | p99 ms |
|---|---:|---:|
| exact top-k | 2.009 | 2.041 |
| StreamIndex scorer + top-k | 3.216 | 3.248 |
| index-cache insert | 0.374 | 0.434 |
| sparse MLA | 0.182 | 0.201 |
| selected gather + MLA | 0.244 | 0.264 |
| scorer -> gather -> MLA chain | 3.292 | 3.318 |

Both protected runs used a clean worktree, pinned vLLM
`d626108b1841888ec90aced33367149a6bbc7e4b`, and authenticated 8/8 host cleanup.
These are isolated-kernel measurements, not full-model quality, HBM, serving
latency, other-generation performance, or throughput claims.

### Compatibility, limitations, and rollback

- Invalid record width/format, cache geometry, shape, or dtype fails loudly.
- The V3.2 quantizer is intentionally specialized: the common
  `quantize_tensor` helper returns an arbitrary `absmax/448` FP32 scale, while
  this cache contract requires that value rounded up to a power of two and
  serialized as four raw FP32 bytes. Exact-byte tests lock down the difference.
- TPU v4 widens FP8 values to BF16 for scorer arithmetic; cache storage remains
  FP8 and current E4M3 values are exactly representable.
- The production bridge and prefill integration are intentionally deferred to
  PR 2 so this kernel review remains bounded.
- Rollback is the five commits in this range; no checkpoint/state migration is
  introduced.

### Checklist

- [x] I have performed a self-review of my code.
- [x] I have added comments for the non-obvious record and sentinel contracts.
- [x] I have added focused tests and a reproducible TPU benchmark.