### PR TITLE
feat(runner): env-gated gang-symmetric dispatch for bare-SPMD gangs

### DIFF
--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -37,6 +37,7 @@ if TYPE_CHECKING:
     MOE_REQUANTIZE_CLIP_PERCENTILE: float | None = None
     ATTN_BUCKETIZED_NUM_REQS: bool = False
     ATTN_CUSTOM_NUM_REQS_BUCKETS: list[int] = []
+    GANG_SYMMETRIC_DISPATCH: bool = False
     LAYOUT_Q_PROJ_AS_NDH: bool = False
     USE_JAX_PROFILER_SERVER: bool = False
     JAX_PROFILER_SERVER_PORT: int = 9999
@@ -329,6 +330,19 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # separated by comma. The max_reqs will alwasy be added to the buckets
     "ATTN_CUSTOM_NUM_REQS_BUCKETS":
     env_int_list("ATTN_CUSTOM_NUM_REQS_BUCKETS"),
+    # Gang-symmetric dispatch (for bare-SPMD gangs where one logical batch is
+    # split across many independent runner processes that share a single libtpu
+    # coordinator domain, e.g. per-process-local rollout engines in an RL loop).
+    # When true, every runner emits a data-INDEPENDENT device-Execute sequence:
+    # the token/req padding buckets collapse to a single max bucket and the
+    # per-step decode count is pinned to static_max_decode_steps. This keeps the
+    # HLO identical across processes at every dispatch ordinal so the gang never
+    # desyncs into an ICI-collective hang. Costs compilation flexibility (one
+    # shape) and forgoes the block-boundary decode clamp, so the caller must
+    # guarantee max_model_len >= max_prompt + static_max_decode_steps. Default
+    # false = stock per-process data-dependent dispatch.
+    "GANG_SYMMETRIC_DISPATCH":
+    env_bool("GANG_SYMMETRIC_DISPATCH"),
     # dictates whether to layout q-proj as NDH (q-heads, model dim, head dim)
     # or DNH (model dim, q-heads, head dim), which is the default (False)
     "LAYOUT_Q_PROJ_AS_NDH":

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1798,6 +1798,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
 
         # Limit max_decode_steps to not cross block boundaries
         max_decode_steps = min(self.static_max_decode_steps, min_remaining)
+        if envs.GANG_SYMMETRIC_DISPATCH:
+            # Gang-symmetric dispatch: pin the per-step decode count so every
+            # process runs the same number of decode Executes (min_remaining is
+            # data-dependent and would desync the gang). The caller must ensure
+            # max_model_len >= max_prompt + static_max_decode_steps so this does
+            # not overrun a KV block boundary.
+            max_decode_steps = self.static_max_decode_steps
         if max_decode_steps <= 0:
             max_decode_steps = 1
         max_decode_steps_arr = jnp.array(max_decode_steps, dtype=jnp.int32)

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -147,6 +147,10 @@ def get_padded_num_reqs_with_upper_limit(x: int, upper_limit: int) -> int:
 
 
 def get_req_paddings(min_req_size: int, max_req_size: int) -> list[int]:
+    # Gang-symmetric dispatch: a single max bucket so every process pads request
+    # counts identically (see tpu_inference.envs.GANG_SYMMETRIC_DISPATCH).
+    if envs.GANG_SYMMETRIC_DISPATCH:
+        return [int(max_req_size)]
     # assert min_req_size is power of 2
     assert (min_req_size & (min_req_size - 1) == 0) and min_req_size > 0
     paddings: list = []
@@ -160,6 +164,9 @@ def get_req_paddings(min_req_size: int, max_req_size: int) -> list[int]:
 
 def get_attn_req_paddings(min_req_size: int, max_req_size: int) -> list[int]:
     """Get num reqs paddings with custom override to reduce compilation time"""
+    if envs.GANG_SYMMETRIC_DISPATCH:
+        # Single max bucket for gang-symmetric dispatch.
+        return [max_req_size]
     if not envs.ATTN_BUCKETIZED_NUM_REQS:
         reqs = [max_req_size]
     elif envs.ATTN_CUSTOM_NUM_REQS_BUCKETS:
@@ -189,6 +196,10 @@ def get_token_paddings(min_token_size: int, max_token_size: int,
         first increase the size to twice,
         then increase the padding size by padding_gap.
     """
+    # Gang-symmetric dispatch: a single max bucket so every process pads token
+    # counts identically (see tpu_inference.envs.GANG_SYMMETRIC_DISPATCH).
+    if envs.GANG_SYMMETRIC_DISPATCH:
+        return [int(max_token_size)]
     # assert min_token_size is power of 2
     assert (min_token_size & (min_token_size - 1) == 0) and min_token_size > 0
     paddings = []


### PR DESCRIPTION
## What

Adds an env-gated **gang-symmetric dispatch** mode (`GANG_SYMMETRIC_DISPATCH`, default `false`) for the case where one logical batch is split across many independent `TPUModelRunner` processes that share a single libtpu coordinator domain — e.g. per-process-local rollout engines in a disaggregated RL loop.

## Why

In that topology each runner otherwise emits a **data-dependent** device-Execute sequence:
- the token/req padding buckets (`get_token_paddings` / `get_req_paddings` / `get_attn_req_paddings`) are chosen from this process's local token/request counts, and
- the per-step decode count is clamped to a per-process `min_remaining` (`min(static_max_decode_steps, min_remaining)`).

With different local data per process, the runners select different padded shapes (different HLO) at the same dispatch ordinal and desync. Any cross-process / ICI collective on the shared coordinator then hangs — one process issues an Execute with no peer.

## What changes

When `GANG_SYMMETRIC_DISPATCH=1`, every runner emits an identical, data-independent Execute sequence:
- the three padding helpers collapse to a single max bucket, so the padded shape (and thus the compiled HLO) is identical across processes at every ordinal;
- `max_decode_steps` is pinned to `static_max_decode_steps` instead of `min(static_max_decode_steps, min_remaining)`, so every process runs the same number of decode Executes.

Default `false` → **zero behavior change** when unset.

## Trade-offs (documented on the flag)

- One padded shape costs compilation flexibility.
- Pinning the decode count forgoes the block-boundary clamp, so the caller must guarantee `max_model_len >= max_prompt + static_max_decode_steps` to avoid a KV block overrun.
- Per-sequence EOS handling is unchanged (sequences still stop at their own EOS via the sampler / `continue_decode` masking); only the dispatch **shape** is made uniform.

## Test

Validated on TPU v7x: a 16-process bare-SPMD disaggregated RL rollout that previously wedged at the first cross-process collective now runs the full generate→train→publish cycle repeatably (8 consecutive cycles, no ICI hang).

`envs.py` / `runner/utils.py` / `runner/tpu_runner.py` all py_compile clean. Follows the existing `envs.ATTN_BUCKETIZED_NUM_REQS` flag idiom.
