### PR TITLE
Score the answer, not the reasoning, in MMLU/GPQA extraction

### DIFF
--- a/scripts/vllm/benchmarking/benchmark_utils.py
+++ b/scripts/vllm/benchmarking/benchmark_utils.py
@@ -88,6 +88,37 @@ def write_to_json(filename: str, records: list) -> None:
         )
 
 
+# MMLU answers are scored as indices into this list; None is "no answer could be
+# read out of the response".
+_MMLU_CHOICES = ["A", "B", "C", "D", None]
+
+# Everything up to and including the last reasoning close tag. Greedy on
+# purpose: a trace that quotes a close tag should not end the block early.
+_REASONING_BLOCK_RE = re.compile(r"(?is).*</(?:think|thinking|reasoning)>")
+_REASONING_OPEN_RE = re.compile(r"(?i)<(?:think|thinking|reasoning)>")
+
+
+def strip_reasoning(text: str) -> str:
+    """Drop a reasoning model's chain of thought, keeping only the answer.
+
+    The answer extractors below take the *first* match in the text, so a trace
+    that weighs "(B)" before settling on "(D)" is scored as B. That is not a
+    corner case for models whose chat template makes thinking mandatory and
+    offers no way to ask for a bare answer.
+
+    An opening tag with no close means the generation was truncated mid-thought.
+    There is no answer in it, so return nothing rather than let the extractors
+    grade abandoned reasoning -- that turns a silent wrong answer into a visible
+    unparsed one.
+    """
+    stripped, n_subs = _REASONING_BLOCK_RE.subn("", text, count=1)
+    if n_subs:
+        return stripped.lstrip()
+    if _REASONING_OPEN_RE.search(text):
+        return ""
+    return text
+
+
 def postprocess_text_mmlu(preds: List[str],
                           targets: List[str]) -> Tuple[List[int], List[int]]:
     """
@@ -99,9 +130,10 @@ def postprocess_text_mmlu(preds: List[str],
 
     Returns:
         Tuple[List[int], List[int]]: List of predicted answers and list of target answers"""
-    choices = ["A", "B", "C", "D", None]
+    choices = _MMLU_CHOICES
 
     def _parse_answer(output):
+        output = strip_reasoning(output)
         # TODO: This parser handles output regardless of whether a chat template is enabled.
         # Currently, the chat-template parsing rules are based on the gpt-oss format.
         # We will need to add rules for other models, as their output formats may differ.
@@ -181,6 +213,12 @@ def eval_accuracy_mmlu(request_outputs: List[RequestFuncOutput]) -> dict:
         references=targets,
     )
     result = {k: float(round(np.mean(v), 4)) for k, v in result.items()}
+    # postprocess_text_mmlu maps an unreadable answer to the index of None. Those
+    # count as wrong, so report them: a high rate means the accuracy number is
+    # measuring the harness rather than the model.
+    unparsed = sum(1 for p in preds if p == _MMLU_CHOICES.index(None))
+    result["unparsed"] = unparsed
+    result["unparsed_rate"] = round(unparsed / len(preds), 4) if preds else 0.0
     result["gen_num"] = len(preds)
     print("\nResults\n")
     print(result)
@@ -243,6 +281,8 @@ def extract_abcd_gpqa(text: str, possible_choices: str = 'ABCD') -> str:
     """
     import re
 
+    text = strip_reasoning(text)
+
     patterns = [
         # "Answer: (C)" or "Answers: (B)"
         re.compile(r'(?ix)\bAnswer[s]?\b\s*[:\-–]?\s*\(\s*([' +
@@ -301,9 +341,11 @@ def extract_abcd_gpqa(text: str, possible_choices: str = 'ABCD') -> str:
             if letter in possible_choices:
                 return letter
 
-    # Last resort: return first letter if it's in possible_choices
+    # Last resort: return first letter if it's in possible_choices. The
+    # emptiness check matters -- `"" in "ABCD"` is True, so an empty response
+    # would otherwise be reported as the answer `""` rather than as unparsed.
     first_char = text.strip()[:1].upper()
-    if first_char in possible_choices:
+    if first_char and first_char in possible_choices:
         return first_char
 
     return None
@@ -321,6 +363,7 @@ def eval_accuracy_gpqa(request_outputs: List[RequestFuncOutput]) -> dict:
     """
     correct = 0
     total = 0
