### PR TITLE
Decoupled Dual Block Pools for Hybrid Mamba/GDN Prefix Caching in Align Mode

### DIFF
--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -137,7 +137,7 @@ class TestDPScheduler:
         mock_structured_output_manager,
     ):
         """Test that mamba_num_blocks is partitioned per DP rank."""
-        mock_kv_cache_config.mamba_num_blocks = 60
+        mock_vllm_config.cache_config.mamba_num_blocks = 60
         scheduler = self._create_scheduler(
             mock_vllm_config,
             mock_kv_cache_config,

--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -55,6 +55,7 @@ class TestDPScheduler:
         config.cache_config = MagicMock()
         config.cache_config.enable_prefix_caching = False
         config.cache_config.prefix_caching_hash_algo = "sha256"
+        config.cache_config.mamba_num_blocks = None
         return config
 
     @pytest.fixture
@@ -136,8 +137,8 @@ class TestDPScheduler:
         mock_kv_cache_config,
         mock_structured_output_manager,
     ):
-        """Test that mamba_num_blocks is partitioned per DP rank."""
-        mock_kv_cache_config.mamba_num_blocks = 60
+        """Test that mamba_num_blocks is partitioned per DP rank from cache_config."""
+        mock_vllm_config.cache_config.mamba_num_blocks = 60
         scheduler = self._create_scheduler(
             mock_vllm_config,
             mock_kv_cache_config,
@@ -148,14 +149,13 @@ class TestDPScheduler:
             assert rank_config.num_blocks == 50
             assert rank_config.mamba_num_blocks == 30
 
-    def test_init_without_mamba_num_blocks_on_kv_cache_config(
+    def test_init_without_mamba_num_blocks(
         self,
         mock_vllm_config,
         mock_kv_cache_config,
         mock_structured_output_manager,
     ):
-        """Test that mamba_num_blocks on cache_config is ignored if not on kv_cache_config."""
-        mock_vllm_config.cache_config.mamba_num_blocks = 60
+        """Test that rank configs have no mamba_num_blocks if not configured."""
         scheduler = self._create_scheduler(
             mock_vllm_config,
             mock_kv_cache_config,

--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -130,6 +130,24 @@ class TestDPScheduler:
                 mock_process = mock_ctx.Process.return_value
                 assert mock_process.start.call_count == 2
 
+    def test_init_with_mamba_num_blocks_per_rank(
+        self,
+        mock_vllm_config,
+        mock_kv_cache_config,
+        mock_structured_output_manager,
+    ):
+        """Test that mamba_num_blocks is partitioned per DP rank."""
+        mock_kv_cache_config.mamba_num_blocks = 60
+        scheduler = self._create_scheduler(
+            mock_vllm_config,
+            mock_kv_cache_config,
+            mock_structured_output_manager,
+        )
+        assert len(scheduler.per_rank_kv_cache_configs) == 2
+        for rank_config in scheduler.per_rank_kv_cache_configs:
+            assert rank_config.num_blocks == 50
+            assert rank_config.mamba_num_blocks == 30
+
     def test_init_with_prefix_caching_enabled(
         self,
         mock_vllm_config,

--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -137,7 +137,7 @@ class TestDPScheduler:
         mock_structured_output_manager,
     ):
         """Test that mamba_num_blocks is partitioned per DP rank."""
-        mock_vllm_config.cache_config.mamba_num_blocks = 60
+        mock_kv_cache_config.mamba_num_blocks = 60
         scheduler = self._create_scheduler(
             mock_vllm_config,
             mock_kv_cache_config,
@@ -147,6 +147,24 @@ class TestDPScheduler:
         for rank_config in scheduler.per_rank_kv_cache_configs:
             assert rank_config.num_blocks == 50
             assert rank_config.mamba_num_blocks == 30
+
+    def test_init_without_mamba_num_blocks_on_kv_cache_config(
+        self,
+        mock_vllm_config,
+        mock_kv_cache_config,
+        mock_structured_output_manager,
+    ):
+        """Test that mamba_num_blocks on cache_config is ignored if not on kv_cache_config."""
+        mock_vllm_config.cache_config.mamba_num_blocks = 60
+        scheduler = self._create_scheduler(
+            mock_vllm_config,
+            mock_kv_cache_config,
+            mock_structured_output_manager,
+        )
+        assert len(scheduler.per_rank_kv_cache_configs) == 2
+        for rank_config in scheduler.per_rank_kv_cache_configs:
+            assert rank_config.num_blocks == 50
+            assert getattr(rank_config, "mamba_num_blocks", None) is None
 
     def test_init_with_prefix_caching_enabled(
         self,

--- a/tests/core/test_hybrid_coordinator.py
+++ b/tests/core/test_hybrid_coordinator.py
@@ -96,6 +96,59 @@ class TestTPUDualBlockPool:
 
         assert dual_pool.reset_prefix_cache() is True
 
+    def test_get_cached_block_multi_group(self):
+        pool_attn = BlockPool(num_gpu_blocks=100,
+                              enable_caching=True,
+                              hash_block_size=16)
+        pool_mamba = BlockPool(num_gpu_blocks=20,
+                               enable_caching=True,
+                               hash_block_size=16)
+        dual_pool = TPUDualBlockPool(pool_attn,
+                                     pool_mamba,
+                                     mamba_group_ids={1})
+
+        pool_attn.get_cached_block = MagicMock()
+        pool_mamba.get_cached_block = MagicMock()
+
+        blk_attn = MagicMock()
+        blk_mamba = MagicMock()
+
+        # Both hit
+        pool_attn.get_cached_block.return_value = [blk_attn]
+        pool_mamba.get_cached_block.return_value = [blk_mamba]
+
+        res = dual_pool.get_cached_block("hash1", [0, 1])
+        assert res == [blk_attn, blk_mamba]
+        pool_attn.get_cached_block.assert_called_with("hash1", [0])
+        pool_mamba.get_cached_block.assert_called_with("hash1", [1])
+
+        # Miss on mamba
+        pool_mamba.get_cached_block.return_value = None
+        assert dual_pool.get_cached_block("hash2", [0, 1]) is None
+
+        # Miss on attn
+        pool_attn.get_cached_block.return_value = None
+        pool_mamba.get_cached_block.return_value = [blk_mamba]
+        assert dual_pool.get_cached_block("hash3", [0, 1]) is None
+
+    def test_evict_blocks_targets_attention_pool_only(self):
+        pool_attn = BlockPool(num_gpu_blocks=100,
+                              enable_caching=True,
+                              hash_block_size=16)
+        pool_mamba = BlockPool(num_gpu_blocks=20,
+                               enable_caching=True,
+                               hash_block_size=16)
+        dual_pool = TPUDualBlockPool(pool_attn,
+                                     pool_mamba,
+                                     mamba_group_ids={1})
+
+        pool_attn.evict_blocks = MagicMock()
+        pool_mamba.evict_blocks = MagicMock()
+
+        dual_pool.evict_blocks({5, 20, 200})
+        pool_attn.evict_blocks.assert_called_once_with({5, 20})
+        pool_mamba.evict_blocks.assert_not_called()
+
 
 class TestTPUHybridKVCacheCoordinator:
 

--- a/tests/core/test_hybrid_coordinator.py
+++ b/tests/core/test_hybrid_coordinator.py
@@ -12,12 +12,12 @@ from vllm.v1.request import Request, RequestStatus
 
 from tpu_inference.core.hybrid_coordinator import (
     TPUDualBlockPool, TPUHybridKVCacheCoordinator, TPUKVCacheManager,
-    install_hybrid_coordinator_hooks)
+    install_hybrid_coordinator_hooks, set_mamba_num_blocks)
 
 
 def _make_mock_hybrid_kv_cache_config(
     num_attn_blocks: int = 500,
-    mamba_num_blocks: int = 50,
+    mamba_num_blocks: int | None = 50,
     block_size: int = 16,
 ) -> KVCacheConfig:
     attn_spec = FullAttentionSpec(
@@ -41,7 +41,8 @@ def _make_mock_hybrid_kv_cache_config(
         kv_cache_tensors=[],
         kv_cache_groups=groups,
     )
-    cfg.mamba_num_blocks = mamba_num_blocks
+    if mamba_num_blocks is not None:
+        set_mamba_num_blocks(mamba_num_blocks)
     return cfg
 
 
@@ -306,3 +307,55 @@ class TestHybridCoordinatorHooks:
         install_hybrid_coordinator_hooks()
         assert mgr_mod.KVCacheManager is TPUKVCacheManager
         assert callable(coord_mod.get_kv_cache_coordinator)
+
+    def test_tpu_get_kv_cache_coordinator_resolves_from_global(self):
+        from tpu_inference.core.hybrid_coordinator import (
+            TPUHybridKVCacheCoordinator, set_mamba_num_blocks,
+            tpu_get_kv_cache_coordinator)
+
+        set_mamba_num_blocks(64)
+        cfg = _make_mock_hybrid_kv_cache_config(num_attn_blocks=100,
+                                                mamba_num_blocks=None)
+        assert getattr(cfg, "mamba_num_blocks", None) is None
+
+        coord_kwargs = dict(
+            max_model_len=1024,
+            max_in_flight_tokens=128,
+            use_eagle=False,
+            enable_caching=True,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=16,
+            hash_block_size=16,
+        )
+        coord = tpu_get_kv_cache_coordinator(cfg, **coord_kwargs)
+        assert isinstance(coord, TPUHybridKVCacheCoordinator)
+        assert coord.mamba_num_blocks == 64
+
+    def test_tpu_get_kv_cache_coordinator_raises_if_missing(self):
+        import pytest
+
+        import tpu_inference.core.hybrid_coordinator as hc_mod
+        from tpu_inference.core.hybrid_coordinator import \
+            tpu_get_kv_cache_coordinator
+        hc_mod._GLOBAL_MAMBA_NUM_BLOCKS = None
+
+        cfg = _make_mock_hybrid_kv_cache_config(num_attn_blocks=100,
+                                                mamba_num_blocks=None)
+        assert getattr(cfg, "mamba_num_blocks", None) is None
+
+        coord_kwargs = dict(
+            max_model_len=1024,
+            max_in_flight_tokens=128,
+            use_eagle=False,
+            enable_caching=True,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=16,
+            hash_block_size=16,
+        )
+        with pytest.raises(ValueError,
+                           match="mamba_num_blocks must be registered"):
+            tpu_get_kv_cache_coordinator(cfg, **coord_kwargs)

--- a/tests/core/test_hybrid_coordinator.py
+++ b/tests/core/test_hybrid_coordinator.py
@@ -297,6 +297,15 @@ class TestTPUHybridKVCacheCoordinator:
         # Mamba block list has length 3 (with null blocks inserted before the match)
         assert len(hit_blocks[1]) == 3
 
+        # Test find_longest_cache_hit_per_group inherited from upstream
+        per_group_blocks, per_group_lengths = coord.find_longest_cache_hit_per_group(
+            block_hashes=hashes,
+            max_cache_hit_length=160,
+        )
+        assert per_group_lengths == (80, 48)
+        assert len(per_group_blocks[0]) == 5
+        assert len(per_group_blocks[1]) == 3
+
 
 class TestHybridCoordinatorHooks:
 
@@ -359,3 +368,67 @@ class TestHybridCoordinatorHooks:
         with pytest.raises(ValueError,
                            match="mamba_num_blocks must be registered"):
             tpu_get_kv_cache_coordinator(cfg, **coord_kwargs)
+
+
+class TestTPUKVCacheManager:
+
+    def test_allocate_slots_dual_pool_gating(self):
+        set_mamba_num_blocks(5)
+        cfg = _make_mock_hybrid_kv_cache_config(num_attn_blocks=10,
+                                                mamba_num_blocks=5)
+        manager = TPUKVCacheManager(
+            kv_cache_config=cfg,
+            max_model_len=1024,
+            scheduler_block_size=16,
+            hash_block_size=16,
+            enable_caching=True,
+        )
+        assert isinstance(manager.coordinator, TPUHybridKVCacheCoordinator)
+
+        req = Request(
+            request_id="req-1",
+            prompt_token_ids=list(range(32)),
+            sampling_params=MagicMock(),
+            pooling_params=None,
+        )
+        req.block_hashes = [BlockHash(f"h_{i}".encode()) for i in range(2)]
+        req.status = RequestStatus.RUNNING
+
+        # 1. Successful allocation
+        blocks = manager.allocate_slots(request=req, num_new_tokens=32)
+        assert blocks is not None
+        assert len(blocks.blocks[0]) == 2  # 2 attn blocks
+        assert len(blocks.blocks[1]) == 2  # 2 mamba blocks (1 null + 1 state)
+
+        # 2. Attention pool exhaustion -> returns None for new request
+        coord = manager.coordinator
+        free_attn = coord.attention_block_pool.get_num_free_blocks()
+        allocated_attn = coord.attention_block_pool.get_new_blocks(free_attn)
+        req2 = Request(
+            request_id="req-2",
+            prompt_token_ids=list(range(16)),
+            sampling_params=MagicMock(),
+            pooling_params=None,
+        )
+        req2.block_hashes = [BlockHash(b"h_req2")]
+        req2.status = RequestStatus.WAITING
+        blocks_no_attn = manager.allocate_slots(request=req2,
+                                                num_new_tokens=16)
+        assert blocks_no_attn is None
+        coord.attention_block_pool.free_blocks(allocated_attn)
+
+        # 3. Mamba pool exhaustion -> returns None (prevents ValueError crash in get_new_blocks)
+        free_mamba = coord.mamba_block_pool.get_num_free_blocks()
+        allocated_mamba = coord.mamba_block_pool.get_new_blocks(free_mamba)
+        req3 = Request(
+            request_id="req-3",
+            prompt_token_ids=list(range(16)),
+            sampling_params=MagicMock(),
+            pooling_params=None,
+        )
+        req3.block_hashes = [BlockHash(b"h_req3")]
+        req3.status = RequestStatus.WAITING
+        blocks_no_mamba = manager.allocate_slots(request=req3,
+                                                 num_new_tokens=16)
+        assert blocks_no_mamba is None
+        coord.mamba_block_pool.free_blocks(allocated_mamba)

--- a/tests/core/test_hybrid_coordinator.py
+++ b/tests/core/test_hybrid_coordinator.py
@@ -1,0 +1,255 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock
+
+import torch
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import (BlockHash,
+                                         make_block_hash_with_group_id)
+from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
+                                        KVCacheGroupSpec, MambaSpec)
+from vllm.v1.request import Request, RequestStatus
+
+from tpu_inference.core.hybrid_coordinator import (
+    TPUDualBlockPool, TPUHybridKVCacheCoordinator, TPUKVCacheManager,
+    install_hybrid_coordinator_hooks)
+
+
+def _make_mock_hybrid_kv_cache_config(
+    num_attn_blocks: int = 500,
+    mamba_num_blocks: int = 50,
+    block_size: int = 16,
+) -> KVCacheConfig:
+    attn_spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    mamba_spec = MambaSpec(
+        shapes=((3, 64), (8, 64, 16)),
+        dtypes=(torch.bfloat16, torch.float32),
+        block_size=block_size,
+        mamba_cache_mode="align",
+    )
+    groups = [
+        KVCacheGroupSpec(kv_cache_spec=attn_spec, layer_names=["attn_0"]),
+        KVCacheGroupSpec(kv_cache_spec=mamba_spec, layer_names=["mamba_0"]),
+    ]
+    cfg = KVCacheConfig(
+        num_blocks=num_attn_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+    )
+    cfg.mamba_num_blocks = mamba_num_blocks
+    return cfg
+
+
+class TestTPUDualBlockPool:
+
+    def test_routing_free_and_touch_to_origin_pools(self):
+        pool_attn = BlockPool(num_gpu_blocks=100,
+                              enable_caching=True,
+                              hash_block_size=16)
+        pool_mamba = BlockPool(num_gpu_blocks=20,
+                               enable_caching=True,
+                               hash_block_size=16)
+
+        dual_pool = TPUDualBlockPool(pool_attn,
+                                     pool_mamba,
+                                     mamba_group_ids={1})
+
+        # Allocate 2 from attn, 1 from mamba
+        attn_blks = pool_attn.get_new_blocks(2)
+        mamba_blks = pool_mamba.get_new_blocks(1)
+
+        assert pool_attn.get_num_free_blocks() == 100 - 1 - 2  # 1 null block
+        assert pool_mamba.get_num_free_blocks() == 20 - 1 - 1
+
+        # Test touch via dual_pool
+        dual_pool.touch([attn_blks[0], mamba_blks[0]])
+        assert attn_blks[0].ref_cnt == 2
+        assert mamba_blks[0].ref_cnt == 2
+
+        # Reset ref_cnt back to 1 for clean free
+        attn_blks[0].ref_cnt = 1
+        mamba_blks[0].ref_cnt = 1
+
+        # Free combined list via dual_pool
+        mixed_blocks = [attn_blks[0], mamba_blks[0], attn_blks[1]]
+        dual_pool.free_blocks(mixed_blocks)
+
+        # Both pools should have all blocks returned
+        assert pool_attn.get_num_free_blocks() == 100 - 1
+        assert pool_mamba.get_num_free_blocks() == 20 - 1
+
+    def test_reset_prefix_cache_clears_both(self):
+        pool_attn = BlockPool(num_gpu_blocks=100,
+                              enable_caching=True,
+                              hash_block_size=16)
+        pool_mamba = BlockPool(num_gpu_blocks=20,
+                               enable_caching=True,
+                               hash_block_size=16)
+        dual_pool = TPUDualBlockPool(pool_attn,
+                                     pool_mamba,
+                                     mamba_group_ids={1})
+
+        assert dual_pool.reset_prefix_cache() is True
+
+
+class TestTPUHybridKVCacheCoordinator:
+
+    def test_decoupled_pool_initialization(self):
+        cfg = _make_mock_hybrid_kv_cache_config(num_attn_blocks=500,
+                                                mamba_num_blocks=50)
+        coord = TPUHybridKVCacheCoordinator(
+            kv_cache_config=cfg,
+            max_model_len=1024,
+            max_in_flight_tokens=128,
+            use_eagle=False,
+            enable_caching=True,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=16,
+            hash_block_size=16,
+        )
+
+        assert coord.attention_block_pool.num_gpu_blocks == 500
+        assert coord.mamba_block_pool.num_gpu_blocks == 50
+
+        # Manager 0 (attn) points to attention pool
+        assert coord.single_type_managers[
+            0].block_pool is coord.attention_block_pool
+        # Manager 1 (mamba) points to mamba pool
+        assert coord.single_type_managers[
+            1].block_pool is coord.mamba_block_pool
+
+    def test_can_allocate_tokens_respects_both_pools(self):
+        cfg = _make_mock_hybrid_kv_cache_config(num_attn_blocks=10,
+                                                mamba_num_blocks=5)
+        coord = TPUHybridKVCacheCoordinator(
+            kv_cache_config=cfg,
+            max_model_len=1024,
+            max_in_flight_tokens=128,
+            use_eagle=False,
+            enable_caching=True,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=16,
+            hash_block_size=16,
+        )
+
+        req = MagicMock(spec=Request)
+        req.request_id = "req-1"
+        req.num_computed_tokens = 0
+        req.status = RequestStatus.RUNNING
+
+        # Request 32 tokens (needs 2 attn blocks, 1 mamba block)
+        can_fit = coord.can_allocate_tokens(
+            request=req,
+            num_tokens=32,
+            new_computed_blocks=([], []),
+            num_encoder_tokens=0,
+            total_computed_tokens=0,
+            num_local_computed_tokens=0,
+            num_tokens_main_model=32,
+            watermark_blocks=0,
+            reserved_blocks=0,
+        )
+        assert can_fit is True
+
+        # Now exhaust attention pool
+        free_attn = coord.attention_block_pool.get_num_free_blocks()
+        allocated_attn = coord.attention_block_pool.get_new_blocks(free_attn)
+        can_fit_no_attn = coord.can_allocate_tokens(
+            request=req,
+            num_tokens=32,
+            new_computed_blocks=([], []),
+            num_encoder_tokens=0,
+            total_computed_tokens=0,
+            num_local_computed_tokens=0,
+            num_tokens_main_model=32,
+            watermark_blocks=0,
+            reserved_blocks=0,
+        )
+        assert can_fit_no_attn is False
+
+        # Free attention pool
+        coord.attention_block_pool.free_blocks(allocated_attn)
+
+        # Now exhaust mamba pool
+        free_mamba = coord.mamba_block_pool.get_num_free_blocks()
+        allocated_mamba = coord.mamba_block_pool.get_new_blocks(free_mamba)
+        can_fit_no_mamba = coord.can_allocate_tokens(
+            request=req,
+            num_tokens=32,
+            new_computed_blocks=([], []),
+            num_encoder_tokens=0,
+            total_computed_tokens=0,
+            num_local_computed_tokens=0,
+            num_tokens_main_model=32,
+            watermark_blocks=0,
+            reserved_blocks=0,
+        )
+        assert can_fit_no_mamba is False
+        coord.mamba_block_pool.free_blocks(allocated_mamba)
+
+    def test_find_longest_cache_hit_reconciles_minimum(self):
+        cfg = _make_mock_hybrid_kv_cache_config(num_attn_blocks=500,
+                                                mamba_num_blocks=50)
+        coord = TPUHybridKVCacheCoordinator(
+            kv_cache_config=cfg,
+            max_model_len=1024,
+            max_in_flight_tokens=128,
+            use_eagle=False,
+            enable_caching=True,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=16,
+            hash_block_size=16,
+        )
+
+        hashes = [BlockHash(f"hash_{i}".encode("utf-8")) for i in range(10)]
+
+        # Simulate: attn cached 5 blocks (80 tokens), mamba cached 3 blocks (48 tokens)
+        # Attn pool caches hashes 0..4 (group_id = 0)
+        attn_blocks = coord.attention_block_pool.get_new_blocks(5)
+        for i, b in enumerate(attn_blocks):
+            coord.attention_block_pool._insert_block_hash(
+                make_block_hash_with_group_id(hashes[i], 0),
+                b,
+                num_tokens=(i + 1) * 16)
+
+        # Mamba pool caches hashes 0..2 (group_id = 1)
+        mamba_blocks = coord.mamba_block_pool.get_new_blocks(3)
+        for i, b in enumerate(mamba_blocks):
+            coord.mamba_block_pool._insert_block_hash(
+                make_block_hash_with_group_id(hashes[i], 1),
+                b,
+                num_tokens=(i + 1) * 16)
+
+        hit_blocks, hit_length, uncached = coord.find_longest_cache_hit(
+            block_hashes=hashes,
+            max_cache_hit_length=160,
+        )
+
+        # Reconciled hit length must be min(80, 48) = 48 tokens (3 blocks)
+        assert hit_length == 48
+        # Attention blocks must be truncated to 3 blocks
+        assert len(hit_blocks[0]) == 3
+        # Mamba block list has length 3 (with null blocks inserted before the match)
+        assert len(hit_blocks[1]) == 3
+
+
+class TestHybridCoordinatorHooks:
+
+    def test_install_hooks(self):
+        import vllm.v1.core.kv_cache_coordinator as coord_mod
+        import vllm.v1.core.kv_cache_manager as mgr_mod
+
+        install_hybrid_coordinator_hooks()
+        assert mgr_mod.KVCacheManager is TPUKVCacheManager
+        assert callable(coord_mod.get_kv_cache_coordinator)

--- a/tests/e2e/test_mamba_prefix_caching.py
+++ b/tests/e2e/test_mamba_prefix_caching.py
@@ -75,7 +75,7 @@ def _generate(mode: str,
             }
         }
     if budget is not None:
-        additional_config["mamba_cache_checkpoint_budget"] = budget
+        additional_config["custom_mamba_cache_size"] = budget
 
     llm = LLM(
         model=MODEL_NAME,

--- a/tests/e2e/test_mamba_prefix_caching.py
+++ b/tests/e2e/test_mamba_prefix_caching.py
@@ -20,6 +20,7 @@ process that already built one fails the engine-core handshake on TPU.
 """
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -54,7 +55,10 @@ QUESTIONS = [
 ]
 
 
-def _generate(mode: str, out_path: str, dp_size: int = 1) -> None:
+def _generate(mode: str,
+              out_path: str,
+              dp_size: int = 1,
+              budget: int | None = None) -> None:
     """Generate the prompt set in this process and dump the result.
 
     Only called in the child process (see `__main__` below), so vllm is
@@ -65,13 +69,13 @@ def _generate(mode: str, out_path: str, dp_size: int = 1) -> None:
 
     additional_config = {}
     if dp_size > 1:
-        additional_config = {
-            "sharding": {
-                "sharding_strategy": {
-                    "enable_dp_attention": True
-                }
+        additional_config["sharding"] = {
+            "sharding_strategy": {
+                "enable_dp_attention": True
             }
         }
+    if budget is not None:
+        additional_config["mamba_cache_checkpoint_budget"] = budget
 
     llm = LLM(
         model=MODEL_NAME,
@@ -112,7 +116,7 @@ def _generate(mode: str, out_path: str, dp_size: int = 1) -> None:
             }, f)
 
 
-def _run_case(mode: str, dp_size: int = 1) -> dict:
+def _run_case(mode: str, dp_size: int = 1, budget: int | None = None) -> dict:
     """Run one engine in a subprocess and return its result."""
     with tempfile.TemporaryDirectory() as tmp:
         out_path = os.path.join(tmp, f"{mode}_dp{dp_size}.json")
@@ -120,36 +124,66 @@ def _run_case(mode: str, dp_size: int = 1) -> dict:
                    MODEL_IMPL_TYPE="vllm",
                    SKIP_JAX_PRECOMPILE="1",
                    VLLM_XLA_CHECK_RECOMPILATION="0")
-        proc = subprocess.run(
-            [sys.executable, __file__, mode, out_path,
-             str(dp_size)],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=1800)
+        cmd = [sys.executable, __file__, mode, out_path, str(dp_size)]
+        if budget is not None:
+            cmd.append(str(budget))
+        proc = subprocess.run(cmd,
+                              env=env,
+                              capture_output=True,
+                              text=True,
+                              timeout=1800)
         if not os.path.exists(out_path):
             raise AssertionError(
                 f"prefix-caching-{mode} (dp={dp_size}) run produced no output\n"
                 f"--- stdout ---\n{proc.stdout[-4000:]}\n"
                 f"--- stderr ---\n{proc.stderr[-4000:]}")
         with open(out_path) as f:
-            return json.load(f)
+            data = json.load(f)
+
+        # Parse compact mamba KV cache log from stdout/stderr of EngineCore
+        combined_logs = proc.stdout + proc.stderr
+        match = re.search(
+            r"Compact-mamba KV cache.*?num_gpu_blocks_override=(\d+).*?_mamba_num_blocks=(\d+)",
+            combined_logs,
+        )
+        if match:
+            data["cache_info"] = {
+                "num_gpu_blocks_override": int(match.group(1)),
+                "mamba_num_blocks": int(match.group(2)),
+            }
+        return data
 
 
-def _verify_mamba_prefix_caching(dp_size: int = 1):
+def _verify_mamba_prefix_caching(dp_size: int = 1, budget: int | None = None):
     """Verify greedy output consistency with prefix caching on vs off."""
-    baseline = _run_case("off", dp_size=dp_size)
-    cached = _run_case("on", dp_size=dp_size)
+    baseline = _run_case("off", dp_size=dp_size, budget=budget)
+    cached = _run_case("on", dp_size=dp_size, budget=budget)
 
     queries = cached["metrics"].get("vllm:prefix_cache_queries", 0)
     hits = cached["metrics"].get("vllm:prefix_cache_hits", 0)
     print(
-        f"  prefix cache (dp={dp_size}): {hits:.0f}/{queries:.0f} tokens hit "
+        f"  prefix cache (dp={dp_size}, budget={budget}): {hits:.0f}/{queries:.0f} tokens hit "
         f"({hits / queries if queries else 0:.1%})")
 
     assert hits > 0, (
         f"no prefix cache hits (dp={dp_size}): the shared prefix was never "
         f"reused, so this test did not exercise mamba state reuse")
+
+    # Verify decoupled dual KV cache pools
+    if "cache_info" in cached:
+        info = cached["cache_info"]
+        attn_blocks = info.get("num_gpu_blocks_override")
+        mamba_blocks = info.get("mamba_num_blocks")
+        print(
+            f"  KV Cache pools (dp={dp_size}): Attention={attn_blocks} blocks, "
+            f"Mamba={mamba_blocks} blocks")
+        if mamba_blocks is not None and attn_blocks is not None:
+            assert attn_blocks > mamba_blocks, (
+                f"Attention pool ({attn_blocks}) must be larger than compact Mamba pool ({mamba_blocks})"
+            )
+            if budget is not None:
+                # With spec budget, mamba pool should be close to active + budget
+                assert mamba_blocks <= 8 * 2 + budget + 8
 
     mismatched = [
         i for i, (
@@ -163,8 +197,8 @@ def _verify_mamba_prefix_caching(dp_size: int = 1):
 
     assert not mismatched, (
         f"{len(mismatched)}/{len(QUESTIONS)} prompts changed when prefix "
-        f"caching was enabled (dp={dp_size}); linear-attention state is not "
-        f"being reused correctly")
+        f"caching was enabled (dp={dp_size}, budget={budget}); linear-attention "
+        f"state is not being reused correctly")
 
 
 def test_mamba_prefix_caching_matches_baseline():
@@ -177,7 +211,14 @@ def test_mamba_prefix_caching_dp_matches_baseline():
     _verify_mamba_prefix_caching(dp_size=2)
 
 
+def test_mamba_prefix_caching_with_tight_checkpoint_budget():
+    """Verify that under a tight checkpoint budget, eviction triggers in Mamba,
+    the coordinator reconciles min(L_attn, L_mamba), and generation remains bit-exact."""
+    _verify_mamba_prefix_caching(dp_size=1, budget=16)
+
+
 if __name__ == "__main__":
     # Child entry point for `_run_case`.
     dp = int(sys.argv[3]) if len(sys.argv) > 3 else 1
-    _generate(sys.argv[1], sys.argv[2], dp)
+    budget = int(sys.argv[4]) if len(sys.argv) > 4 else None
+    _generate(sys.argv[1], sys.argv[2], dp, budget=budget)

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -1289,9 +1289,10 @@ class TestKVCacheManager:
             self):
         """In align mode (prefix caching enabled), compact-mamba allocates
         active slots (max_num_reqs + 1) plus a checkpoint budget (default
-        max(max_num_reqs * 3, 1536)) for Mamba, and sizes the Attention pool
+        2x max_num_reqs) for Mamba, and sizes the Attention pool
         from the remaining HBM."""
-        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        from tpu_inference.runner.kv_cache_manager import (
+            KVCacheManager, MambaCheckpointBudgetMultiplier)
         manager = KVCacheManager(self.runner)
         manager.use_mla = False
 
@@ -1313,7 +1314,7 @@ class TestKVCacheManager:
                                              attn_page=attn_page,
                                              unpadded_mamba=unpadded_mamba)
 
-        expected_mamba = 257 + 256 * 8
+        expected_mamba = (257 + 256 * MambaCheckpointBudgetMultiplier.DEFAULT)
         assert manager._mamba_num_blocks == expected_mamba
         assert self.runner.cache_config.mamba_num_blocks == expected_mamba
 

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -1285,6 +1285,81 @@ class TestKVCacheManager:
         assert manager._mamba_num_blocks is None
         assert self.runner.cache_config.num_gpu_blocks_override == 999
 
+    def test_compact_mamba_override_in_align_mode_allocates_checkpoint_budget(
+            self):
+        """In align mode (prefix caching enabled), compact-mamba allocates
+        active slots (max_num_reqs + 1) plus a checkpoint budget (default
+        max(max_num_reqs * 3, 1536)) for Mamba, and sizes the Attention pool
+        from the remaining HBM."""
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        avail_per_device = 304 * (2**30) // 4
+        attn_page = 2**20
+        unpadded_mamba = 2 * (2**20)
+        max_num_reqs = 256
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = None
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, avail_per_device)] * 4):
+            self._run_compact_mamba_override(manager,
+                                             attn_page=attn_page,
+                                             unpadded_mamba=unpadded_mamba)
+
+        expected_mamba = 257 + 256 * 8
+        assert manager._mamba_num_blocks == expected_mamba
+        assert self.runner.cache_config.mamba_num_blocks == expected_mamba
+
+        avail_per_tensor = (304 * 2**30) // 15
+        expected_attn = (avail_per_tensor -
+                         3 * expected_mamba * unpadded_mamba) // attn_page
+        assert (
+            self.runner.cache_config.num_gpu_blocks_override == expected_attn)
+
+    def test_compact_mamba_override_in_align_mode_custom_checkpoint_budget(
+            self):
+        """Custom mamba_cache_checkpoint_budget in additional_config is honored."""
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        avail_per_device = 304 * (2**30) // 4
+        attn_page = 2**20
+        unpadded_mamba = 2 * (2**20)
+        max_num_reqs = 256
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = None
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.vllm_config.additional_config[
+            "mamba_cache_checkpoint_budget"] = 2000
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, avail_per_device)] * 4):
+            self._run_compact_mamba_override(manager,
+                                             attn_page=attn_page,
+                                             unpadded_mamba=unpadded_mamba)
+
+        expected_mamba = 257 + 2000
+        assert manager._mamba_num_blocks == expected_mamba
+        assert self.runner.cache_config.mamba_num_blocks == expected_mamba
+
+        avail_per_tensor = (304 * 2**30) // 15
+        expected_attn = (avail_per_tensor -
+                         3 * expected_mamba * unpadded_mamba) // attn_page
+        assert (
+            self.runner.cache_config.num_gpu_blocks_override == expected_attn)
+
     def test_get_kv_cache_spec_pure_attention_no_cache_config_updates(self):
         mock_attn = MagicMock(spec=MambaBase)
         layers = {'layer.0': mock_attn}

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -1361,6 +1361,46 @@ class TestKVCacheManager:
         assert (
             self.runner.cache_config.num_gpu_blocks_override == expected_attn)
 
