### PR TITLE
[Sampler] Sample from vocab-sharded logits instead of all-gathering the vocab

### DIFF
--- a/tests/layers/jax/sample/test_sampling.py
+++ b/tests/layers/jax/sample/test_sampling.py
@@ -16,16 +16,17 @@
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from jax.experimental import mesh_utils
 from jax.sharding import Mesh
 from vllm.v1.outputs import LogprobsTensors
 
+from tpu_inference import envs
 from tpu_inference.layers.common.sharding import ShardingAxisName
-from tpu_inference.layers.jax.sample.sampling import (PromptLogprobsAsyncData,
-                                                      PromptLogprobsReqSnap,
-                                                      compute_logprobs,
-                                                      compute_prompt_logprobs,
-                                                      gather_logprobs, sample)
+from tpu_inference.layers.jax.sample.sampling import (
+    PromptLogprobsAsyncData, PromptLogprobsReqSnap, _apply_sampling_transforms,
+    _can_sample_vocab_sharded, compute_logprobs, compute_prompt_logprobs,
+    gather_logprobs, sample, vocab_sharded_sampling_allowed)
 from tpu_inference.layers.jax.sample.sampling_metadata import \
     TPUSupportedSamplingMetadata
 
@@ -292,3 +293,156 @@ class TestComputePromptLogprobs:
         assert snap.start_idx == 0
         assert snap.num_logits == 2
         assert snap.is_last_chunk is False
