### PR TITLE
perf(sample): enable distributed top-k candidate sampling and keep vocab logits sharded

### DIFF
--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -21,16 +21,79 @@ from jax.sharding import Mesh
 from vllm.v1.outputs import LogprobsTensors
 
 from tpu_inference.layers.common.sharding import ShardingAxisName
-from tpu_inference.layers.jax.sample.sampling import (PromptLogprobsAsyncData,
-                                                      PromptLogprobsReqSnap,
-                                                      compute_logprobs,
-                                                      compute_prompt_logprobs,
-                                                      gather_logprobs, sample)
+from tpu_inference.layers.jax.sample.sampling import (
+    PromptLogprobsAsyncData, PromptLogprobsReqSnap, _apply_sampling_transforms,
+    _merge_topk_candidates, compute_logprobs, compute_prompt_logprobs,
+    gather_logprobs, sample)
 from tpu_inference.layers.jax.sample.sampling_metadata import \
     TPUSupportedSamplingMetadata
 
 
 class TestSampling:
+
+    def test_distributed_candidates_match_full_vocab_filters(self):
+        batch_size = 2
+        num_shards = 8
+        shard_vocab_size = 256
+        vocab_size = num_shards * shard_vocab_size
+        logits = jax.random.normal(jax.random.key(7), (batch_size, vocab_size),
+                                   dtype=jnp.float32)
+        temperature = jnp.array([1.0, 0.7], dtype=jnp.float32)
+        top_p = jnp.array([0.95, 0.8], dtype=jnp.float32)
+        metadata = TPUSupportedSamplingMetadata(
+            temperature=temperature,
+            top_k=jnp.full((batch_size, ), 64, dtype=jnp.int32),
+            top_p=top_p,
+            do_sampling=True,
+            logprobs=False,
+        )
+        expected = _apply_sampling_transforms(logits, metadata)
+
+        scaled = logits / temperature[:, None]
+        sharded = scaled.reshape(batch_size, num_shards, shard_vocab_size)
+        local_values, local_ids = jax.lax.top_k(sharded, 128)
+        shard_offsets = (jnp.arange(num_shards, dtype=jnp.int32) *
+                         shard_vocab_size)
+        local_ids += shard_offsets[None, :, None]
+        candidate_values = local_values.reshape(batch_size, -1)
+        candidate_ids = local_ids.reshape(batch_size, -1)
+        filtered_values, filtered_ids, incomplete = (_merge_topk_candidates(
+            candidate_values, candidate_ids, top_p))
+
+        actual = jnp.full_like(expected, -1e12)
+        actual = actual.at[jnp.arange(batch_size)[:, None],
+                           filtered_ids].set(filtered_values)
+        assert not np.asarray(incomplete).any()
+        np.testing.assert_array_equal(actual, expected)
+
+    def test_distributed_candidates_preserve_topk_boundary_tie(self):
+        candidate_values = jnp.linspace(1.0, 0.0, 256,
+                                        dtype=jnp.float32)[None, :]
+        candidate_values = candidate_values.at[0, 64].set(candidate_values[0,
+                                                                           63])
+        candidate_ids = jnp.arange(256, dtype=jnp.int32)[None, :]
+        filtered, _, incomplete = _merge_topk_candidates(
+            candidate_values,
+            candidate_ids,
+            jnp.array([1.0], dtype=jnp.float32),
+        )
+        assert not bool(incomplete[0])
+        assert int(jnp.sum(filtered[0] > -1e11)) >= 65
+
+    def test_distributed_candidates_detect_truncated_tie_group(self):
+        candidate_values = jnp.concatenate((jnp.full(
+            (128, ),
+            10.0, dtype=jnp.float32), jnp.arange(0,
+                                                 -128,
+                                                 -1,
+                                                 dtype=jnp.float32)))[None, :]
+        candidate_ids = jnp.arange(256, dtype=jnp.int32)[None, :]
+        _, _, incomplete = _merge_topk_candidates(
+            candidate_values,
+            candidate_ids,
+            jnp.array([0.95], dtype=jnp.float32),
+        )
+        assert bool(incomplete[0])
 
     def test_compute_logprobs(self):
         logits = jnp.array([[1.0, 2.0, 3.0], [3.0, 2.0, 1.0]],

--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -24,12 +24,20 @@ from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling import (
     PromptLogprobsAsyncData, PromptLogprobsReqSnap, _apply_sampling_transforms,
     _merge_topk_candidates, compute_logprobs, compute_prompt_logprobs,
-    gather_logprobs, sample)
+    distributed_sampling_allowed, gather_logprobs, sample)
 from tpu_inference.layers.jax.sample.sampling_metadata import \
     TPUSupportedSamplingMetadata
 
 
 class TestSampling:
+
+    @staticmethod
+    def test_distributed_sampling_allowed():
+        assert distributed_sampling_allowed(False, "processed_logprobs")
+        assert distributed_sampling_allowed(True, "raw_logprobs")
+        assert distributed_sampling_allowed(True, "raw_logits")
+        assert not distributed_sampling_allowed(True, "processed_logprobs")
+        assert not distributed_sampling_allowed(True, "processed_logits")
 
     def test_distributed_candidates_match_full_vocab_filters(self):
         batch_size = 2

--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -23,8 +23,9 @@ from vllm.v1.outputs import LogprobsTensors
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling import (
     PromptLogprobsAsyncData, PromptLogprobsReqSnap, _apply_sampling_transforms,
-    _merge_topk_candidates, compute_logprobs, compute_prompt_logprobs,
-    distributed_sampling_allowed, gather_logprobs, sample)
+    _can_sample_distributed, _merge_topk_candidates, compute_logprobs,
+    compute_prompt_logprobs, distributed_sampling_allowed, gather_logprobs,
+    sample)
 from tpu_inference.layers.jax.sample.sampling_metadata import \
     TPUSupportedSamplingMetadata
 
@@ -38,6 +39,25 @@ class TestSampling:
         assert distributed_sampling_allowed(True, "raw_logits")
         assert not distributed_sampling_allowed(True, "processed_logprobs")
         assert not distributed_sampling_allowed(True, "processed_logits")
+
+    def test_distributed_sampling_requires_positive_top_p(self):
+        metadata = TPUSupportedSamplingMetadata(
+            temperature=jnp.array([0.7, 0.7], dtype=jnp.float32),
+            top_k=jnp.array([20, 20], dtype=jnp.int32),
+            top_p=jnp.array([0.9, 0.0], dtype=jnp.float32),
+            do_sampling=True,
+            logprobs=False,
+        )
+        assert not bool(_can_sample_distributed(metadata))
+
+        greedy_metadata = TPUSupportedSamplingMetadata(
+            temperature=jnp.array([0.7, 0.0], dtype=jnp.float32),
+            top_k=metadata.top_k,
+            top_p=metadata.top_p,
+            do_sampling=True,
+            logprobs=False,
+        )
+        assert bool(_can_sample_distributed(greedy_metadata))
 
     def test_distributed_candidates_match_full_vocab_filters(self):
         batch_size = 2

