### PR TITLE
[ragged_gather_reduce]: enable more flexible column partitioning for v5p

### DIFF
--- a/tpu_inference/kernels/sparse_core/ragged_gather_reduce_v2.py
+++ b/tpu_inference/kernels/sparse_core/ragged_gather_reduce_v2.py
@@ -127,18 +127,21 @@ def _calculate_num_column_partitions(hidden_size: int, input_size: int,
                                      num_cores: int, num_lanes: int,
                                      num_simd_lanes: int) -> int:
     """Calculates the number of row partitions."""
+
     # Each column partition should be multiple of 128 (number of lanes) due to
     # DMA requirements.
     # Prefer to use a large number of column partitions, as long as each
     # partition's size is not too small for DMA pipeline efficiency and each
     # partition's size can divide the hidden size.
 
+    def _can_split_further(num_column_partitions: int) -> bool:
+        return (num_cores % (num_column_partitions * 2) == 0
+                and hidden_size % (num_lanes * num_column_partitions * 2) == 0)
+
     # Each column partition will do DMA pipelining on col_size.
     preferred_num_stages = 4
     num_column_partitions = 1
-    while (num_cores % (num_column_partitions * 2) == 0
-           and hidden_size % (num_lanes * num_column_partitions * 2) == 0
-           and hidden_size //
+    while (_can_split_further(num_column_partitions) and hidden_size //
            (num_column_partitions * 2 * num_lanes) >= preferred_num_stages):
         next_candidate = num_column_partitions * 2
         next_row_partitions = num_cores // next_candidate
@@ -159,6 +162,11 @@ def _calculate_num_column_partitions(hidden_size: int, input_size: int,
             break
 
         num_column_partitions = next_candidate
+
+    # Keep splitting until num_row_partitions <= num_simd_lanes (hard limit).
+    while (num_cores // num_column_partitions > num_simd_lanes
+           and _can_split_further(num_column_partitions)):
+        num_column_partitions *= 2
 
     return num_column_partitions
 


### PR DESCRIPTION
## Problem

On v5p, running Qwen3.5-35B-A3B-FP8 with expert parallelism (`MODEL_IMPL_TYPE=vllm`, attention DP 4, 8192 batched tokens) fails inside the MoE combine:

```
File ".../tpu_inference/kernels/sparse_core/ragged_gather_reduce_v2.py", line 631, in ragged_gather_reduce
    assert (num_row_partitions <= num_simd_lanes), f"{num_row_partitions=} must be <= {num_simd_lanes=}"
AssertionError: num_row_partitions=16 must be <= num_simd_lanes=8
```

v5p has 4 SparseCores x 16 subcores (64 subcores) with 8 SIMD lanes per subcore. For `hidden_size=2048`, `_calculate_num_column_partitions` stops at 4 column partitions because splitting to 8 would leave only 2 DMA pipeline stages (below the preferred 4), and then derives `64 // 4 = 16` row partitions, which exceeds the 8-lane limit. The pipeline-depth heuristic stops the loop before the hard constraint is met.

## Fix

After the heuristic loop, keep doubling the column split while the 128-lane alignment and exact hidden-size divisibility still hold, until `num_cores // num_column_partitions <= num_simd_lanes`. For v5p / hidden 2048 this yields 8 column partitions and 8 row partitions.

Shapes that cannot be split exactly to satisfy the limit (e.g. `hidden_size=2816` on 8-lane chips) still hit the existing assertion.

Every shape the previous cost model handled validly gets the same partitioning as before. On v7x the only affected shapes are hidden sizes 256, 512 and 768, which previously asserted.

## Testing

- Host-side sweep of the cost model over v5p / v6e / v7x SparseCore grids: partitioning is unchanged wherever the old code satisfied the lane limit; v5p / hidden 2048 now resolves to 8 column partitions.
- Not run on v5p / v6e hardware.