+
+
+class TestVocabShardedSampling:
+    """Vocab-sharded sampling: sampling over per-shard candidates.
+
+    The mesh shards the vocab over every local device, so on a multi-device
+    host (or `--xla_force_host_platform_device_count`) the candidates really
+    are merged across shards; the assertions hold for any device count.
+    """
+
+    @staticmethod
+    def _mesh():
+        devices = np.array(jax.devices())
+        return Mesh(devices.reshape(1, -1), ("data", ShardingAxisName.MODEL))
+
+    @staticmethod
+    def _metadata(temperature, top_k, top_p):
+        return TPUSupportedSamplingMetadata(
+            temperature=jnp.asarray(temperature, dtype=jnp.float32),
+            top_k=jnp.asarray(top_k, dtype=jnp.int32),
+            top_p=jnp.asarray(top_p, dtype=jnp.float32),
+            _cache_collision_dummy=None,
+            do_sampling=True,
+            logprobs=False,
+        )
+
+    def _sample(self, monkeypatch, enabled, rng, logits, metadata):
+        del monkeypatch  # Kept so the call sites read the same as before.
+        tokens, _ = sample(rng,
+                           self._mesh(),
+                           logits,
+                           metadata,
+                           vocab_sharded=enabled)
+        return np.asarray(tokens)
+
+    @staticmethod
+    def _allowed(logits, metadata):
+        processed = _apply_sampling_transforms(logits, metadata)
+        return np.asarray(processed > -1e11)
+
+    def test_can_sample_vocab_sharded(self):
+        cap = envs.VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES
+        # Real rows with 0 < top_k <= cap and top_p > 0, plus padded slots
+        # (DEFAULT_SAMPLING_PARAMS: temperature -1, top_k 0) which are greedy.
+        ok = self._metadata([0.7, 1.0, -1.0, -1.0], [50, cap, 0, 0],
+                            [0.95, 1.0, 1.0, 1.0])
+        assert bool(_can_sample_vocab_sharded(ok))
+        # A real row without a top-k filter, or above the candidate budget,
+        # forces the replicated path.
+        no_top_k = self._metadata([0.7, 0.7], [50, 0], [1.0, 1.0])
+        assert not bool(_can_sample_vocab_sharded(no_top_k))
+        too_many = self._metadata([0.7, 0.7], [50, cap + 1], [1.0, 1.0])
+        assert not bool(_can_sample_vocab_sharded(too_many))
+        # Greedy rows are exact whatever their top_k.
+        greedy = self._metadata([0.0, 0.0], [0, cap + 1], [1.0, 1.0])
+        assert bool(_can_sample_vocab_sharded(greedy))
+
+    def test_greedy_rows_match_argmax(self, monkeypatch):
+        logits = jax.random.normal(jax.random.PRNGKey(1), (8, 1024))
+        # Rows 0-3 greedy (incl. padded-slot params), rows 4-7 sampled.
+        metadata = self._metadata([0.0, -1.0, 0.0, -1.0] + [0.7] * 4,
+                                  [0, 0, 5, 0] + [20] * 4,
+                                  [1.0, 1.0, 0.5, 1.0] + [0.9] * 4)
+        tokens = self._sample(monkeypatch, True, jax.random.PRNGKey(0), logits,
+                              metadata)
+        np.testing.assert_array_equal(
+            tokens[:4],
+            np.asarray(jnp.argmax(logits, axis=-1))[:4])
+
+    def test_greedy_ties_take_lowest_id(self, monkeypatch):
+        logits = jnp.zeros((2, 1024)).at[0, 7].set(3.0).at[0, 900].set(3.0)
+        logits = logits.at[1, 1023].set(2.0).at[1, 500].set(2.0)
+        metadata = self._metadata([0.0, 0.0], [0, 0], [1.0, 1.0])
+        tokens = self._sample(monkeypatch, True, jax.random.PRNGKey(0), logits,
+                              metadata)
+        np.testing.assert_array_equal(tokens, [7, 500])
+
+    def test_sampled_tokens_stay_in_top_k_top_p_set(self, monkeypatch):
+        logits = 3.0 * jax.random.normal(jax.random.PRNGKey(2), (64, 1024))
+        metadata = self._metadata([0.7] * 64, [20] * 64, [0.9] * 64)
+        allowed = self._allowed(logits, metadata)
+        for seed in range(4):
+            tokens = self._sample(monkeypatch, True, jax.random.PRNGKey(seed),
+                                  logits, metadata)
+            assert allowed[np.arange(64), tokens].all()
+
+    def test_distribution_matches_replicated_path(self, monkeypatch):
+        num_rows, vocab = 8192, 256
+        row = 2.0 * jax.random.normal(jax.random.PRNGKey(3), (vocab, ))
+        logits = jnp.broadcast_to(row, (num_rows, vocab))
+        metadata = self._metadata([0.8] * num_rows, [6] * num_rows,
+                                  [0.95] * num_rows)
+        reference = np.asarray(
+            jax.nn.softmax(_apply_sampling_transforms(logits, metadata)[0]))
+        tokens = self._sample(monkeypatch, True, jax.random.PRNGKey(0), logits,
+                              metadata)
+        empirical = np.bincount(tokens, minlength=vocab) / num_rows
+        # Every draw is inside the kept set and the frequencies match the
+        # reference probabilities to well within binomial noise.
+        assert empirical[reference == 0].sum() == 0
+        tolerance = 5 * np.sqrt(reference * (1 - reference) / num_rows)
+        assert (np.abs(empirical - reference) <= tolerance + 1e-3).all()
+
+    def test_falls_back_when_a_row_exceeds_the_candidate_budget(
+            self, monkeypatch):
+        logits = jax.random.normal(jax.random.PRNGKey(4), (8, 1024))
+        metadata = self._metadata([0.7] * 8, [50] * 7 + [2000], [0.95] * 8)
+        rng = jax.random.PRNGKey(5)
+        sharded = self._sample(monkeypatch, True, rng, logits, metadata)
+        replicated = self._sample(monkeypatch, False, rng, logits, metadata)
+        # The fallback is the replicated path itself, same key, same draw.
+        np.testing.assert_array_equal(sharded, replicated)
+
+    def test_vocab_sharded_off_keeps_the_replicated_path(self, monkeypatch):
+        logits = jax.random.normal(jax.random.PRNGKey(6), (4, 1024))
+        metadata = self._metadata([0.7] * 4, [50] * 4, [0.95] * 4)
+        rng = jax.random.PRNGKey(7)
+        tokens = self._sample(monkeypatch, False, rng, logits, metadata)
+        allowed = self._allowed(logits, metadata)
+        assert allowed[np.arange(4), tokens].all()
+
+    @pytest.mark.parametrize("logprobs,logprobs_mode,expected", [
+        (False, "raw_logprobs", True),
+        (True, "raw_logprobs", True),
+        (True, "raw_logits", True),
+        (False, "processed_logprobs", True),
+        (True, "processed_logprobs", False),
+        (True, "processed_logits", False),
+    ])
+    def test_vocab_sharded_sampling_allowed(self, logprobs, logprobs_mode,
+                                            expected):
+        """Only the processed_* logprobs modes consume the processed logits,
+        and only when logprobs were requested; everything else stays sharded."""
+        assert vocab_sharded_sampling_allowed(logprobs,
+                                              logprobs_mode) is expected
+
+    def test_candidate_budget_env_controls_the_exact_range(self, monkeypatch):
+        """A smaller VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES shrinks the exact
+        top_k range: top_k=50 is exact at the default 64 but falls back at 8."""
+        logits = jax.random.normal(jax.random.PRNGKey(8), (4, 1024))
+        metadata = self._metadata([0.7] * 4, [50] * 4, [0.95] * 4)
+        rng = jax.random.PRNGKey(9)
+        replicated = self._sample(monkeypatch, False, rng, logits, metadata)
+        monkeypatch.setenv("VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES", "8")
+        # The budget is read at trace time; do not reuse the default trace.
+        sample.clear_cache()
+        try:
+            sharded = self._sample(monkeypatch, True, rng, logits, metadata)
+        finally:
+            monkeypatch.delenv("VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES")
+            sample.clear_cache()
+        # Fell back to the replicated path: same key, same draw.
+        np.testing.assert_array_equal(sharded, replicated)

