### PR TITLE
[WIP] Debug PCP accuracy gap (gsm8k 0.80 vs 0.96) + fix PCP mamba boot crash

### DIFF
--- a/tests/layers/common/test_sharding.py
+++ b/tests/layers/common/test_sharding.py
@@ -329,14 +329,14 @@ class TestLazyShardingAxisName(unittest.TestCase):
     @patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", False)
     def test_use_2d_tp_selects_base(self):
         lazy = LazyShardingAxisName()
-        _ = lazy.SEQUENCE
+        _ = lazy.DENSE_DATA
         self.assertIs(lazy._cls, ShardingAxisNameBase)
 
     @patch("tpu_inference.layers.common.sharding.envs.USE_2D_TP", False)
     @patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN", False)
     def test_both_false_selects_2d(self):
         lazy = LazyShardingAxisName()
-        _ = lazy.SEQUENCE
+        _ = lazy.DENSE_DATA
         self.assertIs(lazy._cls, ShardingAxisName2D)
 
     def test_cls_cached_after_first_access(self):
@@ -345,7 +345,7 @@ class TestLazyShardingAxisName(unittest.TestCase):
                    False), \
              patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN",
                    False):
-            _ = lazy.SEQUENCE
+            _ = lazy.DENSE_DATA
             first_cls = lazy._cls
 
         # Even with different env vars, _cls should not change
@@ -353,7 +353,7 @@ class TestLazyShardingAxisName(unittest.TestCase):
                    True), \
              patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN",
                    True):
-            _ = lazy.SEQUENCE
+            _ = lazy.DENSE_DATA
             self.assertIs(lazy._cls, first_cls)
 
     def test_initialized_after_env_change_uses_new_value(self):
@@ -372,7 +372,7 @@ class TestLazyShardingAxisName(unittest.TestCase):
                    True), \
              patch("tpu_inference.layers.common.sharding.envs.NEW_MODEL_DESIGN",
                    False):
-            _ = lazy.SEQUENCE  # initialized here, after env changed
+            _ = lazy.DENSE_DATA  # initialized here, after env changed
             self.assertIs(lazy._cls, ShardingAxisNameBase)
 
 

--- a/tests/layers/vllm/test_fused_moe.py
+++ b/tests/layers/vllm/test_fused_moe.py
@@ -119,7 +119,7 @@ class TestMaybeReduceSharedExpertOutput:
 
     def test_passthrough_when_shared_output_none(self):
         runner = _make_runner()
-        with patch.object(fm, "_all_reduce_over_tp") as reduce:
+        with patch.object(fm, "_sum_partials") as reduce:
             assert runner._maybe_reduce_shared_expert_output(None) is None
         reduce.assert_not_called()
 
@@ -129,7 +129,7 @@ class TestMaybeReduceSharedExpertOutput:
         shared = torch.ones(2, 3)
         with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=True), \
-             patch.object(fm, "_all_reduce_over_tp") as reduce:
+             patch.object(fm, "_sum_partials") as reduce:
             out = runner._maybe_reduce_shared_expert_output(shared)
         reduce.assert_not_called()
         assert out is shared
@@ -141,7 +141,7 @@ class TestMaybeReduceSharedExpertOutput:
         shared = torch.ones(2, 3)
         with patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=False), \
-             patch.object(fm, "_all_reduce_over_tp") as reduce:
+             patch.object(fm, "_sum_partials") as reduce:
             out = runner._maybe_reduce_shared_expert_output(shared)
         reduce.assert_not_called()
         assert out is shared
@@ -155,26 +155,47 @@ class TestMaybeReduceSharedExpertOutput:
                           new_callable=PropertyMock, return_value=True), \
              patch.object(fm, "_get_mesh", return_value=mesh), \
              patch.object(fm, "is_attn_dp", return_value=False), \
-             patch.object(fm, "_all_reduce_over_tp",
+             patch.object(fm, "_sum_partials",
                           return_value=reduced) as reduce:
             out = runner._maybe_reduce_shared_expert_output(shared)
-        reduce.assert_called_once_with(shared, mesh,
-                                       fm.ShardingAxisName.MLP_TENSOR)
+        reduce.assert_called_once_with(shared)
         assert out is reduced
 
     def test_reduces_shared_output_under_attention_dp(self):
+        # Under attention DP the fused kernel reduces its own output, so the
+        # shared-expert partial stack is summed on the early path (its
+        # leading axis is sharded over the in-group TP axis). Drives the real
+        # ``_fused_output_is_reduced`` property via ``is_attn_dp``.
         runner = _make_runner(shared_experts=object())
         shared = torch.ones(2, 3)
         reduced = torch.full((2, 3), 7.0)
         mesh = object()
         with patch.object(fm, "_get_mesh", return_value=mesh), \
              patch.object(fm, "is_attn_dp", return_value=True), \
-             patch.object(fm, "_all_reduce_over_tp",
+             patch.object(fm, "_sum_partials",
                           return_value=reduced) as reduce:
             out = runner._maybe_reduce_shared_expert_output(shared)
-        reduce.assert_called_once_with(shared, mesh,
-                                       fm.ShardingAxisName.ATTN_HEAD)
+        reduce.assert_called_once_with(shared)
         assert out is reduced
+
+    def test_pcp_is_plain_tp(self):
+        # PCP is not attention DP (tokens are replicated over pcp outside
+        # attention, weights shard over pcp as extra TP), so a GMM backend
+        # whose reduction matches the shared expert's takes the deferred path:
+        # nothing is reduced early, shared + fused are reduced together late.
+        runner = _make_runner(shared_experts=object())
+        shared = torch.ones(2, 3)
+        with patch.object(fm, "_get_mesh", return_value=object()), \
+             patch.object(fm, "is_attn_dp", return_value=False), \
+             patch.object(fm, "select_moe_backend_from_fused_moe_config",
+                          return_value=MoEBackend.GMM_EP), \
+             patch.object(fm, "_gmm_and_shared_reduce_over_same_axes",
+                          return_value=True), \
+             patch.object(fm, "_sum_partials") as reduce:
+            assert runner._fused_output_is_reduced is False
+            out = runner._maybe_reduce_shared_expert_output(shared)
+        reduce.assert_not_called()
+        assert out is shared
 
 
 # ---------------------------------------------------------------------------
@@ -189,7 +210,7 @@ class TestMaybeReduceFinalOutput:
         states = torch.arange(8, dtype=torch.float32).reshape(2, 4)
         with patch.object(fm, "_get_mesh", return_value=object()), \
              patch.object(fm, "is_attn_dp", return_value=True), \
-             patch.object(fm, "_all_reduce_over_tp") as reduce:
+             patch.object(fm, "_sum_partials") as reduce:
             out = runner._maybe_reduce_final_output(states, trunc_size=3)
         reduce.assert_not_called()
         torch.testing.assert_close(out, states[..., :3])
@@ -201,7 +222,7 @@ class TestMaybeReduceFinalOutput:
              patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=False), \
-             patch.object(fm, "_all_reduce_over_tp") as reduce:
+             patch.object(fm, "_sum_partials") as reduce:
             out = runner._maybe_reduce_final_output(states, trunc_size=2)
         reduce.assert_not_called()
         torch.testing.assert_close(out, states[..., :2])
@@ -215,7 +236,7 @@ class TestMaybeReduceFinalOutput:
              patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=True), \
-             patch.object(fm, "_all_reduce_over_tp") as reduce:
+             patch.object(fm, "_sum_partials") as reduce:
             out = runner._maybe_reduce_final_output(states, trunc_size=2)
         reduce.assert_not_called()
         torch.testing.assert_close(out, states[..., :2])
@@ -229,9 +250,9 @@ class TestMaybeReduceFinalOutput:
              patch.object(fm, "is_attn_dp", return_value=False), \
              patch.object(fm.VllmMoERunner, "_fused_output_is_reduced",
                           new_callable=PropertyMock, return_value=False), \
