### PR TITLE
[CI] Make Buildkite job logs surface the actual error

### DIFF
--- a/.buildkite/scripts/run_in_docker.sh
+++ b/.buildkite/scripts/run_in_docker.sh
@@ -155,8 +155,12 @@ gcloud storage rsync \
 # ==========================================
 set +e # Temporarily disable exit on error to capture exit code
 
+# Container output is teed here so the failure summary at the bottom can quote
+# it without making the reader expand the collapsed run group.
+RUN_LOG="$(mktemp)"
+
 # Ensure the docker container is killed if the wrapper script exits, fails, or is cancelled.
-trap 'docker kill "$IMAGE_NAME" 2>/dev/null || true' EXIT INT TERM
+trap 'docker kill "$IMAGE_NAME" 2>/dev/null || true; rm -f "$RUN_LOG"' EXIT INT TERM
 
 # Some test scripts set tp=2 on TPU_VERSION=tpu7x to mitigate test failures.
 # TODO (Qiliang Cui) Investigate why tensor-parallel-size=1 breaks in tpu7x.
@@ -200,8 +204,8 @@ docker run \
   -e NUM_PRECOMPILE_WORKERS="${NUM_PRECOMPILE_WORKERS:-1}" \
    "${BENCHMARK_DOCKER_ARGS[@]}" \
   "$FULL_IMAGE_TAG" \
-  "$@" # Pass all script arguments as the command to run in the container
-DOCKER_EXIT_CODE=$?
+  "$@" 2>&1 | tee "$RUN_LOG" # Pass all script arguments as the command to run in the container
+DOCKER_EXIT_CODE=${PIPESTATUS[0]}
 
 set -e
 
@@ -210,7 +214,7 @@ set -e
 # ==========================================
 echo "[INFO] Docker finished with exit code ${DOCKER_EXIT_CODE}."
 
-if [ $DOCKER_EXIT_CODE -eq 0 ]; then
+if [ "$DOCKER_EXIT_CODE" -eq 0 ]; then
   echo "[INFO] Syncing local JAX Cache back to GCS..."
   gcloud storage rsync \
     --recursive \
@@ -223,7 +227,24 @@ else
   echo "[WARN] Docker exited with non-zero code ${DOCKER_EXIT_CODE}. Skipping syncing local JAX Cache back to GCS to avoid potential cache corruption."
 fi
 
-echo "--- Cleaning up Docker resources after run"
+# `~~~` rather than `---`: this group is housekeeping, and Buildkite expands the
+# last `---` group whenever a log has no `+++` group at all -- which is how a
+# red job used to open on docker cleanup output instead of on the error.
+echo "~~~ Cleaning up Docker resources after run"
 cleanup_docker_resource "${IMAGE_NAME}"
 
-exit $DOCKER_EXIT_CODE
+# Must be the last thing printed: `+++` is expanded by default, and its mere
+# presence stops Buildkite from expanding the trailing cleanup group instead.
+if [ "$DOCKER_EXIT_CODE" -ne 0 ]; then
+  echo "+++ :boom: ${BUILDKITE_LABEL:-Command} failed (exit ${DOCKER_EXIT_CODE})"
+  FATAL_LINES="$(grep -m5 -E '\b[A-Za-z_]*(Error|Exception): |\[Errno [0-9]+\]|_FAIL:|^FAILED ' "$RUN_LOG" || true)"
+  if [ -n "$FATAL_LINES" ]; then
+    echo "First errors in the container output:"
+    echo "$FATAL_LINES"
+    echo
+  fi
+  echo "Last 40 lines of container output:"
+  tail -n 40 "$RUN_LOG"
+fi
+
+exit "$DOCKER_EXIT_CODE"

--- a/.buildkite/scripts/run_multihost.sh
+++ b/.buildkite/scripts/run_multihost.sh
@@ -93,7 +93,7 @@ fi
 
 # Auto-generate SSH Key if it doesn't exist (e.g. in Buildkite CI)
 if [ ! -f ~/.ssh/id_rsa ]; then
-    echo "--- Auto-generating SSH key for passwordless auth..."
+    echo "~~~ Auto-generating SSH key for passwordless auth..."
     mkdir -p ~/.ssh
     ssh-keygen -t rsa -b 4096 -N "" -f ~/.ssh/id_rsa -q
 fi
