### PR TITLE
[Fix] Qwen3.5-397B Prefill Benchmark initialization failure due to KV cache OOM after enabling hybrid prefix caching

### DIFF
--- a/.buildkite/benchmark/cases/daily/Qwen3.5_397B_prefill.json
+++ b/.buildkite/benchmark/cases/daily/Qwen3.5_397B_prefill.json
@@ -35,6 +35,7 @@
           "max-model-len": 10240,
           "kv-cache-dtype": "fp8",
           "gpu-memory-utilization": 0.8,
+          "no-enable-prefix-caching": true,
           "enable-expert-parallel": true,
           "async-scheduling": true
         }
@@ -83,6 +84,7 @@
           "max-model-len": 10240,
           "kv-cache-dtype": "fp8",
           "gpu-memory-utilization": 0.8,
+          "no-enable-prefix-caching": true,
           "enable-expert-parallel": true,
           "async-scheduling": true
         }
@@ -131,6 +133,7 @@
           "max-model-len": 10240,
           "kv-cache-dtype": "fp8",
           "gpu-memory-utilization": 0.6,
+          "no-enable-prefix-caching": true,
           "enable-expert-parallel": true,
           "async-scheduling": true
         }
@@ -179,6 +182,7 @@
           "max-model-len": 10240,
           "kv-cache-dtype": "fp8",
           "gpu-memory-utilization": 0.6,
+          "no-enable-prefix-caching": true,
           "enable-expert-parallel": true,
           "async-scheduling": true
         }
@@ -227,6 +231,7 @@
           "max-model-len": 10240,
           "kv-cache-dtype": "fp8",
           "gpu-memory-utilization": 0.6,
+          "no-enable-prefix-caching": true,
           "enable-expert-parallel": true,
           "async-scheduling": true
         }
@@ -275,6 +280,7 @@
           "max-model-len": 10240,
           "kv-cache-dtype": "fp8",
           "gpu-memory-utilization": 0.6,
+          "no-enable-prefix-caching": true,
           "enable-expert-parallel": true,
           "async-scheduling": true
         }


### PR DESCRIPTION
### Summary
Explicitly disable prefix caching (`--no-enable-prefix-caching`) for Qwen3.5-397B prefill benchmark cases in `.buildkite/benchmark/cases/daily/Qwen3.5_397B_prefill.json`.

---

### Motivation / Why
Following #3422 (*Enable Prefix Caching for Hybrid Linear-Attention Models*), hybrid models now default to `mamba_cache_mode='align'` when prefix caching is enabled. In this mode, each 16-token KV cache block requires allocating padded Mamba recurrent states across all 60 layers (~12.9 MB/block).

For `max_model_len: 10240`, vLLM's startup validation (`_check_enough_kv_cache_memory`) requires at least **116.73 GiB** of KV cache memory. On `tpu7x-8` (757.91 GiB HBM) with 375.67 GiB model weights, setting `gpu-memory-utilization: 0.6` leaves only **78.89 GiB** available, causing engine initialization to fail with `ValueError`. [buildkite failed test](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/2284#01a0526f-191b-42db-8f55-ff49f2d37a02)

Because this is a pure prefill benchmark using a `random` dataset (no shared prefix between requests), prefix caching provides no caching benefits and unnecessarily bloats KV cache requirements. Adding `--no-enable-prefix-caching` restores compact Mamba state allocation and matches the baseline behavior prior to #3422 .

---

### Changes
* Added `"no-enable-prefix-caching": true` to `server_command_options.args` across all benchmark cases (`GBS1` ~ `GBS32`) in `.buildkite/benchmark/cases/daily/Qwen3.5_397B_prefill.json`.

---

### Verification
[buildkite test](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/2301#01a055d2-4b0f-48d2-956e-90fb6c216faa)