+    unparsed = 0
 
     for output in request_outputs:
         if not output.success:
@@ -330,7 +373,9 @@ def eval_accuracy_gpqa(request_outputs: List[RequestFuncOutput]) -> dict:
         target = output.input_request.completion  # This is 'A', 'B', 'C', or 'D'
 
         extracted = extract_abcd_gpqa(generated_text)
-        if extracted == target.upper():
+        if extracted is None:
+            unparsed += 1
+        elif extracted == target.upper():
             correct += 1
         total += 1
 
@@ -339,6 +384,12 @@ def eval_accuracy_gpqa(request_outputs: List[RequestFuncOutput]) -> dict:
         "accuracy": round(accuracy, 4),
         "correct": correct,
         "total": total,
+        # No answer could be read out of the response -- truncated generation or
+        # an answer format the patterns miss. These count against accuracy, so a
+        # high rate here means the accuracy number is measuring the harness
+        # rather than the model.
+        "unparsed": unparsed,
+        "unparsed_rate": round(unparsed / total, 4) if total > 0 else 0.0,
         "gen_num": len(request_outputs),
     }
     print("\nGPQA Results\n")

--- a/scripts/vllm/benchmarking/benchmark_utils.py
+++ b/scripts/vllm/benchmarking/benchmark_utils.py
@@ -350,18 +350,10 @@ def extract_abcd_gpqa(text: str, possible_choices: str = 'ABCD') -> str:
     #
     # The letter must not run straight into an alphanumeric, or every sentence
     # opening with a word like "Although" or "Because" is graded as its first
-    # letter. On a sample of English prose that fired on 17% of sentences for
-    # ABCD and 43% for MMMU-Pro's ABCDEFGHIJ, and the wrong answers it produced
-    # were indistinguishable from real ones -- precisely what `unparsed` exists
-    # to surface. The lookahead is a strict tightening of the old bare
-    # first-character check: it never grades a response that check left alone,
-    # and never turns one letter into another, so accuracy can only hold steady
-    # or fall and `unparsed` can only rise.
+    # letter.
     #
     # A lookahead rather than a required character, so a response that is just
-    # "D" still matches at end of text. It also subsumes the old emptiness
-    # guard: `"" in "ABCD"` is True, so an empty response used to be reported
-    # as the answer `""`, and now simply fails to match.
+    # "D" still matches at end of text.
     match = re.match(r'^([' + possible_choices + r'])(?![A-Za-z0-9])',
                      text.strip(), re.IGNORECASE)
     if match:

--- a/scripts/vllm/benchmarking/benchmark_utils.py
+++ b/scripts/vllm/benchmarking/benchmark_utils.py
@@ -94,7 +94,11 @@ _MMLU_CHOICES = ["A", "B", "C", "D", None]
 
 # Everything up to and including the last reasoning close tag. Greedy on
 # purpose: a trace that quotes a close tag should not end the block early.
-_REASONING_BLOCK_RE = re.compile(r"(?is).*</(?:think|thinking|reasoning)>")
+# Anchored on purpose too: the block can only start at the beginning of the
+# text, and saying so keeps the engine from retrying the greedy `.*` from every
+# offset when there is no close tag at all -- the common case for a
+# non-reasoning model, and quadratic in the length of the completion.
+_REASONING_BLOCK_RE = re.compile(r"(?is)^.*</(?:think|thinking|reasoning)>")
 _REASONING_OPEN_RE = re.compile(r"(?i)<(?:think|thinking|reasoning)>")
 
 
@@ -309,10 +313,16 @@ def extract_abcd_gpqa(text: str, possible_choices: str = 'ABCD') -> str:
         # Markdown wrapped: *A*, **B**, _C_, __D__
         re.compile(r'(?x)(?<![A-Za-z0-9])(?:\*{1,2}|_{1,2})([' +
                    possible_choices + r'])(?:\*{1,2}|_{1,2})(?![A-Za-z0-9])'),
