### PR TITLE
[Fix] Gemma4-26B-A4B failed due to qwix tried to quantize tensor that already in FP8

### DIFF
--- a/.buildkite/benchmark/cases/daily/Gemma4-26B-dataset_custom-inlen_1024-outlen_500.json
+++ b/.buildkite/benchmark/cases/daily/Gemma4-26B-dataset_custom-inlen_1024-outlen_500.json
@@ -44,7 +44,7 @@
           "kv-cache-dtype": "fp8",
           "gpu-memory-utilization": 0.9,
           "async-scheduling": true,
-          "additional-config": "{\"quantization\": { \"qwix\": { \"rules\": [{ \"module_path\": \".*\", \"weight_qtype\": \"float8_e4m3fn\", \"act_qtype\": \"float8_e4m3fn\"}]}}}"
+          "additional-config": "{\"quantization\": { \"qwix\": { \"rules\": [{ \"module_path\": \".*experts.*\"}, { \"module_path\": \".*\", \"weight_qtype\": \"float8_e4m3fn\", \"act_qtype\": \"float8_e4m3fn\"}]}}}"
         }
       },
       "client_command_options": {
@@ -100,7 +100,7 @@
           "kv-cache-dtype": "fp8",
           "gpu-memory-utilization": 0.9,
           "async-scheduling": true,
-          "additional-config": "{\"quantization\": { \"qwix\": { \"rules\": [{ \"module_path\": \".*\", \"weight_qtype\": \"float8_e4m3fn\", \"act_qtype\": \"float8_e4m3fn\"}]}}, \"mm-encoder-tp-mode\": \"data\"}",
+          "additional-config": "{\"quantization\": { \"qwix\": { \"rules\": [{ \"module_path\": \".*experts.*\"}, { \"module_path\": \".*\", \"weight_qtype\": \"float8_e4m3fn\", \"act_qtype\": \"float8_e4m3fn\"}]}}, \"mm-encoder-tp-mode\": \"data\"}",
           "compilation-config": "{\"cudagraph_mm_encoder\": true}",
           "disable-chunked-mm-input": true
         }


### PR DESCRIPTION
### Description

Update the daily Gemma 4 26B benchmark configuration to exclude moe paths from qwix module_path to prevent double-quantization.

---
### Motivation/Why
The environment variable `MOE_REQUANTIZE_WEIGHT_DTYPE=float8_e4m3fn` requantizes Gemma 4 MoE expert
weights during model loading. The previous global QWiX rule also matched the
MoE expert subtree and attempted to apply QWiX FP8 quantization to values that
were already on the FP8 MoE path, which could trigger the Gemma 4 quantization error: `ValueError: Refuse to quantize: float8_e4m3fn`.

This commit makes qwix quantization to skip MoE expert subtrees to avoid double quantization.
  
The change is limited to the two daily benchmark server configurations:
- `Gemma4-26B-A4B-1k/500-GBS256`
- `Gemma4-26B-A4B-1k/1f512x512/500-GBS256`

---
### Verification
Trigger the buildkite test with argument:
```
MLCOMPASS_SELECT_TESTS="vllm:tpu_v7x_8_queue:Gemma4-26B-A4B-1k/500-GBS256,vllm:tpu_v7x_8_queue:Gemma4-26B-A4B-1k/1f512x512/500-GBS256"
UPLOAD_DB="false"
```

[buildkite test](https://buildkite.com/tpu-commons/tpu-inference-benchmark/builds/2371/list?sid=01a0614d-9e51-4d0e-a97b-0bfa306fb731&tab=output)   