### PR TITLE
[Bugfix] Report HBM across all local chips in the get_memory_info shim

### DIFF
--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -50,6 +50,13 @@ if hasattr(torch, "accelerator") and hasattr(torch.accelerator,
             except AttributeError:
                 # Backend exposes no memory stats; callers that derive a budget
                 # from this take their minimum-work path instead of crashing.
+                # `logger` is resolved from module globals at call time, so it
+                # is defined by the time any caller reaches this branch.
+                logger.warning(
+                    "JAX backend exposes no memory stats; reporting 0 bytes "
+                    "free/total from torch.accelerator.get_memory_info(). "
+                    "Callers that size work by free HBM will fall back to "
+                    "their minimum-work path, which may hurt performance.")
                 return 0, 0
 
     torch.accelerator.get_memory_info = _patched_get_memory_info

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -25,28 +25,19 @@ if hasattr(torch, "accelerator") and hasattr(torch.accelerator, "empty_cache"):
 
     torch.accelerator.empty_cache = _patched_empty_cache
 
-# Monkeypatch torch.accelerator.get_memory_info to answer from the JAX device.
+# Monkeypatch torch.accelerator.get_memory_info to answer from the JAX devices.
 # torchax registers "jax" as a PrivateUse1 device, and torch.accelerator's memory
 # APIs resolve the device via torch._C._accelerator_getDeviceIndex(), which
 # raises "PyTorch is not linked with support for jax devices". vLLM model code
 # on the torchax path calls get_memory_info() to size work by free HBM (e.g.
 # Gemma4ForConditionalGeneration._process_image_input chunks the vision
 # encoder by it), and an unhandled raise there kills the EngineCore mid-request.
+# Delegate to TpuPlatform.mem_get_info() so the numbers stay SPMD-aggregated
+# across local devices, matching the global tensor dimensions the budget math
+# is expressed in.
 if hasattr(torch, "accelerator") and hasattr(torch.accelerator,
                                              "get_memory_info"):
     _orig_get_memory_info = torch.accelerator.get_memory_info
-
-    def _jax_device_memory_info() -> Tuple[int, int]:
-        """(free_bytes, total_bytes) of the first local JAX device.
-
-        Falls back to (0, 0) when the backend exposes no memory stats; callers
-        that derive a budget from it then take their minimum-work path instead
-        of crashing.
-        """
-        stats = jax.local_devices()[0].memory_stats() or {}
-        total = int(stats.get("bytes_limit", 0))
-        in_use = int(stats.get("bytes_in_use", 0))
-        return max(total - in_use, 0), total
 
     def _patched_get_memory_info(*args, **kwargs) -> Tuple[int, int]:
         try:
@@ -54,7 +45,12 @@ if hasattr(torch, "accelerator") and hasattr(torch.accelerator,
         except RuntimeError as e:
             if "jax" not in str(e):
                 raise
-            return _jax_device_memory_info()
+            try:
+                return TpuPlatform.mem_get_info()
+            except AttributeError:
+                # Backend exposes no memory stats; callers that derive a budget
+                # from this take their minimum-work path instead of crashing.
+                return 0, 0
 
     torch.accelerator.get_memory_info = _patched_get_memory_info
 from vllm.platforms.interface import Platform, PlatformEnum


### PR DESCRIPTION
# Description

The `torch.accelerator.get_memory_info` shim answered from `jax.local_devices()[0]` only, so on a multi-chip host it reported one chip's HBM. Callers on the torchax path size work by that number against global tensor dimensions (e.g. `Gemma4ForConditionalGeneration._process_image_input` chunks the vision encoder by free HBM), so a single-chip figure under-budgets by the number of local chips.

Delegate to the existing `TpuPlatform.mem_get_info()`, which already sums `bytes_limit`/`bytes_in_use` across all local devices for exactly this reason. The `(0, 0)` fallback when the backend exposes no memory stats is preserved, and unrelated `RuntimeError`s still propagate.

# Tests

No new tests — the existing shim coverage in `tests/platforms/test_tpu_platform.py` (`TestTorchAcceleratorGetMemoryInfoShim`, plus `test_mem_get_info`) still describes the intended behavior and passes unchanged:

```
pytest tests/platforms/test_tpu_platform.py -k "GetMemoryInfoShim or mem_get_info"
6 passed
```

# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