-        # Final fallback: line that's exactly "A", "B.", "C)", etc.
+        # Final fallback: line that's exactly "A", "B.", "C)", etc. The outer
+        # quotes are single on purpose -- as a triple-quoted string the
+        # `possible_choices` splice is literal text, which collapses the class
+        # to the letters of this source line and grades prose such as
+        # "however ..." as the answer H. The trailing `$` has no `.*` before
+        # it for the same reason: with one, every line *starting* with a
+        # choice letter matches, which is not "exactly".
         re.compile(
-            r'''(?x)^\s*(?:\*{1,2}|_{1,2})?([' + possible_choices + r'])(?:\*{1,2}|_{1,2})?\s*[\.\)\-–:]?\s*.*$''',
-            re.MULTILINE),
+            r'(?x)^\s*(?:\*{1,2}|_{1,2})?([' + possible_choices +
+            r'])(?:\*{1,2}|_{1,2})?\s*[\.\)\-–:]?\s*$', re.MULTILINE),
     ]
 
     # Also check for gpt-oss style "assistantfinal" block
@@ -365,10 +375,12 @@ def eval_accuracy_gpqa(request_outputs: List[RequestFuncOutput]) -> dict:
     total = 0
     unparsed = 0
 
+    # Failed requests are scored, not skipped, to match eval_accuracy_mmlu.
+    # Their generated_text is empty, so they land in `unparsed` -- which is
+    # where a request that produced no readable answer belongs, whatever the
+    # reason. Skipping them instead would hide a run that mostly errored out
+    # behind an accuracy computed over the handful that succeeded.
     for output in request_outputs:
-        if not output.success:
-            continue
-
         generated_text = output.generated_text
         target = output.input_request.completion  # This is 'A', 'B', 'C', or 'D'
 
@@ -384,10 +396,10 @@ def eval_accuracy_gpqa(request_outputs: List[RequestFuncOutput]) -> dict:
         "accuracy": round(accuracy, 4),
         "correct": correct,
         "total": total,
-        # No answer could be read out of the response -- truncated generation or
-        # an answer format the patterns miss. These count against accuracy, so a
-        # high rate here means the accuracy number is measuring the harness
-        # rather than the model.
+        # No answer could be read out of the response -- a failed request, a
+        # truncated generation, or an answer format the patterns miss. These
+        # count against accuracy, so a high rate here means the accuracy number
+        # is measuring the harness rather than the model.
         "unparsed": unparsed,
         "unparsed_rate": round(unparsed / total, 4) if total > 0 else 0.0,
         "gen_num": len(request_outputs),

--- a/scripts/vllm/benchmarking/benchmark_utils.py
+++ b/scripts/vllm/benchmarking/benchmark_utils.py
@@ -313,13 +313,7 @@ def extract_abcd_gpqa(text: str, possible_choices: str = 'ABCD') -> str:
         # Markdown wrapped: *A*, **B**, _C_, __D__
         re.compile(r'(?x)(?<![A-Za-z0-9])(?:\*{1,2}|_{1,2})([' +
                    possible_choices + r'])(?:\*{1,2}|_{1,2})(?![A-Za-z0-9])'),
-        # Final fallback: line that's exactly "A", "B.", "C)", etc. The outer
-        # quotes are single on purpose -- as a triple-quoted string the
-        # `possible_choices` splice is literal text, which collapses the class
-        # to the letters of this source line and grades prose such as
-        # "however ..." as the answer H. The trailing `$` has no `.*` before
-        # it for the same reason: with one, every line *starting* with a
-        # choice letter matches, which is not "exactly".
+        # Final fallback: line that's exactly "A", "B.", "C)", etc.
         re.compile(
             r'(?x)^\s*(?:\*{1,2}|_{1,2})?([' + possible_choices +
             r'])(?:\*{1,2}|_{1,2})?\s*[\.\)\-–:]?\s*$', re.MULTILINE),
@@ -351,12 +345,27 @@ def extract_abcd_gpqa(text: str, possible_choices: str = 'ABCD') -> str:
             if letter in possible_choices:
                 return letter
 
