### PR TITLE
[Runner] Cap the request ids attached to the execute_model trace annotation

### DIFF
--- a/tests/runner/test_utils.py
+++ b/tests/runner/test_utils.py
@@ -14,9 +14,10 @@ from jax._src.interpreters import pxla
 from jax._src.pallas.utils import next_power_of_2
 
 from tpu_inference.runner.utils import (
-    PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR, AggregatedStatsLogger,
-    ForbidCompile, InferencePhase, LatencyTracker, PhasedBasedProfiler,
-    determine_phase_from_batch_composition_stats, get_batch_composition_stats,
+    MAX_TRACED_REQUEST_IDS, PHASED_PROFILER_NUM_STEPS_TO_PROFILE_FOR,
+    AggregatedStatsLogger, ForbidCompile, InferencePhase, LatencyTracker,
+    PhasedBasedProfiler, determine_phase_from_batch_composition_stats,
+    extract_request_ids_for_tracing, get_batch_composition_stats,
     get_padded_num_reqs_with_upper_limit, get_padded_token_len,
     get_req_paddings, get_token_paddings)
 
@@ -98,6 +99,41 @@ def test_get_paddings():
     actual_paddings = get_token_paddings(min_token_size, max_token_size,
                                          padding_gap)
     assert actual_paddings == expected_paddings
+
+
+def _tracing_batch(num_reqs):
+    input_batch = MagicMock()
+    input_batch.num_reqs = num_reqs
+    input_batch.req_ids = [f"cmpl-{i}" for i in range(num_reqs)]
+    scheduler_output = MagicMock()
+    scheduler_output.num_scheduled_tokens = {
+        rid: 1
+        for rid in input_batch.req_ids
+    }
+    return input_batch, scheduler_output
+
+
+def test_extract_request_ids_for_tracing():
+    input_batch, scheduler_output = _tracing_batch(3)
+    scheduler_output.num_scheduled_tokens["cmpl-1"] = 0
+    kwargs = extract_request_ids_for_tracing(input_batch, scheduler_output)
+    # Requests with nothing scheduled this step are skipped; numbering is
+    # contiguous over the traced ones.
+    assert kwargs == {"request_id1": "cmpl-0", "request_id2": "cmpl-2"}
+
+
+def test_extract_request_ids_for_tracing_caps_kwargs():
+    num_reqs = MAX_TRACED_REQUEST_IDS + 500
+    input_batch, scheduler_output = _tracing_batch(num_reqs)
+    kwargs = extract_request_ids_for_tracing(input_batch, scheduler_output)
+    assert len(kwargs) == MAX_TRACED_REQUEST_IDS
+    assert kwargs["request_id1"] == "cmpl-0"
+    assert kwargs[f"request_id{MAX_TRACED_REQUEST_IDS}"] == (
+        f"cmpl-{MAX_TRACED_REQUEST_IDS - 1}")
+    # nanobind rejects calls with more than 1024 keyword arguments; the
+    # capped mapping must still be accepted by TraceAnnotation.
+    with jax.profiler.TraceAnnotation("execute_model", **kwargs):
+        pass
 
 
 def test_get_padded_token_len():

--- a/tpu_inference/runner/utils.py
+++ b/tpu_inference/runner/utils.py
@@ -62,11 +62,20 @@ def get_kv_transfer_metadata(kv: list[Any]) -> tuple[str, int]:
     return dims_str, kv_size_bytes
 
 
+# jax.profiler.TraceAnnotation is a nanobind function, and nanobind rejects
+# calls with more than 1024 keyword arguments. Keep the per-request kwargs
+# below that so a large batch cannot fail execute_model while tracing is on.
+MAX_TRACED_REQUEST_IDS = 1000
+
+
 def extract_request_ids_for_tracing(
     input_batch: InputBatch,
     scheduler_output: Optional[Any] = None,
 ) -> dict[str, str]:
-    """Extracts request IDs from an InputBatch and formats them for XProf tracing."""
+    """Extracts request IDs from an InputBatch and formats them for XProf tracing.
+
+    At most MAX_TRACED_REQUEST_IDS ids are returned (in batch order).
+    """
     req_id_kwargs = {}
     try:
         num_reqs = input_batch.num_reqs
@@ -84,6 +93,10 @@ def extract_request_ids_for_tracing(
                     continue
             active_req_ids.append(rid)
 
+        if len(active_req_ids) > MAX_TRACED_REQUEST_IDS:
+            logger.debug(f"Tracing only the first {MAX_TRACED_REQUEST_IDS} of "
+                         f"{len(active_req_ids)} active request IDs.")
+            active_req_ids = active_req_ids[:MAX_TRACED_REQUEST_IDS]
         trimmed_req_ids = [
             trim_request_id_suffix(rid) for rid in active_req_ids
         ]


### PR DESCRIPTION
## Summary

`extract_request_ids_for_tracing` turns every active request id into a keyword argument of `jax.profiler.TraceAnnotation`. That is a nanobind function, and nanobind rejects calls with more than 1024 keyword arguments. With profiling enabled and more than ~1024 requests scheduled in a step (large `max_num_seqs`, e.g. RL rollouts), `execute_model` fails with:

```
TypeError: nanobind::detail::nb_func_vectorcall(): too many (> 1024) keyword arguments.
```

This PR keeps at most `MAX_TRACED_REQUEST_IDS = 1000` ids (in batch order) and logs at debug level when the remainder is dropped. Batches below the cap are annotated exactly as before.

## Test

- `test_extract_request_ids_for_tracing`: requests with nothing scheduled are skipped and the numbering stays contiguous (the pre-existing behavior).
- `test_extract_request_ids_for_tracing_caps_kwargs`: 1500 active requests yield 1000 kwargs, the first and last are the expected ids, and the result is accepted by `jax.profiler.TraceAnnotation` (which reproduces the nanobind error without the cap).