--- a/tests/runner/test_decode_loop.py
+++ b/tests/runner/test_decode_loop.py
@@ -157,7 +157,7 @@ def test_continue_decode_early_exit():
         logits = logits.at[:, 0].set(pos)
         return logits
 
-    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata, **kwargs):
         pos = logits[:, 0].astype(jnp.int32)
         token_table = jnp.array(
             [
@@ -263,7 +263,7 @@ def test_continue_decode_with_experts():
     def mock_compute_logits_fn(state, hidden_states, _):
         return jnp.zeros((batch_size, 100))
 
-    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata, **kwargs):
         return jnp.array([42, 43], dtype=jnp.int32), None
 
     rng = jax.random.PRNGKey(0)
@@ -343,7 +343,7 @@ def test_continue_decode_no_exit_on_eos():
         logits = logits.at[:, 0].set(pos)
         return logits
 
-    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata, **kwargs):
         pos = logits[:, 0].astype(jnp.int32)
         token_table = jnp.array(
             [
@@ -447,7 +447,7 @@ def test_continue_decode_exit_on_eos_interval():
         logits = logits.at[:, 0].set(pos)
         return logits
 
-    def mock_sample_fn(rng, mesh, logits, sampling_metadata):
+    def mock_sample_fn(rng, mesh, logits, sampling_metadata, **kwargs):
         pos = logits[:, 0].astype(jnp.int32)
         # Token table: step 0 (pos 0) produces 99 (EOS) for req 1
         token_table = jnp.array(

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -235,6 +235,11 @@ def test_integer_env_vars(monkeypatch: pytest.MonkeyPatch):
     monkeypatch.setenv("CONTINUE_DECODE_EOS_CHECK_INTERVAL", "8")
     assert envs.CONTINUE_DECODE_EOS_CHECK_INTERVAL == 8
 
+    # Test VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES (default 64)
+    assert envs.VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES == 64
+    monkeypatch.setenv("VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES", "128")
+    assert envs.VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES == 128
+
 
 def test_model_impl_type_choices(monkeypatch: pytest.MonkeyPatch):
     # Test case sensitive choices

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -44,6 +44,7 @@ if TYPE_CHECKING:
     CONTINUE_DECODE_EOS_CHECK_INTERVAL: int = 1
     USE_BATCHED_RPA_KERNEL: bool = False
     USE_BATCHED_RPA_SEQ_ON_LANE: bool = False
+    VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES: int = 64
     # Optional operator override for the RPA v3 kernel block sizes, one per
     # case. Each is a comma-separated 4-tuple (bq_sz, bkv_sz, bq_csz, bkv_csz).
     # Empty (default) = use the built-in tuned/heuristic sizes.
@@ -357,6 +358,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     env_bool("USE_BATCHED_RPA_KERNEL"),
     "USE_BATCHED_RPA_SEQ_ON_LANE":
     env_bool("USE_BATCHED_RPA_SEQ_ON_LANE"),
+    # Candidates each tensor-parallel shard keeps for vocab-sharded sampling.
+    # Rows with 0 < top_k <= this value are sampled exactly; a batch with a
+    # larger top_k falls back to sampling over the full vocab. Raise it if
+    # your requests use a larger top_k; larger values only grow the merge.
+    "VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES":
+    lambda: int(os.getenv("VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES") or "64"),
     # Optional operator override for RPA v3 kernel block sizes, per case.
     # Comma-separated 4-tuple: bq_sz,bkv_sz,bq_csz,bkv_csz. Empty = use the
     # built-in tuned/heuristic sizes. Lets operators retune the decode

--- a/tpu_inference/layers/jax/sample/sampling.py
+++ b/tpu_inference/layers/jax/sample/sampling.py
@@ -21,6 +21,7 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from vllm.v1.outputs import LogprobsTensors
 
+from tpu_inference import envs
 from tpu_inference.layers.common.binary_search import topk_mask, topp_mask
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling_metadata import \
@@ -32,6 +33,23 @@ if TYPE_CHECKING:
     from tpu_inference.runner.input_batch import CachedRequestState
 
 _SAMPLING_EPS = 1e-5
+
+
+def _num_vocab_sharded_candidates() -> int:
+    """Candidates each vocab shard contributes to vocab-sharded sampling.
+
+    Rows with 0 < top_k <= this many candidates are sampled exactly (see
+    _can_sample_vocab_sharded). Read from VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES
+    at trace time, so it is fixed for the life of the process.
+    """
+    num_candidates = envs.VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES
+    if num_candidates < 1:
+        raise ValueError("VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES must be >= 1, "
+                         f"got {num_candidates}")
+    return num_candidates
+
+
+_MASKED_LOGIT = -1e12
 
 
 @dataclass
@@ -102,19 +120,233 @@ def _apply_sampling_transforms(
     return logits
 
 
-@jax.jit(static_argnames=["mesh"])
+def _mesh_axes(mesh: Mesh, axis_name) -> tuple[str, ...]:
+    """The names in `axis_name` (a name or a tuple of names) present in mesh."""
+    names = axis_name if isinstance(axis_name,
+                                    (tuple, list)) else (axis_name, )
+    return tuple(name for name in names if name in mesh.axis_names)
+
+
+def _vocab_sharded_specs(mesh: Mesh):
+    """(batch_axes, vocab_axis) for vocab-sharded sampling, or None.
+
+    Returns None when the mesh has no model axis to shard the vocab over, in
+    which case there is nothing to gain from the sharded path.
+    """
+    vocab_axes = _mesh_axes(mesh, ShardingAxisName.MODEL)
+    if not vocab_axes:
+        return None
+    batch_axes = _mesh_axes(mesh, ShardingAxisName.ATTN_DATA)
+    return (batch_axes or None), vocab_axes[0]
+
+
+def _can_sample_vocab_sharded(
+        tpu_sampling_metadata: TPUSupportedSamplingMetadata) -> jax.Array:
+    """Whether every row is sampled exactly by the vocab-sharded path.
+
+    A row is exact when it is greedy (the argmax is always among the
+    candidates) or when 0 < top_k <= the per-shard candidate budget and
+    top_p > 0, since the union of the per-shard top candidates then contains
+    the whole top-k set and the top-p cutoff is computed over that set. Padded
+    request slots carry DEFAULT_SAMPLING_PARAMS (temperature -1, top_k 0), so
+    they count as greedy and never force the fallback.
+    """
+    is_greedy = tpu_sampling_metadata.temperature < _SAMPLING_EPS
+    top_k = tpu_sampling_metadata.top_k
+    exact = ((top_k > 0) & (top_k <= _num_vocab_sharded_candidates()) &
+             (tpu_sampling_metadata.top_p > 0.0))
+    return jnp.all(is_greedy | exact)
+
+
+def _merged_candidates(logits: jax.Array, vocab_axis: str,
+                       num_candidates: int) -> tuple[jax.Array, jax.Array]:
+    """Top candidates of every vocab shard, gathered along the vocab axis.
+
+    Args:
+        logits: this shard's slice, (batch_shard, vocab_shard).
+        vocab_axis: mesh axis the vocab is sharded over.
+        num_candidates: candidates taken from each shard.
+
+    Returns:
+        (values, token_ids), each (batch_shard, num_shards * num_candidates),
+        with token_ids in the global vocab.
+    """
+    vocab_shard = logits.shape[-1]
+    values, local_ids = jax.lax.top_k(logits, num_candidates)
+    token_ids = local_ids + jax.lax.axis_index(vocab_axis) * vocab_shard
+    values = jax.lax.all_gather(values, vocab_axis)
+    token_ids = jax.lax.all_gather(token_ids, vocab_axis)
+    num_shards = values.shape[0]
+    values = jnp.transpose(values,
+                           (1, 0, 2)).reshape(-1, num_shards * num_candidates)
+    token_ids = jnp.transpose(token_ids,
+                              (1, 0, 2)).reshape(-1,
+                                                 num_shards * num_candidates)
+    return values, token_ids
+
+
+def _sample_vocab_sharded_block(
+    rng: jax.Array,
+    logits: jax.Array,
+    temperature: jax.Array,
+    top_k: jax.Array,
+    top_p: jax.Array,
+    batch_axes: tuple[str, ...] | None,
+    vocab_axis: str,
+) -> jax.Array:
+    """Per-shard body of vocab-sharded sampling; returns (batch_shard,) tokens.
+
+    Mirrors sample()'s replicated path on the merged candidates: temperature,
+    top-k (ties at the k-th value kept, like topk_mask), top-p (smallest
+    prefix of the sorted probabilities with mass >= p, like topp_mask), then a
+    categorical draw; greedy rows take the argmax (lowest id among ties, like
+    jnp.argmax). Candidates that are not in a row's top-k set are masked, so
+    the softmax normalizes over exactly the same set as the replicated path.
+    """
+    num_candidates = _num_vocab_sharded_candidates()
+    values, token_ids = _merged_candidates(logits, vocab_axis, num_candidates)
+
+    row_max = jnp.max(values, axis=-1, keepdims=True)
+    greedy_tokens = jnp.min(jnp.where(values >= row_max, token_ids,
+                                      jnp.iinfo(jnp.int32).max),
+                            axis=-1)
+
+    scaled = values / temperature[:, None]
+    sorted_desc = -jnp.sort(-scaled, axis=-1)
+    kth = jnp.take_along_axis(sorted_desc,
+                              jnp.clip(top_k, 1, scaled.shape[-1])[:, None] -
+                              1,
+                              axis=-1)
+    masked = jnp.where((top_k > 0)[:, None] & (scaled < kth), _MASKED_LOGIT,
+                       scaled)
+
+    probs = jax.nn.softmax(masked, axis=-1)
+    sorted_probs = -jnp.sort(-probs, axis=-1)
+    cumulative = jnp.cumsum(sorted_probs, axis=-1)
+    cutoff_index = jnp.argmax(cumulative >= top_p[:, None], axis=-1)
+    cutoff = jnp.take_along_axis(sorted_probs, cutoff_index[:, None], axis=-1)
+    masked = jnp.where((top_p < 1.0)[:, None] & (probs < cutoff),
+                       _MASKED_LOGIT, masked)
+
+    # Every batch shard receives the same key; fold in the shard's index so
+    # rows on different shards draw independent noise.
+    shard_index = jnp.int32(0)
+    for axis in batch_axes or ():
+        shard_index = (shard_index * jax.lax.axis_size(axis) +
+                       jax.lax.axis_index(axis))
+    choice = jax.random.categorical(jax.random.fold_in(rng, shard_index),
+                                    masked)
+    sampled = jnp.take_along_axis(token_ids, choice[:, None], axis=-1)[:, 0]
+    tokens = jnp.where(temperature < _SAMPLING_EPS, greedy_tokens, sampled)
+    # The value is already identical on every vocab shard (it is built from
+    # the gathered candidates); the reduction makes that replication explicit
+    # for the shard_map output spec.
+    return jax.lax.pmax(tokens, vocab_axis)
+
+
+def _sample_vocab_sharded(
+    rng: jax.Array,
+    mesh: Mesh,
+    logits: jax.Array,
+    tpu_sampling_metadata: TPUSupportedSamplingMetadata,
+    batch_axes: tuple[str, ...] | None,
+    vocab_axis: str,
+) -> jax.Array:
+    """Samples from logits sharded over the vocab; returns replicated tokens."""
+    batch_spec = P(batch_axes)
+    logits_spec = P(batch_axes, vocab_axis)
+    logits = jax.lax.with_sharding_constraint(logits,
+                                              NamedSharding(mesh, logits_spec))
+
+    def block(rng, logits, temperature, top_k, top_p):
+        return _sample_vocab_sharded_block(rng, logits, temperature, top_k,
+                                           top_p, batch_axes, vocab_axis)
+
+    tokens = jax.shard_map(
+        block,
+        mesh=mesh,
+        in_specs=(P(), logits_spec, batch_spec, batch_spec, batch_spec),
+        out_specs=batch_spec,
+    )(rng, logits, tpu_sampling_metadata.temperature.astype(jnp.float32),
+      tpu_sampling_metadata.top_k, tpu_sampling_metadata.top_p)
+    return jax.lax.with_sharding_constraint(tokens, NamedSharding(mesh, P()))
+
+
+def vocab_sharded_sampling_allowed(logprobs: bool, logprobs_mode) -> bool:
+    """Whether sample() may keep the logits vocab-sharded.
+
+    The vocab-sharded path returns the raw, still-sharded logits instead of
+    the processed (temperature / top-k / top-p) ones, so it cannot serve the
+    processed_* logprobs modes. Those are the only consumers of the processed
+    logits, and only when logprobs were requested.
+    """
+    return not (logprobs and str(logprobs_mode).startswith("processed"))
+
+
+@jax.jit(static_argnames=["mesh", "vocab_sharded"])
 def sample(
     rng: jax.Array,
     mesh: Mesh,
     logits: jax.Array,
     tpu_sampling_metadata: TPUSupportedSamplingMetadata,
+    vocab_sharded: bool = True,
 ) -> jax.Array:
+    """Samples the next token of every row of (B, vocab_size) logits.
+
+    Returns (tokens, logits): the logits are the processed (temperature /
+    top-k / top-p) ones for sampled rows and the raw ones for greedy rows.
+
+    With vocab_sharded (the default) the logits are not all-gathered over the
+    vocab: each vocab shard contributes its top candidates and sampling runs on
+    those (see _sample_vocab_sharded_block). The returned logits are then the
+    raw, still vocab-sharded logits, so callers that need processed logits
+    (logprobs_mode="processed_*") pass vocab_sharded=False; see
+    vocab_sharded_sampling_allowed.
+    """
     # (B, vocab_size)
     if tpu_sampling_metadata._cache_collision_dummy is not None:
         # Force a dependency on the dummy tensor's shape to ensure unique HLO.
         logits = logits + 0 * jnp.sum(
             tpu_sampling_metadata._cache_collision_dummy)
 
+    vocab_sharded_specs = (_vocab_sharded_specs(mesh)
+                           if tpu_sampling_metadata.do_sampling
+                           and vocab_sharded else None)
+    if vocab_sharded_specs is not None:
+        # Both branches of the cond return the logits with the vocab still
+        # sharded, so choosing the fallback at runtime never adds the
+        # all-gather to the sharded path.
+        batch_axes, vocab_axis = vocab_sharded_specs
+        logits = logits.astype(jnp.float32)
+        logits_sharding = NamedSharding(mesh, P(batch_axes, vocab_axis))
+
+        def sharded(operands):
+            rng, logits = operands
+            tokens = _sample_vocab_sharded(rng, mesh, logits,
+                                           tpu_sampling_metadata, batch_axes,
+                                           vocab_axis)
+            return tokens, logits
+
+        def replicated(operands):
+            rng, logits = operands
+            tokens, ret_logits = _sample_replicated(rng, mesh, logits,
+                                                    tpu_sampling_metadata)
+            return tokens, jax.lax.with_sharding_constraint(
+                ret_logits, logits_sharding)
+
+        return jax.lax.cond(_can_sample_vocab_sharded(tpu_sampling_metadata),
+                            sharded, replicated, (rng, logits))
+
+    return _sample_replicated(rng, mesh, logits, tpu_sampling_metadata)
+
+
+def _sample_replicated(
+    rng: jax.Array,
+    mesh: Mesh,
+    logits: jax.Array,
+    tpu_sampling_metadata: TPUSupportedSamplingMetadata,
+) -> tuple[jax.Array, jax.Array]:
+    """sample() over logits replicated along the vocab."""
     if tpu_sampling_metadata.do_sampling:
         # Unshard the logits explicity to avoid latency increase.
         # TODO(gxd3): revisit if the 2nd dimension of the logits can be sharded

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -32,7 +32,8 @@ from tpu_inference.layers.common.attention_metadata import (
     SharedAttentionMetadata, pcp_cache_page_buckets)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling import (
-    compute_and_gather_logprobs, compute_and_gather_prompt_logprobs, sample)
+    compute_and_gather_logprobs, compute_and_gather_prompt_logprobs, sample,
+    vocab_sharded_sampling_allowed)
 from tpu_inference.layers.jax.sample.sampling_metadata import \
     TPUSupportedSamplingMetadata
 from tpu_inference.logger import init_logger
@@ -1004,6 +1005,10 @@ class CompilationManager:
                         _cache_collision_dummy=_cache_collision_dummy,
                         do_sampling=do_sampling,
                         logprobs=logprobs)
+                    # Same static choice the runner makes at serving time, so
+                    # the precompiled entry is the one that gets hit.
+                    vocab_sharded = vocab_sharded_sampling_allowed(
+                        logprobs, self.runner.model_config.logprobs_mode)
                     self._run_compilation(
                         f"worker{self.runner.rank} sample",
                         sample,
@@ -1011,10 +1016,12 @@ class CompilationManager:
                         self.runner.mesh,
                         logits,
                         sampling_metadata,
+                        call_kwargs={"vocab_sharded": vocab_sharded},
                         compile_only=False,
                         num_reqs=num_reqs,
                         do_sampling=do_sampling,
                         logprobs=logprobs,
+                        vocab_sharded=vocab_sharded,
                     )
 
         self._sampling_precompiled = True

--- a/tpu_inference/runner/decode_loop.py
+++ b/tpu_inference/runner/decode_loop.py
@@ -132,6 +132,9 @@ def _decode_core_impl(
     continue_decode_eos_check_interval: int = 1,
 ):
     has_logprobs = False if sampling_metadata is None else sampling_metadata.logprobs
+    from tpu_inference.layers.jax.sample.sampling import \
+        vocab_sharded_sampling_allowed
+    vocab_sharded = vocab_sharded_sampling_allowed(has_logprobs, logprobs_mode)
 
     def _run_one_step(step_idx, ct, am, pos, sl, kvc):
         step_rng = step_rngs[step_idx]
@@ -166,8 +169,11 @@ def _decode_core_impl(
         )
         logits = compute_logits_fn(state, hidden_states, None)
         logits = logits.astype(jnp.float32)
-        next_tokens, processed_logits = sample_fn(step_rng, mesh, logits,
-                                                  sampling_metadata)
+        next_tokens, processed_logits = sample_fn(step_rng,
+                                                  mesh,
+                                                  logits,
+                                                  sampling_metadata,
+                                                  vocab_sharded=vocab_sharded)
         (new_active_mask, next_input_ids, new_positions, new_seq_lens,
          step_record_tokens, any_hit_eos) = _update_loop_state(
              next_tokens,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -63,7 +63,7 @@ from tpu_inference.layers.jax.sample.rejection_sampler import RejectionSampler
 from tpu_inference.layers.jax.sample.sampling import (
     PromptLogprobsAsyncData, PromptLogprobsReqSnap,
     _jax_logprobs_copy_to_host_async, compute_and_gather_logprobs,
-    compute_prompt_logprobs, sample)
+    compute_prompt_logprobs, sample, vocab_sharded_sampling_allowed)
 from tpu_inference.layers.jax.sample.sampling_metadata import \
     TPUSupportedSamplingMetadata
 from tpu_inference.logger import init_logger
@@ -2009,6 +2009,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             step_rng = self.rng_params_for_sampling
 
         processed_bonus_logits = None
+        vocab_sharded = vocab_sharded_sampling_allowed(
+            tpu_sampling_metadata.logprobs, self.model_config.logprobs_mode)
         if spec_decode_metadata is None:
             logits = logits.astype(jnp.float32)
             with self.maybe_forbid_compile:
@@ -2017,6 +2019,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                     self.mesh,
                     logits,
                     tpu_sampling_metadata,
+                    vocab_sharded=vocab_sharded,
                 )
         else:
             if tpu_sampling_metadata.do_sampling:
@@ -2032,6 +2035,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 self.mesh,
                 bonus_logits,
                 tpu_sampling_metadata,
+                vocab_sharded=vocab_sharded,
             )
             target_logits = self._select_from_array_fn(
                 logits, spec_decode_metadata.target_logits_indices, self.mesh,


### PR DESCRIPTION
## Summary

`sample()` all-gathers the `(batch, vocab)` logits over the tensor-parallel axis on every decode step ("Unshard the logits explicitly…", with a TODO asking whether the vocab dimension could stay sharded) and then runs top-k / top-p / categorical on the replicated array, on every device. For a 151,936-token vocab that is a ~78 MB f32 gather per DP rank per step, followed by the 32–33 vocab-wide reduction sweeps of `topk_mask` and `topp_mask`, all redundant across the TP devices. In an xprof profile of a Qwen3-0.6B GRPO rollout (DP16 × TP8, TPU v7x) this was ~30% of the decode step's device time.

This PR makes sampling run on vocab-sharded logits. Each vocab shard keeps its top `VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES` (default 64) candidates and only those (values and global ids, ~0.4 MB) are gathered; top-k, top-p and the categorical draw run on the merged candidates.

**Exactness.** The kept set is the same as the replicated path's:
- the union of the per-shard top candidates contains the global top-k for `k <=` the candidate budget;
- ties at the k-th value are kept, like `topk_mask`;
- the top-p cutoff is the smallest prefix of the sorted probabilities with mass `>= p`, like `topp_mask`;
- candidates outside the top-k set are masked, so the softmax normalizes over exactly the same set (up to float32 summation order);
- greedy rows take the argmax with the lowest id among ties, like `jnp.argmax`.

The sampled tokens follow the same distribution as before but are not bitwise identical, since the random draw is over the candidates rather than the full vocab. Different batch shards fold their shard index into the key so they draw independent noise.

**Fallback.** Rows are exact when greedy, or when `0 < top_k <=` the candidate budget and `top_p > 0`. A batch containing any other sampling row takes the replicated path through a `lax.cond`; both branches leave the returned logits vocab-sharded, so a runtime fallback never adds the gather to the hot path. Padded request slots carry `DEFAULT_SAMPLING_PARAMS` (temperature −1, top_k 0), i.e. greedy, so they never force the fallback (in an earlier version of this change a guard on `top_k > 0` alone was silently tripped by the padded rows on every step).

**Constraints.** The returned logits are the raw, still-sharded logits. The only consumers of the processed logits are the `processed_*` logprobs modes, and only when logprobs were requested, so the runner and the decode loop pass `vocab_sharded=False` in exactly that case (`vocab_sharded_sampling_allowed`) and sampling stays on the replicated path. Sampled-token logprobs (`compute_and_gather_logprobs`) still run on the replicated logits; sharding that path is a natural follow-up.

**Measured** on TPU v7x GRPO rollouts (2048 sequences/step, generation cap 8192, top_k 50, top_p 1.0): −5.8 s/step at DP16 × TP8 (123.2 s → 118.0 s) and −9.5 s/step at DP32 × TP4 (99.7 s → 90.2 s), with reward and completion-length distributions unchanged across 20-step runs.

## Tests

`tests/layers/jax/sample/test_sampling.py::TestVocabShardedSampling` (mesh shards the vocab over every local device; run with `--xla_force_host_platform_device_count=4` to exercise the multi-shard merge on CPU):
- `_can_sample_vocab_sharded`: padded slots and greedy rows never force the fallback; a real row without a top-k filter or above the candidate budget does.
- greedy rows match `jnp.argmax`, including the lowest-id tie rule;
- sampled tokens always lie in the top-k / top-p set of `_apply_sampling_transforms`;
- over 8192 identical rows the empirical distribution matches the replicated path's probabilities within binomial noise, with zero mass outside the kept set;
- a batch with a `top_k=2000` row produces exactly the replicated path's tokens (same key);
- `vocab_sharded=False` keeps the replicated path;
- lowering `VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES` to 8 makes a `top_k=50` batch fall back to the replicated path's tokens;
- `vocab_sharded_sampling_allowed` picks the replicated path only for `processed_*` logprobs modes with logprobs on.

Also: `tests/test_envs.py` (`VOCAB_SHARDED_SAMPLING_NUM_CANDIDATES` defaults to 64 and honors an override).