-    # Last resort: return first letter if it's in possible_choices. The
-    # emptiness check matters -- `"" in "ABCD"` is True, so an empty response
-    # would otherwise be reported as the answer `""` rather than as unparsed.
-    first_char = text.strip()[:1].upper()
-    if first_char and first_char in possible_choices:
-        return first_char
+    # Last resort: the response leads with a bare choice letter, as in
+    # "C) Paris" or "D is correct because ...".
+    #
+    # The letter must not run straight into an alphanumeric, or every sentence
+    # opening with a word like "Although" or "Because" is graded as its first
+    # letter. On a sample of English prose that fired on 17% of sentences for
+    # ABCD and 43% for MMMU-Pro's ABCDEFGHIJ, and the wrong answers it produced
+    # were indistinguishable from real ones -- precisely what `unparsed` exists
+    # to surface. The lookahead is a strict tightening of the old bare
+    # first-character check: it never grades a response that check left alone,
+    # and never turns one letter into another, so accuracy can only hold steady
+    # or fall and `unparsed` can only rise.
+    #
+    # A lookahead rather than a required character, so a response that is just
+    # "D" still matches at end of text. It also subsumes the old emptiness
+    # guard: `"" in "ABCD"` is True, so an empty response used to be reported
+    # as the answer `""`, and now simply fails to match.
+    match = re.match(r'^([' + possible_choices + r'])(?![A-Za-z0-9])',
+                     text.strip(), re.IGNORECASE)
+    if match:
+        return match.group(1).upper()
 
     return None
 

--- a/tests/scripts/test_benchmark_utils.py
+++ b/tests/scripts/test_benchmark_utils.py
@@ -14,6 +14,7 @@
 
 import importlib.util
 import sys
+import time
 import types
 from pathlib import Path
 
@@ -115,6 +116,19 @@ def test_strip_reasoning_passes_through_empty_string():
     assert strip_reasoning("") == ""
 
 
+def test_strip_reasoning_no_close_tag_is_not_quadratic():
+    # _REASONING_BLOCK_RE must stay anchored. Unanchored, the greedy `.*` is
+    # retried from every offset whenever there is no close tag -- the common
+    # case, since a non-reasoning model never emits one. Measured on the
+    # unanchored pattern: 200k chars took 9.4 s; anchored it is under a
+    # millisecond, so this threshold has several orders of magnitude of slack
+    # and is not a timing-sensitive test.
+    text = "x" * 200_000
+    start = time.perf_counter()
+    assert strip_reasoning(text) == text
+    assert time.perf_counter() - start < 2.0
+
+
 # --------------------------------------------------------------------------
 # extract_abcd_gpqa
 # --------------------------------------------------------------------------
@@ -142,6 +156,67 @@ def test_gpqa_empty_response_is_unparsed():
 def test_gpqa_unchanged_without_reasoning_tags():
     assert _MODULE.extract_abcd_gpqa("Answer: C") == "C"
     assert _MODULE.extract_abcd_gpqa("The answer is (A)") == "A"
+
+
+# --------------------------------------------------------------------------
+# extract_abcd_gpqa: the "line that's exactly a letter" final fallback
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("B", "B"),
+    ("B.", "B"),
+    ("C)", "C"),
+    ("**D**", "D"),
+    ("__A__", "A"),
+    ("  D  ", "D"),
+])
+def test_gpqa_bare_letter_line(text, expected):
+    assert _MODULE.extract_abcd_gpqa(text) == expected
+
+
+@pytest.mark.parametrize("text,choices,expected", [
+    ("Reasoning done.\nD", "ABCD", "D"),
+    ("The answer follows.\nE", "ABCDEFGHIJ", "E"),
+])
+def test_gpqa_bare_letter_on_a_later_line(text, choices, expected):
+    # The fallback is MULTILINE, so the answer need not be on the first line.
+    # This never worked before: as a triple-quoted string the pattern's
+    # character class was the letters of its own source, which contains no
+    # uppercase, so a bare "D" on its own line matched nothing.
+    assert _MODULE.extract_abcd_gpqa(text,
+                                     possible_choices=choices) == expected
+
+
+@pytest.mark.parametrize(
+    "text,choices",
+    [
+        # Lowercase b/c fall inside the old broken class (from the literal
+        # "possible_choices" text), so these were graded as B and C.
+        ("Not enough data.\nbecause of the gradient.", "ABCD"),
+        ("Unclear.\ncannot determine this.", "ABCD"),
+        # e/h/i additionally land in range for MMMU-Pro's wider choice set.
+        ("Unclear.\nhowever the figure is odd.", "ABCDEFGHIJ"),
+        ("Unclear.\neach option is plausible.", "ABCDEFGHIJ"),
+    ])
+def test_gpqa_prose_line_is_not_an_answer(text, choices):
+    assert _MODULE.extract_abcd_gpqa(text, possible_choices=choices) is None
+
+
+def test_gpqa_fallback_requires_the_whole_line():
+    # Guards the missing `.*` before `$`: with one, any line *starting* with a
+    # choice letter matches, which is not the "exactly" the fallback promises.
+    assert _MODULE.extract_abcd_gpqa(
+        "Not enough data.\nBoth are viable.") is None
+
+
+def test_gpqa_fallback_honours_possible_choices():
+    # E is out of range for the default ABCD but in range for MMMU-Pro. The
+    # leading word must not itself start with a choice letter, or the
+    # last-resort first-character branch answers before the fallback runs.
+    assert _MODULE.extract_abcd_gpqa("Finished.\nE") is None
+    assert _MODULE.extract_abcd_gpqa("Finished.\nE",
+                                     possible_choices="ABCDEFGHIJ") == "E"
 
 
 # --------------------------------------------------------------------------