+    def test_compact_mamba_override_in_align_mode_tight_hbm_clamps_gracefully(
+            self):
+        """In tight HBM where 50% budget <= active_mamba_blocks, checkpoint
+        budget shrinks to 0 (clamped to active_mamba_blocks) rather than
+        aborting compact sizing."""
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        # Set avail_per_tensor = 600 MiB (total avail = 600 * 15 = 9000 MiB across 4 devices)
+        avail_per_device = (600 * (2**20) * 15) // 4
+        attn_page = 2**20  # 1 MiB
+        unpadded_mamba = 2 * (2**20)  # 2 MiB
+        max_num_reqs = 64  # active_mamba_blocks = 65, default budget = 128 -> unclamped = 193
+        # mamba_slot_cost = 3 * 2 MiB = 6 MiB
+        # 50% HBM = 300 MiB -> max_mamba_blocks = 50 (< active_mamba_blocks=65)
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = None
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, avail_per_device)] * 4):
+            self._run_compact_mamba_override(manager,
+                                             attn_page=attn_page,
+                                             unpadded_mamba=unpadded_mamba)
+
+        # Clamped to active_mamba_blocks (65) rather than aborting to uniform layout
+        expected_mamba = 65
+        assert manager._mamba_num_blocks == expected_mamba
+        assert self.runner.cache_config.mamba_num_blocks == expected_mamba
+
+        avail_per_tensor = 600 * (2**20)
+        expected_attn = (avail_per_tensor -
+                         3 * expected_mamba * unpadded_mamba) // attn_page
+        assert self.runner.cache_config.num_gpu_blocks_override == expected_attn
+
     def test_get_kv_cache_spec_pure_attention_no_cache_config_updates(self):
         mock_attn = MagicMock(spec=MambaBase)
         layers = {'layer.0': mock_attn}

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -1261,7 +1261,7 @@ class TestKVCacheManager:
         assert manager._mamba_num_blocks is None
         assert self.runner.cache_config.num_gpu_blocks_override is None
 
