### PR TITLE
[Maxtext] Fix MoE EP support and GDN recurrent state sharding

### DIFF
--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -224,6 +224,7 @@ class ShardingConfigManager:
         decode_context_parallelism = parallel_config.decode_context_parallel_size
         prefill_context_parallelism = parallel_config.prefill_context_parallel_size
 
+        expert_parallelism = sharding_strategy.get("expert_parallelism", None)
         if expert_parallelism is None:
             if parallel_config.enable_expert_parallel:
                 expert_parallelism = pc_tensor_parallelism

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -218,18 +218,24 @@ class ShardingConfigManager:
                                                     False)
         if envs.TPU_MULTIPROCESS_DP:
             data_parallelism = 1
-        expert_parallelism = sharding_strategy.get("expert_parallelism", 1)
         sequence_parallelism = sharding_strategy.get("sequence_parallelism", 1)
         device_indexes = sharding_strategy.get("device_indexes", None)
 
         decode_context_parallelism = parallel_config.decode_context_parallel_size
         prefill_context_parallelism = parallel_config.prefill_context_parallel_size
 
-        if pc_tensor_parallelism != ss_tensor_parallelsim and ss_tensor_parallelsim:
-            # The user has explicitly set the tensor parallelism in the sharding config.
-            tensor_parallelism = ss_tensor_parallelsim
+        if expert_parallelism is None:
+            if parallel_config.enable_expert_parallel:
+                expert_parallelism = pc_tensor_parallelism
+                tensor_parallelism = 1
+            else:
+                expert_parallelism = 1
+                tensor_parallelism = pc_tensor_parallelism
         else:
-            tensor_parallelism = pc_tensor_parallelism
+            if pc_tensor_parallelism != ss_tensor_parallelsim and ss_tensor_parallelsim:
+                tensor_parallelism = ss_tensor_parallelsim
+            else:
+                tensor_parallelism = pc_tensor_parallelism
 
         if tensor_parallelism % decode_context_parallelism != 0:
             raise ValueError(

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -353,10 +353,45 @@ def get_flax_model(
                                pooler=pooler,
                                is_draft_model=is_draft_model)
     vllm_config.model_config.dtype = original_dtype
-    kv_cache_sharding = NamedSharding(
+
+    attn_kv_sharding = NamedSharding(
         mesh,
         PartitionSpec(ShardingAxisName.BATCH, ShardingAxisName.KV_CONTEXT,
                       ShardingAxisName.KV_HEAD))
+
+    gdn_conv_sharding = NamedSharding(
+        mesh,
+        PartitionSpec(ShardingAxisName.ATTN_DATA, None, ShardingAxisName.ATTN_HEAD))
+    gdn_ssm_sharding = NamedSharding(
+        mesh,
+        PartitionSpec(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None, None))
+    gdn_kv_sharding = (gdn_conv_sharding, gdn_ssm_sharding)
+
+    hf_cfg = vllm_config.model_config.hf_config
+    if isinstance(hf_cfg, dict):
+        text_cfg = hf_cfg.get("text_config", hf_cfg)
+        layer_types = text_cfg.get("layer_types", None)
+    else:
+        text_cfg = getattr(hf_cfg, "text_config", hf_cfg)
+        layer_types = getattr(text_cfg, "layer_types", None)
+        if layer_types is None and hasattr(hf_cfg, "to_dict"):
+            layer_types = hf_cfg.to_dict().get("text_config", {}).get("layer_types", None)
+    if layer_types:
+        kv_cache_sharding = [
+            gdn_kv_sharding if lt == "linear_attention" else attn_kv_sharding
+            for lt in layer_types
+        ]
+        logger.info(f"Successfully configured heterogeneous KV cache sharding for {len(layer_types)} layers "
+                    f"({layer_types.count('linear_attention')} GDN layers, {layer_types.count('full_attention')} Full Attn layers).")
+    else:
+        interval = getattr(text_cfg, "full_attention_interval", 4) if not isinstance(text_cfg, dict) else text_cfg.get("full_attention_interval", 4)
+        num_layers = getattr(text_cfg, "num_hidden_layers", 40) if not isinstance(text_cfg, dict) else text_cfg.get("num_hidden_layers", 40)
+        kv_cache_sharding = [
+            attn_kv_sharding if (i + 1) % interval == 0 else gdn_kv_sharding
+            for i in range(num_layers)
+        ]
+        logger.info(f"Fallback configured KV cache sharding with interval={interval}, total_layers={num_layers}.")
+
     hidden_states_sharding = NamedSharding(mesh,
                                            PartitionSpec(
                                                ShardingAxisName.ATTN_DATA,


### PR DESCRIPTION
# Description

This PR fixes two major communication bottlenecks in MaxText/JAX inference on TPU:
1. **Honor `--enable-expert-parallel` in `ShardingConfigManager`**:
   - Previously, `expert_parallelism` defaulted to 1 because `parallel_config.enable_expert_parallel` was ignored, causing all 256 experts to replicate on every device and triggering redundant token `All-Gather` before MoE layers.
   - Now properly routes devices to `expert_parallelism` when EP is enabled.
2. **Fix GDN Recurrent State Sharding**:
   - In `model_loader.py`, correctly extract `layer_types` from `text_config` (for composite/hybrid architectures like Qwen 3.5).
   - Prevents GDN layers from falling back to 3D attention KV cache sharding (`PartitionSpec(BATCH, KV_CONTEXT, KV_HEAD)`), which previously mis-sharded the recurrent state along Dim 2 (key_dim) and caused an expensive 538 MB `All-to-All` collective on every GDN step.
   - Sets correct 4D sharding `PartitionSpec(ATTN_DATA, ATTN_HEAD, None, None)`.

FIXES: b/549307194

# Tests

- Verified on TPU VM (v7x) with Qwen3.5-35B:
  - Confirmed pre-MoE `all-gather` is eliminated when running with EP.
  - Confirmed GDN `all-to-all` is eliminated and recurrent state maintains `[pages, heads, d_k, d_v]` sharding across decode steps.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