@@ -187,25 +262,64 @@ def test_eval_accuracy_gpqa_reports_unparsed():
     assert result["accuracy"] == 0.25
 
 
-def test_eval_accuracy_gpqa_skips_failed_requests():
+def test_eval_accuracy_gpqa_counts_failed_requests_as_unparsed():
+    # Failed requests are scored rather than skipped, matching
+    # eval_accuracy_mmlu. Their generated_text is empty, so they are unparsed.
     outputs = [
         _output("Answer: (D)", completion="D"),
-        _output("<think>truncated", completion="D", success=False),
+        _output("", completion="D", success=False),
     ]
     result = _MODULE.eval_accuracy_gpqa(outputs)
 
-    assert result["total"] == 1
-    assert result["unparsed"] == 0
+    assert result["correct"] == 1
+    assert result["total"] == 2
+    assert result["unparsed"] == 1
+    assert result["unparsed_rate"] == 0.5
+    assert result["accuracy"] == 0.5
     assert result["gen_num"] == 2
 
 
-def test_eval_accuracy_gpqa_no_successful_outputs():
+def test_eval_accuracy_gpqa_all_requests_failed():
     result = _MODULE.eval_accuracy_gpqa(
-        [_output("Answer: (D)", success=False)])
+        [_output("", success=False),
+         _output("", success=False)])
+
+    # A run that errored out end to end reports 0% accuracy at a 100% unparsed
+    # rate, rather than hiding behind an empty denominator.
+    assert result["total"] == 2
+    assert result["unparsed"] == 2
+    assert result["unparsed_rate"] == 1.0
+    assert result["accuracy"] == 0.0
+
+
+def test_eval_accuracy_gpqa_empty_input():
+    result = _MODULE.eval_accuracy_gpqa([])
 
     assert result["total"] == 0
     assert result["unparsed_rate"] == 0.0
     assert result["accuracy"] == 0.0
+
+
+def test_eval_accuracy_gpqa_matches_mmlu_on_failed_requests(monkeypatch):
+    # The two datasets should report the same unparsed_rate for the same mix
+    # of failures; that was the point of aligning them.
+    monkeypatch.setattr(
+        _MODULE, "evaluate",
+        types.SimpleNamespace(load=lambda name: types.SimpleNamespace(
+            compute=lambda predictions, references: {"accuracy": 0.0})))
+    monkeypatch.setattr(_MODULE, "nltk",
+                        types.SimpleNamespace(download=lambda name: None))
+
+    outputs = [
+        _output("Answer: (D)", completion="D"),
+        _output("", completion="D", success=False),
+        _output("", completion="D", success=False),
+    ]
+    gpqa = _MODULE.eval_accuracy_gpqa(outputs)
+    mmlu = _MODULE.eval_accuracy_mmlu(outputs)
+
+    assert gpqa["unparsed"] == mmlu["unparsed"] == 2
+    assert gpqa["unparsed_rate"] == mmlu["unparsed_rate"] == 0.6667
 
 
 def test_eval_accuracy_mmlu_reports_unparsed(monkeypatch):