@@ -105,7 +105,7 @@ cleanup() {
   if [[ "${CLEANUP_DONE:-}" == "true" ]]; then return; fi
   CLEANUP_DONE="true"
   set +e
-  echo "🧹 Cleaning up containers on head and workers..."
+  echo "~~~ 🧹 Cleaning up containers on head and workers..."
   IFS=',' read -r -a WORKER_IPS_ARRAY <<< "${WORKER_IPS:-}"
   
   echo "   -> Cleaning workers..."
@@ -136,7 +136,34 @@ cleanup() {
   echo "✅ Cleanup complete."
   set -e
 }
-trap cleanup EXIT SIGINT SIGTERM
+
+# Buildkite expands the last `---` group whenever a log contains no `+++` group
+# at all, so a failing job used to open on whatever the cleanup trap printed
+# last. Run cleanup first, then emit the failure summary as a `+++` group: it is
+# expanded by default, and its presence suppresses the `---` fallback entirely.
+on_exit() {
+  local rc=$?
+  cleanup
+  { set +x; } 2>/dev/null
+  if [[ ${rc} -ne 0 ]]; then
+    echo "+++ :boom: ${BUILDKITE_LABEL:-Multihost run} failed (exit ${rc})"
+    if [[ -s /tmp/vllm_serve.log ]]; then
+      local fatal
+      fatal=$(grep -m5 -E '\b[A-Za-z_]*(Error|Exception): |\[Errno [0-9]+\]|EngineCore failed to start|ActorDiedError' /tmp/vllm_serve.log || true)
+      if [[ -n "${fatal}" ]]; then
+        echo "First errors in the vLLM server log:"
+        echo "${fatal}"
+        echo
+      fi
+      echo "Last 40 lines of the vLLM server log:"
+      tail -n 40 /tmp/vllm_serve.log
+    else
+      echo "No vLLM server log was produced; the run failed during cluster bring-up."
+    fi
+  fi
+  return ${rc}
+}
+trap on_exit EXIT SIGINT SIGTERM
 
 wait_for_server() {
   local port=$1
@@ -212,7 +239,7 @@ SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 TOP_DIR=$(dirname "$(dirname "$SCRIPT_DIR")")
 
 # Prune Head Node BEFORE building the new image to ensure we have disk space
-echo "--- Pruning Docker on Head Node to clear disk space..."
+echo "~~~ Pruning Docker on Head Node to clear disk space..."
 docker system prune -a --volumes -f || true
 
 # Source the environment setup script
@@ -336,7 +363,7 @@ if [[ "${VLLM_SERVE_CMD}" =~ --port[=\ ]+([0-9]+) ]]; then
 fi
 
 # Clean up potential leftovers from previous runs
-echo "--- Cleaning up previous cluster state..."
+echo "~~~ Cleaning up previous cluster state..."
 cleanup
 CLEANUP_DONE="false"
 

--- a/.buildkite/scripts/setup_docker_env.sh
+++ b/.buildkite/scripts/setup_docker_env.sh
@@ -40,7 +40,9 @@ cleanup_docker_resource() {
 
   # Iterate and cleanup
   for IMG in "${TARGET_IMAGES[@]}"; do
-    echo "----------------------------------------"
+    # Not "---...": Buildkite reads a leading `---` as a log group header, so a
+    # plain dashed rule silently opens an anonymous group per image.
+    echo "========================================"
     echo "Starting cleanup for ${IMG}"
 
     # Use format to get "Repository ID" and use awk for exact or suffix matching.
@@ -65,8 +67,10 @@ cleanup_docker_resource() {
       fi
       
       echo "Removing old ${IMG} image(s) by ID..."
-      # Using ID directly ensures all tags of that specific image are untagged and removed
-      echo "$OLD_IMAGES" | xargs -r docker rmi -f
+      # Using ID directly ensures all tags of that specific image are untagged and removed.
+      # Output is one "Untagged:"/"Deleted:" line per layer -- dozens of lines of
+      # sha256 noise per run, with nothing actionable in them.
+      echo "$OLD_IMAGES" | xargs -r docker rmi -f >/dev/null
     else
       echo "No images matching ${IMG} found to clean up."
     fi
@@ -201,7 +205,8 @@ setup_environment() {
   # ==========================================
   if [[ "${USE_PREBUILT_IMAGE:-0}" == "1" ]]; then
     echo "Pulling pre-built Docker image: ${CI_IMAGE_REPO}:${CACHE_TAG} ..."
-    docker pull "${CI_IMAGE_REPO}:${CACHE_TAG}"
+    # -q: the layer-by-layer pull progress is several hundred lines per job.
+    docker pull -q "${CI_IMAGE_REPO}:${CACHE_TAG}"
     verify_image_vllm "${CI_IMAGE_REPO}:${CACHE_TAG}" "${VLLM_COMMIT_HASH}"
     docker tag "${CI_IMAGE_REPO}:${CACHE_TAG}" "${IMAGE_NAME}:${TPU_INFERENCE_HASH}"
     docker tag "${CI_IMAGE_REPO}:${CACHE_TAG}" "${IMAGE_NAME}:latest"

--- a/scripts/multihost/run_cluster.sh
+++ b/scripts/multihost/run_cluster.sh
@@ -123,7 +123,8 @@ fi
 if [[ "${IS_MULTI_HOST_BENCH:-false}" != "true" ]]; then
     echo "Ensuring we have the latest image for ${DOCKER_IMAGE}..."
     docker rmi "${DOCKER_IMAGE}" > /dev/null 2>&1 || true
-    docker pull "${DOCKER_IMAGE}"
+    # -q: the layer-by-layer pull progress is ~600 lines per multihost job.
+    docker pull -q "${DOCKER_IMAGE}"
 else
     echo "IS_MULTI_HOST_BENCH is true, skipping image pull to use prebuilt image ${DOCKER_IMAGE}."
 fi


### PR DESCRIPTION
Red CI jobs auto-expand the docker-cleanup section instead of the failure. Buildkite only expands the last collapsed `---` group when a log has no `+++` group at all, and we never emitted one.

- Emit a `+++` failure summary as the very last thing in the log: grepped fatal lines plus the last 40 lines of container output. Its presence also stops the `---` fallback.
- Demote housekeeping groups `---` → `~~~` so they collapse into one de-emphasized expander row.
- Drop progress-bar noise: `docker pull -q`, silence per-layer `docker rmi` output, and stop `echo "-----"` rules from silently opening anonymous groups.

Rationale in the commit message. Verified with shellcheck and by replaying a real failing job's output through the summary logic.