-             patch.object(fm, "_all_reduce_over_tp",
+             patch.object(fm, "_sum_partials",
                           return_value=reduced) as reduce:
             out = runner._maybe_reduce_final_output(states, trunc_size=3)
-        reduce.assert_called_once_with(states, mesh)
+        reduce.assert_called_once_with(states)
         # Reduction happens first, then the padding is stripped.
         torch.testing.assert_close(out, reduced[..., :3])

--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -39,7 +39,7 @@ from vllm.model_executor.model_loader import get_model as vllm_get_model
 from tests.layers.common import utils as test_utils
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
-from tpu_inference.layers.vllm.custom_ops.fused_moe import _all_reduce_over_tp
+from tpu_inference.layers.vllm.custom_ops.fused_moe import _sum_partials
 from tpu_inference.layers.vllm.interface.moe import FusedMoEFactory
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.unquantized import (
@@ -212,9 +212,10 @@ def test_row_parallel_linear(model, bias, num_devices, enable_sp,
 @pytest.mark.parametrize("num_devices", [1, jax.local_device_count()])
 def test_row_parallel_linear_defer_all_reduce(model, num_devices):
     """reduce_results=False routes through sharded_matmul: the layer returns
-    per-shard partial sums (the psum is actually skipped, which a plain einsum
+    the per-shard partial sums stacked under a leading axis sharded over the
+    contraction axis (the psum is actually skipped, which a plain einsum
     under GSPMD cannot do) and the caller's single deferred all-reduce
-    (VllmMoERunner._all_reduce_over_tp) reconstructs the full result.
+    (VllmMoERunner._sum_partials) reconstructs the full result.
 
     No bias: vLLM's RowParallelLinear rejects reduce_results=False with an
     in-layer bias."""
@@ -278,10 +279,10 @@ def test_row_parallel_linear_defer_all_reduce(model, num_devices):
         if num_devices > 1:
             # The psum was actually skipped: pre-reduction output is partial,
             # not the full matmul.
-            partial = j2t(deferred.to(torch.float32)).to(dtype)
+            partial = j2t(deferred[0].to(torch.float32)).to(dtype)
             assert not torch.allclose(partial, expected)
 
-        reduced = _all_reduce_over_tp(deferred, mesh)
+        reduced = _sum_partials(deferred)
         jax_output = j2t(reduced.to(torch.float32)).to(dtype)
 
     torch.testing.assert_close(expected, jax_output)

--- a/tpu_inference/layers/common/attention_interface.py
+++ b/tpu_inference/layers/common/attention_interface.py
@@ -38,6 +38,7 @@ from tpu_inference.layers.common.attention_metadata import (
     AttentionMetadata, SharedAttentionMetadata)
 from tpu_inference.layers.common.cp_attention import dcp_forward, pcp_forward
 from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.common.utils import replicate_kv_heads_for_tp
 from tpu_inference.logger import init_logger
 from tpu_inference.utils import get_megacore, get_mesh_shape_product
 
@@ -424,20 +425,10 @@ def sharded_ragged_paged_attention(
     attn_logits_soft_cap: float | None = None,
 ):
     """Shards along KV heads."""
-    # Handle GQA/MQA where num_kv_heads < tp_size
-    # We replicate KV heads to match tp_size so that we can shard them evenly.
+    # Handle GQA/MQA where num_kv_heads < tp_size: replicate KV heads so the
+    # head dim shards evenly.
     # TODO (ranlihao): This is not performant and introduces extra overhead during inference. We need to handle this during weight loading
-    tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
-    if tp_size > 1:
-        num_kv_heads = k.shape[1]
-        if num_kv_heads < tp_size:
-            if tp_size % num_kv_heads != 0:
-                raise ValueError(
-                    f"For GQA/MQA, tp_size {tp_size} must be divisible by num_kv_heads {num_kv_heads}"
-                )
-            factor = tp_size // num_kv_heads
-            k = jnp.repeat(k, factor, axis=1)
-            v = jnp.repeat(v, factor, axis=1)
+    k, v = replicate_kv_heads_for_tp(mesh, k, v)
 
     qkv_spec = P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None)
     kv_cache_spec = P(ShardingAxisName.ATTN_DATA, None,

--- a/tpu_inference/layers/common/cp_attention.py
+++ b/tpu_inference/layers/common/cp_attention.py
@@ -22,6 +22,7 @@ from jax.sharding import PartitionSpec as P
 import tpu_inference.kernels.experimental.rpa_v3_cp.kernel as rpa_v3_cp
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
 from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.layers.common.utils import replicate_kv_heads_for_tp
 from tpu_inference.logger import init_logger
 from tpu_inference.utils import get_mesh_shape_product
 
@@ -174,17 +175,7 @@ def dcp_forward(
     dcp_size = mesh.shape[dcp_axis]
 
     # GQA/MQA: replicate KV heads to match ATTN_HEAD sharding before shard_map.
-    tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
-    if tp_size > 1:
-        num_kv_heads = k.shape[1]
-        if num_kv_heads < tp_size:
-            if tp_size % num_kv_heads != 0:
-                raise ValueError(
-                    f"tp_size {tp_size} must be divisible by num_kv_heads {num_kv_heads}"
-                )
-            factor = tp_size // num_kv_heads
-            k = jnp.repeat(k, factor, axis=1)
-            v = jnp.repeat(v, factor, axis=1)
+    k, v = replicate_kv_heads_for_tp(mesh, k, v)
 
     cp_rank_global = jnp.arange(dcp_size, dtype=jnp.int32)
 
@@ -291,8 +282,12 @@ def pcp_forward(
       2. current phase         local Q (head+tail) attends all-gathered current KV
       3. merge_attn_states     lse-weighted combine
     """
-    pcp_axis = ShardingAxisName.PREFILL_CONTEXT
+    pcp_axis = ShardingAxisName.PCP
     pcp_size = get_mesh_shape_product(mesh, pcp_axis)
+
+    # GQA/MQA: replicate KV heads to match ATTN_HEAD sharding, mirroring
+    # dcp_forward — tp may exceed the head count (e.g. NKV=2 at tp=4).
+    k, v = replicate_kv_heads_for_tp(mesh, k, v)
     two_p = 2 * pcp_size
     padded_q_len = q.shape[0]
     C = padded_q_len // two_p

--- a/tpu_inference/layers/common/fused_moe_gmm.py
+++ b/tpu_inference/layers/common/fused_moe_gmm.py
@@ -325,11 +325,15 @@ def moe_gmm_local(x: jax.Array,
                 out = jax.lax.psum(chunk_hidden,
                                    axis_name=reduction_axis).astype(x.dtype)
             else:
-                out = chunk_hidden.astype(x.dtype)
+                # Deferred: hand the partial out under a leading axis sharded
+                # over the reduction axis (an honest sharding, summed later by
+                # linear.sum_partials) rather than a replicated out_spec.
+                out = chunk_hidden.astype(x.dtype)[None]
         out_list.append(out)
 
-    return jnp.concatenate(out_list,
-                           axis=0) if len(out_list) > 1 else out_list[0]
+    if len(out_list) == 1:
+        return out_list[0]
+    return jnp.concatenate(out_list, axis=1 if defer_all_reduce else 0)
 
 
 def tensor_parallel_gmm(
@@ -372,6 +376,9 @@ def tensor_parallel_gmm(
 
     if scatter_results:
         final_out_specs = attn_data_p_spec
+    elif defer_all_reduce:
+        final_out_specs = P(ShardingAxisName.MLP_TENSOR,
+                            ShardingAxisName.MLP_DATA)
     else:
         final_out_specs = data_p_spec
 
@@ -457,6 +464,8 @@ def expert_parallel_gmm(
         final_out_specs = attn_data_p_spec
     elif enable_rs_kernel:
         final_out_specs = ep_data_p_spec
+    elif defer_all_reduce:
+        final_out_specs = P(ShardingAxisName.EXPERT, ShardingAxisName.MLP_DATA)
     else:
         final_out_specs = data_p_spec
 
@@ -785,4 +794,4 @@ def fused_moe_func(
             defer_all_reduce=defer_all_reduce,
         )
 
-    return x[:num_tokens, :hidden_size]
+    return x[..., :num_tokens, :hidden_size]

--- a/tpu_inference/layers/common/gdn_attention.py
+++ b/tpu_inference/layers/common/gdn_attention.py
@@ -100,37 +100,38 @@ def run_jax_gdn_attention(
         read_state_indices = state_indices
 
     in_specs = (
-        P(ShardingAxisName.ATTN_DATA,
-          ShardingAxisName.ATTN_HEAD),  # j_mixed_qkv
-        P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD),  # j_b
-        P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD),  # j_a
-        P(ShardingAxisName.ATTN_DATA, None,
-          ShardingAxisName.ATTN_HEAD),  # conv_state
-        P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None,
+        P(ShardingAxisName.DENSE_DATA,
+          ShardingAxisName.DENSE_TENSOR),  # j_mixed_qkv
+        P(ShardingAxisName.DENSE_DATA, ShardingAxisName.DENSE_TENSOR),  # j_b
+        P(ShardingAxisName.DENSE_DATA, ShardingAxisName.DENSE_TENSOR),  # j_a
+        P(ShardingAxisName.DENSE_DATA, None,
+          ShardingAxisName.DENSE_TENSOR),  # conv_state
+        P(ShardingAxisName.DENSE_DATA, ShardingAxisName.DENSE_TENSOR, None,
           None),  # recurrent_state
-        P(ShardingAxisName.ATTN_HEAD, None, None),  # j_conv_weight
-        P(ShardingAxisName.ATTN_HEAD)
+        P(ShardingAxisName.DENSE_TENSOR, None, None),  # j_conv_weight
+        P(ShardingAxisName.DENSE_TENSOR)
         if j_conv_bias is not None else None,  # j_conv_bias
-        P(ShardingAxisName.ATTN_HEAD),  # j_A_log
-        P(ShardingAxisName.ATTN_HEAD),  # j_dt_bias
-        P(ShardingAxisName.ATTN_DATA),  # query_start_loc
-        P(ShardingAxisName.ATTN_DATA),  # state_indices
-        P(ShardingAxisName.ATTN_DATA),  # distribution
-        P(ShardingAxisName.ATTN_DATA),  # seq_lens
-        P(ShardingAxisName.ATTN_DATA),  # read_state_indices
+        P(ShardingAxisName.DENSE_TENSOR),  # j_A_log
+        P(ShardingAxisName.DENSE_TENSOR),  # j_dt_bias
+        P(ShardingAxisName.DENSE_DATA),  # query_start_loc
+        P(ShardingAxisName.DENSE_DATA),  # state_indices
+        P(ShardingAxisName.DENSE_DATA),  # distribution
+        P(ShardingAxisName.DENSE_DATA),  # seq_lens
+        P(ShardingAxisName.DENSE_DATA),  # read_state_indices
     )
 
     out_specs = (
         (
-            P(ShardingAxisName.ATTN_DATA, None,
-              ShardingAxisName.ATTN_HEAD),  # new_conv_state
-            P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None,
+            P(ShardingAxisName.DENSE_DATA, None,
+              ShardingAxisName.DENSE_TENSOR),  # new_conv_state
+            P(ShardingAxisName.DENSE_DATA, ShardingAxisName.DENSE_TENSOR, None,
               None),  # new_recurrent_state
         ),
-        P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD),  # output
+        P(ShardingAxisName.DENSE_DATA,
+          ShardingAxisName.DENSE_TENSOR),  # output
     )
 
-    tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
+    tp_size = get_mesh_shape_product(mesh, ShardingAxisName.DENSE_TENSOR)
 
     p_run_jax_gdn_attention_local = functools.partial(
         wrapper.fused_conv1d_gdn,

--- a/tpu_inference/layers/common/linear.py
+++ b/tpu_inference/layers/common/linear.py
@@ -90,13 +90,32 @@ def xla_quantized_matmul(
     return out.astype(x.dtype)
 
 
+def _axes(spec_entry):
+    if spec_entry is None:
+        return ()
+    return spec_entry if isinstance(spec_entry, tuple) else (spec_entry, )
+
+
+def sum_partials(partials: jax.Array) -> jax.Array:
+    """Reduce the leading partial axis produced by a deferred matmul (or a
+    deferred fused MoE): one all-reduce over the axis it is sharded on."""
+    return jnp.sum(partials, axis=0)
+
+
 def sharded_matmul(x: jax.Array,
                    w: jax.Array,
                    weight_sharding: P | NamedSharding,
+                   input_sharding: P,
+                   output_sharding: P,
                    *,
                    mesh: Mesh | None = None,
                    defer_all_reduce: bool = False) -> jax.Array:
     """Matmul that can skip its all-reduce (``defer_all_reduce=True``).
+
+    ``weight_sharding``, ``input_sharding`` and ``output_sharding`` are the
+    shard_map specs of w, x and the result, decided by the layer's
+    QuantLinearConfig. x may carry extra leading batch dims after its token
+    dim.
 
     A plain einsum under GSPMD is always all-reduced by the partitioner, so it
     runs in shard_map. No bias: vLLM's RowParallelLinear rejects
@@ -105,25 +124,43 @@ def sharded_matmul(x: jax.Array,
     if isinstance(weight_sharding, NamedSharding):
         mesh = mesh or weight_sharding.mesh
         weight_sharding = weight_sharding.spec
-    in_axis, out_axis = weight_sharding
-    # x may have extra leading batch dims.
+    in_axis, _ = weight_sharding
     batch_dims = (None, ) * (x.ndim - 2)
-    x_spec = P(ShardingAxisName.ATTN_DATA, *batch_dims, in_axis)
+    input_sharding = P(input_sharding[0], *batch_dims, input_sharding[-1])
+    output_sharding = P(*output_sharding[:-1], *batch_dims,
+                        output_sharding[-1])
+    in_tokens = _axes(input_sharding[0])
+    out_tokens = _axes(output_sharding[-2])
+
+    # The attention q/k/v layer has already pinned its input replicated
+    # over pcp (VllmColumnParallelLinear.forward); this slices it to the
+    # matmul's token layout.
     x = jax.lax.with_sharding_constraint(
         x,
-        NamedSharding(mesh, x_spec) if mesh else x_spec)
+        NamedSharding(mesh, input_sharding) if mesh else input_sharding)
 
     def wrapper(x, w):
         out = x @ w
-        if in_axis and not defer_all_reduce:
+        if in_axis is not None:
+            if defer_all_reduce:
+                # Hand the partial sums out under a leading axis sharded
+                # over the contraction axis (see sum_partials): a partial
+                # must never leave shard_map declared replicated, XLA takes
+                # that as a promise.
+                return out[None]
             out = jax.lax.psum(out, axis_name=in_axis)
+        # All-gather any token axis the output no longer splits over (an
+        # attention out-projection under pcp rejoins the replicated residual).
+        for axis in in_tokens:
+            if axis not in out_tokens and jax.lax.axis_size(axis) > 1:
+                out = jax.lax.all_gather(out, axis, axis=0, tiled=True)
         return out
 
     return jax.shard_map(
         wrapper,
         mesh=mesh,
-        in_specs=(x_spec, weight_sharding),
-        out_specs=P(ShardingAxisName.ATTN_DATA, *batch_dims, out_axis),
+        in_specs=(input_sharding, weight_sharding),
+        out_specs=output_sharding,
         check_vma=False,
     )(x, w)
 
@@ -132,6 +169,8 @@ def sharded_quantized_matmul(x: jax.Array,
                              w_q: jax.Array,
                              w_s: jax.Array,
                              weight_sharding: P | NamedSharding,
+                             input_sharding: P,
+                             output_sharding: P,
                              *,
                              mesh: Mesh | None = None,
                              defer_all_reduce: bool = False,
@@ -144,6 +183,8 @@ def sharded_quantized_matmul(x: jax.Array,
         w_q: Weight quantized array. [n_input_features, n_output_features]
         w_s: Weight quantization scale. [n_output_features] for xla quantized matmul, [n_blocks, 1, n_output_features] for quantized matmul kernel
         weight_sharding: PartitionSpec or NamedSharding for the weight tensor.
+        input_sharding, output_sharding: PartitionSpecs of x and of the result,
+            decided by the layer's QuantLinearConfig.
         mesh: (Optional) Mesh to shard on. If None, mesh from current context is used, similar to jax.shard_map().
         defer_all_reduce: (Optional) If True, defer the all-reduce (psum) over
             the contracting (in) axis: it is not performed here even when that
@@ -167,7 +208,8 @@ def sharded_quantized_matmul(x: jax.Array,
     # NOTE (jacobplatin/kyuyeunk) there have been numeric issues (concerning) NaNs
     # with the kernel and thus we disable it for now.
     in_axis, out_axis = weight_spec
-    x_sharding = P(ShardingAxisName.ATTN_DATA, in_axis)
+    in_tokens = _axes(input_sharding[0])
+    out_tokens = _axes(output_sharding[-2])
     enable_quantized_matmul_kernel = w_s is not None and (len(
         w_s.shape) == 3 or len(w_s.shape) == 4)
     if enable_quantized_matmul_kernel:
@@ -186,11 +228,11 @@ def sharded_quantized_matmul(x: jax.Array,
         else:
             # 1D (channelwise) case
             scale_sharding = P(out_axis, )
-    out_sharding = P(ShardingAxisName.ATTN_DATA, out_axis)
-
+    # x was pinned replicated over pcp by the attention layer if needed
+    # (VllmColumnParallelLinear.forward); slice it to the matmul's layout.
     x = jax.lax.with_sharding_constraint(
         x,
-        NamedSharding(mesh, x_sharding) if mesh else x_sharding)
+        NamedSharding(mesh, input_sharding) if mesh else input_sharding)
 
     def wrapper(x, w_q, w_s):
         if enable_quantized_matmul_kernel:
@@ -210,15 +252,25 @@ def sharded_quantized_matmul(x: jax.Array,
                                           w_q,
                                           w_s,
                                           quantize_activation=maybe_quantize_x)
-        if in_axis and not defer_all_reduce:
+        if in_axis is not None:
+            if defer_all_reduce:
+                # Partial sums under a leading axis sharded over the
+                # contraction axis (see sum_partials): a partial must never
+                # leave shard_map declared replicated.
+                return output[None]
             output = jax.lax.psum(output, axis_name=in_axis)
+        # All-gather any token axis the output no longer splits over (an
+        # attention out-projection under pcp rejoins the replicated residual).
+        for axis in in_tokens:
+            if axis not in out_tokens and jax.lax.axis_size(axis) > 1:
+                output = jax.lax.all_gather(output, axis, axis=0, tiled=True)
         return output
 
     return jax.shard_map(
         wrapper,
         mesh=mesh,
-        in_specs=(x_sharding, weight_spec, scale_sharding),
-        out_specs=(out_sharding),
+        in_specs=(input_sharding, weight_spec, scale_sharding),
+        out_specs=output_sharding,
         check_vma=False,
     )(x, w_q, w_s)
 

--- a/tpu_inference/layers/common/quantization/configs.py
+++ b/tpu_inference/layers/common/quantization/configs.py
@@ -25,24 +25,42 @@ class QuantLinearConfig:
                  *,
                  enable_sp: bool,
                  output_sizes: list[int],
-                 weight_sharding: P | None = None,
+                 weight_sharding: P,
+                 input_sharding: P,
+                 output_sharding: P,
+                 deferred_output_sharding: P | None = None,
                  defer_all_reduce: bool = False):
         # Output size across all TP ranks.
         self.output_sizes = output_sizes
-        self.weight_sharding = weight_sharding if weight_sharding is not None else P(
-            None, None)
+        # shard_map specs of the matmul's weight, x and result; a row-parallel
+        # layer that may hand out its partial sums instead of reducing them
+        # (see set_defer_all_reduce) also gives that output's spec.
+        self.weight_sharding = weight_sharding
+        self.input_sharding = input_sharding
+        self.output_sharding = output_sharding
+        self._reduced_output_sharding = output_sharding
+        self.deferred_output_sharding = deferred_output_sharding
+        # Attention q/k/v takes the residual stream (replicated over pcp,
+        # DENSE_DATA) but works on tokens split over pcp (ATTN_DATA). The
+        # layer pins the input replicated before the matmul slices it, so
+        # the split layout does not propagate back into the residual (see
+        # VllmColumnParallelLinear.forward). False for every other layer.
+        self.pin_input_replicated = False
         self.fuse_matmuls = True
         self.enable_sp = enable_sp
-        self.input_sharding = None
-        self.output_sharding = None
+        # Sequence parallelism: layouts the layer's activations are resharded
+        # to around the matmul (None = leave them as they arrive).
+        self.sp_input_sharding = None
+        self.sp_output_sharding = None
         self.mesh = None
 
         # If True, defer the all-reduce (psum) over the contracting (in) axis of
         # the matmul: it is not performed here even when that axis is sharded.
-        # The matmul then returns per-shard partial sums and the caller is
-        # responsible for reducing them later (e.g. fusing the reduction with a
-        # downstream collective).
-        self.defer_all_reduce = defer_all_reduce
+        # The matmul then returns the per-shard partial sums stacked under a
+        # leading axis, and the caller reduces them later (sum_partials).
+        self.defer_all_reduce = False
+        if defer_all_reduce:
+            self.set_defer_all_reduce(True)
 
         self.bias_sharding = P(self.weight_sharding[1])
         # n_shards is always the TP degree for the weight's output axis, derived
@@ -53,3 +71,14 @@ class QuantLinearConfig:
         self.enable_quantized_matmul_kernel = envs.ENABLE_QUANTIZED_MATMUL_KERNEL
         self.requant_block_size = envs.REQUANTIZE_BLOCK_SIZE
         self.requant_weight_dtype = to_jax_dtype(envs.REQUANTIZE_WEIGHT_DTYPE)
+
+    def set_defer_all_reduce(self, defer_all_reduce: bool) -> None:
+        """Whether a row-parallel matmul hands out its partial sums instead
+        of reducing them; the output spec follows."""
+        if defer_all_reduce:
+            assert self.deferred_output_sharding is not None, (
+                "no deferred_output_sharding for this layer")
+            self.output_sharding = self.deferred_output_sharding
+        else:
+            self.output_sharding = self._reduced_output_sharding
+        self.defer_all_reduce = defer_all_reduce

--- a/tpu_inference/layers/common/quantization/fp8.py
+++ b/tpu_inference/layers/common/quantization/fp8.py
@@ -52,6 +52,8 @@ class Fp8LinearMethod:
             weight_jax,
             weight_scale_jax,
             self.linear_config.weight_sharding,
+            self.linear_config.input_sharding,
+            self.linear_config.output_sharding,
             mesh=self.linear_config.mesh,
             defer_all_reduce=self.linear_config.defer_all_reduce)
 
@@ -75,6 +77,8 @@ class Fp8LinearMethod:
                 weight,
                 weight_scale,
                 self.linear_config.weight_sharding,
+                self.linear_config.input_sharding,
+                self.linear_config.output_sharding,
                 mesh=mesh,
                 defer_all_reduce=self.linear_config.defer_all_reduce)
 

--- a/tpu_inference/layers/common/quantization/unquantized.py
+++ b/tpu_inference/layers/common/quantization/unquantized.py
@@ -61,6 +61,8 @@ class UnquantizedLinearMethod:
                 x_jax,
                 weight_jax,
                 self.linear_config.weight_sharding,
+                self.linear_config.input_sharding,
+                self.linear_config.output_sharding,
                 mesh=self.linear_config.mesh,
                 defer_all_reduce=self.linear_config.defer_all_reduce,
             )

--- a/tpu_inference/layers/common/sharding.py
+++ b/tpu_inference/layers/common/sharding.py
@@ -36,7 +36,7 @@ MESH_AXIS_NAMES_2D = ('data', 'model')
 
 class ShardingAxisNameBase:
     """Base class for sharding axis names."""
-    SEQUENCE = (
+    DENSE_DATA = (
         'data',
         'attn_dp',
         'attn_dp_expert',
@@ -45,6 +45,11 @@ class ShardingAxisNameBase:
     ATTN_DATA_EXPERT = ('attn_dp_expert', 'expert')
     MLP_DATA = 'data'
     ATTN_HEAD = ('model', 'expert', 'dcp')  # Q heads
+    # Tensor axis for layers whose tokens are replicated across pcp (their
+    # token axis is DENSE_DATA): GDN, MLPs, shared experts, routers, norms.
+    # Only softmax attention keeps tokens split over pcp (ATTN_DATA /
+    # ATTN_HEAD); everything else treats pcp as extra tensor parallelism.
+    DENSE_TENSOR = ('model', 'expert', 'dcp', 'pcp')
     KV_HEAD = ('model', 'expert')
     ATTN_TENSOR = None
     MLP_TENSOR = ('attn_dp', 'attn_dp_expert', 'expert', 'model', 'dcp', 'pcp')
@@ -64,7 +69,7 @@ class ShardingAxisNameBase:
     KV_CONTEXT = ('pcp', 'dcp')
 
     # PCP input sharding
-    PREFILL_CONTEXT = 'pcp'
+    PCP = 'pcp'
 
     # Vision encoder sharding axes
     VIT_BATCH = ('data', 'attn_dp', 'attn_dp_expert')
@@ -77,8 +82,9 @@ class ShardingAxisName2D:
     We should use ShardingAxisNameBase once the new MoE kernel supports
     more general mesh shapes. For now, this is the default sharding axes.
     """
-    SEQUENCE = 'data'
+    DENSE_DATA = 'data'
     ATTN_DATA = 'data'
+    DENSE_TENSOR = 'model'
     MLP_DATA = 'data'
     ATTN_HEAD = 'model'
     KV_HEAD = 'model'
@@ -90,7 +96,7 @@ class ShardingAxisName2D:
     VOCAB = ('data', 'model')
     BATCH = 'data'
     KV_CONTEXT = None
-    PREFILL_CONTEXT = None
+    PCP = None
 
     MODEL = 'model'
 
@@ -139,16 +145,12 @@ ShardingAxisName = LazyShardingAxisName()
 
 
 def is_attn_dp(mesh: Mesh) -> bool:
-    """Whether attention data-parallelism is active on ``mesh``.
-
-    True when the attention-data axes carry a factor beyond plain data
-    parallelism (i.e. ``attn_dp`` * ``attn_dp_expert`` > 1), meaning attention
-    is replicated over more data-parallel shards than the MLP/data axis alone.
-    """
-    attn_dp_size = utils.get_mesh_shape_product(mesh,
-                                                ShardingAxisName.ATTN_DATA)
-    dp_size = utils.get_mesh_shape_product(mesh, ShardingAxisName.MLP_DATA)
-    return (attn_dp_size // dp_size) > 1
+    """Whether attention data parallelism is active on ``mesh``: the attn_dp
+    axes split the token stream into independent request groups. 'pcp' does
+    not count — it splits within a request, and outside attention tokens
+    are replicated over it (plain TP)."""
+    return utils.get_mesh_shape_product(mesh,
+                                        ['attn_dp', 'attn_dp_expert']) > 1
 
 
 @dataclass

--- a/tpu_inference/layers/common/utils.py
+++ b/tpu_inference/layers/common/utils.py
@@ -178,3 +178,26 @@ def cpu_mesh() -> Mesh:
 def cpu_mesh_context():
     """A context to enforce using CPU mesh, used for loading weights on CPU."""
     return jax.set_mesh(cpu_mesh())
+
+
+def replicate_kv_heads_for_tp(mesh, k, v):
+    """Replicate KV heads (dim 1) when the head-sharding axis exceeds them.
+
+    GQA/MQA models can have fewer KV heads than the ATTN_HEAD mesh product;
+    replicating makes the head dim evenly shardable. Returns (k, v) unchanged
+    when no replication is needed.
+    """
+    from tpu_inference.layers.common.sharding import ShardingAxisName
+    from tpu_inference.utils import get_mesh_shape_product
+    tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
+    if tp_size > 1:
+        num_kv_heads = k.shape[1]
+        if num_kv_heads < tp_size:
+            if tp_size % num_kv_heads != 0:
+                raise ValueError(
+                    f"For GQA/MQA, tp_size {tp_size} must be divisible by "
+                    f"num_kv_heads {num_kv_heads}")
+            factor = tp_size // num_kv_heads
+            k = jnp.repeat(k, factor, axis=1)
+            v = jnp.repeat(v, factor, axis=1)
+    return k, v

--- a/tpu_inference/layers/jax/quantization/configs.py
+++ b/tpu_inference/layers/jax/quantization/configs.py
@@ -20,6 +20,7 @@ import jax
 
 from tpu_inference.layers.common.quantization.configs import \
     QuantLinearConfig as CommonQuantLinearConfig
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax import JaxModule
 from tpu_inference.layers.jax.quantization import QuantizeMethodBase
 
@@ -185,15 +186,23 @@ class QuantLinearConfig(CommonQuantLinearConfig):
             output_sizes = layer.output_sizes
         else:
             output_sizes = [math.prod(self.out_features)]
-        super().__init__(enable_sp=enable_sp, output_sizes=output_sizes)
-
-        # Update weight_sharding and bias_sharding for 2D matmul compatibility
+        # 2D matmul view of the weight; JAX-native layers work on tokens
+        # split over ATTN_DATA.
         if self.batch_features:
-            self.weight_sharding = _to_partition_spec(
-                weight.get_metadata().get("out_sharding", ()))
+            weight_sharding = _to_partition_spec(weight.get_metadata().get(
+                "out_sharding", ()))
         else:
-            self.weight_sharding = jax.sharding.PartitionSpec(
+            weight_sharding = jax.sharding.PartitionSpec(
                 *(self.in_features_sharding + self.out_features_sharding))
+        in_axis, = self.in_features_sharding
+        out_axis, = self.out_features_sharding
+        super().__init__(enable_sp=enable_sp,
+                         output_sizes=output_sizes,
+                         weight_sharding=weight_sharding,
+                         input_sharding=jax.sharding.PartitionSpec(
+                             ShardingAxisName.ATTN_DATA, in_axis),
+                         output_sharding=jax.sharding.PartitionSpec(
+                             ShardingAxisName.ATTN_DATA, out_axis))
 
         self.bias_sharding = jax.sharding.PartitionSpec(
             *self.out_features_sharding)

--- a/tpu_inference/layers/jax/quantization/unquantized.py
+++ b/tpu_inference/layers/jax/quantization/unquantized.py
@@ -29,6 +29,7 @@ from tpu_inference.layers.common.process_weights.moe_weights import (
     shard_moe_weights)
 from tpu_inference.layers.common.quantization import unquantized as jax_common
 from tpu_inference.layers.common.quantization.configs import QuantLinearConfig
+from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.common.utils import (
     cpu_mesh_context, reorder_concatenated_tensor_for_sharding)
 from tpu_inference.layers.jax import JaxModule
@@ -358,11 +359,16 @@ class UnquantizedConfig(QuantizationConfig):
             # Read the weight's partition spec so n_shards = get_mesh_shape_product
             # picks up the TP degree from the active mesh automatically.
             sharding = layer.weight.get_metadata().get("out_sharding", None)
-            weight_sharding = P(*sharding) if sharding is not None else None
-            linear_config = QuantLinearConfig(enable_sp=False,
-                                              output_sizes=list(
-                                                  layer.output_sizes),
-                                              weight_sharding=weight_sharding)
+            weight_sharding = P(
+                *sharding) if sharding is not None else P(None, None)
+            # A column projection on tokens split over ATTN_DATA.
+            linear_config = QuantLinearConfig(
+                enable_sp=False,
+                output_sizes=list(layer.output_sizes),
+                weight_sharding=weight_sharding,
+                input_sharding=P(ShardingAxisName.ATTN_DATA, None),
+                output_sharding=P(ShardingAxisName.ATTN_DATA,
+                                  weight_sharding[1]))
             return UnquantizedMergedLinearMethod(linear_config)
         if isinstance(layer, JaxEinsum):
             # Derive output's last dim from the einsum string.
@@ -371,8 +377,13 @@ class UnquantizedConfig(QuantizationConfig):
             last_out_char = einsum_str.split("->")[1][-1]
             out_size = layer.kernel_shape[w_axis.index(last_out_char)]
 
-            linear_config = QuantLinearConfig(enable_sp=False,
-                                              output_sizes=[out_size])
+            # Applied through the einsum path: the 2D specs are not used.
+            linear_config = QuantLinearConfig(
+                enable_sp=False,
+                output_sizes=[out_size],
+                weight_sharding=P(None, None),
+                input_sharding=P(ShardingAxisName.ATTN_DATA, None),
+                output_sharding=P(ShardingAxisName.ATTN_DATA, None))
             return UnquantizedLinearMethod(linear_config)
         if isinstance(layer, (JaxRoutedExperts, JaxMoE)):
             return UnquantizedFusedMoEMethod(layer)

--- a/tpu_inference/layers/vllm/custom_ops/fused_moe.py
+++ b/tpu_inference/layers/vllm/custom_ops/fused_moe.py
@@ -12,14 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import jax
 import torch
 from jax.sharding import Mesh
-from jax.sharding import PartitionSpec as P
-from torchax.interop import jax_view, shard_map, torch_view
+from torchax.interop import jax_view, torch_view
 from vllm.logger import init_logger
 from vllm.model_executor.layers.fused_moe.runner.moe_runner import MoERunner
 
+from tpu_inference.layers.common.linear import sum_partials
 from tpu_inference.layers.common.moe import MoEBackend
 from tpu_inference.layers.common.sharding import ShardingAxisName, is_attn_dp
 from tpu_inference.layers.vllm.interface.moe import \
@@ -39,24 +38,17 @@ def _get_mesh() -> Mesh | None:
         return None
 
 
-def _all_reduce_over_tp(t: torch.Tensor,
-                        mesh: Mesh,
-                        axis_name=None) -> torch.Tensor:
-    """All-reduce an unreduced local sum over the TP axis."""
-    if axis_name is None:
-        axis_name = ShardingAxisName.MLP_TENSOR
-    spec = P(ShardingAxisName.ATTN_DATA, None)
-
-    @shard_map(mesh=mesh, in_specs=spec, out_specs=spec, check_vma=False)
-    def _reduce(x):
-        return jax.lax.psum(x, axis_name=axis_name)
-
-    return torch_view(_reduce(jax_view(t)))
+def _sum_partials(t: torch.Tensor) -> torch.Tensor:
+    """Reduce the leading partial axis of a deferred (unreduced) output — a
+    shared expert's down_proj and/or the fused experts — with one all-reduce
+    (see linear.sum_partials)."""
+    return torch_view(sum_partials(jax_view(t)))
 
 
 def _gmm_and_shared_reduce_over_same_axes(mesh: Mesh,
                                           moe_backend: MoEBackend) -> bool:
-    """Whether the GMM reduction collapses exactly the shared expert's TP axes.
+    """Whether the GMM reduction collapses exactly the shared expert's TP axes
+    (DENSE_TENSOR, the axis its linears shard over).
 
     Only axes that actually shard (size > 1) on ``mesh`` count, so axis-name
     tuples that differ only in size-1 axes still match.
@@ -69,7 +61,7 @@ def _gmm_and_shared_reduce_over_same_axes(mesh: Mesh,
         return frozenset(a for a in axes
                          if get_mesh_shape_product(mesh, a) > 1)
 
-    return effective(gmm_axis) == effective(ShardingAxisName.MLP_TENSOR)
+    return effective(gmm_axis) == effective(ShardingAxisName.DENSE_TENSOR)
 
 
 @MoERunner.register_oot
@@ -121,9 +113,10 @@ class VllmMoERunner(MoERunner):
         """Early all-reduce path: reduce the shared-expert output on its own.
 
         When the fused kernel already reduced its output, the shared-expert
-        output (produced unreduced by its RowParallelLinear, whose all-reduce
-        was skipped via ``reduce_results=False``) must be reduced separately so the
-        two match before being summed downstream. Under sequence parallelism a
+        output (a ``[n_shards, tokens, hidden]`` partial stack from its
+        RowParallelLinear, whose all-reduce was skipped via
+        ``reduce_results=False``) must be reduced separately so the two match
+        before being summed downstream. Under sequence parallelism a
         separate all-gather step in the model handles this instead.
         """
         mesh = _get_mesh()
@@ -134,11 +127,12 @@ class VllmMoERunner(MoERunner):
         if fused_output_is_reduced is None:
             fused_output_is_reduced = self._fused_output_is_reduced
 
+        # The partial stack is sharded over the shared expert's own TP axis
+        # (DENSE_TENSOR; ATTN_HEAD under attention DP), so summing it is the
+        # right reduction on every mesh — PCP is plain TP here.
         if (shared_output is not None and fused_output_is_reduced
                 and not self.moe_config.is_sequence_parallel):
-            axis_name = (ShardingAxisName.ATTN_HEAD
-                         if is_attn_dp(mesh) else ShardingAxisName.MLP_TENSOR)
-            shared_output = _all_reduce_over_tp(shared_output, mesh, axis_name)
+            shared_output = _sum_partials(shared_output)
         return shared_output
 
     def _maybe_reduce_final_output(
@@ -150,10 +144,10 @@ class VllmMoERunner(MoERunner):
         """Late all-reduce path: reduce the combined (shared + fused) output.
 
         When the fused kernel did not reduce its output, the shared and fused
-        outputs were summed while still unreduced and the combined result is
-        all-reduced here in a single collective instead of two. Under attention-DP the
-        reduction is handled by a separate reduce-scatter pass in the model, so
-        only the padding is stripped here.
+        partial stacks were summed while still unreduced and the combined
+        result is all-reduced here in a single collective instead of two.
+        Under attention-DP the reduction is handled by a separate
+        reduce-scatter pass in the model, so only the padding is stripped here.
         """
         mesh = _get_mesh()
         if mesh is None:
@@ -166,5 +160,5 @@ class VllmMoERunner(MoERunner):
         is_sequence_parallel = self.moe_config.is_sequence_parallel
 
         if not is_dp and not is_sequence_parallel and not output_is_reduced:
-            states = _all_reduce_over_tp(states, mesh)
+            states = _sum_partials(states)
         return states[..., :trunc_size]

--- a/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
+++ b/tpu_inference/layers/vllm/custom_ops/gdn_attention_op.py
@@ -14,6 +14,7 @@
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import torch
 # NOTE: we don't specify this in our requirements.txt but it should be coming
 # from upstream vLLM
@@ -84,6 +85,26 @@ def gdn_attention_core_tpu(
     j_b = jax_view(b)
     j_a = jax_view(a)
 
+    # Under PCP the runner lays the token buffer out in head-tail rank order
+    # (tpu_runner row_perm) so attention ranks get contiguous chunks.  The GDN
+    # scan is sequential over tokens, so restore token order here and permute
+    # the output back below.  Tokens are replicated across pcp in the GDN
+    # domain (DENSE_DATA sharding), so both permutes are local gathers.
+    pcp_size = get_mesh_shape_product(mesh, ShardingAxisName.PCP)
+    if pcp_size > 1:
+        two_p = 2 * pcp_size
+        pcp_chunk = j_mixed_qkv.shape[0] // two_p
+        row = np.array(
+            [c for r in range(pcp_size) for c in (r, two_p - 1 - r)])
+        inv = np.empty_like(row)
+        inv[row] = np.arange(two_p)
+        tok_order = (jnp.arange(two_p)[inv, None] * pcp_chunk +
+                     jnp.arange(pcp_chunk)[None, :]).reshape(-1)
+        rank_order = (jnp.arange(two_p)[row, None] * pcp_chunk +
+                      jnp.arange(pcp_chunk)[None, :]).reshape(-1)
+        j_b = j_b[tok_order]
+        j_a = j_a[tok_order]
+
     j_conv_weight = jax_view(layer_module.conv1d.weight)
     j_conv_bias = jax_view(layer_module.conv1d.bias
                            ) if layer_module.conv1d.bias is not None else None
@@ -95,13 +116,18 @@ def gdn_attention_core_tpu(
     # Use reorder_concatenated_tensor_for_sharding to reorder into correct layout
     key_dim = n_kq * d_k
     value_dim = n_v * d_v
-    tp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_HEAD)
-    dp_size = get_mesh_shape_product(mesh, ShardingAxisName.ATTN_DATA)
+    tp_size = get_mesh_shape_product(mesh, ShardingAxisName.DENSE_TENSOR)
+    dp_size = get_mesh_shape_product(mesh, ShardingAxisName.DENSE_DATA)
 
     j_mixed_qkv = reorder_concatenated_tensor_for_sharding(
         j_mixed_qkv, [key_dim, key_dim, value_dim], tp_size, -1)
     j_conv_weight = reorder_concatenated_tensor_for_sharding(
         j_conv_weight, [key_dim, key_dim, value_dim], tp_size, 0)
+    if pcp_size > 1:
+        # Permute tokens after the feature reorder (they commute) so the
+        # linear's un-interleave and this re-interleave stay adjacent for XLA
+        # to fold into a shard-local op instead of resharding via all-to-all.
+        j_mixed_qkv = j_mixed_qkv[tok_order]
 
     layer_idx = vllm_context.layer_name_to_kvcache_index[layer_name]
     conv_state, recurrent_state = vllm_context.kv_caches[layer_idx]
@@ -186,6 +212,9 @@ def gdn_attention_core_tpu(
          mesh=mesh,
          read_state_indices=read_state_indices_sliced,
      )
+    if pcp_size > 1:
+        # Back to the runner's rank-order layout for the layers downstream.
+        j_output = j_output[rank_order]
     if state_len > kernel_size - 1:
         remaining_old_state = conv_state[:, kernel_size - 1:, :]
         new_conv_state = jnp.concatenate(

--- a/tpu_inference/layers/vllm/custom_ops/linear.py
+++ b/tpu_inference/layers/vllm/custom_ops/linear.py
@@ -15,6 +15,7 @@
 import jax
 import jax.numpy as jnp
 import torch
+from jax.sharding import NamedSharding
 from jax.sharding import PartitionSpec as P
 from torch.nn.parameter import Parameter
 from torchax.interop import jax_view, shard_map, torch_view
@@ -39,13 +40,29 @@ class VllmRowParallelLinear(RowParallelLinear):
 
         linear_config = getattr(self.quant_method, "linear_config", None)
         if linear_config is not None:
-            linear_config.defer_all_reduce = not self.reduce_results
+            linear_config.set_defer_all_reduce(not self.reduce_results)
 
     def forward(
         self,
         input_,
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
         return super().forward(input_)
+
+
+def _pin_input_replicated(module, input_):
+    """An attention q/k/v layer takes the residual stream, which is
+    replicated over pcp; pin that layout so the matmul's slice to the
+    attention token layout does not propagate the split back into the
+    residual (re-gathered before every dense layer). No-op unless the
+    layer's config marks it (attention column projections) and a mesh is
+    present."""
+    lc = getattr(getattr(module, "quant_method", None), "linear_config", None)
+    if lc is None or not getattr(lc, "pin_input_replicated", False) \
+            or lc.mesh is None:
+        return input_
+    spec = P(ShardingAxisName.DENSE_DATA, None)
+    input_.shard_(NamedSharding(lc.mesh, spec))  # in-place, returns None
+    return input_
 
 
 @ColumnParallelLinear.register_oot
@@ -55,7 +72,7 @@ class VllmColumnParallelLinear(ColumnParallelLinear):
         self,
         input_,
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
-        return super().forward(input_)
+        return super().forward(_pin_input_replicated(self, input_))
 
 
 @ReplicatedLinear.register_oot
@@ -159,6 +176,7 @@ class VllmQKVParallelLinear(QKVParallelLinear):
         self,
         x: torch.Tensor,
     ) -> torch.Tensor | tuple[torch.Tensor, Parameter | None]:
+        x = _pin_input_replicated(self, x)
         if self.num_kv_head_replicas == 1:
             return super().forward(x)
 

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a4_nvfp4.py
@@ -237,6 +237,8 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
             weight_jax,
             weight_scale_jax,
             self.linear_config.weight_sharding,
+            self.linear_config.input_sharding,
+            self.linear_config.output_sharding,
             mesh=self.linear_config.mesh,
             maybe_quantize_x=(self.activation_type != W4A4ActivationType.BF16),
         )
@@ -263,6 +265,8 @@ class VllmCompressedTensorsW4A4Fp4(CompressedTensorsW4A4Fp4):
                 weight_jax,
                 weight_scale_jax,
                 self.linear_config.weight_sharding,
+                self.linear_config.input_sharding,
+                self.linear_config.output_sharding,
                 mesh=self.linear_config.mesh,
                 maybe_quantize_x=(self.activation_type
                                   != W4A4ActivationType.BF16),

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w4a8_fp8.py
@@ -245,6 +245,8 @@ class VllmCompressedTensorsW4A8Fp8(CompressedTensorsW4A8Fp8):
             weight_jax,
             weight_scale_jax,
             self.linear_config.weight_sharding,
+            self.linear_config.input_sharding,
+            self.linear_config.output_sharding,
             mesh=self.linear_config.mesh,
             defer_all_reduce=self.linear_config.defer_all_reduce)
 
@@ -270,6 +272,8 @@ class VllmCompressedTensorsW4A8Fp8(CompressedTensorsW4A8Fp8):
                 weight_jax,
                 weight_scale_jax,
                 self.linear_config.weight_sharding,
+                self.linear_config.input_sharding,
+                self.linear_config.output_sharding,
                 mesh=self.linear_config.mesh,
                 defer_all_reduce=self.linear_config.defer_all_reduce,
             )

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_fp8.py
@@ -253,6 +253,8 @@ class VllmCompressedTensorsW8A8Fp8(CompressedTensorsW8A8Fp8):
                 weight_jax,
                 weight_scale_jax,
                 self.linear_config.weight_sharding,
+                self.linear_config.input_sharding,
+                self.linear_config.output_sharding,
                 mesh=self.linear_config.mesh,
                 defer_all_reduce=self.linear_config.defer_all_reduce)
 
@@ -298,6 +300,8 @@ class VllmCompressedTensorsW8A8Fp8(CompressedTensorsW8A8Fp8):
                     weight_jax,
                     weight_scale_jax,
                     self.linear_config.weight_sharding,
+                    self.linear_config.input_sharding,
+                    self.linear_config.output_sharding,
                     mesh=self.linear_config.mesh,
                     defer_all_reduce=self.linear_config.defer_all_reduce)
 

--- a/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
+++ b/tpu_inference/layers/vllm/quantization/compressed_tensors/schemes/compressed_tensors_w8a8_int8.py
@@ -200,6 +200,8 @@ class VllmCompressedTensorsW8A8Int8(CompressedTensorsW8A8Int8):
             weight_jax,
             weight_scale_jax,
             self.linear_config.weight_sharding,
+            self.linear_config.input_sharding,
+            self.linear_config.output_sharding,
             mesh=self.linear_config.mesh,
             defer_all_reduce=self.linear_config.defer_all_reduce,
         )
@@ -227,6 +229,8 @@ class VllmCompressedTensorsW8A8Int8(CompressedTensorsW8A8Int8):
                 weight_jax,
                 weight_scale_jax,
                 self.linear_config.weight_sharding,
+                self.linear_config.input_sharding,
+                self.linear_config.output_sharding,
                 mesh=self.linear_config.mesh,
                 defer_all_reduce=self.linear_config.defer_all_reduce,
             )

--- a/tpu_inference/layers/vllm/quantization/configs.py
+++ b/tpu_inference/layers/vllm/quantization/configs.py
@@ -43,25 +43,58 @@ class VllmQuantLinearConfig(QuantLinearConfig):
     def __init__(self, vllm_config: VllmConfig, mesh: Mesh, layer: LinearBase):
         assert isinstance(layer, LinearBase)
 
+        # Softmax attention keeps its tokens split over pcp (ATTN_DATA) and
+        # shards heads over ATTN_HEAD; every other linear — GDN projections,
+        # dense MLPs, shared experts, routers — sees tokens replicated over
+        # pcp (DENSE_DATA) and shards over DENSE_TENSOR, which also spans pcp.
+        # A reduced row-parallel output is always DENSE_DATA (an attention
+        # out-projection is gathered over pcp back onto the residual stream);
+        # a deferred one is the partial stack [n_shards, tokens, out].
+        if self._is_attention(layer):
+            tensor_axis, tokens = (ShardingAxisName.ATTN_HEAD,
+                                   ShardingAxisName.ATTN_DATA)
+        else:
+            tensor_axis, tokens = (ShardingAxisName.DENSE_TENSOR,
+                                   ShardingAxisName.DENSE_DATA)
+
+        deferred_output_sharding = None
+        pin_input_replicated = False
+        if isinstance(layer, RowParallelLinear):
+            weight_sharding = P(tensor_axis, None)
+            input_sharding = P(tokens, tensor_axis)
+            output_sharding = P(ShardingAxisName.DENSE_DATA, None)
+            deferred_output_sharding = P(tensor_axis, tokens, None)
+        elif isinstance(layer, ColumnParallelLinear):
+            weight_sharding = P(None, tensor_axis)
+            input_sharding = P(tokens, None)
+            output_sharding = P(tokens, tensor_axis)
+            pin_input_replicated = self._is_attention(layer)
+        elif isinstance(layer, ReplicatedLinear):
+            weight_sharding = P(None, None)
+            input_sharding = P(ShardingAxisName.DENSE_DATA, None)
+            output_sharding = P(ShardingAxisName.DENSE_DATA, None)
+        else:
+            raise NotImplementedError(
+                f"Unsupported linear layer type {type(layer)}")
+
         super().__init__(
             enable_sp=vllm_config.compilation_config.pass_config.enable_sp,
-            output_sizes=[layer.output_size])
+            output_sizes=[layer.output_size],
+            weight_sharding=weight_sharding,
+            input_sharding=input_sharding,
+            output_sharding=output_sharding,
+            deferred_output_sharding=deferred_output_sharding)
+        self.pin_input_replicated = pin_input_replicated
         self.mesh = mesh
         self.tp_size = get_mesh_shape_product(self.mesh,
                                               ShardingAxisName.MLP_TENSOR)
 
-        self.n_shards = get_mesh_shape_product(self.mesh,
-                                               self.weight_sharding[1])
-
         if isinstance(layer, RowParallelLinear):
-            self.weight_sharding = P(ShardingAxisName.ATTN_HEAD, None)
             if self.enable_sp:
-                self.output_sharding = P(ShardingAxisName.MLP_TENSOR, None)
+                self.sp_output_sharding = P(ShardingAxisName.MLP_TENSOR, None)
         elif isinstance(layer, ColumnParallelLinear):
-            self.weight_sharding = P(None, ShardingAxisName.ATTN_HEAD)
-
             if self.enable_sp:
-                self.input_sharding = P(ShardingAxisName.MLP_TENSOR, None)
+                self.sp_input_sharding = P(ShardingAxisName.MLP_TENSOR, None)
 
             if isinstance(layer, MergedColumnParallelLinear) or isinstance(
                     layer, QKVParallelLinear):
@@ -72,12 +105,6 @@ class VllmQuantLinearConfig(QuantLinearConfig):
                 vllm_config.scheduler_config.max_num_batched_tokens,
                 vllm_config.parallel_config.tensor_parallel_size,
                 layer._get_name())
-        elif isinstance(layer, ReplicatedLinear):
-            self.weight_sharding = P(None, None)
-        else:
-            logger.warning(
-                "Unsupported linear layer type of %s. Can potentially yield "
-                " bad performance.", type(layer))
 
         if isinstance(layer, QKVParallelLinear):
             self.num_proj = 3
@@ -90,6 +117,18 @@ class VllmQuantLinearConfig(QuantLinearConfig):
         self.n_shards = get_mesh_shape_product(self.mesh,
                                                self.weight_sharding[1])
 
+    @staticmethod
+    def _is_attention(layer: LinearBase) -> bool:
+        """Softmax-attention projection (q/k/v, o_proj)? o_proj and an MLP
+        down_proj are both RowParallelLinear, so attention is told apart by
+        the module path (self_attn.*, attn.*, attention.*); GDN's
+        linear_attn.* is not attention in this sense."""
+        if isinstance(layer, QKVParallelLinear):
+            return True
+        prefix = getattr(layer, "prefix", "")
+        return ("attn" in prefix
+                or "attention" in prefix) and "linear_attn" not in prefix
+
     def get_input_sharding(self, x: torchax.tensor.Tensor):
         if not self.enable_sp:
             return None
@@ -97,7 +136,7 @@ class VllmQuantLinearConfig(QuantLinearConfig):
         # NOTE(chengjiyao): make sure the sharded token_num is larger than TPU_SECOND_LAST_MINOR
         if token_num // self.tp_size < TPU_SECOND_LAST_MINOR:
             return None
-        return self.input_sharding
+        return self.sp_input_sharding
 
     def get_output_sharding(self, x: torchax.tensor.Tensor):
         if self.enable_sp:
@@ -105,7 +144,7 @@ class VllmQuantLinearConfig(QuantLinearConfig):
             # NOTE(chengjiyao): make sure the sharded token_num is larger than TPU_SECOND_LAST_MINOR
             if token_num // self.tp_size < TPU_SECOND_LAST_MINOR:
                 return None
-        return self.output_sharding
+        return self.sp_output_sharding
 
 
 class VllmQuantConfig:

--- a/tpu_inference/layers/vllm/quantization/nvfp4.py
+++ b/tpu_inference/layers/vllm/quantization/nvfp4.py
@@ -265,6 +265,8 @@ class VllmNvfp4LinearMethod(VllmUnquantizedLinearMethod):
             weight_jax,
             weight_scale_jax,
             self.linear_config.weight_sharding,
+            self.linear_config.input_sharding,
+            self.linear_config.output_sharding,
             mesh=self.linear_config.mesh,
             defer_all_reduce=self.linear_config.defer_all_reduce)
 
@@ -288,6 +290,8 @@ class VllmNvfp4LinearMethod(VllmUnquantizedLinearMethod):
                 weight,
                 weight_scale,
                 self.linear_config.weight_sharding,
+                self.linear_config.input_sharding,
+                self.linear_config.output_sharding,
                 mesh=mesh,
                 defer_all_reduce=self.linear_config.defer_all_reduce)
 

--- a/tpu_inference/models/vllm/vllm_model_wrapper.py
+++ b/tpu_inference/models/vllm/vllm_model_wrapper.py
@@ -480,7 +480,8 @@ class VllmModelWrapper:
             out_shardings=(
                 None,  # kv_caches - keep original sharding
                 NamedSharding(self.mesh,
-                              PartitionSpec(ShardingAxisName.ATTN_DATA, None)),
+                              PartitionSpec(ShardingAxisName.DENSE_DATA,
+                                            None)),
                 None,  # list of aux hidden states
                 None,  # expert ids
             ),
@@ -493,7 +494,8 @@ class VllmModelWrapper:
             out_shardings=(
                 None,  # kv_caches - keep original sharding
                 NamedSharding(self.mesh,
-                              PartitionSpec(ShardingAxisName.ATTN_DATA, None)),
+                              PartitionSpec(ShardingAxisName.DENSE_DATA,
+                                            None)),
                 None,  # empty list
                 None,  # expert ids
             ),

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -412,9 +412,8 @@ class CompilationManager:
         pcp = None
         if pcp_size > 1:
             n_reqs = self.runner.max_num_reqs
-            pcp_spec = NamedSharding(
-                self.runner.mesh,
-                PartitionSpec(ShardingAxisName.PREFILL_CONTEXT, None))
+            pcp_spec = NamedSharding(self.runner.mesh,
+                                     PartitionSpec(ShardingAxisName.PCP, None))
             repl = NamedSharding(self.runner.mesh, PartitionSpec())
             pcp = PCPMetadata(
                 query_start_loc=device_array(self.runner.mesh,
@@ -851,7 +850,6 @@ class CompilationManager:
                     array,
                     indices_to_select,
                     self.runner.mesh,
-                    self.runner.vllm_config.sharding_config.prefill_cp_size,
                     compile_only=True,
                     array_size=array_size,
                     index_size=indices_count,
@@ -1279,7 +1277,6 @@ class CompilationManager:
                     array,
                     indices_bonus,
                     self.runner.mesh,
-                    self.runner.vllm_config.sharding_config.prefill_cp_size,
                     num_logits=num_logits,
                     num_reqs=num_reqs,
                 )
@@ -1293,7 +1290,6 @@ class CompilationManager:
                     array,
                     indices_target,
                     self.runner.mesh,
-                    self.runner.vllm_config.sharding_config.prefill_cp_size,
                     num_logits=num_logits,
                 )
 

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -874,6 +874,15 @@ class KVCacheManager:
             mamba_num_blocks = (self._mamba_num_blocks
                                 if self._mamba_num_blocks is not None else
                                 num_blocks)
+            # The mamba cache shards axis 0 over ATTN_DATA (which includes pcp),
+            # but `num_blocks` above was only rounded to BATCH (no pcp). On the
+            # fallback path (`_mamba_num_blocks is None`: uniform sizing under
+            # mamba_cache_mode='align' or a pinned override) an odd count then
+            # fails the NamedSharding tiling check under PCP (e.g. 8121 % 8).
+            # Round down to the mamba axis-0 mesh product so it divides evenly.
+            mamba_divisor = common_utils.get_mesh_shape_product(
+                self.runner.mesh, ShardingAxisName.ATTN_DATA)
+            mamba_num_blocks = (mamba_num_blocks // mamba_divisor) * mamba_divisor
             if self.actual_mamba_num_blocks is None:
                 self.actual_mamba_num_blocks = mamba_num_blocks
 

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1712,14 +1712,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 full_hidden_states,
                 lora_metadata,
             )
-            logits = self._select_from_array_fn(
-                full_logits, logits_indices, self.mesh,
-                self.vllm_config.sharding_config.prefill_cp_size)
+            logits = self._select_from_array_fn(full_logits, logits_indices,
+                                                self.mesh)
         else:
             full_logits = None
-            hidden_states = self._select_from_array_fn(
-                hidden_states, logits_indices, self.mesh,
-                self.vllm_config.sharding_config.prefill_cp_size)
+            hidden_states = self._select_from_array_fn(hidden_states,
+                                                       logits_indices,
+                                                       self.mesh)
             logits = self.compute_logits_fn(
                 self.state_leaves,
                 hidden_states,
@@ -2025,8 +2024,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 bonus_rng = step_rng
                 rejection_rng = step_rng
             bonus_logits = self._select_from_array_fn(
-                logits, spec_decode_metadata.bonus_logits_indices, self.mesh,
-                self.vllm_config.sharding_config.prefill_cp_size)
+                logits, spec_decode_metadata.bonus_logits_indices, self.mesh)
             bonus_token_ids, processed_bonus_logits = sample(
                 bonus_rng,
                 self.mesh,
@@ -2034,8 +2032,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 tpu_sampling_metadata,
             )
             target_logits = self._select_from_array_fn(
-                logits, spec_decode_metadata.target_logits_indices, self.mesh,
-                self.vllm_config.sharding_config.prefill_cp_size)
+                logits, spec_decode_metadata.target_logits_indices, self.mesh)
             assert input_ids is not None
             draft_token_ids = self._extract_draft_token_ids(
                 input_ids, spec_decode_metadata.final_logits_indices,
@@ -2282,19 +2279,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         return model_runner_output
 
     @staticmethod
-    @functools.partial(jax.jit, static_argnums=(2, 3))
-    def _select_from_array_fn(array, indices_to_select, mesh, pcp_size=1):
+    @functools.partial(jax.jit, static_argnums=(2, ))
+    def _select_from_array_fn(array, indices_to_select, mesh):
 
         def select_local_fn(local_array, local_indices):
-            if pcp_size > 1:
-                # Under PCP each shard holds a slice of the sequence, so the
-                # rows named by `local_indices` may live on another shard.
-                # TODO(wenxindong): Remove the all-gather.
-                local_array = jax.lax.all_gather(
-                    local_array,
-                    ShardingAxisName.PREFILL_CONTEXT,
-                    axis=0,
-                    tiled=True)
             # XLA keeps the whole row-gather output in scoped VMEM, so one
             # gather of [n, vocab_shard] logits rows exceeds the 32M scoped
             # limit once n grows (e.g. spec decode with max_num_seqs=16:
@@ -2309,10 +2297,13 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             out = jax.lax.map(lambda ix: local_array[ix], idx)
             return out.reshape(-1, *local_array.shape[1:])[:n]
 
+        # The rows named by `local_indices` may live anywhere in the
+        # sequence under PCP, so the array is taken replicated over pcp
+        # (DENSE_DATA; the model returns hidden states that way).
         ret = jax.shard_map(
             select_local_fn,
             mesh=mesh,
-            in_specs=(PartitionSpec(ShardingAxisName.ATTN_DATA),
+            in_specs=(PartitionSpec(ShardingAxisName.DENSE_DATA),
                       PartitionSpec(ShardingAxisName.ATTN_DATA)),
             out_specs=PartitionSpec(ShardingAxisName.ATTN_DATA))(
                 array, indices_to_select)
@@ -2917,9 +2908,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 last % pcp_chunk_size)
             logits_indices_view[1:] = -1
 
-            pcp_spec = NamedSharding(
-                self.mesh, PartitionSpec(ShardingAxisName.PREFILL_CONTEXT,
-                                         None))
+            pcp_spec = NamedSharding(self.mesh,
+                                     PartitionSpec(ShardingAxisName.PCP, None))
             repl = NamedSharding(self.mesh, PartitionSpec())
             (pcp_query_start_loc,
              pcp_q_pos_offsets) = device_array(self.mesh,


### PR DESCRIPTION
## Summary

Debugging the PCP accuracy gap on Qwen3.5-35B-A3B-FP8 (gsm8k **pcp8 ≈ 0.80 vs tp8 ≈ 0.975**, coherent output). This PR contains one **confirmed fix** so far (a PCP+mamba startup crash) and documents the accuracy investigation; the accuracy root cause is narrowed but not yet closed — **draft / WIP**.

## Confirmed fix in this PR

**Round mamba cache `num_blocks` to the ATTN_DATA mesh product under PCP** (`runner/kv_cache_manager.py`). The mamba (GDN) state cache shards axis 0 over `ATTN_DATA` (includes `pcp`), but `num_blocks` was only rounded to `BATCH` (no `pcp`). On the uniform-sizing fallback path (`mamba_cache_mode='align'`, or a pinned `num_gpu_blocks_override`) the mamba block count inherits only the BATCH rounding, so an odd count fails JAX's `NamedSharding` tiling check under PCP (`8121 % 8 != 0` → `IndivisibleError` in `create_mamba_cache`) and the engine crashes at startup. Now rounded to the ATTN_DATA product; no-op on the compact path and when `pcp=1`.

This surfaced because the mamba-`align` prefix-caching path (now default-on for hybrid) takes the uniform-sizing fallback. Note also that **mamba-`align` prefix caching garbles hybrid output** (gsm8k `!!!!!` on cache hits) — accuracy runs must use `--no-enable-prefix-caching` until that is fixed separately.

## Accuracy investigation (0.80 → target 0.96), verified findings

Baseline (fp8 KV, prefix caching off, LIMIT=200, same problems):

| config | gsm8k |
|---|---|
| tp8 | 0.975 |
| pcp8 | 0.77–0.80 |

**Failure mode:** of 200 problems, 43 are tp-right/pcp-wrong; all are **coherent but mis-reasoned from early in the CoT** (wrong problem setup, not late arithmetic drift) → a degraded *prefill representation*, not decode numerical noise.

**Ruled out:**
- **Full-attention ring kernel precision.** Keeping softmax `p` fp32 in `rpa_v3_cp` (matching the TP kernel) left pcp8 at 0.80 (within noise). Also, single-chunk gsm8k prefill skips the cache-phase ring entirely (`cp_attention.py` `cache_pages==0`), so the ring is not on the critical path here.
- **GDN-under-PCP path.** The head-tail token un-permute (`gdn_attention_op.py`) is an exact inverse of the runner's `row_perm`; the metadata (`query_start_loc`/`seq_lens`/`distribution`) reduces GDN to one full-length natural-order sequence; and the head/state sharding over `DENSE_TENSOR` is identical between TP8 and PCP8 (only the mesh axis differs). Decisively, **GDN's output is invariant to the pcp count**, yet the accuracy is pcp-count-*dependent* (pcp8 ≈ 0.799 < tp4pcp2 ≈ 0.832) — so the loss cannot originate in GDN.

**Narrowed suspect:** the pcp-count-dependent loss lives where behavior scales with the number of head-tail chunks (`2·pcp`) — the **full-attention current-phase head-tail handling in `cp_attention.py`** (per-chunk `q_pos_offsets`, causal masking across the reordered head/tail chunks, and the `merge_attn_states` weighting), which is *not* the ring kernel and was not addressed by the precision experiment. Finer chunking (larger pcp) = more tail boundaries = more error, matching `pcp8 < tp4pcp2`.

**Decisive next experiment:** teacher-forced per-position argmax/logprob compare of TP8 vs PCP8 over all prompt positions, bucketed by natural position. Prediction: divergence concentrates in the last-chunk / tail-rank positions, pinpointing the current-phase tail handling.

## Status

- [x] Fix the PCP+mamba startup crash (this PR).
- [ ] Localize the current-phase head-tail divergence (teacher-forced position diff).
- [ ] Fix and verify pcp8 gsm8k → ~0.96.