--- a/tests/scripts/test_benchmark_utils.py
+++ b/tests/scripts/test_benchmark_utils.py
@@ -1,0 +1,235 @@
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import importlib.util
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+_BENCHMARKING_DIR = (Path(__file__).parents[2] / "scripts" / "vllm" /
+                     "benchmarking")
+# benchmark_utils imports its siblings (backend_request_func,
+# benchmark_dataset) by bare name, the way benchmark_serving.py runs it.
+sys.path.insert(0, str(_BENCHMARKING_DIR))
+
+_SPEC = importlib.util.spec_from_file_location(
+    "benchmark_utils", _BENCHMARKING_DIR / "benchmark_utils.py")
+assert _SPEC is not None and _SPEC.loader is not None
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+
+strip_reasoning = _MODULE.strip_reasoning
+
+# postprocess_text_mmlu encodes "no answer could be read" as the index of None.
+_UNPARSED = _MODULE._MMLU_CHOICES.index(None)
+
+
+def _output(generated_text: str, completion: str = "D", success: bool = True):
+    """A stand-in for RequestFuncOutput with only the fields the evals read."""
+    return types.SimpleNamespace(
+        success=success,
+        generated_text=generated_text,
+        input_request=types.SimpleNamespace(completion=completion),
+    )
+
+
+# --------------------------------------------------------------------------
+# strip_reasoning
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("tag", ["think", "thinking", "reasoning"])
+def test_strip_reasoning_removes_closed_block(tag):
+    text = f"<{tag}>I lean towards (B)</{tag}>Answer: (D)"
+    assert strip_reasoning(text) == "Answer: (D)"
+
+
+@pytest.mark.parametrize("tag", ["think", "thinking", "reasoning"])
+def test_strip_reasoning_is_case_insensitive(tag):
+    text = f"<{tag.upper()}>maybe (B)</{tag.upper()}>Answer: (D)"
+    assert strip_reasoning(text) == "Answer: (D)"
+
+
+def test_strip_reasoning_spans_newlines():
+    text = "<think>line one\nline two mentions (B)\n</think>\nAnswer: (D)"
+    assert strip_reasoning(text) == "Answer: (D)"
+
+
+def test_strip_reasoning_keeps_text_without_tags():
+    text = "The answer is (D) because of the second law."
+    assert strip_reasoning(text) == text
+
+
+def test_strip_reasoning_handles_missing_open_tag():
+    # Some serving stacks pre-fill the opening tag in the chat template, so it
+    # never appears in the completion -- only the close tag does.
+    assert strip_reasoning("weighed (B)</think>Answer: (D)") == "Answer: (D)"
+
+
+def test_strip_reasoning_strips_through_last_close_tag():
+    text = ("<think>first (A)</think>interlude (B)"
+            "<think>second (C)</think>Answer: (D)")
+    assert strip_reasoning(text) == "Answer: (D)"
+
+
+def test_strip_reasoning_greedy_past_quoted_close_tag():
+    # Documented trade-off: a trace that quotes a close tag must not end the
+    # block early, so the last one in the text wins.
+    text = "<think>the model writes </think> in its trace</think>Answer: (D)"
+    assert strip_reasoning(text) == "Answer: (D)"
+
+
+def test_strip_reasoning_drops_leading_whitespace_after_block():
+    assert strip_reasoning(
+        "<think>x</think>  \n\t Answer: (D)") == "Answer: (D)"
+
+
+def test_strip_reasoning_preserves_trailing_whitespace():
+    assert strip_reasoning("<think>x</think>Answer: (D)\n") == "Answer: (D)\n"
+
+
+def test_strip_reasoning_truncated_generation_returns_empty():
+    # An open tag with no close means the generation ran out of budget
+    # mid-thought. There is no answer in it to grade.
+    assert strip_reasoning("<think>Let me consider (B), but wait") == ""
+
+
+def test_strip_reasoning_empty_block_returns_empty():
+    assert strip_reasoning("<think>reasoned but never answered</think>") == ""
+
+
+def test_strip_reasoning_passes_through_empty_string():
+    assert strip_reasoning("") == ""
+
+
+# --------------------------------------------------------------------------
+# extract_abcd_gpqa
+# --------------------------------------------------------------------------
+
+
+def test_gpqa_scores_answer_not_reasoning():
+    # The reasoning states an answer in the same format the extractor looks
+    # for; only the one after the close tag should count.
+    text = ("<think>Answer: (B)? No, that ignores the catalyst.</think>"
+            "Answer: (D)")
+    assert _MODULE.extract_abcd_gpqa(text) == "D"
+
+
+def test_gpqa_truncated_reasoning_is_unparsed():
+    assert _MODULE.extract_abcd_gpqa("<think>I think (B) because") is None
+
+
+def test_gpqa_empty_response_is_unparsed():
+    # Regression: `"" in "ABCD"` is True, so the last-resort branch used to
+    # report an empty response as the answer `""`.
+    assert _MODULE.extract_abcd_gpqa("") is None
+    assert _MODULE.extract_abcd_gpqa("   \n ") is None
+
+
+def test_gpqa_unchanged_without_reasoning_tags():
+    assert _MODULE.extract_abcd_gpqa("Answer: C") == "C"
+    assert _MODULE.extract_abcd_gpqa("The answer is (A)") == "A"
+
+
+# --------------------------------------------------------------------------
+# postprocess_text_mmlu
+# --------------------------------------------------------------------------
+
+
+def test_mmlu_scores_answer_not_reasoning():
+    preds, targets = _MODULE.postprocess_text_mmlu(
+        ["<think>maybe (B)</think>Answer: (D)"], ["D"])
+    assert preds == targets
+
+
+def test_mmlu_truncated_reasoning_is_unparsed():
+    preds, _ = _MODULE.postprocess_text_mmlu(["<think>weighing (B) against"],
+                                             ["D"])
+    assert preds == [_UNPARSED]
+
+
+def test_mmlu_unchanged_without_reasoning_tags():
+    preds, targets = _MODULE.postprocess_text_mmlu(["Thus answer: C"], ["C"])
+    assert preds == targets
+
+
+# --------------------------------------------------------------------------
+# unparsed reporting
+# --------------------------------------------------------------------------
+
+
+def test_eval_accuracy_gpqa_reports_unparsed():
+    outputs = [
+        _output("<think>(B)?</think>Answer: (D)", completion="D"),  # correct
+        _output("Answer: (A)", completion="D"),  # wrong
+        _output("<think>truncated", completion="D"),  # unparsed
+        _output("", completion="D"),  # unparsed
+    ]
+    result = _MODULE.eval_accuracy_gpqa(outputs)
+
+    assert result["correct"] == 1
+    assert result["total"] == 4
+    assert result["unparsed"] == 2
+    assert result["unparsed_rate"] == 0.5
+    assert result["accuracy"] == 0.25
+
+
+def test_eval_accuracy_gpqa_skips_failed_requests():
+    outputs = [
+        _output("Answer: (D)", completion="D"),
+        _output("<think>truncated", completion="D", success=False),
+    ]
+    result = _MODULE.eval_accuracy_gpqa(outputs)
+
+    assert result["total"] == 1
+    assert result["unparsed"] == 0
+    assert result["gen_num"] == 2
+
+
+def test_eval_accuracy_gpqa_no_successful_outputs():
+    result = _MODULE.eval_accuracy_gpqa(
+        [_output("Answer: (D)", success=False)])
+
+    assert result["total"] == 0
+    assert result["unparsed_rate"] == 0.0
+    assert result["accuracy"] == 0.0
+
+
+def test_eval_accuracy_mmlu_reports_unparsed(monkeypatch):
+    # eval_accuracy_mmlu pulls the accuracy metric over the network and
+    # downloads nltk corpora; neither is what is under test here.
+    monkeypatch.setattr(
+        _MODULE, "evaluate",
+        types.SimpleNamespace(load=lambda name: types.SimpleNamespace(
+            compute=lambda predictions, references: {
+                "accuracy":
+                sum(p == r for p, r in zip(predictions, references)) / len(
+                    predictions)
+            })))
+    monkeypatch.setattr(_MODULE, "nltk",
+                        types.SimpleNamespace(download=lambda name: None))
+
+    outputs = [
+        _output("<think>(B)?</think>Answer: (D)", completion="D"),  # correct
+        _output("Answer: (A)", completion="D"),  # wrong
+        _output("<think>truncated", completion="D"),  # unparsed
+    ]
+    result = _MODULE.eval_accuracy_mmlu(outputs)
+
+    assert result["unparsed"] == 1
+    assert result["unparsed_rate"] == 0.3333
+    assert result["gen_num"] == 3
+    assert result["accuracy"] == 0.3333

