### PR TITLE
[Fix] Preserve layer order in KV cache slots for sequential decoders (MaxText)

### DIFF
--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -931,6 +931,16 @@ class KVCacheManager:
 
                     slots.setdefault(slot_key, []).append(layer_name)
 
+        # Ensure slots are ordered by layer index for sequential decoders (e.g. MaxText)
+        def _get_layer_idx(name: str) -> int:
+            try:
+                return int(name.split('.')[-1])
+            except (ValueError, IndexError):
+                return 0
+
+        slots = dict(
+            sorted(slots.items(), key=lambda item: _get_layer_idx(item[1][0])))
+
         # Pass 2: Allocate one physical cache per unique slot and map layers
         for slot_key, layer_names in slots.items():
             first_layer_name = layer_names[0]


### PR DESCRIPTION
# Description

In PR #3481, KV cache allocation was refactored into two passes. When using the latest vLLM KV cache tensor layout for hybrid attention + mamba models (e.g. Qwen3.5), `kv_cache_tensors` groups layers by type (all Mamba layers first, then all Attention layers). 
As a result, `Pass 2` iterated through `slots` and allocated all Mamba caches into `kv_caches[0..29]` and all Attention caches into `kv_caches[30..39]`.

Sequential decoders like MaxText (Flax NNX) iterate over layers sequentially and index `kv_cache = kv_caches[lyr]`. For hybrid models:
- Layer 3 is an Attention layer, but `kv_caches[3]` retrieved a 3D Mamba cache instead of the 5D attention cache.
- This immediately caused a crash during execution:
  ```text
  ValueError: shard_map applied to '_ragged_paged_attention': in_specs[3] has length 5, but the passed args[3][0] has shape bfloat16[1028,3,8192], which has rank 3 (and 3 < 5)

# Tests

Please describe how you tested this change, and include any instructions and/or
commands to reproduce.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