--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -42,7 +42,7 @@ class TestSampling:
         top_p = jnp.array([0.95, 0.8], dtype=jnp.float32)
         metadata = TPUSupportedSamplingMetadata(
             temperature=temperature,
-            top_k=jnp.full((batch_size, ), 64, dtype=jnp.int32),
+            top_k=jnp.array([20, 64], dtype=jnp.int32),
             top_p=top_p,
             do_sampling=True,
             logprobs=False,
@@ -58,7 +58,7 @@ class TestSampling:
         candidate_values = local_values.reshape(batch_size, -1)
         candidate_ids = local_ids.reshape(batch_size, -1)
         filtered_values, filtered_ids, incomplete = (_merge_topk_candidates(
-            candidate_values, candidate_ids, top_p))
+            candidate_values, candidate_ids, metadata.top_k, top_p))
 
         actual = jnp.full_like(expected, -1e12)
         actual = actual.at[jnp.arange(batch_size)[:, None],
@@ -75,6 +75,7 @@ class TestSampling:
         filtered, _, incomplete = _merge_topk_candidates(
             candidate_values,
             candidate_ids,
+            jnp.array([64], dtype=jnp.int32),
             jnp.array([1.0], dtype=jnp.float32),
         )
         assert not bool(incomplete[0])
@@ -91,6 +92,7 @@ class TestSampling:
         _, _, incomplete = _merge_topk_candidates(
             candidate_values,
             candidate_ids,
+            jnp.array([64], dtype=jnp.int32),
             jnp.array([0.95], dtype=jnp.float32),
         )
         assert bool(incomplete[0])

--- a/tests/runner/test_decode_loop.py
+++ b/tests/runner/test_decode_loop.py
@@ -157,7 +157,7 @@ def test_continue_decode_early_exit():
         logits = logits.at[:, 0].set(pos)
         return logits
 
-    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata, **kwargs):
         pos = logits[:, 0].astype(jnp.int32)
         token_table = jnp.array(
             [
@@ -263,7 +263,7 @@ def test_continue_decode_with_experts():
     def mock_compute_logits_fn(state, hidden_states, _):
         return jnp.zeros((batch_size, 100))
 
-    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata, **kwargs):
         return jnp.array([42, 43], dtype=jnp.int32), None
 
     rng = jax.random.PRNGKey(0)
@@ -343,7 +343,7 @@ def test_continue_decode_no_exit_on_eos():
         logits = logits.at[:, 0].set(pos)
         return logits
 
-    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata, **kwargs):
         pos = logits[:, 0].astype(jnp.int32)
         token_table = jnp.array(
             [
@@ -447,7 +447,7 @@ def test_continue_decode_exit_on_eos_interval():
         logits = logits.at[:, 0].set(pos)
         return logits
 
-    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata, **kwargs):
         pos = logits[:, 0].astype(jnp.int32)
         # Token table: step 0 (pos 0) produces 99 (EOS) for req 1
         token_table = jnp.array(

--- a/tests/runner/test_decode_loop.py
+++ b/tests/runner/test_decode_loop.py
@@ -444,7 +444,7 @@ def _lower_decode_core(continue_decode_eos_check_interval):
         logits = jnp.zeros((batch_size, 100))
         return logits.at[:, 0].set(hidden_states[:, 0, 0])
 
-    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata, **kwargs):
         pos = logits[:, 0].astype(jnp.int32)
         token_table = jnp.array(
             [[42, 43], [44, 99], [99, 50], [60, 61], [70, 71]],

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -64,6 +64,8 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("USE_MOE_EP_KERNEL", "0")
     monkeypatch.setenv("LAYOUT_Q_PROJ_AS_NDH", "0")
     monkeypatch.setenv("USE_BATCHED_RPA_KERNEL", "0")
+    monkeypatch.setenv("SAMPLING_KEEP_SHARDED_LOGITS", "0")
+    monkeypatch.setenv("USE_DISTRIBUTED_TOPK_SAMPLING", "0")
     monkeypatch.setenv("DISABLE_WEIGHT_REQUANTIZATION", "0")
 
     # Test SKIP_JAX_PRECOMPILE (default False)
@@ -111,6 +113,16 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     assert envs.USE_BATCHED_RPA_KERNEL is False
     monkeypatch.setenv("USE_BATCHED_RPA_KERNEL", "1")
     assert envs.USE_BATCHED_RPA_KERNEL is True
+
+    assert envs.SAMPLING_KEEP_SHARDED_LOGITS is False
+    monkeypatch.setenv("SAMPLING_KEEP_SHARDED_LOGITS", "1")
+    assert envs.SAMPLING_KEEP_SHARDED_LOGITS is True
+    monkeypatch.setenv("SAMPLING_KEEP_SHARDED_LOGITS", "0")
+
+    assert envs.USE_DISTRIBUTED_TOPK_SAMPLING is False
+    monkeypatch.setenv("USE_DISTRIBUTED_TOPK_SAMPLING", "1")
+    assert envs.USE_DISTRIBUTED_TOPK_SAMPLING is True
+    monkeypatch.setenv("USE_DISTRIBUTED_TOPK_SAMPLING", "0")
 
 
 def test_moe_stage_weights_on_host(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -65,7 +65,6 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("LAYOUT_Q_PROJ_AS_NDH", "0")
     monkeypatch.setenv("USE_BATCHED_RPA_KERNEL", "0")
     monkeypatch.setenv("SAMPLING_KEEP_SHARDED_LOGITS", "0")
-    monkeypatch.setenv("USE_DISTRIBUTED_TOPK_SAMPLING", "0")
     monkeypatch.setenv("DISABLE_WEIGHT_REQUANTIZATION", "0")
 
     # Test SKIP_JAX_PRECOMPILE (default False)
@@ -118,11 +117,6 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("SAMPLING_KEEP_SHARDED_LOGITS", "1")
     assert envs.SAMPLING_KEEP_SHARDED_LOGITS is True
     monkeypatch.setenv("SAMPLING_KEEP_SHARDED_LOGITS", "0")
-
-    assert envs.USE_DISTRIBUTED_TOPK_SAMPLING is False
-    monkeypatch.setenv("USE_DISTRIBUTED_TOPK_SAMPLING", "1")
-    assert envs.USE_DISTRIBUTED_TOPK_SAMPLING is True
-    monkeypatch.setenv("USE_DISTRIBUTED_TOPK_SAMPLING", "0")
 
 
 def test_distributed_sampling_max_top_k(monkeypatch: pytest.MonkeyPatch):

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -125,6 +125,13 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("USE_DISTRIBUTED_TOPK_SAMPLING", "0")
 
 
+def test_distributed_sampling_max_top_k(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("DISTRIBUTED_SAMPLING_MAX_TOP_K", raising=False)
+    assert envs.DISTRIBUTED_SAMPLING_MAX_TOP_K == 64
+    monkeypatch.setenv("DISTRIBUTED_SAMPLING_MAX_TOP_K", "32")
+    assert envs.DISTRIBUTED_SAMPLING_MAX_TOP_K == 32
+
+
 def test_moe_stage_weights_on_host(monkeypatch: pytest.MonkeyPatch):
     """MOE_STAGE_WEIGHTS_ON_HOST is opt-in: off unless it is asked for."""
     monkeypatch.delenv("MOE_STAGE_WEIGHTS_ON_HOST", raising=False)

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -64,7 +64,6 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("USE_MOE_EP_KERNEL", "0")
     monkeypatch.setenv("LAYOUT_Q_PROJ_AS_NDH", "0")
     monkeypatch.setenv("USE_BATCHED_RPA_KERNEL", "0")
-    monkeypatch.setenv("SAMPLING_KEEP_SHARDED_LOGITS", "0")
     monkeypatch.setenv("DISABLE_WEIGHT_REQUANTIZATION", "0")
 
     # Test SKIP_JAX_PRECOMPILE (default False)
@@ -112,11 +111,6 @@ def test_boolean_env_vars(monkeypatch: pytest.MonkeyPatch):
     assert envs.USE_BATCHED_RPA_KERNEL is False
     monkeypatch.setenv("USE_BATCHED_RPA_KERNEL", "1")
     assert envs.USE_BATCHED_RPA_KERNEL is True
-
-    assert envs.SAMPLING_KEEP_SHARDED_LOGITS is False
-    monkeypatch.setenv("SAMPLING_KEEP_SHARDED_LOGITS", "1")
-    assert envs.SAMPLING_KEEP_SHARDED_LOGITS is True
-    monkeypatch.setenv("SAMPLING_KEEP_SHARDED_LOGITS", "0")
 
 
 def test_distributed_sampling_max_top_k(monkeypatch: pytest.MonkeyPatch):

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -86,7 +86,6 @@ if TYPE_CHECKING:
     TPU_MESH_SORT_BY_COORDS: bool = False
     VERIFY_WEIGHTS: bool = False
     SAMPLING_MICROBATCH_SIZE: int = 0
-    SAMPLING_KEEP_SHARDED_LOGITS: bool = False
     DISTRIBUTED_SAMPLING_MAX_TOP_K: int = 64
 
 
@@ -514,10 +513,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Microbatch size for sampling block. Set to 0 to disable microbatching (disabled by default).
     "SAMPLING_MICROBATCH_SIZE":
     lambda: int(os.getenv("SAMPLING_MICROBATCH_SIZE", "0")),
-    # Keep vocabulary logits sharded across TP shards during sampling to avoid
-    # an expensive all-gather across TP before sampling.
-    "SAMPLING_KEEP_SHARDED_LOGITS":
-    env_bool("SAMPLING_KEEP_SHARDED_LOGITS", default=False),
     # Largest runtime top-k handled by distributed candidate sampling. This is
     # read at trace time so candidate tensor shapes remain static.
     "DISTRIBUTED_SAMPLING_MAX_TOP_K":

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -87,6 +87,7 @@ if TYPE_CHECKING:
     VERIFY_WEIGHTS: bool = False
     SAMPLING_MICROBATCH_SIZE: int = 0
     SAMPLING_KEEP_SHARDED_LOGITS: bool = False
+    DISTRIBUTED_SAMPLING_MAX_TOP_K: int = 64
     USE_DISTRIBUTED_TOPK_SAMPLING: bool = False
 
 
@@ -518,6 +519,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # an expensive all-gather across TP before sampling.
     "SAMPLING_KEEP_SHARDED_LOGITS":
     env_bool("SAMPLING_KEEP_SHARDED_LOGITS", default=False),
+    # Largest runtime top-k handled by distributed candidate sampling. This is
+    # read at trace time so candidate tensor shapes remain static.
+    "DISTRIBUTED_SAMPLING_MAX_TOP_K":
+    lambda: int(os.getenv("DISTRIBUTED_SAMPLING_MAX_TOP_K", "64")),
     # Sample supported top-k requests from compact sharded candidates. The
     # sampler falls back to its general path for unsupported or incomplete
     # candidate sets.

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -85,7 +85,6 @@ if TYPE_CHECKING:
     VLLM_INCREMENTAL_FP8_LOADING: bool = False
     TPU_MESH_SORT_BY_COORDS: bool = False
     VERIFY_WEIGHTS: bool = False
-    SAMPLING_MICROBATCH_SIZE: int = 0
     DISTRIBUTED_SAMPLING_MAX_TOP_K: int = 64
 
 
@@ -510,9 +509,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # RL weight sync: verify tensor checksums after each Raiden H2D transfer.
     "VERIFY_WEIGHTS":
     env_bool("VERIFY_WEIGHTS", default=False),
-    # Microbatch size for sampling block. Set to 0 to disable microbatching (disabled by default).
-    "SAMPLING_MICROBATCH_SIZE":
-    lambda: int(os.getenv("SAMPLING_MICROBATCH_SIZE", "0")),
     # Largest runtime top-k handled by distributed candidate sampling. This is
     # read at trace time so candidate tensor shapes remain static.
     "DISTRIBUTED_SAMPLING_MAX_TOP_K":

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -88,7 +88,6 @@ if TYPE_CHECKING:
     SAMPLING_MICROBATCH_SIZE: int = 0
     SAMPLING_KEEP_SHARDED_LOGITS: bool = False
     DISTRIBUTED_SAMPLING_MAX_TOP_K: int = 64
-    USE_DISTRIBUTED_TOPK_SAMPLING: bool = False
 
 
 def env_with_choices(
@@ -523,11 +522,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # read at trace time so candidate tensor shapes remain static.
     "DISTRIBUTED_SAMPLING_MAX_TOP_K":
     lambda: int(os.getenv("DISTRIBUTED_SAMPLING_MAX_TOP_K", "64")),
-    # Sample supported top-k requests from compact sharded candidates. The
-    # sampler falls back to its general path for unsupported or incomplete
-    # candidate sets.
-    "USE_DISTRIBUTED_TOPK_SAMPLING":
-    env_bool("USE_DISTRIBUTED_TOPK_SAMPLING", default=False),
 }
 
 

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -85,6 +85,9 @@ if TYPE_CHECKING:
     VLLM_INCREMENTAL_FP8_LOADING: bool = False
     TPU_MESH_SORT_BY_COORDS: bool = False
     VERIFY_WEIGHTS: bool = False
+    SAMPLING_MICROBATCH_SIZE: int = 0
+    SAMPLING_KEEP_SHARDED_LOGITS: bool = False
+    USE_DISTRIBUTED_TOPK_SAMPLING: bool = False
 
 
 def env_with_choices(
@@ -508,6 +511,18 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # RL weight sync: verify tensor checksums after each Raiden H2D transfer.
     "VERIFY_WEIGHTS":
     env_bool("VERIFY_WEIGHTS", default=False),
+    # Microbatch size for sampling block. Set to 0 to disable microbatching (disabled by default).
+    "SAMPLING_MICROBATCH_SIZE":
+    lambda: int(os.getenv("SAMPLING_MICROBATCH_SIZE", "0")),
+    # Keep vocabulary logits sharded across TP shards during sampling to avoid
+    # an expensive all-gather across TP before sampling.
+    "SAMPLING_KEEP_SHARDED_LOGITS":
+    env_bool("SAMPLING_KEEP_SHARDED_LOGITS", default=False),
+    # Sample supported top-k requests from compact sharded candidates. The
+    # sampler falls back to its general path for unsupported or incomplete
+    # candidate sets.
+    "USE_DISTRIBUTED_TOPK_SAMPLING":
+    env_bool("USE_DISTRIBUTED_TOPK_SAMPLING", default=False),
 }
 
 

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -67,6 +67,11 @@ def _distributed_sampling_fits(mesh: Mesh, vocab_size: int) -> bool:
     return local_vocab_size >= _distributed_sampling_candidates_per_shard()
 
 
+def distributed_sampling_allowed(logprobs: bool, logprobs_mode) -> bool:
+    """Whether sampling can return raw logits for the requested logprob mode."""
+    return not (logprobs and str(logprobs_mode).startswith("processed"))
+
+
 @dataclass
 class PromptLogprobsReqSnap:
     """Per-request state snapshotted at step N for use in get_output()."""
@@ -315,12 +320,13 @@ def _distributed_topk_sample(
     )(rng, logits, temperature, top_k, top_p)
 
 
-@jax.jit(static_argnames=["mesh"])
+@jax.jit(static_argnames=["mesh", "allow_distributed_sampling"])
 def sample(
     rng: jax.Array,
     mesh: Mesh,
     logits: jax.Array,
     tpu_sampling_metadata: TPUSupportedSamplingMetadata,
+    allow_distributed_sampling: bool = True,
 ) -> jax.Array:
     # (B, vocab_size)
     if tpu_sampling_metadata._cache_collision_dummy is not None:
@@ -349,7 +355,7 @@ def sample(
             return tokens, output_logits
 
         use_distributed_candidates = (
-            not tpu_sampling_metadata.logprobs
+            allow_distributed_sampling
             and _distributed_sampling_fits(mesh, logits.shape[-1]))
         if use_distributed_candidates:
             # Candidate shapes use a trace-time maximum; each request's top-k
@@ -378,9 +384,9 @@ def sample(
                 def use_candidate_result(_):
                     tokens = jnp.where(is_greedy, greedy_tokens,
                                        sampled_tokens)
-                    # No caller consumes processed logits when logprobs=False.
-                    # Returning the input preserves the API without forcing a
-                    # full-vocabulary filtered-logits materialization.
+                    # Processed-logit modes disable this path. Returning the
+                    # raw input supports raw logprobs without materializing
+                    # full-vocabulary filtered logits.
                     return tokens, logits
 
                 return lax.cond(incomplete_candidates,

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -17,10 +17,12 @@ from typing import TYPE_CHECKING, Dict, List, Optional
 
 import jax
 import jax.numpy as jnp
+from jax import lax
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from vllm.v1.outputs import LogprobsTensors
 
+from tpu_inference import envs
 from tpu_inference.layers.common.binary_search import topk_mask, topp_mask
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling_metadata import \
@@ -32,6 +34,11 @@ if TYPE_CHECKING:
     from tpu_inference.runner.input_batch import CachedRequestState
 
 _SAMPLING_EPS = 1e-5
+# Candidate tensor shapes must be static inside the compiled sampler. Keep the
+# supported top-k and candidate capacity explicit; requests outside this fast
+# path continue through the general full-vocabulary implementation.
+_DISTRIBUTED_SAMPLING_SUPPORTED_TOP_K = 64
+_DISTRIBUTED_SAMPLING_CANDIDATES_PER_SHARD = 128
 
 
 @dataclass
@@ -102,6 +109,176 @@ def _apply_sampling_transforms(
     return logits
 
 
+def _apply_sampling_transforms_microbatched(
+    logits: jax.Array,
+    tpu_sampling_metadata: TPUSupportedSamplingMetadata,
+) -> jax.Array:
+    """Apply sampling transforms in sequential, scratchpad-sized chunks.
+
+    The top-k and top-p implementations repeatedly reduce over the complete
+    vocabulary. Processing large request batches at once can push their working
+    set out of fast TPU memory. Keep the existing path for small or non-divisible
+    batches, and split larger divisible batches into fixed-size chunks.
+    """
+    batch_size = logits.shape[0]
+    microbatch_size = envs.SAMPLING_MICROBATCH_SIZE
+    if (microbatch_size <= 0 or batch_size <= microbatch_size
+            or batch_size % microbatch_size != 0):
+        return _apply_sampling_transforms(logits, tpu_sampling_metadata)
+
+    num_microbatches = batch_size // microbatch_size
+    microbatch_logits = logits.reshape(
+        (num_microbatches, microbatch_size, logits.shape[-1]))
+    microbatch_temperature = tpu_sampling_metadata.temperature.reshape(
+        (num_microbatches, microbatch_size))
+    microbatch_top_k = tpu_sampling_metadata.top_k.reshape(
+        (num_microbatches, microbatch_size))
+    microbatch_top_p = tpu_sampling_metadata.top_p.reshape(
+        (num_microbatches, microbatch_size))
+
+    def transform_microbatch(inputs):
+        chunk_logits, temperature, top_k, top_p = inputs
+        chunk_metadata = TPUSupportedSamplingMetadata(
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+            do_sampling=True,
+        )
+        return _apply_sampling_transforms(chunk_logits, chunk_metadata)
+
+    processed_logits = jax.lax.map(
+        transform_microbatch,
+        (microbatch_logits, microbatch_temperature, microbatch_top_k,
+         microbatch_top_p),
+    )
+    return processed_logits.reshape(logits.shape)
+
+
+def _merge_topk_candidates(
+    candidate_values: jax.Array,
+    candidate_ids: jax.Array,
+    top_p: jax.Array,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Applies exact threshold top-k and top-p to gathered candidates.
+
+    The production top-k retains every value tied with rank 64. A larger
+    per-shard candidate set lets this path retain those ties too. The result is
+    incomplete only when a shard's last retained value reaches the global
+    threshold, because that shard may have omitted more qualifying values.
+    """
+    if (candidate_values.shape[-1] % _DISTRIBUTED_SAMPLING_CANDIDATES_PER_SHARD
+            != 0):
+        raise ValueError("Candidate dimension must contain complete shards")
+    global_topk, _ = lax.top_k(candidate_values,
+                               _DISTRIBUTED_SAMPLING_SUPPORTED_TOP_K)
+    threshold = global_topk[:, -1]
+    shard_candidates = candidate_values.reshape(
+        candidate_values.shape[0], -1,
+        _DISTRIBUTED_SAMPLING_CANDIDATES_PER_SHARD)
+    shard_tails = shard_candidates[:, :, -1]
+    incomplete = jnp.any(shard_tails >= threshold[:, None], axis=-1)
+    topk_values = jnp.where(candidate_values >= threshold[:, None],
+                            candidate_values, -1e12)
+    filtered_values = topp_mask(topk_values, top_p, replace_val=-1e12)
+    return filtered_values, candidate_ids, incomplete
+
+
+def _distributed_topk_sample(
+    rng: jax.Array,
+    mesh: Mesh,
+    logits: jax.Array,
+    temperature: jax.Array,
+    top_p: jax.Array,
+) -> tuple[jax.Array, jax.Array]:
+    """Samples from the exact global top-64 set using sharded candidates.
+
+    Every TP shard contributes its local top-128. The global rank-64 value is
+    used as a threshold so all boundary ties are retained. Callers fall back
+    only if a shard may have omitted additional values at that threshold.
+
+    Returns sampled global token IDs and a replicated scalar indicating that
+    the gathered candidates may not contain the complete top-k tie group.
+    """
+    data_spec = P(ShardingAxisName.MLP_DATA)
+    logits_spec = P(ShardingAxisName.MLP_DATA, ShardingAxisName.MLP_TENSOR)
+    replicated = P()
+
+    def local_sample(local_rng, local_logits, local_temperature, local_top_p):
+        local_vocab_size = local_logits.shape[-1]
+        if local_vocab_size < _DISTRIBUTED_SAMPLING_CANDIDATES_PER_SHARD:
+            raise ValueError(
+                "Distributed top-k sampling requires at least 128 logits per "
+                "vocabulary shard")
+
+        microbatch_size = envs.SAMPLING_MICROBATCH_SIZE
+        batch_size = local_logits.shape[0]
+        if (microbatch_size <= 0 or batch_size <= microbatch_size
+                or batch_size % microbatch_size != 0):
+            microbatch_size = batch_size
+        num_microbatches = batch_size // microbatch_size
+
+        logits_mb = local_logits.reshape(num_microbatches, microbatch_size,
+                                         local_vocab_size)
+        temperature_mb = local_temperature.reshape(num_microbatches,
+                                                   microbatch_size)
+        top_p_mb = local_top_p.reshape(num_microbatches, microbatch_size)
+        rngs = jax.random.split(local_rng, num_microbatches)
+        shard_index = lax.axis_index(ShardingAxisName.MLP_TENSOR)
+
+        def sample_microbatch(inputs):
+            key, chunk_logits, chunk_temperature, chunk_top_p = inputs
+            # Greedy rows do not consume the categorical result. A safe
+            # positive temperature avoids reversing their candidate ordering.
+            safe_temperature = jnp.where(
+                chunk_temperature < _SAMPLING_EPS,
+                jnp.ones_like(chunk_temperature),
+                chunk_temperature,
+            )
+            scaled_logits = chunk_logits / safe_temperature[:, None]
+            local_values, local_ids = lax.top_k(
+                scaled_logits, _DISTRIBUTED_SAMPLING_CANDIDATES_PER_SHARD)
+            local_ids = (local_ids + shard_index * local_vocab_size).astype(
+                jnp.int32)
+
+            candidate_values = lax.all_gather(
+                local_values,
+                ShardingAxisName.MLP_TENSOR,
+                axis=-1,
+                tiled=True,
+            )
+            candidate_ids = lax.all_gather(
+                local_ids,
+                ShardingAxisName.MLP_TENSOR,
+                axis=-1,
+                tiled=True,
+            )
+            filtered_values, candidate_ids, incomplete = (
+                _merge_topk_candidates(candidate_values, candidate_ids,
+                                       chunk_top_p))
+            incomplete = jnp.logical_and(incomplete, chunk_temperature
+                                         >= _SAMPLING_EPS)
+            sampled_positions = jax.random.categorical(key, filtered_values)
+            sampled_ids = jnp.take_along_axis(candidate_ids,
+                                              sampled_positions[:, None],
+                                              axis=-1)[:, 0]
+            return sampled_ids, incomplete
+
+        sampled_ids, incomplete_candidates = lax.map(
+            sample_microbatch,
+            (rngs, logits_mb, temperature_mb, top_p_mb),
+        )
+        return (sampled_ids.reshape(batch_size),
+                jnp.any(incomplete_candidates))
+
+    return jax.shard_map(
+        local_sample,
+        mesh=mesh,
+        in_specs=(replicated, logits_spec, data_spec, data_spec),
+        out_specs=(data_spec, replicated),
+        check_vma=False,
+    )(rng, logits, temperature, top_p)
+
+
 @jax.jit(static_argnames=["mesh"])
 def sample(
     rng: jax.Array,
@@ -115,10 +292,11 @@ def sample(
         logits = logits + 0 * jnp.sum(
             tpu_sampling_metadata._cache_collision_dummy)
 
-    if tpu_sampling_metadata.do_sampling:
-        # Unshard the logits explicity to avoid latency increase.
-        # TODO(gxd3): revisit if the 2nd dimension of the logits can be sharded
-        # instead of being replicated.
+    should_unshard_logits = not (envs.USE_DISTRIBUTED_TOPK_SAMPLING
+                                 or envs.SAMPLING_KEEP_SHARDED_LOGITS)
+    if tpu_sampling_metadata.do_sampling and should_unshard_logits:
+        # Unshard the logits explicitly to preserve the baseline execution path
+        # for models not enabling sharded sampling.
         logits = jax.lax.with_sharding_constraint(
             logits, NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
 
@@ -128,16 +306,61 @@ def sample(
         ret_tokens = greedy_tokens
         ret_logits = logits
     else:
-        processed_logits = _apply_sampling_transforms(logits,
-                                                      tpu_sampling_metadata)
-        # (batch_size,)
-        next_tokens = jax.random.categorical(rng, processed_logits)
-        # Note: avoid using the sample result when temperature < _SAMPLING_EPS
-        # If temperature < 0, logits /= temperatures will flip the result, causing error.
         is_greedy = tpu_sampling_metadata.temperature < _SAMPLING_EPS
-        ret_tokens = jnp.where(is_greedy, greedy_tokens, next_tokens)
-        ret_logits = jnp.where(jnp.expand_dims(is_greedy, axis=-1), logits,
-                               processed_logits)
+
+        def sample_full_vocab(_):
+            processed_logits = _apply_sampling_transforms_microbatched(
+                logits, tpu_sampling_metadata)
+            sampled_tokens = jax.random.categorical(rng, processed_logits)
+            tokens = jnp.where(is_greedy, greedy_tokens, sampled_tokens)
+            output_logits = jnp.where(is_greedy[:, None], logits,
+                                      processed_logits)
+            return tokens, output_logits
+
+        use_distributed_candidates = (envs.USE_DISTRIBUTED_TOPK_SAMPLING
+                                      and not tpu_sampling_metadata.logprobs)
+        if use_distributed_candidates:
+            # Candidate shapes are compile-time constants, so this fast path
+            # currently specializes top-k=64. Greedy and padded rows do not
+            # consume a random sample and therefore need not request top-k=64.
+            supported = jnp.all(
+                jnp.logical_or(
+                    is_greedy,
+                    tpu_sampling_metadata.top_k ==
+                    _DISTRIBUTED_SAMPLING_SUPPORTED_TOP_K,
+                ))
+
+            def sample_candidates(_):
+                sampled_tokens, incomplete_candidates = (
+                    _distributed_topk_sample(
+                        rng,
+                        mesh,
+                        logits,
+                        tpu_sampling_metadata.temperature,
+                        tpu_sampling_metadata.top_p,
+                    ))
+
+                def use_candidate_result(_):
+                    tokens = jnp.where(is_greedy, greedy_tokens,
+                                       sampled_tokens)
+                    # No caller consumes processed logits when logprobs=False.
+                    # Returning the input preserves the API without forcing a
+                    # full-vocabulary filtered-logits materialization.
+                    return tokens, logits
+
+                return lax.cond(incomplete_candidates,
+                                sample_full_vocab,
+                                use_candidate_result,
+                                operand=None)
+
+            ret_tokens, ret_logits = lax.cond(
+                supported,
+                sample_candidates,
+                sample_full_vocab,
+                operand=None,
+            )
+        else:
+            ret_tokens, ret_logits = sample_full_vocab(None)
     # Replicate the result so that in multi-controller jax setup
     # (i.e. Ray based multi-host setup), we won't hit error like
     # RuntimeError: Fetching value for `jax.Array` that spans non-addressable

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -337,11 +337,9 @@ def sample(
         is_greedy = tpu_sampling_metadata.temperature < _SAMPLING_EPS
 
         def sample_full_vocab(_):
-            full_logits = logits
-            if not envs.SAMPLING_KEEP_SHARDED_LOGITS:
-                full_logits = jax.lax.with_sharding_constraint(
-                    full_logits,
-                    NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
+            full_logits = jax.lax.with_sharding_constraint(
+                logits,
+                NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
             processed_logits = _apply_sampling_transforms_microbatched(
                 full_logits, tpu_sampling_metadata)
             sampled_tokens = jax.random.categorical(rng, processed_logits)

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -34,11 +34,21 @@ if TYPE_CHECKING:
     from tpu_inference.runner.input_batch import CachedRequestState
 
 _SAMPLING_EPS = 1e-5
-# Candidate tensor shapes must be static inside the compiled sampler. Keep the
-# supported top-k and candidate capacity explicit; requests outside this fast
-# path continue through the general full-vocabulary implementation.
-_DISTRIBUTED_SAMPLING_SUPPORTED_TOP_K = 64
-_DISTRIBUTED_SAMPLING_CANDIDATES_PER_SHARD = 128
+
+
+def _distributed_sampling_max_top_k() -> int:
+    """Static top-k capacity used to shape the compiled candidate sampler."""
+    max_top_k = envs.DISTRIBUTED_SAMPLING_MAX_TOP_K
+    if max_top_k < 1:
+        raise ValueError("DISTRIBUTED_SAMPLING_MAX_TOP_K must be >= 1, got "
+                         f"{max_top_k}")
+    return max_top_k
+
+
+def _distributed_sampling_candidates_per_shard() -> int:
+    # Retaining twice the supported top-k reduces tie-overflow fallbacks while
+    # preserving the existing 128 candidates for the default max_top_k of 64.
+    return 2 * _distributed_sampling_max_top_k()
 
 
 @dataclass
@@ -157,24 +167,26 @@ def _apply_sampling_transforms_microbatched(
 def _merge_topk_candidates(
     candidate_values: jax.Array,
     candidate_ids: jax.Array,
+    top_k: jax.Array,
     top_p: jax.Array,
 ) -> tuple[jax.Array, jax.Array, jax.Array]:
     """Applies exact threshold top-k and top-p to gathered candidates.
 
-    The production top-k retains every value tied with rank 64. A larger
-    per-shard candidate set lets this path retain those ties too. The result is
-    incomplete only when a shard's last retained value reaches the global
-    threshold, because that shard may have omitted more qualifying values.
+    The production top-k retains every value tied with the requested rank. A
+    larger per-shard candidate set lets this path retain those ties too. The
+    result is incomplete only when a shard's last retained value reaches the
+    global threshold, because that shard may have omitted more qualifying
+    values.
     """
-    if (candidate_values.shape[-1] % _DISTRIBUTED_SAMPLING_CANDIDATES_PER_SHARD
-            != 0):
+    candidates_per_shard = _distributed_sampling_candidates_per_shard()
+    if candidate_values.shape[-1] % candidates_per_shard != 0:
         raise ValueError("Candidate dimension must contain complete shards")
     global_topk, _ = lax.top_k(candidate_values,
-                               _DISTRIBUTED_SAMPLING_SUPPORTED_TOP_K)
-    threshold = global_topk[:, -1]
+                               _distributed_sampling_max_top_k())
+    threshold = jnp.take_along_axis(global_topk, top_k[:, None] - 1,
+                                    axis=-1)[:, 0]
     shard_candidates = candidate_values.reshape(
-        candidate_values.shape[0], -1,
-        _DISTRIBUTED_SAMPLING_CANDIDATES_PER_SHARD)
+        candidate_values.shape[0], -1, candidates_per_shard)
     shard_tails = shard_candidates[:, :, -1]
     incomplete = jnp.any(shard_tails >= threshold[:, None], axis=-1)
     topk_values = jnp.where(candidate_values >= threshold[:, None],
@@ -188,13 +200,15 @@ def _distributed_topk_sample(
     mesh: Mesh,
     logits: jax.Array,
     temperature: jax.Array,
+    top_k: jax.Array,
     top_p: jax.Array,
 ) -> tuple[jax.Array, jax.Array]:
-    """Samples from the exact global top-64 set using sharded candidates.
+    """Samples from the exact requested global top-k using sharded candidates.
 
-    Every TP shard contributes its local top-128. The global rank-64 value is
-    used as a threshold so all boundary ties are retained. Callers fall back
-    only if a shard may have omitted additional values at that threshold.
+    Every TP shard contributes a static number of local candidates. The
+    requested global top-k value is used as a dynamic threshold so all boundary
+    ties are retained. Callers fall back if a shard may have omitted additional
+    values at that threshold.
 
     Returns sampled global token IDs and a replicated scalar indicating that
     the gathered candidates may not contain the complete top-k tie group.
@@ -203,12 +217,14 @@ def _distributed_topk_sample(
     logits_spec = P(ShardingAxisName.MLP_DATA, ShardingAxisName.MLP_TENSOR)
     replicated = P()
 
-    def local_sample(local_rng, local_logits, local_temperature, local_top_p):
+    def local_sample(local_rng, local_logits, local_temperature, local_top_k,
+                     local_top_p):
+        candidates_per_shard = _distributed_sampling_candidates_per_shard()
         local_vocab_size = local_logits.shape[-1]
-        if local_vocab_size < _DISTRIBUTED_SAMPLING_CANDIDATES_PER_SHARD:
+        if local_vocab_size < candidates_per_shard:
             raise ValueError(
-                "Distributed top-k sampling requires at least 128 logits per "
-                "vocabulary shard")
+                "Distributed top-k sampling requires at least "
+                f"{candidates_per_shard} logits per vocabulary shard")
 
         microbatch_size = envs.SAMPLING_MICROBATCH_SIZE
         batch_size = local_logits.shape[0]
@@ -221,12 +237,14 @@ def _distributed_topk_sample(
                                          local_vocab_size)
         temperature_mb = local_temperature.reshape(num_microbatches,
                                                    microbatch_size)
+        top_k_mb = local_top_k.reshape(num_microbatches, microbatch_size)
         top_p_mb = local_top_p.reshape(num_microbatches, microbatch_size)
         rngs = jax.random.split(local_rng, num_microbatches)
         shard_index = lax.axis_index(ShardingAxisName.MLP_TENSOR)
 
         def sample_microbatch(inputs):
-            key, chunk_logits, chunk_temperature, chunk_top_p = inputs
+            (key, chunk_logits, chunk_temperature, chunk_top_k,
+             chunk_top_p) = inputs
             # Greedy rows do not consume the categorical result. A safe
             # positive temperature avoids reversing their candidate ordering.
             safe_temperature = jnp.where(
@@ -236,7 +254,7 @@ def _distributed_topk_sample(
             )
             scaled_logits = chunk_logits / safe_temperature[:, None]
             local_values, local_ids = lax.top_k(
-                scaled_logits, _DISTRIBUTED_SAMPLING_CANDIDATES_PER_SHARD)
+                scaled_logits, candidates_per_shard)
             local_ids = (local_ids + shard_index * local_vocab_size).astype(
                 jnp.int32)
 
@@ -252,9 +270,11 @@ def _distributed_topk_sample(
                 axis=-1,
                 tiled=True,
             )
+            safe_top_k = jnp.clip(chunk_top_k, 1,
+                                  _distributed_sampling_max_top_k())
             filtered_values, candidate_ids, incomplete = (
                 _merge_topk_candidates(candidate_values, candidate_ids,
-                                       chunk_top_p))
+                                       safe_top_k, chunk_top_p))
             incomplete = jnp.logical_and(incomplete, chunk_temperature
                                          >= _SAMPLING_EPS)
             sampled_positions = jax.random.categorical(key, filtered_values)
@@ -265,7 +285,7 @@ def _distributed_topk_sample(
 
         sampled_ids, incomplete_candidates = lax.map(
             sample_microbatch,
-            (rngs, logits_mb, temperature_mb, top_p_mb),
+            (rngs, logits_mb, temperature_mb, top_k_mb, top_p_mb),
         )
         return (sampled_ids.reshape(batch_size),
                 jnp.any(incomplete_candidates))
@@ -273,10 +293,10 @@ def _distributed_topk_sample(
     return jax.shard_map(
         local_sample,
         mesh=mesh,
-        in_specs=(replicated, logits_spec, data_spec, data_spec),
+        in_specs=(replicated, logits_spec, data_spec, data_spec, data_spec),
         out_specs=(data_spec, replicated),
         check_vma=False,
-    )(rng, logits, temperature, top_p)
+    )(rng, logits, temperature, top_k, top_p)
 
 
 @jax.jit(static_argnames=["mesh"])
@@ -320,14 +340,16 @@ def sample(
         use_distributed_candidates = (envs.USE_DISTRIBUTED_TOPK_SAMPLING
                                       and not tpu_sampling_metadata.logprobs)
         if use_distributed_candidates:
-            # Candidate shapes are compile-time constants, so this fast path
-            # currently specializes top-k=64. Greedy and padded rows do not
-            # consume a random sample and therefore need not request top-k=64.
+            # Candidate shapes use a trace-time maximum; each request's top-k
+            # remains dynamic. Greedy and padded rows do not consume a sample.
             supported = jnp.all(
                 jnp.logical_or(
                     is_greedy,
-                    tpu_sampling_metadata.top_k ==
-                    _DISTRIBUTED_SAMPLING_SUPPORTED_TOP_K,
+                    jnp.logical_and(
+                        tpu_sampling_metadata.top_k > 0,
+                        tpu_sampling_metadata.top_k <=
+                        _distributed_sampling_max_top_k(),
+                    ),
                 ))
 
             def sample_candidates(_):
@@ -337,6 +359,7 @@ def sample(
                         mesh,
                         logits,
                         tpu_sampling_metadata.temperature,
+                        tpu_sampling_metadata.top_k,
                         tpu_sampling_metadata.top_p,
                     ))
 

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -72,6 +72,17 @@ def distributed_sampling_allowed(logprobs: bool, logprobs_mode) -> bool:
     return not (logprobs and str(logprobs_mode).startswith("processed"))
 
 
+def _can_sample_distributed(
+        tpu_sampling_metadata: TPUSupportedSamplingMetadata) -> jax.Array:
+    """Whether every row is supported by distributed candidate sampling."""
+    is_greedy = tpu_sampling_metadata.temperature < _SAMPLING_EPS
+    supported = ((tpu_sampling_metadata.top_k > 0) &
+                 (tpu_sampling_metadata.top_k <=
+                  _distributed_sampling_max_top_k()) &
+                 (tpu_sampling_metadata.top_p > 0.0))
+    return jnp.all(is_greedy | supported)
+
+
 @dataclass
 class PromptLogprobsReqSnap:
     """Per-request state snapshotted at step N for use in get_output()."""
@@ -260,6 +271,10 @@ def _distributed_topk_sample(
                                                    microbatch_size)
         top_k_mb = local_top_k.reshape(num_microbatches, microbatch_size)
         top_p_mb = local_top_p.reshape(num_microbatches, microbatch_size)
+        data_axis = ShardingAxisName.MLP_DATA
+        if data_axis in mesh.axis_names and mesh.shape[data_axis] > 1:
+            local_rng = jax.random.fold_in(local_rng,
+                                           lax.axis_index(data_axis))
         rngs = jax.random.split(local_rng, num_microbatches)
         shard_index = lax.axis_index(ShardingAxisName.MLP_TENSOR)
 
@@ -360,15 +375,7 @@ def sample(
         if use_distributed_candidates:
             # Candidate shapes use a trace-time maximum; each request's top-k
             # remains dynamic. Greedy and padded rows do not consume a sample.
-            supported = jnp.all(
-                jnp.logical_or(
-                    is_greedy,
-                    jnp.logical_and(
-                        tpu_sampling_metadata.top_k > 0,
-                        tpu_sampling_metadata.top_k <=
-                        _distributed_sampling_max_top_k(),
-                    ),
-                ))
+            supported = _can_sample_distributed(tpu_sampling_metadata)
 
             def sample_candidates(_):
                 sampled_tokens, incomplete_candidates = (

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -151,51 +151,6 @@ def _apply_sampling_transforms(
     return logits
 
 
-def _apply_sampling_transforms_microbatched(
-    logits: jax.Array,
-    tpu_sampling_metadata: TPUSupportedSamplingMetadata,
-) -> jax.Array:
-    """Apply sampling transforms in sequential, scratchpad-sized chunks.
-
-    The top-k and top-p implementations repeatedly reduce over the complete
-    vocabulary. Processing large request batches at once can push their working
-    set out of fast TPU memory. Keep the existing path for small or non-divisible
-    batches, and split larger divisible batches into fixed-size chunks.
-    """
-    batch_size = logits.shape[0]
-    microbatch_size = envs.SAMPLING_MICROBATCH_SIZE
-    if (microbatch_size <= 0 or batch_size <= microbatch_size
-            or batch_size % microbatch_size != 0):
-        return _apply_sampling_transforms(logits, tpu_sampling_metadata)
-
-    num_microbatches = batch_size // microbatch_size
-    microbatch_logits = logits.reshape(
-        (num_microbatches, microbatch_size, logits.shape[-1]))
-    microbatch_temperature = tpu_sampling_metadata.temperature.reshape(
-        (num_microbatches, microbatch_size))
-    microbatch_top_k = tpu_sampling_metadata.top_k.reshape(
-        (num_microbatches, microbatch_size))
-    microbatch_top_p = tpu_sampling_metadata.top_p.reshape(
-        (num_microbatches, microbatch_size))
-
-    def transform_microbatch(inputs):
-        chunk_logits, temperature, top_k, top_p = inputs
-        chunk_metadata = TPUSupportedSamplingMetadata(
-            temperature=temperature,
-            top_k=top_k,
-            top_p=top_p,
-            do_sampling=True,
-        )
-        return _apply_sampling_transforms(chunk_logits, chunk_metadata)
-
-    processed_logits = jax.lax.map(
-        transform_microbatch,
-        (microbatch_logits, microbatch_temperature, microbatch_top_k,
-         microbatch_top_p),
-    )
-    return processed_logits.reshape(logits.shape)
-
-
 def _merge_topk_candidates(
     candidate_values: jax.Array,
     candidate_ids: jax.Array,
@@ -258,73 +213,50 @@ def _distributed_topk_sample(
                 "Distributed top-k sampling requires at least "
                 f"{candidates_per_shard} logits per vocabulary shard")
 
-        microbatch_size = envs.SAMPLING_MICROBATCH_SIZE
-        batch_size = local_logits.shape[0]
-        if (microbatch_size <= 0 or batch_size <= microbatch_size
-                or batch_size % microbatch_size != 0):
-            microbatch_size = batch_size
-        num_microbatches = batch_size // microbatch_size
-
-        logits_mb = local_logits.reshape(num_microbatches, microbatch_size,
-                                         local_vocab_size)
-        temperature_mb = local_temperature.reshape(num_microbatches,
-                                                   microbatch_size)
-        top_k_mb = local_top_k.reshape(num_microbatches, microbatch_size)
-        top_p_mb = local_top_p.reshape(num_microbatches, microbatch_size)
         data_axis = ShardingAxisName.MLP_DATA
         if data_axis in mesh.axis_names and mesh.shape[data_axis] > 1:
             local_rng = jax.random.fold_in(local_rng,
                                            lax.axis_index(data_axis))
-        rngs = jax.random.split(local_rng, num_microbatches)
+        # Preserve the candidate sampler's existing key derivation.
+        sample_rng = jax.random.split(local_rng, 1)[0]
         shard_index = lax.axis_index(ShardingAxisName.MLP_TENSOR)
 
-        def sample_microbatch(inputs):
-            (key, chunk_logits, chunk_temperature, chunk_top_k,
-             chunk_top_p) = inputs
-            # Greedy rows do not consume the categorical result. A safe
-            # positive temperature avoids reversing their candidate ordering.
-            safe_temperature = jnp.where(
-                chunk_temperature < _SAMPLING_EPS,
-                jnp.ones_like(chunk_temperature),
-                chunk_temperature,
-            )
-            scaled_logits = chunk_logits / safe_temperature[:, None]
-            local_values, local_ids = lax.top_k(
-                scaled_logits, candidates_per_shard)
-            local_ids = (local_ids + shard_index * local_vocab_size).astype(
-                jnp.int32)
-
-            candidate_values = lax.all_gather(
-                local_values,
-                ShardingAxisName.MLP_TENSOR,
-                axis=-1,
-                tiled=True,
-            )
-            candidate_ids = lax.all_gather(
-                local_ids,
-                ShardingAxisName.MLP_TENSOR,
-                axis=-1,
-                tiled=True,
-            )
-            safe_top_k = jnp.clip(chunk_top_k, 1,
-                                  _distributed_sampling_max_top_k())
-            filtered_values, candidate_ids, incomplete = (
-                _merge_topk_candidates(candidate_values, candidate_ids,
-                                       safe_top_k, chunk_top_p))
-            incomplete = jnp.logical_and(incomplete, chunk_temperature
-                                         >= _SAMPLING_EPS)
-            sampled_positions = jax.random.categorical(key, filtered_values)
-            sampled_ids = jnp.take_along_axis(candidate_ids,
-                                              sampled_positions[:, None],
-                                              axis=-1)[:, 0]
-            return sampled_ids, incomplete
-
-        sampled_ids, incomplete_candidates = lax.map(
-            sample_microbatch,
-            (rngs, logits_mb, temperature_mb, top_k_mb, top_p_mb),
+        # Greedy rows do not consume the categorical result. A safe positive
+        # temperature avoids reversing their candidate ordering.
+        safe_temperature = jnp.where(
+            local_temperature < _SAMPLING_EPS,
+            jnp.ones_like(local_temperature),
+            local_temperature,
         )
-        return (sampled_ids.reshape(batch_size),
-                jnp.any(incomplete_candidates))
+        scaled_logits = local_logits / safe_temperature[:, None]
+        local_values, local_ids = lax.top_k(scaled_logits,
+                                            candidates_per_shard)
+        local_ids = (local_ids + shard_index * local_vocab_size).astype(
+            jnp.int32)
+
+        candidate_values = lax.all_gather(
+            local_values,
+            ShardingAxisName.MLP_TENSOR,
+            axis=-1,
+            tiled=True,
+        )
+        candidate_ids = lax.all_gather(
+            local_ids,
+            ShardingAxisName.MLP_TENSOR,
+            axis=-1,
+            tiled=True,
+        )
+        safe_top_k = jnp.clip(local_top_k, 1,
+                              _distributed_sampling_max_top_k())
+        filtered_values, candidate_ids, incomplete = _merge_topk_candidates(
+            candidate_values, candidate_ids, safe_top_k, local_top_p)
+        incomplete = jnp.logical_and(incomplete,
+                                     local_temperature >= _SAMPLING_EPS)
+        sampled_positions = jax.random.categorical(sample_rng, filtered_values)
+        sampled_ids = jnp.take_along_axis(candidate_ids,
+                                          sampled_positions[:, None],
+                                          axis=-1)[:, 0]
+        return sampled_ids, jnp.any(incomplete)
 
     return jax.shard_map(
         local_sample,
@@ -361,7 +293,7 @@ def sample(
             full_logits = jax.lax.with_sharding_constraint(
                 logits,
                 NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
-            processed_logits = _apply_sampling_transforms_microbatched(
+            processed_logits = _apply_sampling_transforms(
                 full_logits, tpu_sampling_metadata)
             sampled_tokens = jax.random.categorical(rng, processed_logits)
             tokens = jnp.where(is_greedy, greedy_tokens, sampled_tokens)

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -51,6 +51,22 @@ def _distributed_sampling_candidates_per_shard() -> int:
     return 2 * _distributed_sampling_max_top_k()
 
 
+def _distributed_sampling_fits(mesh: Mesh, vocab_size: int) -> bool:
+    """Whether each vocab shard can provide the static candidate capacity."""
+    tensor_axes = ShardingAxisName.MLP_TENSOR
+    tensor_axes = tensor_axes if isinstance(tensor_axes, (tuple, list)) else (
+        tensor_axes, )
+    tensor_axes = tuple(axis for axis in tensor_axes
+                        if axis is not None and axis in mesh.axis_names)
+    if not tensor_axes:
+        return False
+    num_vocab_shards = 1
+    for axis in tensor_axes:
+        num_vocab_shards *= mesh.shape[axis]
+    local_vocab_size = vocab_size // num_vocab_shards
+    return local_vocab_size >= _distributed_sampling_candidates_per_shard()
+
+
 @dataclass
 class PromptLogprobsReqSnap:
     """Per-request state snapshotted at step N for use in get_output()."""
@@ -312,14 +328,6 @@ def sample(
         logits = logits + 0 * jnp.sum(
             tpu_sampling_metadata._cache_collision_dummy)
 
-    should_unshard_logits = not (envs.USE_DISTRIBUTED_TOPK_SAMPLING
-                                 or envs.SAMPLING_KEEP_SHARDED_LOGITS)
-    if tpu_sampling_metadata.do_sampling and should_unshard_logits:
-        # Unshard the logits explicitly to preserve the baseline execution path
-        # for models not enabling sharded sampling.
-        logits = jax.lax.with_sharding_constraint(
-            logits, NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
-
     greedy_tokens = jnp.argmax(logits, axis=-1)
     logits = logits.astype(jnp.float32)
     if not tpu_sampling_metadata.do_sampling:
@@ -329,16 +337,22 @@ def sample(
         is_greedy = tpu_sampling_metadata.temperature < _SAMPLING_EPS
 
         def sample_full_vocab(_):
+            full_logits = logits
+            if not envs.SAMPLING_KEEP_SHARDED_LOGITS:
+                full_logits = jax.lax.with_sharding_constraint(
+                    full_logits,
+                    NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
             processed_logits = _apply_sampling_transforms_microbatched(
-                logits, tpu_sampling_metadata)
+                full_logits, tpu_sampling_metadata)
             sampled_tokens = jax.random.categorical(rng, processed_logits)
             tokens = jnp.where(is_greedy, greedy_tokens, sampled_tokens)
-            output_logits = jnp.where(is_greedy[:, None], logits,
+            output_logits = jnp.where(is_greedy[:, None], full_logits,
                                       processed_logits)
             return tokens, output_logits
 
-        use_distributed_candidates = (envs.USE_DISTRIBUTED_TOPK_SAMPLING
-                                      and not tpu_sampling_metadata.logprobs)
+        use_distributed_candidates = (
+            not tpu_sampling_metadata.logprobs
+            and _distributed_sampling_fits(mesh, logits.shape[-1]))
         if use_distributed_candidates:
             # Candidate shapes use a trace-time maximum; each request's top-k
             # remains dynamic. Greedy and padded rows do not consume a sample.

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -54,8 +54,8 @@ def _distributed_sampling_candidates_per_shard() -> int:
 def _distributed_sampling_fits(mesh: Mesh, vocab_size: int) -> bool:
     """Whether each vocab shard can provide the static candidate capacity."""
     tensor_axes = ShardingAxisName.MLP_TENSOR
-    tensor_axes = tensor_axes if isinstance(tensor_axes, (tuple, list)) else (
-        tensor_axes, )
+    tensor_axes = tensor_axes if isinstance(tensor_axes,
+                                            (tuple, list)) else (tensor_axes, )
     tensor_axes = tuple(axis for axis in tensor_axes
                         if axis is not None and axis in mesh.axis_names)
     if not tensor_axes:
@@ -76,10 +76,10 @@ def _can_sample_distributed(
         tpu_sampling_metadata: TPUSupportedSamplingMetadata) -> jax.Array:
     """Whether every row is supported by distributed candidate sampling."""
     is_greedy = tpu_sampling_metadata.temperature < _SAMPLING_EPS
-    supported = ((tpu_sampling_metadata.top_k > 0) &
-                 (tpu_sampling_metadata.top_k <=
-                  _distributed_sampling_max_top_k()) &
-                 (tpu_sampling_metadata.top_p > 0.0))
+    supported = (
+        (tpu_sampling_metadata.top_k > 0) &
+        (tpu_sampling_metadata.top_k <= _distributed_sampling_max_top_k()) &
+        (tpu_sampling_metadata.top_p > 0.0))
     return jnp.all(is_greedy | supported)
 
 
@@ -172,8 +172,8 @@ def _merge_topk_candidates(
                                _distributed_sampling_max_top_k())
     threshold = jnp.take_along_axis(global_topk, top_k[:, None] - 1,
                                     axis=-1)[:, 0]
-    shard_candidates = candidate_values.reshape(
-        candidate_values.shape[0], -1, candidates_per_shard)
+    shard_candidates = candidate_values.reshape(candidate_values.shape[0], -1,
+                                                candidates_per_shard)
     shard_tails = shard_candidates[:, :, -1]
     incomplete = jnp.any(shard_tails >= threshold[:, None], axis=-1)
     topk_values = jnp.where(candidate_values >= threshold[:, None],
@@ -250,8 +250,8 @@ def _distributed_topk_sample(
                               _distributed_sampling_max_top_k())
         filtered_values, candidate_ids, incomplete = _merge_topk_candidates(
             candidate_values, candidate_ids, safe_top_k, local_top_p)
-        incomplete = jnp.logical_and(incomplete,
-                                     local_temperature >= _SAMPLING_EPS)
+        incomplete = jnp.logical_and(incomplete, local_temperature
+                                     >= _SAMPLING_EPS)
         sampled_positions = jax.random.categorical(sample_rng, filtered_values)
         sampled_ids = jnp.take_along_axis(candidate_ids,
                                           sampled_positions[:, None],
@@ -291,8 +291,8 @@ def sample(
 
         def sample_full_vocab(_):
             full_logits = jax.lax.with_sharding_constraint(
-                logits,
-                NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA, None)))
+                logits, NamedSharding(mesh, P(ShardingAxisName.ATTN_DATA,
+                                              None)))
             processed_logits = _apply_sampling_transforms(
                 full_logits, tpu_sampling_metadata)
             sampled_tokens = jax.random.categorical(rng, processed_logits)
@@ -301,9 +301,9 @@ def sample(
                                       processed_logits)
             return tokens, output_logits
 
-        use_distributed_candidates = (
-            allow_distributed_sampling
-            and _distributed_sampling_fits(mesh, logits.shape[-1]))
+        use_distributed_candidates = (allow_distributed_sampling
+                                      and _distributed_sampling_fits(
+                                          mesh, logits.shape[-1]))
         if use_distributed_candidates:
             # Candidate shapes use a trace-time maximum; each request's top-k
             # remains dynamic. Greedy and padded rows do not consume a sample.

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -32,7 +32,8 @@ from tpu_inference.layers.common.attention_metadata import (
     SharedAttentionMetadata, pcp_cache_page_buckets)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling import (
-    compute_and_gather_logprobs, compute_and_gather_prompt_logprobs, sample)
+    compute_and_gather_logprobs, compute_and_gather_prompt_logprobs,
+    distributed_sampling_allowed, sample)
 from tpu_inference.layers.jax.sample.sampling_metadata import \
     TPUSupportedSamplingMetadata
 from tpu_inference.logger import init_logger
@@ -1004,6 +1005,8 @@ class CompilationManager:
                         _cache_collision_dummy=_cache_collision_dummy,
                         do_sampling=do_sampling,
                         logprobs=logprobs)
+                    allow_distributed_sampling = distributed_sampling_allowed(
+                        logprobs, self.runner.model_config.logprobs_mode)
                     self._run_compilation(
                         f"worker{self.runner.rank} sample",
                         sample,
@@ -1011,10 +1014,15 @@ class CompilationManager:
                         self.runner.mesh,
                         logits,
                         sampling_metadata,
+                        call_kwargs={
+                            "allow_distributed_sampling":
+                            allow_distributed_sampling
+                        },
                         compile_only=False,
                         num_reqs=num_reqs,
                         do_sampling=do_sampling,
                         logprobs=logprobs,
+                        allow_distributed_sampling=allow_distributed_sampling,
                     )
 
         self._sampling_precompiled = True

--- a/tpu_inference/runner/decode_loop.py
+++ b/tpu_inference/runner/decode_loop.py
@@ -132,6 +132,10 @@ def _decode_core_impl(
     continue_decode_eos_check_interval: int = 1,
 ):
     has_logprobs = False if sampling_metadata is None else sampling_metadata.logprobs
+    from tpu_inference.layers.jax.sample.sampling import \
+        distributed_sampling_allowed
+    allow_distributed_sampling = distributed_sampling_allowed(
+        has_logprobs, logprobs_mode)
 
     def _run_one_step(step_idx, ct, am, pos, sl, kvc):
         step_rng = step_rngs[step_idx]
@@ -166,8 +170,12 @@ def _decode_core_impl(
         )
         logits = compute_logits_fn(state, hidden_states, None)
         logits = logits.astype(jnp.float32)
-        next_tokens, processed_logits = sample_fn(step_rng, mesh, logits,
-                                                  sampling_metadata)
+        next_tokens, processed_logits = sample_fn(
+            step_rng,
+            mesh,
+            logits,
+            sampling_metadata,
+            allow_distributed_sampling=allow_distributed_sampling)
         (new_active_mask, next_input_ids, new_positions, new_seq_lens,
          step_record_tokens, any_hit_eos) = _update_loop_state(
              next_tokens,
@@ -381,9 +389,10 @@ def continue_decode(
       model_fn: Stable model forward callable.
       compute_logits_fn: Stable logits callable.
       sample_fn: Stable sampling callable with signature
-        (rng, mesh, logits, sampling_metadata) -> (next_tokens, _). Must be a
-        stable object (not a per-call closure) so the jit cache persists;
-        per-call sampling data is threaded via `sampling_metadata`.
+        (rng, mesh, logits, sampling_metadata, allow_distributed_sampling=...)
+        -> (next_tokens, _). Must be a stable object (not a per-call closure)
+        so the jit cache persists; per-call sampling data is threaded via
+        `sampling_metadata`.
       init_state: Initial TpuSamplingState.
       kv_caches: KV caches. Donated into the fused loop and returned updated.
       max_decode_steps: Max steps to run (static loop bound).

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -63,7 +63,7 @@ from tpu_inference.layers.jax.sample.rejection_sampler import RejectionSampler
 from tpu_inference.layers.jax.sample.sampling import (
     PromptLogprobsAsyncData, PromptLogprobsReqSnap,
     _jax_logprobs_copy_to_host_async, compute_and_gather_logprobs,
-    compute_prompt_logprobs, sample)
+    compute_prompt_logprobs, distributed_sampling_allowed, sample)
 from tpu_inference.layers.jax.sample.sampling_metadata import \
     TPUSupportedSamplingMetadata
 from tpu_inference.logger import init_logger
@@ -2009,6 +2009,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             step_rng = self.rng_params_for_sampling
 
         processed_bonus_logits = None
+        allow_distributed_sampling = distributed_sampling_allowed(
+            tpu_sampling_metadata.logprobs, self.model_config.logprobs_mode)
         if spec_decode_metadata is None:
             logits = logits.astype(jnp.float32)
             with self.maybe_forbid_compile:
@@ -2017,6 +2019,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     self.mesh,
                     logits,
                     tpu_sampling_metadata,
+                    allow_distributed_sampling=allow_distributed_sampling,
                 )
         else:
             if tpu_sampling_metadata.do_sampling:
@@ -2032,6 +2035,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 self.mesh,
                 bonus_logits,
                 tpu_sampling_metadata,
+                allow_distributed_sampling=allow_distributed_sampling,
             )
             target_logits = self._select_from_array_fn(
                 logits, spec_decode_metadata.target_logits_indices, self.mesh,


### PR DESCRIPTION
### Summary
This PR introduces distributed candidate sampling and an option to retain vocabulary logits in sharded layout across TP shards during sampling to reduce latency and memory traffic:


1. **Retain Sharded Logits**: Avoids all-gathering the full 262k vocabulary logits prior to sampling, saving ~330µs. 
2. **Distributed Top-K Candidate Sampling (`DISTRIBUTED_SAMPLING_MAX_TOP_K`)**: Each TP shard extracts its top `2*DISTRIBUTED_SAMPLING_MAX_TOP_K` candidates locally. With the default maximum of, this gathers 128 candidates per shard (1,024 candidates across 8 shards), and applies each request's runtime top-k and top-p values.
3. **Exactness Guarantee**: Uses the requested top-k threshold and preserves boundary ties. It safely falls back to full-vocabulary sampling if a shard may have omitted candidates tied at threshold. 
4. **Safety & Fallbacks**:
   - `DISTRIBUTED_SAMPLING_MAX_TOP_K` defaults to 64 and controls the static compiled candidate capacity
   - Raw logprobs supported; processed logprobs modes use the full-vocabulary path when logprobs are requested
   - The full-vocabulary path explicitly unshards logits, preserving the existing fallback behaviour. 


### Benchmark Results
We tested on Gemma4 MoE model on v6e-8:
```
export DISTRIBUTED_SAMPLING_MAX_TOP_K=64
vllm serve google/gemma-4-26B-A4B-it \
  --max-model-len=4096 \
  --max-num-seqs=256 \
  --tensor-parallel-size=8 \
  --max-num-batched-tokens=4096 \
  --gpu-memory-utilization=0.85 \
  --async-scheduling \
  --kv-cache-dtype=fp8 \
  --limit-mm-per-prompt '{"image":0,"video":0,"audio":0}' \
  --block-size=128 \
  --additional-config \
  '{"sharding":{"sharding_strategy":{"tensor_parallelism":8,"expert_parallelism":1}}}'

vllm bench serve \
        --backend openai \
        --endpoint /v1/completions \
        --model google/gemma-4-26B-A4B-it \
        --port 8000 \
        --dataset-name random \
        --random-input-len 1024 \
        --random-output-len 128 \
        --request-rate inf \
        --num-prompts 500 \
        --ignore-eos
```
- Reduced `jit(sample)` latency from 19.3 ms to 2.9 ms (-85%).
<img width="552" height="307" alt="Screenshot 2026-09-10 at 10 20 17 PM" src="https://github.com/user-attachments/assets/4f93f5ef-96af-4270-b46c-2009a5e83022" />

<img width="326" height="296" alt="Screenshot 2026-09-10 at 10 19 07 PM" src="https://github.com/user-attachments/assets/8a50aca4-c5c3-48c0-9496-91e55bc48d53" />


### Tests Added
- `test_distributed_candidates_match_full_vocab_filters`
- `test_distributed_candidates_preserve_topk_boundary_tie`
- `test_distributed_candidates_detect_truncated_tie_group`
- Env var tests in `tests/test_envs.py`