--- a/tests/scripts/test_benchmark_utils.py
+++ b/tests/scripts/test_benchmark_utils.py
@@ -210,6 +210,78 @@ def test_gpqa_fallback_requires_the_whole_line():
         "Not enough data.\nBoth are viable.") is None
 
 
+# --------------------------------------------------------------------------
+# extract_abcd_gpqa: the "leads with a bare choice letter" last resort
+# --------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("text,expected", [
+    ("C) Paris", "C"),
+    ("D is correct because the enthalpy is negative.", "D"),
+    ("A. The reaction proceeds via an SN2 mechanism.", "A"),
+    ("B: option two", "B"),
+    ("C - the third one", "C"),
+    ("d) lowercase is still an answer", "D"),
+    ("  D  ", "D"),
+])
+def test_gpqa_last_resort_reads_a_leading_letter(text, expected):
+    assert _MODULE.extract_abcd_gpqa(text) == expected
+
+
+@pytest.mark.parametrize("text", [
+    "Although the reaction is exothermic, entropy dominates.",
+    "Because the catalyst lowers the activation energy.",
+    "Considering all of the options, none fit perfectly.",
+    "An alternative explanation involves resonance.",
+    "During the reaction, the intermediate forms.",
+    "Denote the enthalpy by H.",
+])
+def test_gpqa_last_resort_ignores_prose(text):
+    # The letter has to be followed by a non-alphanumeric. Without that, the
+    # old bare first-character check graded 17% of English sentences (43% for
+    # MMMU-Pro's wider set) on spelling alone, as answers indistinguishable
+    # from real ones rather than as unparsed.
+    assert _MODULE.extract_abcd_gpqa(text) is None
+
+
+def test_gpqa_last_resort_still_grades_a_leading_article():
+    # Known residual: "A" as an indefinite article is followed by a space, so
+    # it is indistinguishable from "D is correct because ...". Keeping this
+    # class is deliberate -- rejecting it would cost the real answers too.
+    assert _MODULE.extract_abcd_gpqa(
+        "A common misconception is that entropy always rises.") == "A"
+
+
+def test_gpqa_last_resort_is_a_strict_tightening():
+    # The rule matches a subset of the old bare first-character check, so a
+    # response can only move from graded to unparsed -- never from one letter
+    # to another, and never from unparsed to graded.
+    def old_last_resort(text, choices="ABCD"):
+        first_char = text.strip()[:1].upper()
+        return first_char if first_char and first_char in choices else None
+
+    corpus = [
+        "C) Paris",
+        "D is correct.",
+        "A. Restated choice.",
+        "Although so.",
+        "Because so.",
+        "Denote H.",
+        "A common case.",
+        "",
+        "   ",
+        "The answer cannot be determined.",
+        "d) lowercase",
+        "B",
+    ]
+    for text in corpus:
+        new = _MODULE.extract_abcd_gpqa(text)
+        old = old_last_resort(text)
+        # Only compare where the last resort is what decided the outcome.
+        if new is not None and old is not None:
+            assert new == old, text
+
+
 def test_gpqa_fallback_honours_possible_choices():
     # E is out of range for the default ABCD but in range for MMMU-Pro. The
     # leading word must not itself start with a choice letter, or the


### PR DESCRIPTION
# Description

The MMLU/GPQA extractors take the first regex match over the whole completion, so for a reasoning model they score the chain of thought rather than the answer. Strip the reasoning block before extracting, and report `unparsed`/`unparsed_rate` so a run the harness couldn't read is distinguishable from one the model got wrong.

Also fixed, found while testing that change: 
- The GPQA final fallback pattern was triple-quoted so `possible_choices` never interpolated; 
- The last resort graded a response by its first character alone, too many false positives.
- GPQA skipped failed requests where MMLU counted them, causing inconsistency. 

# Tests

`python -m pytest tests/scripts/test_benchmark_utils.py -q` — 59 new tests, all passing. Each fix was mutation-tested rather than only run green: reverting it fails 19/7/6/3/1 tests respectively. The regex anchor is semantics-preserving so nothing behavioural catches it; it has a timing assertion instead (2 s threshold against 9.4 s unanchored, sub-millisecond anchored).
