### PR TITLE
[Perf/Fix] Configure heterogeneous KV cache sharding for GDN/Mamba in model_loader

### DIFF
--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -353,10 +353,87 @@ def get_flax_model(
                                pooler=pooler,
                                is_draft_model=is_draft_model)
     vllm_config.model_config.dtype = original_dtype
-    kv_cache_sharding = NamedSharding(
+    attn_kv_sharding = NamedSharding(
         mesh,
         PartitionSpec(ShardingAxisName.BATCH, ShardingAxisName.KV_CONTEXT,
                       ShardingAxisName.KV_HEAD))
+    gdn_conv_sharding = NamedSharding(
+        mesh,
+        PartitionSpec(ShardingAxisName.ATTN_DATA, None,
+                      ShardingAxisName.ATTN_HEAD))
+    gdn_ssm_sharding = NamedSharding(
+        mesh,
+        PartitionSpec(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD,
+                      None, None))
+    gdn_kv_sharding = (gdn_conv_sharding, gdn_ssm_sharding)
+
+    hf_cfg = vllm_config.model_config.hf_config
+    if isinstance(hf_cfg, dict):
+        text_cfg = hf_cfg.get("text_config", hf_cfg)
+        layer_types = text_cfg.get("layer_types", None)
+    else:
+        text_cfg = getattr(hf_cfg, "text_config", hf_cfg)
+        layer_types = getattr(text_cfg, "layer_types", None)
+        if layer_types is None and hasattr(hf_cfg, "to_dict"):
+            layer_types = hf_cfg.to_dict().get("text_config",
+                                               {}).get("layer_types", None)
+
+    additional_cfg = getattr(vllm_config, "additional_config", {}) or {}
+    maxtext_cfg = additional_cfg.get("maxtext_config", {})
+    model_name = maxtext_cfg.get("model_name", "") or getattr(
+        vllm_config.model_config, "model", "")
+
+    explicit_interval = getattr(
+        text_cfg, "full_attention_interval",
+        None) if not isinstance(text_cfg, dict) else text_cfg.get(
+            "full_attention_interval", None)
+
+    is_hybrid = ((layer_types is not None and any(lt == "linear_attention"
+                                                  for lt in layer_types))
+                 or explicit_interval is not None
+                 or getattr(vllm_config.model_config, "is_hybrid", False)
+                 or "qwen3_5" in model_name.lower()
+                 or "qwen3.5" in model_name.lower())
+
+    if is_hybrid:
+        if layer_types:
+            first_type = layer_types[0]
+            if first_type == "linear_attention":
+                mamba_count = sum(1 for lt in layer_types
+                                  if lt == "linear_attention")
+                attn_count = len(layer_types) - mamba_count
+                kv_cache_sharding = [gdn_kv_sharding] * mamba_count + [
+                    attn_kv_sharding
+                ] * attn_count
+            else:
+                attn_count = sum(1 for lt in layer_types
+                                 if lt != "linear_attention")
+                mamba_count = len(layer_types) - attn_count
+                kv_cache_sharding = [attn_kv_sharding] * attn_count + [
+                    gdn_kv_sharding
+                ] * mamba_count
+            logger.info(
+                f"Successfully configured heterogeneous KV cache sharding for {len(layer_types)} layers "
+                f"({mamba_count} GDN layers, {attn_count} Full Attn layers in physical slot order)."
+            )
+        else:
+            interval = 4 if explicit_interval is None else explicit_interval
+            num_layers = getattr(
+                text_cfg, "num_hidden_layers",
+                40) if not isinstance(text_cfg, dict) else text_cfg.get(
+                    "num_hidden_layers", 40)
+            attn_count = num_layers // interval
+            mamba_count = num_layers - attn_count
+            kv_cache_sharding = [gdn_kv_sharding] * mamba_count + [
+                attn_kv_sharding
+            ] * attn_count
+            logger.info(
+                f"Configured fallback KV cache sharding for hybrid model with interval={interval}, "
+                f"total_layers={num_layers} ({mamba_count} GDN, {attn_count} Full Attn in physical slot order)."
+            )
+    else:
+        kv_cache_sharding = attn_kv_sharding
+
     hidden_states_sharding = NamedSharding(mesh,
                                            PartitionSpec(
                                                ShardingAxisName.ATTN_DATA,


### PR DESCRIPTION
# Description

Currently, `model_loader.py` defines a single attention-oriented `kv_cache_sharding = NamedSharding(mesh, PartitionSpec(ShardingAxisName.BATCH, ShardingAxisName.KV_CONTEXT, ShardingAxisName.KV_HEAD))` and applies it to all layers via JIT `out_shardings`.
For hybrid models with linear attention / GDN / Mamba layers (such as Qwen 3.5):
- GDN's `recurrent_state` (SSM state) has shape `[num_blocks, num_heads, d_k, d_v] = [1028, 32, 128, 128]`.
- Applying the attention spec forces dimension 2 (`d_k=128`) to be sharded across `KV_HEAD` (e.g. split into `[2, 64]` on TP=2), while `run_jax_gdn_attention` expects dimension 1 (heads) to be sharded.
- This layout/sharding mismatch forces XLA to insert a massive **257MB All-to-All** per GDN layer on every step, followed by an asynchronous SparseCore layout formatting offload (`sparse-core-data-format-call`, ~188 μs per layer). Across 30 GDN layers, this causes ~6 ms of pure overhead per step.


### Fix
Construct a heterogeneous `kv_cache_sharding` list matching the model's `layer_types`:
- Full Attention layers use `attn_kv_sharding`: `(BATCH, KV_CONTEXT, KV_HEAD)`.
- GDN layers use `gdn_kv_sharding`: `(conv_sharding, ssm_sharding)` with `recurrent_state` sharded as `PartitionSpec(ATTN_DATA, ATTN_HEAD, None, None)`.

Related Bug: b/549307194

# Tests

- Tested with Qwen-3.5-397B on TPU v7x-8.
- Traces collected with Xprof confirm that the 257MB All-to-All and SparseCore data formatting offloads have completely disappeared.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
