### PR TITLE
[continue_decode] Skip the per-step EOS reduction when the EOS check is off

### DIFF
--- a/tests/runner/test_decode_loop.py
+++ b/tests/runner/test_decode_loop.py
@@ -17,7 +17,8 @@ import jax.numpy as jnp
 import numpy as np
 
 from tpu_inference.layers.common.attention_metadata import AttentionMetadata
-from tpu_inference.runner.decode_loop import (TpuSamplingState, _split_rngs,
+from tpu_inference.runner.decode_loop import (TpuSamplingState,
+                                              _decode_core_impl, _split_rngs,
                                               _update_loop_state,
                                               continue_decode)
 
@@ -406,6 +407,102 @@ def test_continue_decode_no_exit_on_eos():
     )
     assert np.array_equal(token_buffer, expected_tokens)
     assert np.array_equal(final_state.active_mask, [False, False])
+
+
+def _lower_decode_core(continue_decode_eos_check_interval):
+    """Lower the fused loop with stub model/sampler fns and return its HLO."""
+    batch_size = 2
+    static_argnames = (
+        "model_fn",
+        "compute_logits_fn",
+        "sample_fn",
+        "mesh",
+        "static_max_decode_steps",
+        "eos_token_id",
+        "padding_token_id",
+        "dp_size",
+        "pad_len",
+        "has_experts",
+        "expert_shape",
+        "expert_dtype",
+        "layer_name_to_kvcache_index",
+        "is_first_rank",
+        "is_last_rank",
+        "max_logprobs",
+        "logprobs_mode",
+        "continue_decode_eos_check_interval",
+    )
+
+    def mock_model_fn(state, kv_caches, current_tokens, attn_metadata, *args,
+                      **kwargs):
+        hidden_states = attn_metadata.input_positions.astype(jnp.float32)[:,
+                                                                          None,
+                                                                          None]
+        return kv_caches, hidden_states, None, None
+
+    def mock_compute_logits_fn(state, hidden_states, _):
+        logits = jnp.zeros((batch_size, 100))
+        return logits.at[:, 0].set(hidden_states[:, 0, 0])
+
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+        pos = logits[:, 0].astype(jnp.int32)
+        token_table = jnp.array(
+            [[42, 43], [44, 99], [99, 50], [60, 61], [70, 71]],
+            dtype=jnp.int32)
+        return token_table[pos, jnp.arange(batch_size)], None
+
+    step_rngs, _ = _split_rngs(jax.random.PRNGKey(0), 5, 5)
+    # jit directly rather than through continue_decode(): its jit carries
+    # compiler_options, which JAX rejects on a nested jit under .lower().
+    lowered = jax.jit(
+        _decode_core_impl, static_argnames=static_argnames
+    ).lower(
+        state={},
+        kv_caches=[jnp.zeros((2, 10))],
+        step_rngs=step_rngs,
+        sampling_metadata=None,
+        inputs_embeds=None,
+        lora_metadata=None,
+        intermediate_tensors=None,
+        block_tables=jnp.zeros((2, 16), dtype=jnp.int32),
+        query_start_loc=jnp.array([0, 1, 2], dtype=jnp.int32),
+        request_distribution=jnp.array([0, 0], dtype=jnp.int32),
+        mamba_state_indices=None,
+        current_tokens=jnp.array([10, 20], dtype=jnp.int32),
+        active_mask=jnp.array([True, True], dtype=jnp.bool_),
+        input_positions=jnp.array([0, 0], dtype=jnp.int32),
+        seq_lens=jnp.array([1, 1], dtype=jnp.int32),
+        model_fn=mock_model_fn,
+        compute_logits_fn=mock_compute_logits_fn,
+        sample_fn=mock_sample_fn,
+        mesh=None,
+        max_decode_steps=5,
+        static_max_decode_steps=5,
+        eos_token_id=(99, ),
+        padding_token_id=-1,
+        dp_size=1,
+        pad_len=0,
+        has_experts=False,
+        expert_shape=None,
+        expert_dtype=None,
+        layer_name_to_kvcache_index=(),
+        is_first_rank=True,
+        is_last_rank=True,
+        max_logprobs=0,
+        logprobs_mode="raw",
+        continue_decode_eos_check_interval=continue_decode_eos_check_interval,
+    )
+    return lowered.compile().as_text()
+
+
+def test_continue_decode_no_exit_on_eos_drops_eos_reduction():
+    """With the EOS check disabled, the compiled loop body must not reduce
+    the per-request EOS hits: cond_fn never reads the flag, so the carried
+    value is left untouched and the reduction (a cross-DP all-reduce on every
+    decode step in the multi-device program) is dead code.
+    """
+    assert "reduce_or" in _lower_decode_core(1)
+    assert "reduce_or" not in _lower_decode_core(-1)
 
 
 def test_continue_decode_exit_on_eos_interval():

--- a/tpu_inference/runner/decode_loop.py
+++ b/tpu_inference/runner/decode_loop.py
@@ -274,9 +274,16 @@ def _decode_core_impl(
             lp_ids_buf = lp_ids_buf.at[i].set(lp_ids_step)
             lp_val_buf = lp_val_buf.at[i].set(lp_val_step)
             lp_ranks_buf = lp_ranks_buf.at[i].set(lp_ranks_step)
+        if continue_decode_eos_check_interval <= 0:
+            # cond_fn never reads the EOS flag in this mode. Carrying it
+            # unchanged lets the compiler drop the per-step `any_hit_eos`
+            # reduction, which is a cross-DP all-reduce over every device
+            # on each decode iteration.
+            new_eos_flag = eos_flag
+        else:
+            new_eos_flag = jnp.logical_or(eos_flag, hit)
         return _pack(i + 1, next_ct, new_mask, new_pos, new_sl, kvc, tb, eb,
-                     lp_ids_buf, lp_val_buf, lp_ranks_buf,
-                     jnp.logical_or(eos_flag, hit))
+                     lp_ids_buf, lp_val_buf, lp_ranks_buf, new_eos_flag)
 
     init_carry = _pack(
         jnp.array(0, dtype=jnp.int32),


### PR DESCRIPTION
## Summary

With `CONTINUE_DECODE_EOS_CHECK_INTERVAL <= 0` the fused decode loop runs to its fixed depth and `cond_fn` never reads the carried EOS flag. The loop body still computed `any_hit_eos` on every iteration to update that flag: a reduction over the batch which, in the sharded program, is an all-reduce across every device once per decode step. In an xprof profile of a DP32 × TP4 GRPO rollout (Qwen3-0.6B, TPU v7x, `max_decode_steps=128`) it accounted for ~216 µs of a ~5.4 ms decode step.

This PR leaves the carried flag untouched in that mode, so the reduction is dead code and XLA drops it. Behavior with an EOS check interval ≥ 1 (the default) is unchanged: the flag is still accumulated and consulted exactly as before.

## Test

`test_continue_decode_no_exit_on_eos_drops_eos_reduction` lowers `_decode_core_impl` with stub model/sampler functions both ways and asserts the `reduce_or` is present in the compiled HLO with the check enabled and absent with it disabled. Existing decode-loop tests (early exit, run-to-depth, interval exit, experts) pass unchanged.