-    def test_compact_mamba_override_respects_user_pinned_override(self):
+    def test_compact_mamba_override_respects_num_gpu_blocks_override(self):
         """When the user pins `num_gpu_blocks_override` explicitly,
         compact-mamba must not clobber it (their explicit choice wins)."""
         from tpu_inference.runner.kv_cache_manager import KVCacheManager
@@ -1292,7 +1292,7 @@ class TestKVCacheManager:
         2x max_num_reqs) for Mamba, and sizes the Attention pool
         from the remaining HBM."""
         from tpu_inference.runner.kv_cache_manager import (
-            KVCacheManager, MambaCheckpointBudgetMultiplier)
+            DEFAULT_MAMBA_CHECKPOINT_BUDGET_MULTIPLIER, KVCacheManager)
         manager = KVCacheManager(self.runner)
         manager.use_mla = False
 
@@ -1314,7 +1314,8 @@ class TestKVCacheManager:
                                              attn_page=attn_page,
                                              unpadded_mamba=unpadded_mamba)
 
-        expected_mamba = (257 + 256 * MambaCheckpointBudgetMultiplier.DEFAULT)
+        expected_mamba = (257 +
+                          256 * DEFAULT_MAMBA_CHECKPOINT_BUDGET_MULTIPLIER)
         assert manager._mamba_num_blocks == expected_mamba
         assert self.runner.cache_config.mamba_num_blocks == expected_mamba
 
@@ -1326,7 +1327,7 @@ class TestKVCacheManager:
 
     def test_compact_mamba_override_in_align_mode_custom_checkpoint_budget(
             self):
-        """Custom mamba_cache_checkpoint_budget in additional_config is honored."""
+        """Custom custom_mamba_cache_size in additional_config is honored."""
         from tpu_inference.runner.kv_cache_manager import KVCacheManager
         manager = KVCacheManager(self.runner)
         manager.use_mla = False
@@ -1340,7 +1341,7 @@ class TestKVCacheManager:
         self.runner.cache_config.num_gpu_blocks_override = None
         self.runner.cache_config.mamba_cache_mode = "align"
         self.runner.vllm_config.additional_config[
-            "mamba_cache_checkpoint_budget"] = 2000
+            "custom_mamba_cache_size"] = 2000
         self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
         self.runner.max_num_reqs = max_num_reqs
 
@@ -1400,6 +1401,104 @@ class TestKVCacheManager:
         expected_attn = (avail_per_tensor -
                          3 * expected_mamba * unpadded_mamba) // attn_page
         assert self.runner.cache_config.num_gpu_blocks_override == expected_attn
+
+    def test_compact_mamba_override_in_align_mode_user_pinned_fitting(self):
+        """In align mode, user-pinned `num_gpu_blocks_override` is respected
+        if total memory fits within available HBM."""
+        from tpu_inference.runner.kv_cache_manager import (
+            DEFAULT_MAMBA_CHECKPOINT_BUDGET_MULTIPLIER, KVCacheManager)
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        avail_per_device = 304 * (2**30) // 4
+        attn_page = 2**20
+        unpadded_mamba = 2 * (2**20)
+        max_num_reqs = 256
+        pinned_attn = 5000
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = pinned_attn
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, avail_per_device)] * 4):
+            self._run_compact_mamba_override(manager,
+                                             attn_page=attn_page,
+                                             unpadded_mamba=unpadded_mamba)
+
+        expected_mamba = (257 +
+                          256 * DEFAULT_MAMBA_CHECKPOINT_BUDGET_MULTIPLIER)
+        assert manager._mamba_num_blocks == expected_mamba
+        assert self.runner.cache_config.mamba_num_blocks == expected_mamba
+        assert self.runner.cache_config.num_gpu_blocks_override == pinned_attn
+
+    def test_compact_mamba_override_in_align_mode_user_pinned_exceeding_hbm_raises(
+            self):
+        """In align mode, if user-pinned `num_gpu_blocks_override` and
+        `custom_mamba_cache_size` burst available HBM, raise ValueError."""
+        import pytest
+
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        avail_per_device = 10 * (2**30) // 4  # 10 GiB total HBM
+        attn_page = 2**20
+        unpadded_mamba = 2 * (2**20)
+        max_num_reqs = 256
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = 100_000  # huge
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.vllm_config.additional_config[
+            "custom_mamba_cache_size"] = 1000
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, avail_per_device)] * 4):
+            with pytest.raises(ValueError, match="exceeds available HBM"):
+                self._run_compact_mamba_override(manager,
+                                                 attn_page=attn_page,
+                                                 unpadded_mamba=unpadded_mamba)
+
+    def test_compact_mamba_override_in_align_mode_user_pinned_shrinks_default_mamba(
+            self):
+        """In align mode, if user-pinned `num_gpu_blocks_override` bursts HBM
+        with default Mamba budget, Mamba budget shrinks down to active slots."""
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        max_num_reqs = 64
+        attn_page = 2**20
+        unpadded_mamba = 2 * (2**20)
+        avail_per_device = (15 * 1000 * (2**20)) // 4
+        pinned_attn = 500
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = pinned_attn
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.vllm_config.additional_config.pop(
+            "custom_mamba_cache_size", None)
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, avail_per_device)] * 4):
+            self._run_compact_mamba_override(manager,
+                                             attn_page=attn_page,
+                                             unpadded_mamba=unpadded_mamba)
+
+        # Mamba shrank to active slots (65)
+        assert manager._mamba_num_blocks == 65
+        assert self.runner.cache_config.mamba_num_blocks == 65
+        assert self.runner.cache_config.num_gpu_blocks_override == pinned_attn
 
     def test_get_kv_cache_spec_pure_attention_no_cache_config_updates(self):
         mock_attn = MagicMock(spec=MambaBase)

--- a/tpu_inference/core/hybrid_coordinator.py
+++ b/tpu_inference/core/hybrid_coordinator.py
@@ -1,0 +1,599 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+from vllm.logger import init_logger
+from vllm.utils.math_utils import cdiv
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_coordinator import (HybridKVCacheCoordinator,
+                                               KVCacheCoordinator)
+from vllm.v1.core.kv_cache_coordinator import \
+    get_kv_cache_coordinator as orig_get_kv_cache_coordinator
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
+from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
+from vllm.v1.core.single_type_kv_cache_manager import (
+    CrossAttentionManager, get_manager_for_kv_cache_spec)
+from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
+                                        MambaSpec)
+from vllm.v1.request import Request, RequestStatus
+
+logger = init_logger(__name__)
+
+_GLOBAL_MAMBA_NUM_BLOCKS: int | None = None
+_HOOKS_INSTALLED: bool = False
+
+
+def set_mamba_num_blocks(num_blocks: int) -> None:
+    """Register the TPU runner's computed Mamba block pool capacity."""
+    global _GLOBAL_MAMBA_NUM_BLOCKS
+    _GLOBAL_MAMBA_NUM_BLOCKS = int(num_blocks)
+
+
+def get_mamba_num_blocks() -> int | None:
+    """Get the registered Mamba block pool capacity."""
+    return _GLOBAL_MAMBA_NUM_BLOCKS
+
+
+class TPUDualBlockPool(BlockPool):
+    """A composite BlockPool that coordinates separate Attention and Mamba pools.
+
+    This ensures that:
+    - Attention and Mamba managers allocate from distinct physical pools with decoupled sizes.
+    - Freeing, evicting, and touching blocks routes each block to its originating pool without cross-contamination.
+    - Any external consumer accessing block_pool from KVCacheManager or scheduler sees a coherent BlockPool interface.
+    """
+
+    def __init__(
+        self,
+        attention_pool: BlockPool,
+        mamba_pool: BlockPool,
+        mamba_group_ids: set[int] | None = None,
+    ):
+        self.attention_pool = attention_pool
+        self.mamba_pool = mamba_pool
+        self.mamba_group_ids = mamba_group_ids or set()
+        self.mamba_block_identities: set[int] = {
+            id(b)
+            for b in mamba_pool.blocks
+        }
+
+        # Mirror essential attributes from attention_pool (primary pool)
+        self.num_gpu_blocks = attention_pool.num_gpu_blocks
+        self.enable_caching = attention_pool.enable_caching
+        self.hash_block_size = attention_pool.hash_block_size
+        self.enable_kv_cache_events = attention_pool.enable_kv_cache_events
+        self.metrics_collector = attention_pool.metrics_collector
+        self.null_block = attention_pool.null_block
+        self.blocks = attention_pool.blocks
+        self.free_block_queue = attention_pool.free_block_queue
+        self.cached_block_hash_to_block = attention_pool.cached_block_hash_to_block
+        self.cached_block_hashes_by_block = attention_pool.cached_block_hashes_by_block
+        self.kv_event_queue = attention_pool.kv_event_queue
+
+    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
+        attn_blocks: list[KVCacheBlock] = []
+        mamba_blocks: list[KVCacheBlock] = []
+        for block in ordered_blocks:
+            if id(block) in self.mamba_block_identities:
+                mamba_blocks.append(block)
+            else:
+                attn_blocks.append(block)
+        if attn_blocks:
+            self.attention_pool.free_blocks(attn_blocks)
+        if mamba_blocks:
+            self.mamba_pool.free_blocks(mamba_blocks)
+
+    def touch(self, blocks: Sequence[KVCacheBlock]) -> None:
+        attn_blocks: list[KVCacheBlock] = []
+        mamba_blocks: list[KVCacheBlock] = []
+        for block in blocks:
+            if id(block) in self.mamba_block_identities:
+                mamba_blocks.append(block)
+            else:
+                attn_blocks.append(block)
+        if attn_blocks:
+            self.attention_pool.touch(attn_blocks)
+        if mamba_blocks:
+            self.mamba_pool.touch(mamba_blocks)
+
+    def get_num_free_blocks(self) -> int:
+        return self.attention_pool.get_num_free_blocks()
+
+    def get_usage(self) -> float:
+        return max(self.attention_pool.get_usage(),
+                   self.mamba_pool.get_usage())
+
+    def reset_prefix_cache(self) -> bool:
+        r1 = self.attention_pool.reset_prefix_cache()
+        r2 = self.mamba_pool.reset_prefix_cache()
+        return r1 and r2
+
+    def take_events(self):
+        return self.attention_pool.take_events() + self.mamba_pool.take_events(
+        )
+
+    def evict_blocks(self, block_ids: set[int]) -> None:
+        attn_ids = {
+            bid
+            for bid in block_ids if bid < len(self.attention_pool.blocks)
+        }
+        if attn_ids:
+            self.attention_pool.evict_blocks(attn_ids)
+        mamba_ids = {
+            bid
+            for bid in block_ids if bid < len(self.mamba_pool.blocks)
+        }
+        if mamba_ids:
+            self.mamba_pool.evict_blocks(mamba_ids)
+
+    def get_cached_block(
+            self, block_hash: BlockHash,
+            kv_cache_group_ids: list[int]) -> list[KVCacheBlock] | None:
+        if any(gid in self.mamba_group_ids for gid in kv_cache_group_ids):
+            return self.mamba_pool.get_cached_block(block_hash,
+                                                    kv_cache_group_ids)
+        return self.attention_pool.get_cached_block(block_hash,
+                                                    kv_cache_group_ids)
+
+
+class TPUHybridKVCacheCoordinator(HybridKVCacheCoordinator):
+    """Decoupled KV cache coordinator for hybrid models under Mamba align mode on TPU.
+
+    Attention layers use a large pool (e.g. ~34,000 blocks) to maximize context length
+    and concurrency, while Mamba layers use a dedicated, compact pool (e.g. 2,048 blocks)
+    for active recurrent states and prefix checkpoints.
+    Prefix cache hits are independently queried from each pool and reconciled via min(),
+    preventing any cache eviction desync.
+    """
+
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        *args,
+        mamba_num_blocks: int | None = None,
+        **kwargs,
+    ):
+        super().__init__(kv_cache_config, *args, **kwargs)
+
+        # Base __init__ initialized self.block_pool with kv_cache_config.num_blocks (Attention pool)
+        self.attention_block_pool = self.block_pool
+
+        # Identify Mamba and Attention group IDs
+        self.mamba_group_ids = {
+            i
+            for i, g in enumerate(kv_cache_config.kv_cache_groups)
+            if isinstance(g.kv_cache_spec, MambaSpec)
+        }
+        self.attention_group_ids = {
+            i
+            for i, g in enumerate(kv_cache_config.kv_cache_groups)
+            if not isinstance(g.kv_cache_spec, MambaSpec)
+        }
+
+        # Resolve mamba_num_blocks
+        if mamba_num_blocks is None:
+            mamba_num_blocks = getattr(kv_cache_config, "mamba_num_blocks",
+                                       None)
+        if mamba_num_blocks is None:
+            mamba_num_blocks = get_mamba_num_blocks()
+        if mamba_num_blocks is None:
+            mamba_num_blocks = min(kv_cache_config.num_blocks, 2048)
+        self.mamba_num_blocks = int(mamba_num_blocks)
+
+        logger.info(
+            "[TPUHybridKVCacheCoordinator] Initializing dual block pools: "
+            "attn_blocks=%d, mamba_blocks=%d (mamba_groups=%s)",
+            self.attention_block_pool.num_gpu_blocks,
+            self.mamba_num_blocks,
+            sorted(self.mamba_group_ids),
+        )
+
+        # Allocate dedicated Mamba block pool
+        self.mamba_block_pool = BlockPool(
+            num_gpu_blocks=self.mamba_num_blocks,
+            enable_caching=self.enable_caching,
+            hash_block_size=self.hash_block_size,
+            enable_kv_cache_events=self.attention_block_pool.
+            enable_kv_cache_events,
+            metrics_collector=self.attention_block_pool.metrics_collector,
+        )
+
+        # Re-bind Mamba managers to mamba_block_pool
+        new_managers = list(self.single_type_managers)
+        for i in self.mamba_group_ids:
+            old_mgr = self.single_type_managers[i]
+            new_managers[i] = get_manager_for_kv_cache_spec(
+                kv_cache_spec=kv_cache_config.kv_cache_groups[i].kv_cache_spec,
+                max_in_flight_tokens=getattr(old_mgr, "max_in_flight_tokens",
+                                             128),
+                max_model_len=self.max_model_len,
+                block_pool=self.mamba_block_pool,
+                enable_caching=self.enable_caching,
+                kv_cache_group_id=i,
+                dcp_world_size=getattr(self, "dcp_world_size", 1),
+                pcp_world_size=getattr(self, "pcp_world_size", 1),
+                scheduler_block_size=self.scheduler_block_size,
+                needs_kv_cache_zeroing=self.kv_cache_config.
+                needs_kv_cache_zeroing,
+            )
+        self.single_type_managers = tuple(new_managers)
+
+        # Replace self.block_pool with TPUDualBlockPool
+        self.block_pool = TPUDualBlockPool(
+            self.attention_block_pool,
+            self.mamba_block_pool,
+            mamba_group_ids=self.mamba_group_ids,
+        )
+
+        # Re-verify and split groups so attention_groups binds to updated managers
+        self.verify_and_split_kv_cache_groups()
+
+    def find_longest_cache_hit(
+        self,
+        block_hashes: list[BlockHash],
+        max_cache_hit_length: int,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], int, int]:
+        num_groups = len(self.kv_cache_config.kv_cache_groups)
+        hit_length = max_cache_hit_length
+        longest_hit_length = 0
+        hit_blocks_by_group: list[list[KVCacheBlock]
+                                  | None] = [None] * num_groups
+        hit_length_by_group: list[int] = [0] * num_groups
+
+        is_simple_hybrid = len(self.attention_groups) == 2 and isinstance(
+            self.attention_groups[0].spec, FullAttentionSpec)
+        eagle_verified: set[int] = set()
+
+        while True:
+            curr_hit_length = hit_length
+
+            for idx, (spec, group_ids, manager_cls,
+                      use_eagle) in enumerate(self.attention_groups):
+                first_group_id = group_ids[0]
+                group_block_size = self.single_type_managers[
+                    first_group_id].block_size
+                cached_blocks = hit_blocks_by_group[first_group_id]
+                if isinstance(spec,
+                              FullAttentionSpec) and cached_blocks is not None:
+                    curr_hit_length = min(curr_hit_length,
+                                          hit_length_by_group[first_group_id])
+                    continue
+
+                drop_eagle_block = use_eagle and idx not in eagle_verified
+                _max_length = curr_hit_length
+                if drop_eagle_block and not isinstance(spec, MambaSpec):
+                    eagle_margin = (
+                        self.hash_block_size if self.enable_partial_hash_hits
+                        and manager_cls.supports_fine_grained_hash_lookup
+                        and group_block_size > self.hash_block_size else
+                        group_block_size)
+                    _max_length = min(curr_hit_length + eagle_margin,
+                                      max_cache_hit_length)
+
+                pool = (self.mamba_block_pool if isinstance(spec, MambaSpec)
+                        else self.attention_block_pool)
+
+                hit_blocks, _new_hit_length = manager_cls.find_longest_cache_hit(
+                    block_hashes=block_hashes,
+                    max_length=_max_length,
+                    kv_cache_group_ids=group_ids,
+                    block_pool=pool,
+                    kv_cache_spec=spec,
+                    drop_eagle_block=drop_eagle_block,
+                    alignment_tokens=self._cache_hit_alignment_tokens,
+                    dcp_world_size=(self.dcp_world_size if isinstance(
+                        spec, FullAttentionSpec) else 1),
+                )
+                if drop_eagle_block:
+                    eagle_verified.add(idx)
+                elif _new_hit_length < curr_hit_length:
+                    eagle_verified.clear()
+                curr_hit_length = _new_hit_length
+                for group_id, blocks in zip(group_ids, hit_blocks):
+                    hit_blocks_by_group[group_id] = blocks
+                    hit_length_by_group[group_id] = _new_hit_length
+
+                longest_hit_length = max(longest_hit_length, curr_hit_length)
+
+            if curr_hit_length >= hit_length:
+                break
+            hit_length = curr_hit_length
+            if is_simple_hybrid:
+                break
+
+        # Truncate full attention blocks to final hit_length
+        first_group = self.attention_groups[0]
+        if isinstance(first_group.spec, FullAttentionSpec):
+            group_block_size = self.single_type_managers[
+                first_group.group_ids[0]].block_size
+            num_blocks = cdiv(hit_length, group_block_size)
+            for group_id in first_group.group_ids:
+                if (blks := hit_blocks_by_group[group_id]) is not None:
+                    del blks[num_blocks:]
+                    hit_length_by_group[group_id] = hit_length
+
+        num_uncached_common_prefix_tokens = longest_hit_length - hit_length
+        cache_hit_blocks = tuple(blocks if blocks is not None else []
+                                 for blocks in hit_blocks_by_group)
+        return cache_hit_blocks, hit_length, num_uncached_common_prefix_tokens
+
+    def find_longest_cache_hit_per_group(
+        self,
+        block_hashes: list[BlockHash],
+        max_cache_hit_length: int,
+    ) -> tuple[tuple[list[KVCacheBlock], ...], tuple[int, ...]]:
+        num_groups = len(self.kv_cache_config.kv_cache_groups)
+        hit_blocks: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
+        hit_lengths: list[int] = [0] * num_groups
+
+        for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
+            pool = (self.mamba_block_pool if isinstance(spec, MambaSpec) else
+                    self.attention_block_pool)
+            blocks, group_hit = manager_cls.find_longest_cache_hit(
+                block_hashes=block_hashes,
+                max_length=max_cache_hit_length,
+                kv_cache_group_ids=group_ids,
+                block_pool=pool,
+                kv_cache_spec=spec,
+                drop_eagle_block=use_eagle,
+                alignment_tokens=self._cache_hit_alignment_tokens,
+            )
+            for gid, blks in zip(group_ids, blocks):
+                hit_blocks[gid] = blks
+                hit_lengths[gid] = group_hit
+
+        return tuple(hit_blocks), tuple(hit_lengths)
+
+    def can_allocate_tokens(
+        self,
+        request: Request,
+        num_tokens: int,
+        new_computed_blocks: tuple[Sequence[KVCacheBlock], ...],
+        num_encoder_tokens: int,
+        total_computed_tokens: int,
+        num_local_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+        watermark_blocks: int = 0,
+        reserved_blocks: int = 0,
+    ) -> bool:
+        attn_blocks_needed = 0
+        mamba_blocks_needed = 0
+
+        for i, manager in enumerate(self.single_type_managers):
+            is_mamba = i in self.mamba_group_ids
+            if isinstance(manager, CrossAttentionManager):
+                needed = manager.get_num_blocks_to_allocate(
+                    request.request_id,
+                    num_encoder_tokens,
+                    [],
+                    0,
+                    0,
+                    num_encoder_tokens,
+                    apply_admission_cap=apply_admission_cap,
+                )
+            else:
+                needed = manager.get_num_blocks_to_allocate(
+                    request.request_id,
+                    num_tokens,
+                    new_computed_blocks[i],
+                    total_computed_tokens,
+                    num_local_computed_tokens,
+                    num_tokens_main_model,
+                    apply_admission_cap=apply_admission_cap,
+                )
+
+            if is_mamba:
+                mamba_blocks_needed += needed
+            else:
+                attn_blocks_needed += needed
+
+        avail_attn = (self.attention_block_pool.get_num_free_blocks() -
+                      reserved_blocks)
+        if attn_blocks_needed + watermark_blocks > avail_attn:
+            return False
+
+        avail_mamba = self.mamba_block_pool.get_num_free_blocks()
+        if mamba_blocks_needed > avail_mamba:
+            return False
+
+        return True
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: tuple[Sequence[KVCacheBlock], ...],
+        num_encoder_tokens: int,
+        total_computed_tokens: int,
+        num_local_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        """Returns attention blocks needed. Used by scheduler for in-flight prefill reservation."""
+        num_blocks_to_allocate = 0
+        for i, manager in enumerate(self.single_type_managers):
+            if i in self.mamba_group_ids:
+                continue
+            if isinstance(manager, CrossAttentionManager):
+                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+                    request_id,
+                    num_encoder_tokens,
+                    [],
+                    0,
+                    0,
+                    num_encoder_tokens,
+                    apply_admission_cap=apply_admission_cap,
+                )
+            else:
+                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+                    request_id,
+                    num_tokens,
+                    new_computed_blocks[i],
+                    total_computed_tokens,
+                    num_local_computed_tokens,
+                    num_tokens_main_model,
+                    apply_admission_cap=apply_admission_cap,
+                )
+        return num_blocks_to_allocate
+
+
+class TPUKVCacheManager(KVCacheManager):
+    """KVCacheManager subclass that coordinates allocation across decoupled pools."""
+
+    def allocate_slots(
+        self,
+        request: Request,
+        num_new_tokens: int,
+        num_new_computed_tokens: int = 0,
+        new_computed_blocks: KVCacheBlocks | None = None,
+        num_lookahead_tokens: int = 0,
+        num_external_computed_tokens: int = 0,
+        delay_cache_blocks: bool = False,
+        num_encoder_tokens: int = 0,
+        full_sequence_must_fit: bool = False,
+        reserved_blocks: int = 0,
+        has_scheduled_reqs: bool = True,
+    ) -> KVCacheBlocks | None:
+        if not isinstance(self.coordinator, TPUHybridKVCacheCoordinator):
+            return super().allocate_slots(
+                request=request,
+                num_new_tokens=num_new_tokens,
+                num_new_computed_tokens=num_new_computed_tokens,
+                new_computed_blocks=new_computed_blocks,
+                num_lookahead_tokens=num_lookahead_tokens,
+                num_external_computed_tokens=num_external_computed_tokens,
+                delay_cache_blocks=delay_cache_blocks,
+                num_encoder_tokens=num_encoder_tokens,
+                full_sequence_must_fit=full_sequence_must_fit,
+                reserved_blocks=reserved_blocks,
+                has_scheduled_reqs=has_scheduled_reqs,
+            )
+
+        if num_new_tokens == 0 and num_external_computed_tokens == 0:
+            raise ValueError(
+                "num_new_tokens must be greater than 0 when there are no "
+                "external computed tokens")
+
+        if new_computed_blocks is not None:
+            new_computed_block_list = new_computed_blocks.blocks
+        else:
+            new_computed_block_list = self.empty_kv_cache_blocks.blocks
+
+        num_local_computed_tokens = (request.num_computed_tokens +
+                                     num_new_computed_tokens)
+        total_computed_tokens = min(
+            num_local_computed_tokens + num_external_computed_tokens,
+            self.max_model_len,
+        )
+
+        watermark_blocks = 0
+        if has_scheduled_reqs and request.status in (
+                RequestStatus.WAITING,
+                RequestStatus.PREEMPTED,
+        ):
+            watermark_blocks = self.watermark_blocks
+
+        if full_sequence_must_fit:
+            full_num_tokens = min(request.num_tokens, self.max_model_len)
+            can_fit = self.coordinator.can_allocate_tokens(
+                request=request,
+                num_tokens=full_num_tokens,
+                new_computed_blocks=new_computed_block_list,
+                num_encoder_tokens=num_encoder_tokens,
+                total_computed_tokens=total_computed_tokens,
+                num_local_computed_tokens=num_local_computed_tokens,
+                num_tokens_main_model=full_num_tokens,
+                apply_admission_cap=True,
+                watermark_blocks=watermark_blocks,
+                reserved_blocks=0,
+            )
+            if not can_fit:
+                return None
+
+        num_tokens_main_model = total_computed_tokens + num_new_tokens
+        num_tokens_need_slot = min(
+            num_tokens_main_model + num_lookahead_tokens, self.max_model_len)
+
+        self.coordinator.remove_skipped_blocks(
+            request.request_id,
+            max(0, total_computed_tokens - request.num_in_flight_tokens),
+            num_prompt_tokens=request.num_prompt_tokens,
+        )
+
+        can_fit = self.coordinator.can_allocate_tokens(
+            request=request,
+            num_tokens=num_tokens_need_slot,
+            new_computed_blocks=new_computed_block_list,
+            num_encoder_tokens=num_encoder_tokens,
+            total_computed_tokens=num_local_computed_tokens +
+            num_external_computed_tokens,
+            num_local_computed_tokens=num_local_computed_tokens,
+            num_tokens_main_model=num_tokens_main_model,
+            apply_admission_cap=False,
+            watermark_blocks=watermark_blocks,
+            reserved_blocks=reserved_blocks,
+        )
+        if not can_fit:
+            return None
+
+        if (new_computed_block_list is not self.empty_kv_cache_blocks.blocks
+                or num_external_computed_tokens > 0):
+            self.coordinator.allocate_new_computed_blocks(
+                request_id=request.request_id,
+                new_computed_blocks=new_computed_block_list,
+                num_local_computed_tokens=num_local_computed_tokens,
+                num_external_computed_tokens=num_external_computed_tokens,
+            )
+
+        new_blocks = self.coordinator.allocate_new_blocks(
+            request.request_id,
+            num_tokens_need_slot,
+            num_tokens_main_model,
+            num_encoder_tokens,
+        )
+
+        if not self.enable_caching or delay_cache_blocks:
+            return self.create_kv_cache_blocks(new_blocks)
+
+        num_tokens_to_cache = min(
+            total_computed_tokens + num_new_tokens,
+            request.num_tokens,
+        )
+        self.coordinator.cache_blocks(request, num_tokens_to_cache)
+
+        return self.create_kv_cache_blocks(new_blocks)
+
+
+def tpu_get_kv_cache_coordinator(
+    kv_cache_config: KVCacheConfig,
+    *args,
+    **kwargs,
+) -> KVCacheCoordinator:
+    enable_caching = kwargs.get("enable_caching", False)
+    if enable_caching and kv_cache_config.has_mamba_layers:
+        return TPUHybridKVCacheCoordinator(kv_cache_config, *args, **kwargs)
+    return orig_get_kv_cache_coordinator(kv_cache_config, *args, **kwargs)
+
+
+def install_hybrid_coordinator_hooks(vllm_config: Any | None = None) -> None:
+    """Installs hooks into vLLM to use TPUHybridKVCacheCoordinator and TPUKVCacheManager."""
+    global _HOOKS_INSTALLED
+    import sys
+
+    import vllm.v1.core.kv_cache_coordinator as coord_mod
+    import vllm.v1.core.kv_cache_manager as mgr_mod
+
+    coord_mod.get_kv_cache_coordinator = tpu_get_kv_cache_coordinator
+    mgr_mod.get_kv_cache_coordinator = tpu_get_kv_cache_coordinator
+    mgr_mod.KVCacheManager = TPUKVCacheManager
+
+    if "vllm.v1.core.sched.scheduler" in sys.modules:
+        sys.modules[
+            "vllm.v1.core.sched.scheduler"].KVCacheManager = TPUKVCacheManager
+
+    _HOOKS_INSTALLED = True
+    logger.info(
+        "[tpu_inference] Installed TPUHybridKVCacheCoordinator hooks into vLLM"
+    )

