### PR TITLE
Fix compatibility with vLLM KV-cache layout standardization

### DIFF
--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -26,9 +26,8 @@ from vllm.model_executor.layers.mamba.abstract import MambaBase
 from vllm.sampling_params import SamplingType
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
-                                        KVCacheGroupSpec, KVCacheTensor,
-                                        MambaSpec, MLAAttentionSpec,
-                                        SlidingWindowMLASpec,
+                                        KVCacheGroupSpec, MambaSpec,
+                                        MLAAttentionSpec, SlidingWindowMLASpec,
                                         SlidingWindowSpec,
                                         UniformTypeKVCacheSpecs)
 from vllm.v1.request import Request
@@ -38,6 +37,8 @@ from tpu_inference.runner.input_batch import CachedRequestState
 from tpu_inference.runner.kv_cache import (_get_mamba_cache_allocator,
                                            get_attention_page_size_bytes)
 from tpu_inference.runner.tpu_runner import TPUModelRunner
+from tpu_inference.vllm_compat import (make_kv_cache_tensor,
+                                       make_mla_attention_spec)
 
 
 class TestKVCacheManager:
@@ -102,7 +103,7 @@ class TestKVCacheManager:
                              kv_cache_spec=mamba_spec),
         ]
         kv_cache_tensors = [
-            KVCacheTensor(
+            make_kv_cache_tensor(
                 size=num_blocks * page_size_bytes,
                 shared_by=layer_names,
             )
@@ -566,7 +567,7 @@ class TestKVCacheManager:
         page_size_bytes = full_attn_spec.page_size_bytes
         for i in range(10):
             kv_cache_tensors.append(
-                KVCacheTensor(
+                make_kv_cache_tensor(
                     size=num_blocks * page_size_bytes,
                     shared_by=[f'layer.{i}', f'layer.{i+10}'],
                 ))
@@ -611,7 +612,7 @@ class TestKVCacheManager:
         ]
         page_size_bytes = full_attn_spec.page_size_bytes
         kv_cache_tensors = [
-            KVCacheTensor(
+            make_kv_cache_tensor(
                 size=num_blocks * page_size_bytes,
                 shared_by=['layer.0'],
             )
@@ -773,7 +774,7 @@ class TestKVCacheManager:
         ]
         page_size_bytes = full_attn_spec.page_size_bytes
         kv_cache_tensors = [
-            KVCacheTensor(
+            make_kv_cache_tensor(
                 size=num_blocks * page_size_bytes,
                 shared_by=[f'layer.{i}'],
             ) for i in range(10)
@@ -839,7 +840,7 @@ class TestKVCacheManager:
         ]
         page_size_bytes = full_attn_spec.page_size_bytes
         kv_cache_tensors = [
-            KVCacheTensor(
+            make_kv_cache_tensor(
                 size=num_blocks * page_size_bytes,
                 shared_by=[f'layer.{i}'],
             ) for i in range(10)
@@ -982,7 +983,7 @@ class TestKVCacheManager:
 
         page_size_bytes = full_attn_spec.page_size_bytes
         kv_cache_tensors = [
-            KVCacheTensor(
+            make_kv_cache_tensor(
                 size=num_blocks * page_size_bytes,
                 shared_by=layer_names,
             )
@@ -1341,7 +1342,7 @@ class TestKVCacheManager:
             KVCacheGroupSpec(layer_names=['layer.1'], kv_cache_spec=attn_spec),
         ]
         kv_cache_tensors = [
-            KVCacheTensor(
+            make_kv_cache_tensor(
                 size=tensor_size,
                 shared_by=layer_names,
             )
@@ -1448,7 +1449,7 @@ class TestKVCacheManager:
                              kv_cache_spec=mamba_spec),
         ]
         kv_cache_tensors = [
-            KVCacheTensor(size=tensor_size, shared_by=list(names))
+            make_kv_cache_tensor(size=tensor_size, shared_by=list(names))
             for names in layer_names_per_tensor
         ]
         kv_cache_config = KVCacheConfig(
@@ -1489,21 +1490,21 @@ class TestKVCacheManager:
         layers (3+); every layer has a swa_cache. Specs mirror what the TPU
         DSv4 classes register (block_size 1024, byte-addressed uint8
         latents, f32 compressor state)."""
-        main_spec = MLAAttentionSpec(block_size=1024,
-                                     num_kv_heads=1,
-                                     head_size=640,
-                                     dtype=torch.uint8,
-                                     compress_ratio=4)
-        idx_spec = MLAAttentionSpec(block_size=1024,
-                                    num_kv_heads=1,
-                                    head_size=256,
-                                    dtype=torch.uint8,
-                                    compress_ratio=4)
-        hca_spec = MLAAttentionSpec(block_size=1024,
-                                    num_kv_heads=1,
-                                    head_size=1024,
-                                    dtype=torch.uint8,
-                                    compress_ratio=128)
+        main_spec = make_mla_attention_spec(block_size=1024,
+                                            num_kv_heads=1,
+                                            head_size=640,
+                                            dtype=torch.uint8,
+                                            compress_ratio=4)
+        idx_spec = make_mla_attention_spec(block_size=1024,
+                                           num_kv_heads=1,
+                                           head_size=256,
+                                           dtype=torch.uint8,
+                                           compress_ratio=4)
+        hca_spec = make_mla_attention_spec(block_size=1024,
+                                           num_kv_heads=1,
+                                           head_size=1024,
+                                           dtype=torch.uint8,
+                                           compress_ratio=128)
         swa_spec = SlidingWindowMLASpec(block_size=128,
                                         num_kv_heads=1,
                                         head_size=1024,
@@ -1581,10 +1582,10 @@ class TestKVCacheManager:
                 offset += page_bytes[name]
             block_stride = max(block_stride, offset)
         return [
-            KVCacheTensor(size=block_stride * num_blocks,
-                          shared_by=layers_by_offset[offset],
-                          offset=offset,
-                          block_stride=block_stride)
+            make_kv_cache_tensor(size=block_stride * num_blocks,
+                                 shared_by=layers_by_offset[offset],
+                                 offset=offset,
+                                 block_stride=block_stride)
             for offset in sorted(layers_by_offset)
         ]
 
@@ -1713,9 +1714,9 @@ class TestKVCacheManager:
         block_stride = sum(page_size * len(slots)
                            for page_size, slots in buckets.items())
         tensors = [
-            KVCacheTensor(size=block_stride * num_blocks,
-                          shared_by=slot,
-                          block_stride=block_stride)
+            make_kv_cache_tensor(size=block_stride * num_blocks,
+                                 shared_by=slot,
+                                 block_stride=block_stride)
             for slots in buckets.values() for slot in slots
         ]
 

--- a/tests/test_vllm_compat.py
+++ b/tests/test_vllm_compat.py
@@ -1,0 +1,131 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from dataclasses import dataclass
+from typing import List
+from unittest.mock import MagicMock
+
+import torch
+
+from tpu_inference.vllm_compat import (get_compress_ratio,
+                                       get_storage_block_size,
+                                       legacy_kv_cache_tensors,
+                                       make_kv_cache_tensor,
+                                       make_mla_attention_spec)
+
+
+@dataclass
+class _NewStyleTensor:
+    """Shape of vLLM's post-8bdc70ec7b KVCacheTensor: one strided span over
+    all same-spec layers of a cache group."""
+    size: int
+    layers: List[str]
+    layer_stride: int
+    block_stride: int
+    offset: int = 0
+
+
+def _config(num_blocks, tensors):
+    config = MagicMock()
+    config.num_blocks = num_blocks
+    config.kv_cache_tensors = tensors
+    return config
+
+
+def _spec(page_size_bytes):
+    spec = MagicMock()
+    spec.page_size_bytes = page_size_bytes
+    return spec
+
+
+class TestMLASpecCompat:
+
+    def test_round_trips_compress_ratio(self):
+        spec = make_mla_attention_spec(block_size=1024,
+                                       num_kv_heads=1,
+                                       head_size=640,
+                                       dtype=torch.uint8,
+                                       compress_ratio=4)
+        assert get_compress_ratio(spec) == 4
+        assert get_storage_block_size(spec) == 1024 // 4
+
+    def test_defaults_to_no_compression(self):
+        spec = make_mla_attention_spec(block_size=128,
+                                       num_kv_heads=1,
+                                       head_size=64,
+                                       dtype=torch.bfloat16)
+        assert get_compress_ratio(spec) == 1
+        assert get_storage_block_size(spec) == 128
+
+
+class TestLegacyKVCacheTensors:
+
+    def test_old_style_passes_through(self):
+        tensors = [
+            make_kv_cache_tensor(size=1024, shared_by=["a"]),
+            make_kv_cache_tensor(size=1024, shared_by=["b"]),
+        ]
+        config = _config(num_blocks=8, tensors=tensors)
+        assert legacy_kv_cache_tensors(config, {}) == tensors
+
+    def test_layer_outer_groups_alias_by_start(self):
+        # Two cache groups, two layers each, layer-outermost layout: layer i
+        # of each group starts at i * layer_stride, so layers at the same
+        # start must land in one shared_by set, in group order.
+        page, num_blocks = 128, 8
+        stride = page * num_blocks
+        tensors = [
+            _NewStyleTensor(size=2 * stride,
+                            layers=["g0.l0", "g0.l1"],
+                            layer_stride=stride,
+                            block_stride=page),
+            _NewStyleTensor(size=2 * stride,
+                            layers=["g1.l0", "g1.l1"],
+                            layer_stride=stride,
+                            block_stride=page),
+        ]
+        specs = {
+            name: _spec(page)
+            for name in ["g0.l0", "g0.l1", "g1.l0", "g1.l1"]
+        }
+        legacy = legacy_kv_cache_tensors(_config(num_blocks, tensors), specs)
+
+        assert [t.shared_by for t in legacy] == [["g0.l0", "g1.l0"],
+                                                 ["g0.l1", "g1.l1"]]
+        for t in legacy:
+            assert t.size == num_blocks * page
+            assert t.size % page == 0
+            assert t.size // page == num_blocks
+            assert t.block_stride == 0
+
+    def test_distinct_offsets_stay_separate(self):
+        # Block-outermost packed layout: layers of one group are adjacent
+        # within a block (layer_stride == their page size), and a second
+        # group overlays only the matching start offset.
+        num_blocks = 4
+        tensors = [
+            _NewStyleTensor(size=4096,
+                            layers=["main", "idx"],
+                            layer_stride=512,
+                            block_stride=1024),
+            _NewStyleTensor(size=4096,
+                            layers=["state"],
+                            layer_stride=512,
+                            block_stride=1024,
+                            offset=0),
+        ]
+        specs = {"main": _spec(512), "idx": _spec(512), "state": _spec(512)}
+        legacy = legacy_kv_cache_tensors(_config(num_blocks, tensors), specs)
+
+        assert [t.shared_by for t in legacy] == [["main", "state"], ["idx"]]

--- a/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_attention.py
+++ b/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_attention.py
@@ -43,8 +43,7 @@ from vllm.models.deepseek_v4 import attention as dsv4_attention
 from vllm.models.deepseek_v4.attention import DeepseekV4Attention
 from vllm.platforms import current_platform
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache
-from vllm.v1.kv_cache_interface import (KVCacheSpec, MLAAttentionSpec,
-                                        SlidingWindowMLASpec)
+from vllm.v1.kv_cache_interface import KVCacheSpec, SlidingWindowMLASpec
 
 from tpu_inference.kernels.experimental.deepseek_v4 import rope as rope_kernel
 from tpu_inference.kernels.experimental.deepseek_v4.core_attention.mla import \
@@ -63,6 +62,7 @@ from tpu_inference.layers.vllm.custom_ops.experimental.deepseek_v4.deepseek_v4_i
 from tpu_inference.logger import init_logger
 from tpu_inference.models.vllm.vllm_model_wrapper_context import \
     get_vllm_model_wrapper_context
+from tpu_inference.vllm_compat import make_mla_attention_spec
 
 logger = init_logger(__name__)
 
@@ -213,7 +213,7 @@ class VllmDeepseekV4MLAAttention(DeepseekV4Attention):
             # In DSV4 FP8 format
             # 448 fp8, 64 bf16, 7 fp8 scales, 7 e8m0 scale for 448 fp8 (block size 64)
             # packed as uint8
-            return MLAAttentionSpec(
+            return make_mla_attention_spec(
                 block_size=vllm_config.cache_config.block_size,
                 num_kv_heads=1,
                 head_size=align_to(448 + 64 * 2 + 7, 128),
@@ -225,7 +225,7 @@ class VllmDeepseekV4MLAAttention(DeepseekV4Attention):
             # For HCA, we store raw bf16 values in the KV cache to avoid
             # expernsive DSV4 FP8 quantization and dequantization. The
             # size of HCA cache only take very small memory overall, so it's ok.
-            return MLAAttentionSpec(
+            return make_mla_attention_spec(
                 block_size=vllm_config.cache_config.block_size,
                 num_kv_heads=1,
                 head_size=512 * 2,

--- a/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_indexer.py
+++ b/tpu_inference/layers/vllm/custom_ops/experimental/deepseek_v4/deepseek_v4_indexer.py
@@ -27,7 +27,6 @@ from vllm.forward_context import get_forward_context
 from vllm.models.deepseek_v4 import attention as dsv4_attention
 from vllm.models.deepseek_v4.attention import (DeepseekV4Indexer,
                                                DeepseekV4IndexerCache)
-from vllm.v1.kv_cache_interface import MLAAttentionSpec
 
 # =====================================================================
 # IMPORT TPU CUSTOM OPS TO TRIGGER vLLM @register_oot DECORATORS
@@ -41,6 +40,7 @@ from tpu_inference.layers.vllm.custom_ops.experimental.deepseek_v4.deepseek_v4_c
 from tpu_inference.logger import init_logger
 from tpu_inference.models.vllm.vllm_model_wrapper_context import \
     get_vllm_model_wrapper_context
+from tpu_inference.vllm_compat import make_mla_attention_spec
 
 logger = init_logger(__name__)
 
@@ -91,7 +91,7 @@ class VllmDeepseekV4IndexerCache(DeepseekV4IndexerCache):
         # 128 fp8, 1 e8m0 scale packed as uint8
         # TODO: consider put the scale as a separate Array / Tensor
         # to reduce large space waste due to padding.
-        return MLAAttentionSpec(
+        return make_mla_attention_spec(
             block_size=self.cache_config.block_size,
             num_kv_heads=1,
             head_size=align_to(128 + 1, 128),

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -207,7 +207,17 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
             "VllmUnquantizedLinearMethod")
 
     def __init__(self, linear_config: VllmQuantLinearConfig):
-        super().__init__(linear_config)
+        if "__init__" in vllm_linear.UnquantizedLinearMethod.__dict__:
+            # Newer vLLM gives UnquantizedLinearMethod its own no-argument
+            # __init__ that does not chain along the MRO, so run it and the
+            # shared TPU init separately.
+            vllm_linear.UnquantizedLinearMethod.__init__(self)
+            common_unquantized.UnquantizedLinearMethod.__init__(
+                self, linear_config)
+        else:
+            # Older vLLM defines no __init__ there, so super() lands directly
+            # on the shared TPU class.
+            super().__init__(linear_config)
 
     def maybe_process_weights(self, layer: torch.nn.Module, param_name: str,
                               args, kwargs):

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -30,8 +30,21 @@ from vllm.models.deepseek_v4.attention import (DeepseekV4Attention,
 from vllm.models.deepseek_v4.compressor import CompressorStateCache
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache
-from vllm.v1.attention.backends.utils import (get_kv_cache_layout,
-                                              set_kv_cache_layout)
+
+try:
+    # Older vLLM (up to and including the LKG pin) keeps the KV cache layout
+    # as process-global state in attention.backends.utils.
+    from vllm.v1.attention.backends.utils import (get_kv_cache_layout,
+                                                  set_kv_cache_layout)
+    record_kv_cache_layout = None
+except ImportError:
+    # vLLM commit 8bdc70ec7b ("Standardize KV cache layout") removed the
+    # global getter/setter; the resolved layout now lives on
+    # cache_config.kv_cache_layout as a KVCacheLayout enum name, with the
+    # legacy "NHD"/"HND" names kept as aliases for "LBNHC"/"LBHNC".
+    from vllm.v1.attention.backends.utils import record_kv_cache_layout
+    get_kv_cache_layout = None
+    set_kv_cache_layout = None
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
                                         KVCacheSpec, MambaSpec,
                                         MLAAttentionSpec, SlidingWindowSpec)
@@ -39,6 +52,7 @@ from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
 from tpu_inference import envs as tpu_envs
 from tpu_inference import utils
 from tpu_inference import utils as common_utils
+from tpu_inference import vllm_compat
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.logger import init_logger
 from tpu_inference.models.common.kv_share import compute_kv_share_map
@@ -61,6 +75,10 @@ logger = init_logger(__name__)
 # default layout (order) used by kv cache manager
 # N=num_blocks, H=num_heads and D=head_size
 DEFAULT_KV_CACHE_LAYOUT = "NHD"
+
+# Newer vLLM stores the layout under its KVCacheLayout enum name; map back to
+# the legacy names the rest of tpu-inference compares against.
+_LEGACY_KV_CACHE_LAYOUT_NAMES = {"LBNHC": "NHD", "LBHNC": "HND"}
 
 
 def is_cache_for_ds_v4(attn_module: AttentionLayerBase) -> bool:
@@ -693,7 +711,10 @@ class KVCacheManager:
 
     def get_kv_cache_layout(self):
         # return the layout (mostly "NHD" or "HND") of kv cache
-        return get_kv_cache_layout()
+        if get_kv_cache_layout is not None:
+            return get_kv_cache_layout()
+        layout = self.runner.vllm_config.cache_config.kv_cache_layout
+        return _LEGACY_KV_CACHE_LAYOUT_NAMES.get(layout, layout)
 
     def maybe_reinitialize_input_batch(self,
                                        kv_cache_config: KVCacheConfig) -> None:
@@ -746,9 +767,19 @@ class KVCacheManager:
                 for layer_name in group.layer_names:
                     layer_name_to_spec[layer_name] = group.kv_cache_spec
 
+        # Newer vLLM describes the tensors as strided spans over a group's
+        # layers; regroup them into the per-aliasing-set (`shared_by`) shape
+        # the code below is written against.
+        kv_cache_tensors = vllm_compat.legacy_kv_cache_tensors(
+            kv_cache_config, layer_name_to_spec)
+
         # set the kv cache layout which is needed by kv connectors
         # NOTE(jcgu): please update the default value when the order changes
-        set_kv_cache_layout(DEFAULT_KV_CACHE_LAYOUT)
+        if set_kv_cache_layout is not None:
+            set_kv_cache_layout(DEFAULT_KV_CACHE_LAYOUT)
+        else:
+            record_kv_cache_layout(self.runner.vllm_config.cache_config,
+                                   DEFAULT_KV_CACHE_LAYOUT)
         # verify kv cache layout is matched between the cache manager and
         # the kv connector (if configured)
         _required_kv_layout = get_kv_connector_cache_layout()
@@ -770,7 +801,7 @@ class KVCacheManager:
         if is_ds_v4(self.runner.vllm_config):
             # DSv4's packed KV cache layout needs its own array/index plan;
             # see `_initialize_ds_v4_kv_cache` for the invariants.
-            self._initialize_ds_v4_kv_cache(kv_cache_config,
+            self._initialize_ds_v4_kv_cache(kv_cache_config, kv_cache_tensors,
                                             layer_name_to_spec, kv_caches,
                                             num_blocks_list, metadata)
             self._log_kv_cache_init(kv_cache_config,
@@ -785,7 +816,7 @@ class KVCacheManager:
         # shared layers
         duplicate_shared_layers = False
         if not duplicate_shared_layers:
-            for kv_cache_tensor in kv_cache_config.kv_cache_tensors:
+            for kv_cache_tensor in kv_cache_tensors:
                 if any(
                         isinstance(layer_name_to_spec[layer_name], MambaSpec)
                         for layer_name in kv_cache_tensor.shared_by):
@@ -797,7 +828,7 @@ class KVCacheManager:
                     )
                     duplicate_shared_layers = True
                     non_mtp_tensors = [
-                        t for t in kv_cache_config.kv_cache_tensors
+                        t for t in kv_cache_tensors
                         if not any("mtp" in name for name in t.shared_by)
                     ]
                     if non_mtp_tensors:
@@ -810,7 +841,7 @@ class KVCacheManager:
                             ) == num_shared_layers, f"Expected all non-MTP kv_cache_tensors to have the same number of shared layers {num_shared_layers}, but found {len(kv_cache_tensor.shared_by)}"
                     break
 
-        for i, kv_cache_tensor in enumerate(kv_cache_config.kv_cache_tensors):
+        for i, kv_cache_tensor in enumerate(kv_cache_tensors):
             if duplicate_shared_layers:
                 total_group_page_size = 0
                 for name in kv_cache_tensor.shared_by:
@@ -924,7 +955,8 @@ class KVCacheManager:
                     # is True, we should init a new kv cache for each layer in shared_by
                     if j == 0 or duplicate_shared_layers:
                         # NOTE: we'll multiply the num_kv_heads by 2 in the function
-                        block_size = layer_spec.storage_block_size
+                        block_size = vllm_compat.get_storage_block_size(
+                            layer_spec)
 
                         kv_cache = create_kv_caches(
                             num_blocks=num_blocks,
@@ -1025,7 +1057,7 @@ class KVCacheManager:
         return base
 
     def _initialize_ds_v4_kv_cache(
-            self, kv_cache_config: KVCacheConfig,
+            self, kv_cache_config: KVCacheConfig, kv_cache_tensors: List,
             layer_name_to_spec: dict[str, KVCacheSpec],
             kv_caches: List[jax.Array], num_blocks_list: List[int],
             metadata: dict[str, KVCacheMetadata]) -> None:
@@ -1075,7 +1107,7 @@ class KVCacheManager:
         # All packed tensors describe the same slab, so they must agree on
         # the block count.
         num_blocks_candidates = set()
-        for tensor in kv_cache_config.kv_cache_tensors:
+        for tensor in kv_cache_tensors:
             if tensor.block_stride:
                 if tensor.size % tensor.block_stride:
                     raise ValueError(
@@ -1096,7 +1128,7 @@ class KVCacheManager:
                 "[kv-cache] DSv4 KVCacheTensors disagree on num_blocks: "
                 f"{sorted(num_blocks_candidates)}; expected one shared block "
                 "count across the packed slab. tensors="
-                f"{kv_cache_config.kv_cache_tensors}")
+                f"{kv_cache_tensors}")
         num_blocks = num_blocks_candidates.pop()
 
         # Default KV cache is sharded over (BATCH=(dp, attn_dp)); num_blocks
@@ -1164,8 +1196,9 @@ class KVCacheManager:
         hca_layer_names: set[str] = set()
         for layer_name in mla_layer_names:
             spec = layer_name_to_spec[layer_name]
-            page_size = spec.storage_block_size * common_utils.get_mesh_shape_product(
-                self.runner.mesh, ShardingAxisName.KV_CONTEXT)
+            page_size = vllm_compat.get_storage_block_size(
+                spec) * common_utils.get_mesh_shape_product(
+                    self.runner.mesh, ShardingAxisName.KV_CONTEXT)
             if layer_name.endswith(self._DS_V4_INDEXER_CACHE_SUFFIX):
                 # Lightning indexer: 128 fp8 values + 1 e8m0 scale per token,
                 # padded to a 256B record; 4 tokens per row.
@@ -1173,7 +1206,8 @@ class KVCacheManager:
                          self._DS_V4_KV_PACKING, 256)
                 _create_cache(shape, layer_name)
                 layer_to_index[layer_name] = len(kv_caches) - 1
-            elif spec.compress_ratio == self._DS_V4_CSA_COMPRESS_RATIO:
+            elif vllm_compat.get_compress_ratio(
+                    spec) == self._DS_V4_CSA_COMPRESS_RATIO:
                 # CSA is split across two arrays, for nope and rope respectively.
                 shape = (num_blocks, page_size, self._DS_V4_KV_PACKING, 128)
                 _create_cache(shape, layer_name)

--- a/tpu_inference/vllm_compat.py
+++ b/tpu_inference/vllm_compat.py
@@ -1,0 +1,130 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Shims that bridge KV-cache API differences across supported vLLM versions.
+
+tpu-inference must run against both the pinned LKG vLLM and vLLM HEAD. vLLM
+commit 8bdc70ec7b ("Standardize KV cache layout") reshaped several KV-cache
+interfaces:
+
+- ``MLAAttentionSpec.compress_ratio`` became ``AttentionSpec.tokens_per_state``
+  and ``storage_block_size`` became ``num_states``.
+- ``KVCacheTensor`` no longer lists the layers aliasing one tensor
+  (``shared_by``); instead each tensor spans all same-spec layers of a group
+  as one strided allocation (``layers``/``layer_stride``/``block_stride``),
+  and cache groups alias by overlapping byte ranges.
+
+The helpers here present the older shapes to the rest of tpu-inference on
+either vLLM version.
+"""
+
+import dataclasses
+from typing import List
+
+from vllm.v1.kv_cache_interface import (KVCacheConfig, KVCacheSpec,
+                                        KVCacheTensor, MLAAttentionSpec)
+
+_MLA_SPEC_HAS_COMPRESS_RATIO = "compress_ratio" in {
+    f.name
+    for f in dataclasses.fields(MLAAttentionSpec)
+}
+
+KV_CACHE_TENSOR_HAS_SHARED_BY = "shared_by" in {
+    f.name
+    for f in dataclasses.fields(KVCacheTensor)
+}
+
+
+def make_mla_attention_spec(*,
+                            compress_ratio: int = 1,
+                            **kwargs) -> MLAAttentionSpec:
+    """Build an MLAAttentionSpec, mapping ``compress_ratio`` to whichever
+    field the running vLLM version uses for it."""
+    if _MLA_SPEC_HAS_COMPRESS_RATIO:
+        return MLAAttentionSpec(compress_ratio=compress_ratio, **kwargs)
+    return MLAAttentionSpec(tokens_per_state=compress_ratio, **kwargs)
+
+
+def get_compress_ratio(spec: KVCacheSpec) -> int:
+    """Tokens compressed into one stored KV state (1 = no compression)."""
+    ratio = getattr(spec, "compress_ratio", None)
+    if ratio is not None:
+        return ratio
+    return int(spec.tokens_per_state)
+
+
+def get_storage_block_size(spec: KVCacheSpec) -> int:
+    """Stored states per block (= block_size / compression ratio)."""
+    size = getattr(spec, "storage_block_size", None)
+    if size is not None:
+        return size
+    return spec.num_states
+
+
+@dataclasses.dataclass
+class LegacyKVCacheTensor:
+    """Old-style KVCacheTensor: one tensor per set of layers aliasing the
+    same memory, sized for a single layer's pages."""
+    size: int  # size of the KV cache tensor in bytes
+    shared_by: List[str]  # layer names that share the same KV cache tensor
+    offset: int = 0  # byte offset of this layer within a contiguous block
+    block_stride: int = 0  # bytes per block in a packed layout (0 = not packed)
+
+
+def make_kv_cache_tensor(*,
+                         size: int,
+                         shared_by: List[str],
+                         offset: int = 0,
+                         block_stride: int = 0):
+    """Build an old-style KV cache tensor: vLLM's own KVCacheTensor when it
+    still has ``shared_by``, our stand-in dataclass otherwise (mainly for
+    tests emulating the engine core)."""
+    if KV_CACHE_TENSOR_HAS_SHARED_BY:
+        return KVCacheTensor(size=size,
+                             shared_by=shared_by,
+                             offset=offset,
+                             block_stride=block_stride)
+    return LegacyKVCacheTensor(size=size,
+                               shared_by=shared_by,
+                               offset=offset,
+                               block_stride=block_stride)
+
+
+def legacy_kv_cache_tensors(kv_cache_config: KVCacheConfig,
+                            layer_name_to_spec: dict[str, KVCacheSpec]):
+    """Present ``kv_cache_config.kv_cache_tensors`` in the old per-aliasing-set
+    shape regardless of vLLM version.
+
+    Old-style tensors (with ``shared_by``) pass through unchanged. New-style
+    strided tensors are regrouped: layers whose regions start at the same
+    absolute byte offset alias each other (that is how the new engine core
+    overlays cache groups), so each distinct start becomes one legacy tensor,
+    ordered by start offset and sized so ``size // page_size_bytes`` yields
+    the config's block count.
+    """
+    tensors = kv_cache_config.kv_cache_tensors
+    if all(hasattr(t, "shared_by") for t in tensors):
+        return list(tensors)
+
+    start_to_layers: dict[int, List[str]] = {}
+    for tensor in tensors:
+        for index, layer_name in enumerate(tensor.layers):
+            start = tensor.offset + index * tensor.layer_stride
+            start_to_layers.setdefault(start, []).append(layer_name)
+
+    return [
+        LegacyKVCacheTensor(size=kv_cache_config.num_blocks *
+                            layer_name_to_spec[layer_names[0]].page_size_bytes,
+                            shared_by=layer_names)
+        for _, layer_names in sorted(start_to_layers.items())
+    ]


### PR DESCRIPTION
## Problem

The `tpu-vllm-integration` (HEAD vLLM) pipeline fails with:

```
ImportError: cannot import name 'get_kv_cache_layout' from 'vllm.v1.attention.backends.utils'
```

vLLM commit `8bdc70ec7b` ("[6/N][KV-Cache Layout Refactor] Standardize KV cache layout (#51718)") reshaped several APIs tpu-inference depends on. The single broken import in `kv_cache_manager.py` transitively breaks 9 modules (`tpu_runner`, `tpu_worker`, `core_tpu`, all connectors, the Ray executor), and fixing the import exposes two more incompatibilities behind it.

## Changes

All fixes are dual-version: they keep working against the pinned LKG vLLM (`d626108b1`, what PR CI builds against) and against vLLM HEAD.

1. **KV cache layout**: `get_kv_cache_layout`/`set_kv_cache_layout` were removed; the resolved layout now lives on `cache_config.kv_cache_layout` as `KVCacheLayout` enum names ("NHD"/"HND" kept as aliases for "LBNHC"/"LBHNC"). `kv_cache_manager` now falls back to `record_kv_cache_layout` + reading `cache_config`, mapping enum names back to the legacy names the rest of tpu-inference compares against.

2. **KVCacheTensor**: the new engine core emits one strided span per (group, spec) covering all its layers (`layers`/`layer_stride`/`block_stride`), with cache groups aliasing by overlapping byte ranges — instead of one tensor per aliasing set (`shared_by`). New `tpu_inference/vllm_compat.py` regroups strided tensors into the legacy per-aliasing-set shape (layers whose regions start at the same absolute byte offset alias each other), which `initialize_kv_cache` and the DSv4 packed path consume unchanged.

3. **MLAAttentionSpec**: `compress_ratio` became `AttentionSpec.tokens_per_state` and `storage_block_size` became `num_states`. Construction and reads go through compat helpers (`make_mla_attention_spec`, `get_compress_ratio`, `get_storage_block_size`).

4. **UnquantizedLinearMethod**: newer vLLM gives it a no-argument `__init__` that does not chain along the MRO, so `VllmUnquantizedLinearMethod` now invokes it and the shared TPU init explicitly instead of relying on the old fall-through to the TPU base class.

## Testing

Verified against both the LKG CI image (vLLM `d626108b1`) and a HEAD-vLLM CI image (vLLM `d3d79ffc1e`, 258 commits past the refactor):

- Full `tpu_inference` import scan: 0 failures on both (was 9 modules failing on HEAD).
- `tests/runner`, `tests/core`, `tests/distributed`, `tests/worker`, `tests/executors`, `tests/platforms`, `tests/spec_decode`: **byte-identical results on both images** (458 passed; the remaining failures are pre-existing no-TPU local-environment failures, identical on unmodified main).
- `tests/models/common/test_model_loader.py`: 26/26 on both (was 2 failing on HEAD from the `UnquantizedLinearMethod` change).
- New unit tests: `tests/test_vllm_compat.py` covers the spec field mapping and the strided→legacy tensor regrouping (layer-outer aliasing, block-outer packed offsets, old-style pass-through).