### PR TITLE
Add tpu_raiden dependency to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -26,3 +26,4 @@ sortedcontainers==2.4.0
 # Upstream pins to 5.5.3 https://github.com/vllm-project/vllm/blob/de3fe8dc62f3d77eb8dab8125ca90436f606bccb/requirements/test/nightly-torch.txt#L32
 transformers>=5.8.0
 tokamax==0.0.13
+tpu_raiden


### PR DESCRIPTION
Fixes #3285


The tpu_raiden package is required for KV cache management features

introduced in v0.25.0 but was missing from requirements.txt, causing

ModuleNotFoundError when importing KVCacheManager.


This change ensures the Docker image properly includes the tpu_raiden

dependency for users to access KV offload and KV connector features.