--- a/tpu_inference/core/hybrid_coordinator.py
+++ b/tpu_inference/core/hybrid_coordinator.py
@@ -20,8 +20,34 @@ from vllm.v1.request import Request, RequestStatus
 
 logger = init_logger(__name__)
 
-_GLOBAL_MAMBA_NUM_BLOCKS: int | None = None
+# ==============================================================================
+# Decoupled Mamba Block Capacity Lifecycle:
+# ------------------------------------------------------------------------------
+# 1. PRODUCER (tpu_inference/runner/kv_cache_manager.py):
+#    During device HBM memory profiling, KVCacheManager calculates the physical
+#    compact Mamba block capacity and writes it to two places:
+#      - cache_config.mamba_num_blocks = int(mamba_num_blocks)
+#      - set_mamba_num_blocks(int(mamba_num_blocks))
+#
+# 2. PARTITIONER / PROPAGATION:
+#    - DP Serving (tpu_inference/core/sched/dp_scheduler.py):
+#      DPScheduler reads the total capacity from `vllm_config.cache_config.mamba_num_blocks`
+#      and shards it per rank:
+#        rank_kv_config.num_blocks = kv_cache_config.num_blocks // dp_size
+#        rank_kv_config.mamba_num_blocks = mamba_num_blocks // dp_size
+#      In the worker subprocess (_scheduler_worker_process), each rank sets:
+#        set_mamba_num_blocks(kv_cache_config.mamba_num_blocks)
+#        cache_config.mamba_num_blocks = kv_cache_config.mamba_num_blocks
+#    - Non-DP Serving (DP=1):
+#      Runs in the same process where KVCacheManager registered the total capacity via
+#      set_mamba_num_blocks().
+#
+# 3. CONSUMER (TPUHybridKVCacheCoordinator):
+#    Resolves mamba_num_blocks directly from get_mamba_num_blocks() (or an explicit
+#    argument) and initializes an independent Mamba BlockPool, failing fast if not set.
+# ==============================================================================
 _HOOKS_INSTALLED: bool = False
+_GLOBAL_MAMBA_NUM_BLOCKS: int | None = None
 
 
 def set_mamba_num_blocks(num_blocks: int) -> None:
@@ -198,12 +224,11 @@ class TPUHybridKVCacheCoordinator(HybridKVCacheCoordinator):
 
         # Resolve mamba_num_blocks
         if mamba_num_blocks is None:
-            mamba_num_blocks = getattr(kv_cache_config, "mamba_num_blocks",
-                                       None)
-        if mamba_num_blocks is None:
             mamba_num_blocks = get_mamba_num_blocks()
         if mamba_num_blocks is None:
-            mamba_num_blocks = min(kv_cache_config.num_blocks, 2048)
+            raise ValueError(
+                "[TPUHybridKVCacheCoordinator] mamba_num_blocks must be registered "
+                "via set_mamba_num_blocks().")
         self.mamba_num_blocks = int(mamba_num_blocks)
 
         logger.info(

--- a/tpu_inference/core/hybrid_coordinator.py
+++ b/tpu_inference/core/hybrid_coordinator.py
@@ -35,6 +35,24 @@ def get_mamba_num_blocks() -> int | None:
     return _GLOBAL_MAMBA_NUM_BLOCKS
 
 
+def is_mamba_spec(spec: Any) -> bool:
+    """Check if a KV cache spec represents a Mamba layer."""
+    if isinstance(spec, MambaSpec):
+        return True
+    if hasattr(spec, "kv_cache_specs"):
+        return any(
+            isinstance(s, MambaSpec) for s in spec.kv_cache_specs.values())
+    if "Mamba" in type(spec).__name__:
+        return True
+    return False
+
+
+def is_mamba_group(group: Any) -> bool:
+    """Check if a KV cache group contains Mamba layers."""
+    spec = getattr(group, "kv_cache_spec", group)
+    return is_mamba_spec(spec)
+
+
 class TPUDualBlockPool(BlockPool):
     """A composite BlockPool that coordinates separate Attention and Mamba pools.
 
@@ -120,12 +138,6 @@ class TPUDualBlockPool(BlockPool):
         }
         if attn_ids:
             self.attention_pool.evict_blocks(attn_ids)
-        mamba_ids = {
-            bid
-            for bid in block_ids if bid < len(self.mamba_pool.blocks)
-        }
-        if mamba_ids:
-            self.mamba_pool.evict_blocks(mamba_ids)
 
     def get_cached_block(
             self, block_hash: BlockHash,
@@ -163,13 +175,17 @@ class TPUHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         self.mamba_group_ids = {
             i
             for i, g in enumerate(kv_cache_config.kv_cache_groups)
-            if isinstance(g.kv_cache_spec, MambaSpec)
+            if is_mamba_group(g)
         }
         self.attention_group_ids = {
             i
             for i, g in enumerate(kv_cache_config.kv_cache_groups)
-            if not isinstance(g.kv_cache_spec, MambaSpec)
+            if not is_mamba_group(g)
         }
+
+        assert len(self.mamba_group_ids) > 0, (
+            f"[TPUHybridKVCacheCoordinator] No Mamba groups identified in "
+            f"kv_cache_groups: {kv_cache_config.kv_cache_groups}")
 
         # Resolve mamba_num_blocks
         if mamba_num_blocks is None:
@@ -219,6 +235,16 @@ class TPUHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             )
         self.single_type_managers = tuple(new_managers)
 
+        for i in self.mamba_group_ids:
+            assert self.single_type_managers[
+                i].block_pool is self.mamba_block_pool, (
+                    f"Manager {i} block_pool was not re-bound to mamba_block_pool!"
+                )
+        for i in self.attention_group_ids:
+            assert self.single_type_managers[
+                i].block_pool is self.attention_block_pool, (
+                    f"Manager {i} block_pool is not attention_block_pool!")
+
         # Replace self.block_pool with TPUDualBlockPool
         self.block_pool = TPUDualBlockPool(
             self.attention_block_pool,
@@ -262,7 +288,7 @@ class TPUHybridKVCacheCoordinator(HybridKVCacheCoordinator):
 
                 drop_eagle_block = use_eagle and idx not in eagle_verified
                 _max_length = curr_hit_length
-                if drop_eagle_block and not isinstance(spec, MambaSpec):
+                if drop_eagle_block and not is_mamba_spec(spec):
                     eagle_margin = (
                         self.hash_block_size if self.enable_partial_hash_hits
                         and manager_cls.supports_fine_grained_hash_lookup
@@ -271,8 +297,8 @@ class TPUHybridKVCacheCoordinator(HybridKVCacheCoordinator):
                     _max_length = min(curr_hit_length + eagle_margin,
                                       max_cache_hit_length)
 
-                pool = (self.mamba_block_pool if isinstance(spec, MambaSpec)
-                        else self.attention_block_pool)
+                pool = (self.mamba_block_pool
+                        if is_mamba_spec(spec) else self.attention_block_pool)
 
                 hit_blocks, _new_hit_length = manager_cls.find_longest_cache_hit(
                     block_hashes=block_hashes,
@@ -328,8 +354,8 @@ class TPUHybridKVCacheCoordinator(HybridKVCacheCoordinator):
         hit_lengths: list[int] = [0] * num_groups
 
         for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
-            pool = (self.mamba_block_pool if isinstance(spec, MambaSpec) else
-                    self.attention_block_pool)
+            pool = (self.mamba_block_pool
+                    if is_mamba_spec(spec) else self.attention_block_pool)
             blocks, group_hit = manager_cls.find_longest_cache_hit(
                 block_hashes=block_hashes,
                 max_length=max_cache_hit_length,
@@ -572,7 +598,8 @@ def tpu_get_kv_cache_coordinator(
     **kwargs,
 ) -> KVCacheCoordinator:
     enable_caching = kwargs.get("enable_caching", False)
-    if enable_caching and kv_cache_config.has_mamba_layers:
+    has_mamba = any(is_mamba_group(g) for g in kv_cache_config.kv_cache_groups)
+    if enable_caching and has_mamba:
         return TPUHybridKVCacheCoordinator(kv_cache_config, *args, **kwargs)
     return orig_get_kv_cache_coordinator(kv_cache_config, *args, **kwargs)
 
@@ -592,6 +619,9 @@ def install_hybrid_coordinator_hooks(vllm_config: Any | None = None) -> None:
     if "vllm.v1.core.sched.scheduler" in sys.modules:
         sys.modules[
             "vllm.v1.core.sched.scheduler"].KVCacheManager = TPUKVCacheManager
+    if "vllm.v1.core.sched.async_scheduler" in sys.modules:
+        sys.modules[
+            "vllm.v1.core.sched.async_scheduler"].KVCacheManager = TPUKVCacheManager
 
     _HOOKS_INSTALLED = True
     logger.info(

--- a/tpu_inference/core/hybrid_coordinator.py
+++ b/tpu_inference/core/hybrid_coordinator.py
@@ -4,7 +4,6 @@ from collections.abc import Iterable, Sequence
 from typing import Any
 
 from vllm.logger import init_logger
-from vllm.utils.math_utils import cdiv
 from vllm.v1.core.block_pool import BlockPool
 from vllm.v1.core.kv_cache_coordinator import (HybridKVCacheCoordinator,
                                                KVCacheCoordinator)
@@ -14,8 +13,7 @@ from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
 from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
 from vllm.v1.core.single_type_kv_cache_manager import (
     CrossAttentionManager, get_manager_for_kv_cache_spec)
-from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
-                                        MambaSpec)
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
 from vllm.v1.request import Request, RequestStatus
 
 logger = init_logger(__name__)
@@ -68,8 +66,6 @@ def is_mamba_spec(spec: Any) -> bool:
     if hasattr(spec, "kv_cache_specs"):
         return any(
             isinstance(s, MambaSpec) for s in spec.kv_cache_specs.values())
-    if "Mamba" in type(spec).__name__:
-        return True
     return False
 
 
@@ -249,6 +245,10 @@ class TPUHybridKVCacheCoordinator(HybridKVCacheCoordinator):
             metrics_collector=self.attention_block_pool.metrics_collector,
         )
 
+        # Unify null_block instance across both pools so TPUDualBlockPool,
+        # attention pool, and Mamba managers share the exact same null block.
+        self.mamba_block_pool.null_block = self.attention_block_pool.null_block
+
         # Re-bind Mamba managers to mamba_block_pool
         new_managers = list(self.single_type_managers)
         for i in self.mamba_group_ids:
@@ -288,122 +288,6 @@ class TPUHybridKVCacheCoordinator(HybridKVCacheCoordinator):
 
         # Re-verify and split groups so attention_groups binds to updated managers
         self.verify_and_split_kv_cache_groups()
-
-    def find_longest_cache_hit(
-        self,
-        block_hashes: list[BlockHash],
-        max_cache_hit_length: int,
-    ) -> tuple[tuple[list[KVCacheBlock], ...], int, int]:
-        num_groups = len(self.kv_cache_config.kv_cache_groups)
-        hit_length = max_cache_hit_length
-        longest_hit_length = 0
-        hit_blocks_by_group: list[list[KVCacheBlock]
-                                  | None] = [None] * num_groups
-        hit_length_by_group: list[int] = [0] * num_groups
-
-        is_simple_hybrid = len(self.attention_groups) == 2 and isinstance(
-            self.attention_groups[0].spec, FullAttentionSpec)
-        eagle_verified: set[int] = set()
-
-        while True:
-            curr_hit_length = hit_length
-
-            for idx, (spec, group_ids, manager_cls,
-                      use_eagle) in enumerate(self.attention_groups):
-                first_group_id = group_ids[0]
-                group_block_size = self.single_type_managers[
-                    first_group_id].block_size
-                cached_blocks = hit_blocks_by_group[first_group_id]
-                if isinstance(spec,
-                              FullAttentionSpec) and cached_blocks is not None:
-                    curr_hit_length = min(curr_hit_length,
-                                          hit_length_by_group[first_group_id])
-                    continue
-
-                drop_eagle_block = use_eagle and idx not in eagle_verified
-                _max_length = curr_hit_length
-                if drop_eagle_block and not is_mamba_spec(spec):
-                    eagle_margin = (
-                        self.hash_block_size if self.enable_partial_hash_hits
-                        and manager_cls.supports_fine_grained_hash_lookup
-                        and group_block_size > self.hash_block_size else
-                        group_block_size)
-                    _max_length = min(curr_hit_length + eagle_margin,
-                                      max_cache_hit_length)
-
-                pool = (self.mamba_block_pool
-                        if is_mamba_spec(spec) else self.attention_block_pool)
-
-                hit_blocks, _new_hit_length = manager_cls.find_longest_cache_hit(
-                    block_hashes=block_hashes,
-                    max_length=_max_length,
-                    kv_cache_group_ids=group_ids,
-                    block_pool=pool,
-                    kv_cache_spec=spec,
-                    drop_eagle_block=drop_eagle_block,
-                    alignment_tokens=self._cache_hit_alignment_tokens,
-                    dcp_world_size=(self.dcp_world_size if isinstance(
-                        spec, FullAttentionSpec) else 1),
-                )
-                if drop_eagle_block:
-                    eagle_verified.add(idx)
-                elif _new_hit_length < curr_hit_length:
-                    eagle_verified.clear()
-                curr_hit_length = _new_hit_length
-                for group_id, blocks in zip(group_ids, hit_blocks):
-                    hit_blocks_by_group[group_id] = blocks
-                    hit_length_by_group[group_id] = _new_hit_length
-
-                longest_hit_length = max(longest_hit_length, curr_hit_length)
-
-            if curr_hit_length >= hit_length:
-                break
-            hit_length = curr_hit_length
-            if is_simple_hybrid:
-                break
-
-        # Truncate full attention blocks to final hit_length
-        first_group = self.attention_groups[0]
-        if isinstance(first_group.spec, FullAttentionSpec):
-            group_block_size = self.single_type_managers[
-                first_group.group_ids[0]].block_size
-            num_blocks = cdiv(hit_length, group_block_size)
-            for group_id in first_group.group_ids:
-                if (blks := hit_blocks_by_group[group_id]) is not None:
-                    del blks[num_blocks:]
-                    hit_length_by_group[group_id] = hit_length
-
-        num_uncached_common_prefix_tokens = longest_hit_length - hit_length
-        cache_hit_blocks = tuple(blocks if blocks is not None else []
-                                 for blocks in hit_blocks_by_group)
-        return cache_hit_blocks, hit_length, num_uncached_common_prefix_tokens
-
-    def find_longest_cache_hit_per_group(
-        self,
-        block_hashes: list[BlockHash],
-        max_cache_hit_length: int,
-    ) -> tuple[tuple[list[KVCacheBlock], ...], tuple[int, ...]]:
-        num_groups = len(self.kv_cache_config.kv_cache_groups)
-        hit_blocks: list[list[KVCacheBlock]] = [[] for _ in range(num_groups)]
-        hit_lengths: list[int] = [0] * num_groups
-
-        for spec, group_ids, manager_cls, use_eagle in self.attention_groups:
-            pool = (self.mamba_block_pool
-                    if is_mamba_spec(spec) else self.attention_block_pool)
-            blocks, group_hit = manager_cls.find_longest_cache_hit(
-                block_hashes=block_hashes,
-                max_length=max_cache_hit_length,
-                kv_cache_group_ids=group_ids,
-                block_pool=pool,
-                kv_cache_spec=spec,
-                drop_eagle_block=use_eagle,
-                alignment_tokens=self._cache_hit_alignment_tokens,
-            )
-            for gid, blks in zip(group_ids, blocks):
-                hit_blocks[gid] = blks
-                hit_lengths[gid] = group_hit
-
-        return tuple(hit_blocks), tuple(hit_lengths)
 
     def can_allocate_tokens(
         self,

--- a/tpu_inference/core/hybrid_coordinator.py
+++ b/tpu_inference/core/hybrid_coordinator.py
@@ -132,6 +132,11 @@ class TPUDualBlockPool(BlockPool):
         )
 
     def evict_blocks(self, block_ids: set[int]) -> None:
+        """Evict invalid blocks from cache on KV transfer failures.
+
+        Note: Block IDs are assumed to belong to attention_pool, as external
+        KV transfer load failures only apply to Attention KV cache.
+        """
         attn_ids = {
             bid
             for bid in block_ids if bid < len(self.attention_pool.blocks)
@@ -142,11 +147,15 @@ class TPUDualBlockPool(BlockPool):
     def get_cached_block(
             self, block_hash: BlockHash,
             kv_cache_group_ids: list[int]) -> list[KVCacheBlock] | None:
-        if any(gid in self.mamba_group_ids for gid in kv_cache_group_ids):
-            return self.mamba_pool.get_cached_block(block_hash,
-                                                    kv_cache_group_ids)
-        return self.attention_pool.get_cached_block(block_hash,
-                                                    kv_cache_group_ids)
+        cached_blocks: list[KVCacheBlock] = []
+        for gid in kv_cache_group_ids:
+            pool = (self.mamba_pool
+                    if gid in self.mamba_group_ids else self.attention_pool)
+            block = pool.get_cached_block(block_hash, [gid])
+            if not block:
+                return None
+            cached_blocks.extend(block)
+        return cached_blocks
 
 
 class TPUHybridKVCacheCoordinator(HybridKVCacheCoordinator):

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -159,6 +159,16 @@ def _scheduler_worker_process(
     import gc
     atexit._clear()
     gc.enable()
+    if getattr(vllm_config.cache_config, "enable_prefix_caching", False):
+        from tpu_inference.core.hybrid_coordinator import \
+            install_hybrid_coordinator_hooks
+        install_hybrid_coordinator_hooks(vllm_config)
+    if getattr(kv_cache_config, "mamba_num_blocks", None) is not None:
+        from tpu_inference.core.hybrid_coordinator import set_mamba_num_blocks
+        set_mamba_num_blocks(kv_cache_config.mamba_num_blocks)
+        if hasattr(vllm_config, "cache_config"):
+            vllm_config.cache_config.mamba_num_blocks = kv_cache_config.mamba_num_blocks
+
     # Initialize the scheduler in this process
     import inspect
     sig = inspect.signature(original_scheduler_cls)
@@ -459,6 +469,9 @@ class DPScheduler(SchedulerInterface):
             caching_hash_fn = get_hash_fn_by_name(
                 vllm_config.cache_config.prefix_caching_hash_algo)
             init_none_hash(caching_hash_fn)
+            from tpu_inference.core.hybrid_coordinator import \
+                install_hybrid_coordinator_hooks
+            install_hybrid_coordinator_hooks(vllm_config)
 
         # The original scheduler class could be Scheduler or AsyncScheduler
         original_scheduler_cls = vllm_config.scheduler_config._original_scheduler_cls
@@ -554,10 +567,21 @@ class DPScheduler(SchedulerInterface):
         multiprocessing.active_children()
 
     def _create_per_rank_configs(self, kv_cache_config: KVCacheConfig) -> None:
+        from tpu_inference.core.hybrid_coordinator import get_mamba_num_blocks
+        mamba_num_blocks = getattr(kv_cache_config, "mamba_num_blocks", None)
+        if mamba_num_blocks is None and hasattr(self.vllm_config,
+                                                "cache_config"):
+            mamba_num_blocks = getattr(self.vllm_config.cache_config,
+                                       "mamba_num_blocks", None)
+        if mamba_num_blocks is None:
+            mamba_num_blocks = get_mamba_num_blocks()
+
         self.per_rank_kv_cache_configs: List[KVCacheConfig] = []
         for _ in range(self.dp_size):
             rank_kv_config = copy.deepcopy(kv_cache_config)
             rank_kv_config.num_blocks = kv_cache_config.num_blocks // self.dp_size
+            if mamba_num_blocks is not None:
+                rank_kv_config.mamba_num_blocks = mamba_num_blocks // self.dp_size
             self.per_rank_kv_cache_configs.append(rank_kv_config)
 
     def _send_command(self,

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -161,11 +161,9 @@ def _scheduler_worker_process(
     gc.enable()
     cache_config = getattr(vllm_config, "cache_config", None)
     if getattr(cache_config, "mamba_cache_mode", "none") == "align":
-        from tpu_inference.core.hybrid_coordinator import (
-            install_hybrid_coordinator_hooks, set_mamba_num_blocks)
+        from tpu_inference.core.hybrid_coordinator import \
+            install_hybrid_coordinator_hooks
         install_hybrid_coordinator_hooks(vllm_config)
-        set_mamba_num_blocks(kv_cache_config.mamba_num_blocks)
-        cache_config.mamba_num_blocks = kv_cache_config.mamba_num_blocks
 
     # Initialize the scheduler in this process
     import inspect
@@ -562,10 +560,7 @@ class DPScheduler(SchedulerInterface):
         multiprocessing.active_children()
 
     def _create_per_rank_configs(self, kv_cache_config: KVCacheConfig) -> None:
-        mamba_num_blocks = getattr(
-            getattr(self.vllm_config, "cache_config", None),
-            "mamba_num_blocks", None)
-
+        mamba_num_blocks = getattr(kv_cache_config, "mamba_num_blocks", None)
         self.per_rank_kv_cache_configs: List[KVCacheConfig] = []
         for _ in range(self.dp_size):
             rank_kv_config = copy.deepcopy(kv_cache_config)

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -159,15 +159,13 @@ def _scheduler_worker_process(
     import gc
     atexit._clear()
     gc.enable()
-    if getattr(vllm_config.cache_config, "enable_prefix_caching", False):
-        from tpu_inference.core.hybrid_coordinator import \
-            install_hybrid_coordinator_hooks
+    cache_config = getattr(vllm_config, "cache_config", None)
+    if getattr(cache_config, "mamba_cache_mode", "none") == "align":
+        from tpu_inference.core.hybrid_coordinator import (
+            install_hybrid_coordinator_hooks, set_mamba_num_blocks)
         install_hybrid_coordinator_hooks(vllm_config)
-    if getattr(kv_cache_config, "mamba_num_blocks", None) is not None:
-        from tpu_inference.core.hybrid_coordinator import set_mamba_num_blocks
         set_mamba_num_blocks(kv_cache_config.mamba_num_blocks)
-        if hasattr(vllm_config, "cache_config"):
-            vllm_config.cache_config.mamba_num_blocks = kv_cache_config.mamba_num_blocks
+        cache_config.mamba_num_blocks = kv_cache_config.mamba_num_blocks
 
     # Initialize the scheduler in this process
     import inspect
@@ -469,9 +467,6 @@ class DPScheduler(SchedulerInterface):
             caching_hash_fn = get_hash_fn_by_name(
                 vllm_config.cache_config.prefix_caching_hash_algo)
             init_none_hash(caching_hash_fn)
-            from tpu_inference.core.hybrid_coordinator import \
-                install_hybrid_coordinator_hooks
-            install_hybrid_coordinator_hooks(vllm_config)
 
         # The original scheduler class could be Scheduler or AsyncScheduler
         original_scheduler_cls = vllm_config.scheduler_config._original_scheduler_cls
@@ -567,14 +562,9 @@ class DPScheduler(SchedulerInterface):
         multiprocessing.active_children()
 
     def _create_per_rank_configs(self, kv_cache_config: KVCacheConfig) -> None:
-        from tpu_inference.core.hybrid_coordinator import get_mamba_num_blocks
-        mamba_num_blocks = getattr(kv_cache_config, "mamba_num_blocks", None)
-        if mamba_num_blocks is None and hasattr(self.vllm_config,
-                                                "cache_config"):
-            mamba_num_blocks = getattr(self.vllm_config.cache_config,
-                                       "mamba_num_blocks", None)
-        if mamba_num_blocks is None:
-            mamba_num_blocks = get_mamba_num_blocks()
+        mamba_num_blocks = getattr(
+            getattr(self.vllm_config, "cache_config", None),
+            "mamba_num_blocks", None)
 
         self.per_rank_kv_cache_configs: List[KVCacheConfig] = []
         for _ in range(self.dp_size):

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -161,9 +161,13 @@ def _scheduler_worker_process(
     gc.enable()
     cache_config = getattr(vllm_config, "cache_config", None)
     if getattr(cache_config, "mamba_cache_mode", "none") == "align":
-        from tpu_inference.core.hybrid_coordinator import \
-            install_hybrid_coordinator_hooks
+        from tpu_inference.core.hybrid_coordinator import (
+            install_hybrid_coordinator_hooks, set_mamba_num_blocks)
         install_hybrid_coordinator_hooks(vllm_config)
+        mamba_num_blocks = getattr(kv_cache_config, "mamba_num_blocks", None)
+        if mamba_num_blocks is not None:
+            set_mamba_num_blocks(mamba_num_blocks)
+            cache_config.mamba_num_blocks = mamba_num_blocks
 
     # Initialize the scheduler in this process
     import inspect
@@ -560,7 +564,11 @@ class DPScheduler(SchedulerInterface):
         multiprocessing.active_children()
 
     def _create_per_rank_configs(self, kv_cache_config: KVCacheConfig) -> None:
-        mamba_num_blocks = getattr(kv_cache_config, "mamba_num_blocks", None)
+        # mamba_num_blocks is computed during device HBM profiling and written to
+        # vllm_config.cache_config. Symmetrically partition across DP ranks.
+        mamba_num_blocks = getattr(
+            getattr(self.vllm_config, "cache_config", None),
+            "mamba_num_blocks", None)
         self.per_rank_kv_cache_configs: List[KVCacheConfig] = []
         for _ in range(self.dp_size):
             rank_kv_config = copy.deepcopy(kv_cache_config)

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -566,9 +566,8 @@ class DPScheduler(SchedulerInterface):
     def _create_per_rank_configs(self, kv_cache_config: KVCacheConfig) -> None:
         # mamba_num_blocks is computed during device HBM profiling and written to
         # vllm_config.cache_config. Symmetrically partition across DP ranks.
-        mamba_num_blocks = getattr(
-            getattr(self.vllm_config, "cache_config", None),
-            "mamba_num_blocks", None)
+        mamba_num_blocks = getattr(self.vllm_config.cache_config,
+                                   "mamba_num_blocks", None)
         self.per_rank_kv_cache_configs: List[KVCacheConfig] = []
         for _ in range(self.dp_size):
             rank_kv_config = copy.deepcopy(kv_cache_config)

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -348,6 +348,10 @@ class TpuPlatform(Platform):
                     "supported on TPU with mamba prefix caching because the "
                     "TPU runner does not implement KV cache block copies; "
                     "leave --prefix-match-unit unset.")
+            elif cache_config.enable_prefix_caching:
+                from tpu_inference.core.hybrid_coordinator import \
+                    install_hybrid_coordinator_hooks
+                install_hybrid_coordinator_hooks(vllm_config)
 
         # vLLM's mm_device_do_normalize skips do_rescale/do_normalize in the
         # CPU processor and instead normalizes inside the vLLM model's vision

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -448,12 +448,17 @@ class KVCacheManager:
                             unpadded_mamba_page_size_bytes)
         attn_per_tensor_avail = avail_per_tensor - mamba_per_tensor
         if attn_per_tensor_avail <= 0 and is_align_mode:
-            # If checkpoint budget is too large for this hardware's HBM,
-            # scale it down so at least 50% of the budget is reserved for Attention
+            # Scale down checkpoint budget if it starves Attention
             mamba_slot_cost = num_mamba_groups * unpadded_mamba_page_size_bytes
             max_mamba_blocks = (avail_per_tensor // 2) // mamba_slot_cost
-            if max_mamba_blocks > active_mamba_blocks:
-                mamba_num_blocks = ((max_mamba_blocks // divisor) * divisor)
+            # Lower bound must be ceiling-aligned so it is never < active_mamba_blocks
+            min_mamba_blocks = (
+                (active_mamba_blocks + divisor - 1) // divisor) * divisor
+            # Upper bound target is floor-aligned to stay within 50% budget
+            target_mamba = (max_mamba_blocks // divisor) * divisor
+            clamped_mamba = max(min_mamba_blocks, target_mamba)
+            if clamped_mamba < mamba_num_blocks:
+                mamba_num_blocks = clamped_mamba
                 mamba_per_tensor = mamba_num_blocks * mamba_slot_cost
                 attn_per_tensor_avail = avail_per_tensor - mamba_per_tensor
 

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 import dataclasses
 import os
-from enum import IntEnum
 from typing import TYPE_CHECKING, List
 
 import jax
@@ -63,15 +62,10 @@ logger = init_logger(__name__)
 # N=num_blocks, H=num_heads and D=head_size
 DEFAULT_KV_CACHE_LAYOUT = "NHD"
 
-
-class MambaCheckpointBudgetMultiplier(IntEnum):
-    """Multiplier for the default Mamba prefix cache checkpoint budget.
-
-    Under align mode, Mamba prefix caching uses a decoupled block pool with a
-    checkpoint budget for cached prefix states:
-        checkpoint_budget = max_num_reqs * MambaCheckpointBudgetMultiplier.DEFAULT
-    """
-    DEFAULT = 2
+# Default multiplier for Mamba prefix cache checkpoint budget.
+# Sized to cache recent prefixes proportionally with concurrency:
+# checkpoint_budget = max_num_reqs * DEFAULT_MAMBA_CHECKPOINT_BUDGET_MULTIPLIER
+DEFAULT_MAMBA_CHECKPOINT_BUDGET_MULTIPLIER = 2
 
 
 def is_cache_for_ds_v4(attn_module: AttentionLayerBase) -> bool:
@@ -359,8 +353,8 @@ class KVCacheManager:
         cache_config = self.runner.cache_config
         is_align_mode = (getattr(cache_config, "mamba_cache_mode",
                                  "none") == "align")
-        user_pinned_override = cache_config.num_gpu_blocks_override is not None
-        if user_pinned_override and not is_align_mode:
+        num_gpu_blocks_override = cache_config.num_gpu_blocks_override is not None
+        if num_gpu_blocks_override and not is_align_mode:
             return
 
         devices = self.runner.mesh.devices.flatten()
@@ -416,11 +410,12 @@ class KVCacheManager:
             # We allocate slots for active requests plus a checkpoint budget
             # for cached prefix states.
             checkpoint_budget = (self.runner.vllm_config.additional_config.get(
-                "mamba_cache_checkpoint_budget", None))
+                "custom_mamba_cache_size", None))
             if checkpoint_budget is None:
                 # Default checkpoint budget scales with concurrency
-                checkpoint_budget = (self.runner.max_num_reqs *
-                                     MambaCheckpointBudgetMultiplier.DEFAULT)
+                checkpoint_budget = (
+                    self.runner.max_num_reqs *
+                    DEFAULT_MAMBA_CHECKPOINT_BUDGET_MULTIPLIER)
             else:
                 checkpoint_budget = int(checkpoint_budget)
             mamba_num_blocks = active_mamba_blocks + checkpoint_budget
@@ -430,13 +425,71 @@ class KVCacheManager:
         mamba_num_blocks = (
             (mamba_num_blocks + divisor - 1) // divisor) * divisor
 
-        if user_pinned_override:
-            # Respect user-pinned attention override, but still register decoupled mamba pool
+        if num_gpu_blocks_override:
+            # Respect user-pinned attention override, but validate total HBM budget
+            avail_per_tensor = avail // group_size
+            attn_per_tensor = (num_attn_groups *
+                               cache_config.num_gpu_blocks_override *
+                               attn_page_size_bytes)
+            mamba_per_tensor = (num_mamba_groups * mamba_num_blocks *
+                                unpadded_mamba_page_size_bytes)
+
+            # If user didn't explicitly set custom_mamba_cache_size, try shrinking
+            # the default Mamba checkpoint budget down to active slots before failing
+            custom_mamba = self.runner.vllm_config.additional_config.get(
+                "custom_mamba_cache_size", None)
+            if custom_mamba is None and (attn_per_tensor + mamba_per_tensor
+                                         > avail_per_tensor):
+                min_mamba_blocks = (
+                    (active_mamba_blocks + divisor - 1) // divisor) * divisor
+                if min_mamba_blocks < mamba_num_blocks:
+                    logger.info(
+                        "Shrinking default Mamba checkpoint budget from %d to "
+                        "%d blocks to accommodate user-pinned attention override "
+                        "(num_gpu_blocks_override=%d).", mamba_num_blocks,
+                        min_mamba_blocks, cache_config.num_gpu_blocks_override)
+                    mamba_num_blocks = min_mamba_blocks
+                    mamba_per_tensor = (num_mamba_groups * mamba_num_blocks *
+                                        unpadded_mamba_page_size_bytes)
+
+            if attn_per_tensor + mamba_per_tensor > avail_per_tensor:
+                attn_gib = (group_size * attn_per_tensor) / (1024**3)
+                mamba_gib = (group_size * mamba_per_tensor) / (1024**3)
+                total_gib = (group_size *
+                             (attn_per_tensor + mamba_per_tensor)) / (1024**3)
+                avail_gib = avail / (1024**3)
+                raise ValueError(
+                    f"User-specified KV cache configuration exceeds available HBM "
+                    f"under gpu_memory_utilization={gpu_mem_util:.2f}: "
+                    f"Attention ({cache_config.num_gpu_blocks_override} blocks) requires {attn_gib:.2f} GiB, "
+                    f"Mamba ({mamba_num_blocks} blocks) requires {mamba_gib:.2f} GiB, "
+                    f"total {total_gib:.2f} GiB > available {avail_gib:.2f} GiB. "
+                    f"Decrease `num_gpu_blocks_override` or `custom_mamba_cache_size`."
+                )
+
             self._mamba_num_blocks = int(mamba_num_blocks)
             cache_config.mamba_num_blocks = int(mamba_num_blocks)
             from tpu_inference.core.hybrid_coordinator import \
                 set_mamba_num_blocks
             set_mamba_num_blocks(int(mamba_num_blocks))
+
+            attn_bytes = (num_attn_layers *
+                          cache_config.num_gpu_blocks_override *
+                          attn_page_size_bytes)
+            mamba_bytes = (num_mamba_layers * mamba_num_blocks *
+                           unpadded_mamba_page_size_bytes)
+            mode_str = " (align mode)" if is_align_mode else ""
+            logger.info(
+                "Compact-mamba KV cache%s: user-pinned num_gpu_blocks_override=%d (attn), "
+                "_mamba_num_blocks=%d. HBM split: attn=%d layers × %d blocks "
+                "× %d B = %.2f GiB; mamba=%d layers × %d slots × %d B = "
+                "%.2f GiB; total=%.2f GiB / avail=%.2f GiB.", mode_str,
+                cache_config.num_gpu_blocks_override, self._mamba_num_blocks,
+                num_attn_layers, cache_config.num_gpu_blocks_override,
+                attn_page_size_bytes, attn_bytes / (1024**3), num_mamba_layers,
+                self._mamba_num_blocks, unpadded_mamba_page_size_bytes,
+                mamba_bytes / (1024**3),
+                (attn_bytes + mamba_bytes) / (1024**3), avail / (1024**3))
             return
 
         # Attention block count: fits into HBM left after mamba.

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -346,21 +346,9 @@ class KVCacheManager:
             both unset.
         """
         cache_config = self.runner.cache_config
-        if cache_config.num_gpu_blocks_override is not None:
-            return
-
-        if getattr(cache_config, "mamba_cache_mode", "none") == "align":
-            # Mamba prefix caching addresses recurrent state by block id from
-            # the mamba block table, so every layer's mamba array must span
-            # the whole block pool. The compact layout deliberately makes it
-            # smaller than the pool, which would put valid block ids out of
-            # range. Fall back to the uniform sizing, which already charges
-            # each block for its mamba pages.
-            logger.info(
-                "Compact-mamba sizing skipped: mamba_cache_mode='align' "
-                "needs one mamba slot per block id. Attention capacity is "
-                "lower than with prefix caching off; raise --block-size to "
-                "trade prefix-cache granularity for capacity.")
+        is_align_mode = (getattr(cache_config, "mamba_cache_mode",
+                                 "none") == "align")
+        if cache_config.num_gpu_blocks_override is not None and not is_align_mode:
             return
 
         devices = self.runner.mesh.devices.flatten()
@@ -410,9 +398,33 @@ class KVCacheManager:
             num_spec = (self.runner.vllm_config.speculative_config.
                         num_speculative_tokens)
         mamba_slot_stride = num_spec + 1
-        mamba_num_blocks = self.runner.max_num_reqs * mamba_slot_stride + 1
+        active_mamba_blocks = self.runner.max_num_reqs * mamba_slot_stride + 1
+        if is_align_mode:
+            # Under align mode, Mamba prefix caching uses a decoupled block pool.
+            # We allocate slots for active requests plus a checkpoint budget
+            # for cached prefix states.
+            checkpoint_budget = (self.runner.vllm_config.additional_config.get(
+                "mamba_cache_checkpoint_budget", None))
+            if checkpoint_budget is None:
+                # Default checkpoint budget scales with concurrency (8x max_num_reqs)
+                checkpoint_budget = self.runner.max_num_reqs * 8
+            else:
+                checkpoint_budget = int(checkpoint_budget)
+            mamba_num_blocks = active_mamba_blocks + checkpoint_budget
+        else:
+            mamba_num_blocks = active_mamba_blocks
+
         mamba_num_blocks = (
             (mamba_num_blocks + divisor - 1) // divisor) * divisor
+
+        if cache_config.num_gpu_blocks_override is not None:
+            # Respect user-pinned attention override, but still register decoupled mamba pool
+            self._mamba_num_blocks = int(mamba_num_blocks)
+            cache_config.mamba_num_blocks = int(mamba_num_blocks)
+            from tpu_inference.core.hybrid_coordinator import \
+                set_mamba_num_blocks
+            set_mamba_num_blocks(int(mamba_num_blocks))
+            return
 
         # Attention block count: fits into HBM left after mamba.
         # `attn_page_size_bytes` is per-block per-attention-layer; the
@@ -422,6 +434,16 @@ class KVCacheManager:
         mamba_per_tensor = (num_mamba_groups * mamba_num_blocks *
                             unpadded_mamba_page_size_bytes)
         attn_per_tensor_avail = avail_per_tensor - mamba_per_tensor
+        if attn_per_tensor_avail <= 0 and is_align_mode:
+            # If checkpoint budget is too large for this hardware's HBM,
+            # scale it down so at least 50% of the budget is reserved for Attention
+            mamba_slot_cost = num_mamba_groups * unpadded_mamba_page_size_bytes
+            max_mamba_blocks = (avail_per_tensor // 2) // mamba_slot_cost
+            if max_mamba_blocks > active_mamba_blocks:
+                mamba_num_blocks = ((max_mamba_blocks // divisor) * divisor)
+                mamba_per_tensor = mamba_num_blocks * mamba_slot_cost
+                attn_per_tensor_avail = avail_per_tensor - mamba_per_tensor
+
         if attn_per_tensor_avail <= 0:
             # Mamba already saturates the budget — pathological
             # configuration (e.g., mamba_unpadded × max_num_reqs alone
@@ -450,18 +472,22 @@ class KVCacheManager:
 
         cache_config.num_gpu_blocks_override = int(attn_num_blocks)
         self._mamba_num_blocks = int(mamba_num_blocks)
+        cache_config.mamba_num_blocks = int(mamba_num_blocks)
+        from tpu_inference.core.hybrid_coordinator import set_mamba_num_blocks
+        set_mamba_num_blocks(int(mamba_num_blocks))
 
         attn_bytes = num_attn_layers * attn_num_blocks * attn_page_size_bytes
         mamba_bytes = (num_mamba_layers * mamba_num_blocks *
                        unpadded_mamba_page_size_bytes)
+        mode_str = " (align mode)" if is_align_mode else ""
         logger.info(
-            "Compact-mamba KV cache: num_gpu_blocks_override=%d (attn), "
+            "Compact-mamba KV cache%s: num_gpu_blocks_override=%d (attn), "
             "_mamba_num_blocks=%d. HBM split: attn=%d layers × %d blocks "
             "× %d B = %.2f GiB; mamba=%d layers × %d slots × %d B = "
-            "%.2f GiB; total=%.2f GiB / avail=%.2f GiB.", attn_num_blocks,
-            mamba_num_blocks, num_attn_layers, attn_num_blocks,
-            attn_page_size_bytes, attn_bytes / (2**30), num_mamba_layers,
-            mamba_num_blocks, unpadded_mamba_page_size_bytes,
+            "%.2f GiB; total=%.2f GiB / avail=%.2f GiB.", mode_str,
+            attn_num_blocks, mamba_num_blocks, num_attn_layers,
+            attn_num_blocks, attn_page_size_bytes, attn_bytes / (2**30),
+            num_mamba_layers, mamba_num_blocks, unpadded_mamba_page_size_bytes,
             mamba_bytes / (2**30), (attn_bytes + mamba_bytes) / (2**30),
             avail / (2**30))
 

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import dataclasses
 import os
+from enum import IntEnum
 from typing import TYPE_CHECKING, List
 
 import jax
@@ -61,6 +62,16 @@ logger = init_logger(__name__)
 # default layout (order) used by kv cache manager
 # N=num_blocks, H=num_heads and D=head_size
 DEFAULT_KV_CACHE_LAYOUT = "NHD"
+
+
+class MambaCheckpointBudgetMultiplier(IntEnum):
+    """Multiplier for the default Mamba prefix cache checkpoint budget.
+
+    Under align mode, Mamba prefix caching uses a decoupled block pool with a
+    checkpoint budget for cached prefix states:
+        checkpoint_budget = max_num_reqs * MambaCheckpointBudgetMultiplier.DEFAULT
+    """
+    DEFAULT = 2
 
 
 def is_cache_for_ds_v4(attn_module: AttentionLayerBase) -> bool:
@@ -348,7 +359,8 @@ class KVCacheManager:
         cache_config = self.runner.cache_config
         is_align_mode = (getattr(cache_config, "mamba_cache_mode",
                                  "none") == "align")
-        if cache_config.num_gpu_blocks_override is not None and not is_align_mode:
+        user_pinned_override = cache_config.num_gpu_blocks_override is not None
+        if user_pinned_override and not is_align_mode:
             return
 
         devices = self.runner.mesh.devices.flatten()
@@ -406,8 +418,9 @@ class KVCacheManager:
             checkpoint_budget = (self.runner.vllm_config.additional_config.get(
                 "mamba_cache_checkpoint_budget", None))
             if checkpoint_budget is None:
-                # Default checkpoint budget scales with concurrency (8x max_num_reqs)
-                checkpoint_budget = self.runner.max_num_reqs * 8
+                # Default checkpoint budget scales with concurrency
+                checkpoint_budget = (self.runner.max_num_reqs *
+                                     MambaCheckpointBudgetMultiplier.DEFAULT)
             else:
                 checkpoint_budget = int(checkpoint_budget)
             mamba_num_blocks = active_mamba_blocks + checkpoint_budget
@@ -417,15 +430,13 @@ class KVCacheManager:
         mamba_num_blocks = (
             (mamba_num_blocks + divisor - 1) // divisor) * divisor
 
-        if cache_config.num_gpu_blocks_override is not None:
+        if user_pinned_override:
             # Respect user-pinned attention override, but still register decoupled mamba pool
             self._mamba_num_blocks = int(mamba_num_blocks)
             cache_config.mamba_num_blocks = int(mamba_num_blocks)
-            from tpu_inference.core.hybrid_coordinator import (
-                install_hybrid_coordinator_hooks, set_mamba_num_blocks)
+            from tpu_inference.core.hybrid_coordinator import \
+                set_mamba_num_blocks
             set_mamba_num_blocks(int(mamba_num_blocks))
-            if cache_config.enable_prefix_caching:
-                install_hybrid_coordinator_hooks(self.runner.vllm_config)
             return
 
         # Attention block count: fits into HBM left after mamba.
@@ -475,11 +486,8 @@ class KVCacheManager:
         cache_config.num_gpu_blocks_override = int(attn_num_blocks)
         self._mamba_num_blocks = int(mamba_num_blocks)
         cache_config.mamba_num_blocks = int(mamba_num_blocks)
-        from tpu_inference.core.hybrid_coordinator import (
-            install_hybrid_coordinator_hooks, set_mamba_num_blocks)
+        from tpu_inference.core.hybrid_coordinator import set_mamba_num_blocks
         set_mamba_num_blocks(int(mamba_num_blocks))
-        if cache_config.enable_prefix_caching:
-            install_hybrid_coordinator_hooks(self.runner.vllm_config)
 
         attn_bytes = num_attn_layers * attn_num_blocks * attn_page_size_bytes
         mamba_bytes = (num_mamba_layers * mamba_num_blocks *

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -421,9 +421,11 @@ class KVCacheManager:
             # Respect user-pinned attention override, but still register decoupled mamba pool
             self._mamba_num_blocks = int(mamba_num_blocks)
             cache_config.mamba_num_blocks = int(mamba_num_blocks)
-            from tpu_inference.core.hybrid_coordinator import \
-                set_mamba_num_blocks
+            from tpu_inference.core.hybrid_coordinator import (
+                install_hybrid_coordinator_hooks, set_mamba_num_blocks)
             set_mamba_num_blocks(int(mamba_num_blocks))
+            if cache_config.enable_prefix_caching:
+                install_hybrid_coordinator_hooks(self.runner.vllm_config)
             return
 
         # Attention block count: fits into HBM left after mamba.
@@ -473,8 +475,11 @@ class KVCacheManager:
         cache_config.num_gpu_blocks_override = int(attn_num_blocks)
         self._mamba_num_blocks = int(mamba_num_blocks)
         cache_config.mamba_num_blocks = int(mamba_num_blocks)
-        from tpu_inference.core.hybrid_coordinator import set_mamba_num_blocks
+        from tpu_inference.core.hybrid_coordinator import (
+            install_hybrid_coordinator_hooks, set_mamba_num_blocks)
         set_mamba_num_blocks(int(mamba_num_blocks))
+        if cache_config.enable_prefix_caching:
+            install_hybrid_coordinator_hooks(self.runner.vllm_config)
 
         attn_bytes = num_attn_layers * attn_num_blocks * attn_page_size_bytes
         mamba_bytes = (num_mamba_layers * mamba_num_blocks *
@@ -902,6 +907,7 @@ class KVCacheManager:
                                 num_blocks)
             if self.actual_mamba_num_blocks is None:
                 self.actual_mamba_num_blocks = mamba_num_blocks
+            kv_cache_config.mamba_num_blocks = int(mamba_num_blocks)
 
             for j, layer_name in enumerate(kv_cache_tensor.shared_by):
                 layer_spec = layer_name_to_spec[layer_name]

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -145,13 +145,8 @@ def hbm_usage_bytes(devices: Any) -> List[Tuple[int, int]]:
                     e)
     else:
         for device in devices:
-            stats = device.memory_stats()
-            if stats:
-                hbm_used = stats["bytes_in_use"]
-                hbm_limit = stats["bytes_limit"]
-            else:
-                hbm_used = 0
-                hbm_limit = 0
+            hbm_used = device.memory_stats()["bytes_in_use"]
+            hbm_limit = device.memory_stats()["bytes_limit"]
             usage.append((hbm_used, hbm_limit))
 
     return usage

--- a/tpu_inference/utils.py
+++ b/tpu_inference/utils.py
@@ -145,8 +145,13 @@ def hbm_usage_bytes(devices: Any) -> List[Tuple[int, int]]:
                     e)
     else:
         for device in devices:
-            hbm_used = device.memory_stats()["bytes_in_use"]
-            hbm_limit = device.memory_stats()["bytes_limit"]
+            stats = device.memory_stats()
+            if stats:
+                hbm_used = stats["bytes_in_use"]
+                hbm_limit = stats["bytes_limit"]
+            else:
+                hbm_used = 0
+                hbm_limit = 0
             usage.append((hbm_used, hbm_limit))
 
     return usage


### PR DESCRIPTION
# Description

Follow up to https://github.com/vllm-project/tpu-inference/pull/3422

Under vLLM's `mamba_cache_mode="align"` (used when prefix caching is enabled on hybrid attention/GDN models such as Qwen 3.5), recurrent states are checkpointed by block ID from the block table. 

Under the default uniform KV cache layout, Attention and Mamba share a single block pool. Because every block ID reserves state across all Mamba/GDN layers:
- Each block ID incurs recurrent state across all GDN layers in addition to attention KV pages.
- Active requests only need a few GDN slots (active slots + prefix checkpoints), but uniform sizing allocates tens of thousands of idle GDN state slots spanning the entire pool.
- This consumes the vast majority of HBM for GDN state, shrinking the Attention pool from ~35,000 blocks down to ~1,500 blocks.

This PR introduces decoupled dual block pools for hybrid models on TPU:

<img width="885" height="525" alt="image" src="https://github.com/user-attachments/assets/d6cbcc50-d502-468c-8f41-ba86987bb4e0" />

1. **`TPUDualBlockPool`**: Manages an `attention_block_pool` (sized to all remaining HBM) and a compact `mamba_block_pool` (sized to active slots + prefix checkpoint budget). Routes `free_blocks()` and `touch()` to their originating pools in O(1) time using object identity (`id(block)`).
2. **`TPUHybridKVCacheCoordinator`**: Rebinds Mamba managers to `mamba_block_pool` while Attention managers use `attention_block_pool`. Gates admission independently across both pools and reconciles prefix cache hits via `min(hit_attn, hit_mamba)`.
3. **`KVCacheManager` sizing**: Automatically sizes `_mamba_num_blocks` with a configurable checkpoint budget (`mamba_cache_checkpoint_budget`), leaving remaining HBM to maximize `num_gpu_blocks_override` for attention.
4. **DP Scheduler support**: Correctly partitions both `num_blocks` and `mamba_num_blocks` per DP rank.

<img width="699" height="487" alt="image" src="https://github.com/user-attachments/assets/ba9f7fb8-6075-42e0-9cf8-c20474c10bf2" />

# Tests

- Unit tests:
  - `pytest tests/core/test_hybrid_coordinator.py` (dual pool routing, admission gating, cache hit reconciliation, hook injection)
  - `pytest tests/core/test_dp_scheduler.py` (per-rank mamba block partitioning)
  - `pytest tests/runner/test_kv_cache_manager.py` (compact mamba override and custom checkpoint budget)
- End-to-end TPU verification:
  - Verified `tests/e2e/test_mamba_prefix_caching.py` on TPU v7x:
    - Single device (DP=1): Attention pool increased from 1,375 to 17,377 blocks, achieving 84.9% prefix hit rate and bit-exact generation against baseline.
    - Data Parallelism (DP=2): Attention pool scaled to 37,960 blocks with 0 token mismatches.
    - Eviction stress test (`budget=16`): Verified that eviction in Mamba pool triggers correct reconciliation without state corruption.

# Checklist
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.