### PR TITLE
[Bug fix] Flax loader: keep kv-cache output sharding

### DIFF
--- a/tests/models/common/test_model_loader.py
+++ b/tests/models/common/test_model_loader.py
@@ -352,7 +352,9 @@ def test_step_fn_kv_cache_sharding_is_a_fixed_point(vllm_config, mesh, rng):
         allocated = jax.tree.map(lambda c: c.sharding, kv_caches)
         cache_index = tuple((f"layer.{i}", i) for i in range(num_layers))
 
-        def step(caches, num_tokens):
+        def step(caches, num_tokens, with_options=True):
+            step_fn = (model.model_fn
+                       if with_options else model.model.step_fn_no_options)
             num_reqs = min(num_tokens, 8)
             attention_metadata = AttentionMetadata(
                 input_positions=jnp.zeros((num_tokens, ), dtype=jnp.int32),
@@ -363,7 +365,7 @@ def test_step_fn_kv_cache_sharding_is_a_fixed_point(vllm_config, mesh, rng):
                 request_distribution=jnp.array([0, 0, num_reqs],
                                                dtype=jnp.int32),
             )
-            return model.model_fn(
+            return step_fn(
                 model.state_leaves,
                 caches,
                 jnp.ones((num_tokens, ), dtype=jnp.int32),
@@ -396,6 +398,13 @@ def test_step_fn_kv_cache_sharding_is_a_fixed_point(vllm_config, mesh, rng):
         with ForbidCompile():
             for num_tokens in buckets:
                 kv_caches = step(kv_caches, num_tokens)
+
+        # The eagle3 drafter and the `continue_decode` loop both call the step
+        # fn from inside an outer jit, where `kv_caches` arrives as tracers
+        # with no queryable sharding. That must still work.
+        traced_step = jax.jit(
+            lambda caches: step(caches, buckets[0], with_options=False))
+        traced_step(kv_caches)
 
 
 def test_get_flax_model_with_pooling(vllm_config, mesh, rng):

--- a/tests/models/common/test_model_loader.py
+++ b/tests/models/common/test_model_loader.py
@@ -315,6 +315,89 @@ def test_get_flax_model(vllm_config, mesh, tie_word_embeddings):
     assert hasattr(model.model, "named_modules")
 
 
+def test_step_fn_kv_cache_sharding_is_a_fixed_point(vllm_config, mesh, rng):
+    """The step fn must return kv-caches sharded exactly as it received them.
+
+    The runner feeds each step's kv-cache output straight back in as the next
+    step's input, so any divergence between the allocated sharding and the
+    sharding the step fn returns changes the jit cache key and forces a
+    recompile mid-run -- which `ForbidCompile` turns into a hard error. This
+    pins the fixed point across the token buckets a draining batch walks
+    through, and asserts the replay compiles nothing.
+    """
+    from tpu_inference.layers.common.attention_metadata import \
+        AttentionMetadata
+    from tpu_inference.runner.kv_cache import create_kv_caches
+    from tpu_inference.runner.utils import ForbidCompile
+
+    init_pp_distributed_environment(ip="",
+                                    rank=0,
+                                    world_size=1,
+                                    device=jax.devices()[0],
+                                    need_pp=False)
+    with jax.set_mesh(mesh), set_current_vllm_config(vllm_config):
+        model = model_loader.get_flax_model(vllm_config, rng, mesh)
+
+        hf_config = vllm_config.model_config.hf_config
+        num_layers = hf_config.num_hidden_layers
+        kv_caches = create_kv_caches(
+            num_blocks=64,
+            block_size=32,
+            num_kv_heads=hf_config.num_key_value_heads,
+            head_size=hf_config.head_dim,
+            mesh=mesh,
+            layer_names=[f"layer.{i}" for i in range(num_layers)],
+            cache_dtype=jnp.bfloat16,
+        )
+        allocated = jax.tree.map(lambda c: c.sharding, kv_caches)
+        cache_index = tuple((f"layer.{i}", i) for i in range(num_layers))
+
+        def step(caches, num_tokens):
+            num_reqs = min(num_tokens, 8)
+            attention_metadata = AttentionMetadata(
+                input_positions=jnp.zeros((num_tokens, ), dtype=jnp.int32),
+                block_tables=jnp.zeros((num_reqs, 4),
+                                       dtype=jnp.int32).reshape(-1),
+                seq_lens=jnp.ones((num_reqs, ), dtype=jnp.int32),
+                query_start_loc=jnp.arange(num_reqs + 1, dtype=jnp.int32),
+                request_distribution=jnp.array([0, 0, num_reqs],
+                                               dtype=jnp.int32),
+            )
+            return model.model_fn(
+                model.state_leaves,
+                caches,
+                jnp.ones((num_tokens, ), dtype=jnp.int32),
+                attention_metadata,
+                None,
+                jnp.zeros((num_tokens, ), dtype=jnp.int32),
+                cache_index,
+                None,
+                None,
+                True,
+                True,
+            )[0]
+
+        # A batch drains through decreasing token buckets; every one of them
+        # must hand back caches sharded the way they were allocated.
+        buckets = (64, 32, 16, 8)
+        for num_tokens in buckets:
+            kv_caches = step(kv_caches, num_tokens)
+            got = jax.tree.map(lambda c: c.sharding, kv_caches)
+            drifted = [(want, have) for want, have in zip(
+                jax.tree.leaves(allocated), jax.tree.leaves(got))
+                       if want != have]
+            assert not drifted, (
+                f"kv-cache sharding drifted at num_tokens={num_tokens}: "
+                f"{len(drifted)} leaf(s) changed, e.g. allocated "
+                f"{drifted[0][0]} came back as {drifted[0][1]}")
+
+        # Replaying the same buckets with the returned caches must reuse the
+        # compiled executables rather than trigger a fresh lowering.
+        with ForbidCompile():
+            for num_tokens in buckets:
+                kv_caches = step(kv_caches, num_tokens)
+
+
 def test_get_flax_model_with_pooling(vllm_config, mesh, rng):
     """Tests that get_flax_model correctly instantiates a pooler when runner_type is 'pooling'."""
     vllm_config.model_config.runner_type = "pooling"

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -353,10 +353,16 @@ def get_flax_model(
                                pooler=pooler,
                                is_draft_model=is_draft_model)
     vllm_config.model_config.dtype = original_dtype
-    kv_cache_sharding = NamedSharding(
-        mesh,
-        PartitionSpec(ShardingAxisName.BATCH, ShardingAxisName.KV_CONTEXT,
-                      ShardingAxisName.KV_HEAD))
+    # The kv-cache output sharding is left as None ("keep original sharding")
+    # so JAX propagates whatever each layer's attention kernel emitted. Every
+    # kernel wrapper (RPA in `attention_interface.py`, GDN in
+    # `gdn_attention.py`, MLA) pins its cache output via shard_map
+    # `out_specs`, which by construction matches the sharding the runner
+    # allocated the cache with in `kv_cache_manager.py`. Forcing a single
+    # attention-shaped spec here instead would silently reshard any leaf
+    # whose layout differs (e.g. the GDN ssm_state `[blocks, heads, dk, dv]`,
+    # which is heads-sharded), costing an all-to-all per layer per step.
+    # This mirrors the torchax path in `models/vllm/vllm_model_wrapper.py`.
     hidden_states_sharding = NamedSharding(mesh,
                                            PartitionSpec(
                                                ShardingAxisName.ATTN_DATA,
@@ -381,7 +387,7 @@ def get_flax_model(
     _wrap_with_jit = functools.partial(
         jax.jit,
         out_shardings=(
-            kv_cache_sharding,
+            None,  # kv_cache - keep original sharding
             hidden_states_sharding,
             hidden_states_sharding,  # aux hidden states
             None,  # expert ids
@@ -406,7 +412,7 @@ def get_flax_model(
 
     @jax.jit(
         out_shardings=(
-            kv_cache_sharding,
+            None,  # kv_cache - keep original sharding
             hidden_states_sharding,
             hidden_states_sharding,  # residual
             None,  # expert ids

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -373,24 +373,12 @@ def get_flax_model(
         model = nnx.merge(graphdef, state)
         return model(*args)
 
-    # The kv-cache entry of `out_shardings` is pinned to the sharding the
-    # runner actually allocated each cache with, read off the `kv_caches`
-    # argument of the first call (see `_get_step_fn`). It can be neither a
-    # single attention-shaped spec nor left unspecified:
-    #
-    #   * A single spec is applied as a pytree prefix, so it would also land
-    #     on the mamba/GDN state leaves that `runner/kv_cache_manager.py`
-    #     allocates with a different layout (e.g. ssm_state
-    #     `[blocks, heads, dk, dv]` is heads-sharded), silently reshuffling
-    #     them and costing an all-to-all per layer per step.
-    #   * Unspecified (`None`) leaves the output sharding to XLA. The runner
-    #     feeds the result straight back in as the next step's `kv_caches`,
-    #     so whenever XLA's choice differs from the allocated sharding the
-    #     jit cache key changes and the step recompiles -- which the runner's
-    #     `ForbidCompile` guard turns into a hard error mid-run.
-    #
-    # Echoing the input sharding satisfies both: every leaf keeps the layout
-    # its kernel emitted, and the cache key is a fixed point across steps.
+    def _kv_cache_out_shardings(kv_caches):
+        leaves = jax.tree.leaves(kv_caches)
+        if any(isinstance(leaf, jax.core.Tracer) for leaf in leaves):
+            return None
+        return jax.tree.map(lambda c: c.sharding, kv_caches)
+
     def _wrap_with_jit(fn, kv_cache_shardings, **jit_kwargs):
         return jax.jit(
             fn,
@@ -408,15 +396,14 @@ def get_flax_model(
         )
 
     # `continue_decode` calls the step fn from inside a `jax.lax.while_loop`
-    # body, where JAX forbids `compiler_options` on a nested jit, so the
-    # options-free twin is built alongside the regular one; the loop jit in
-    # `runner/decode_loop.py` supplies the options for the whole fused
-    # program. Both are built on first use, keyed by the kv-cache shardings
-    # so a reallocation with a new layout rebuilds rather than reshards.
+    # body, where JAX forbids `compiler_options` on a nested jit. Build an
+    # options-free twin for that path; the loop jit in `runner/decode_loop.py`
+    # supplies the options for the whole fused program. Mirrors the torchax
+    # path in `models/vllm/vllm_model_wrapper.py`.
     _step_fns: Dict[Tuple[bool, Any], Any] = {}
 
     def _get_step_fn(kv_caches, with_options: bool):
-        shardings = jax.tree.map(lambda c: c.sharding, kv_caches)
+        shardings = _kv_cache_out_shardings(kv_caches)
         key = (with_options, tuple(jax.tree.leaves(shardings)))
         fn = _step_fns.get(key)
         if fn is None:
@@ -430,7 +417,7 @@ def get_flax_model(
     _draft_step_fns: Dict[Any, Any] = {}
 
     def _get_draft_step_fn(kv_caches):
-        shardings = jax.tree.map(lambda c: c.sharding, kv_caches)
+        shardings = _kv_cache_out_shardings(kv_caches)
         key = tuple(jax.tree.leaves(shardings))
         fn = _draft_step_fns.get(key)
         if fn is None:
@@ -506,15 +493,12 @@ def get_flax_model(
     precompile_vision_encoder_fn = getattr(model, "precompile_vision_encoder",
                                            None)
     # `graphdef` and the state treedef are captured in each closure; the
-    # runner passes pre-flattened `state_leaves` as the first positional arg,
-    # and `kv_caches` as the second -- the latter is what the step fns are
-    # keyed on, so it must stay positional.
+    # runner passes pre-flattened `state_leaves` as the first positional arg.
     model_supports_spec_step = supports_kw(model_class.__call__,
                                            "spec_step_idx")
 
     def _resolve_step_fn(kv_caches, with_options: bool):
         if is_draft_model:
-            # The draft jit carries no compiler options, so it is its own twin.
             return _get_draft_step_fn(kv_caches)
         return _get_step_fn(kv_caches, with_options)
 

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -353,16 +353,6 @@ def get_flax_model(
                                pooler=pooler,
                                is_draft_model=is_draft_model)
     vllm_config.model_config.dtype = original_dtype
-    # The kv-cache output sharding is left as None ("keep original sharding")
-    # so JAX propagates whatever each layer's attention kernel emitted. Every
-    # kernel wrapper (RPA in `attention_interface.py`, GDN in
-    # `gdn_attention.py`, MLA) pins its cache output via shard_map
-    # `out_specs`, which by construction matches the sharding the runner
-    # allocated the cache with in `kv_cache_manager.py`. Forcing a single
-    # attention-shaped spec here instead would silently reshard any leaf
-    # whose layout differs (e.g. the GDN ssm_state `[blocks, heads, dk, dv]`,
-    # which is heads-sharded), costing an all-to-all per layer per step.
-    # This mirrors the torchax path in `models/vllm/vllm_model_wrapper.py`.
     hidden_states_sharding = NamedSharding(mesh,
                                            PartitionSpec(
                                                ShardingAxisName.ATTN_DATA,
@@ -387,7 +377,7 @@ def get_flax_model(
     _wrap_with_jit = functools.partial(
         jax.jit,
         out_shardings=(
-            None,  # kv_cache - keep original sharding
+            None,  # kv_cache
             hidden_states_sharding,
             hidden_states_sharding,  # aux hidden states
             None,  # expert ids
@@ -412,7 +402,7 @@ def get_flax_model(
 
     @jax.jit(
         out_shardings=(
-            None,  # kv_cache - keep original sharding
+            None,  # kv_cache
             hidden_states_sharding,
             hidden_states_sharding,  # residual
             None,  # expert ids

--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -11,8 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import functools
-from typing import Any, Optional
+from typing import Any, Dict, Optional, Tuple
 
 import jax
 import numpy as np
@@ -362,7 +361,7 @@ def get_flax_model(
     # https://flax.readthedocs.io/en/latest/guides/performance.html
     graphdef, state = nnx.split(jit_model)
 
-    # Capture the nnx.State treedef once. `run_model` accepts a flat tuple
+    # Capture the nnx.State treedef once. The step fn accepts a flat tuple
     # of array leaves at dispatch time and reconstructs the state via this
     # treedef. The runner does the flatten of `state` once at init, which
     # avoids the per-call `nnx.Variable` pytree traversal that otherwise
@@ -374,43 +373,82 @@ def get_flax_model(
         model = nnx.merge(graphdef, state)
         return model(*args)
 
-    _wrap_with_jit = functools.partial(
-        jax.jit,
-        out_shardings=(
-            None,  # kv_cache
-            hidden_states_sharding,
-            hidden_states_sharding,  # aux hidden states
-            None,  # expert ids
-        ),
-        donate_argnums=1,  # 0 is state_leaves, 1 is kv_cache
-        static_argnums=(
-            6, 9, 10
-        ),  # 6 is layer_name_to_kvcache_index, 9 is is_first_rank, 10 is is_last_rank
-    )
+    # The kv-cache entry of `out_shardings` is pinned to the sharding the
+    # runner actually allocated each cache with, read off the `kv_caches`
+    # argument of the first call (see `_get_step_fn`). It can be neither a
+    # single attention-shaped spec nor left unspecified:
+    #
+    #   * A single spec is applied as a pytree prefix, so it would also land
+    #     on the mamba/GDN state leaves that `runner/kv_cache_manager.py`
+    #     allocates with a different layout (e.g. ssm_state
+    #     `[blocks, heads, dk, dv]` is heads-sharded), silently reshuffling
+    #     them and costing an all-to-all per layer per step.
+    #   * Unspecified (`None`) leaves the output sharding to XLA. The runner
+    #     feeds the result straight back in as the next step's `kv_caches`,
+    #     so whenever XLA's choice differs from the allocated sharding the
+    #     jit cache key changes and the step recompiles -- which the runner's
+    #     `ForbidCompile` guard turns into a hard error mid-run.
+    #
+    # Echoing the input sharding satisfies both: every leaf keeps the layout
+    # its kernel emitted, and the cache key is a fixed point across steps.
+    def _wrap_with_jit(fn, kv_cache_shardings, **jit_kwargs):
+        return jax.jit(
+            fn,
+            out_shardings=(
+                kv_cache_shardings,
+                hidden_states_sharding,
+                hidden_states_sharding,  # aux hidden states
+                None,  # expert ids
+            ),
+            donate_argnums=1,  # 0 is state_leaves, 1 is kv_cache
+            static_argnums=(
+                6, 9, 10
+            ),  # 6 is layer_name_to_kvcache_index, 9 is is_first_rank, 10 is is_last_rank
+            **jit_kwargs,
+        )
 
     # `continue_decode` calls the step fn from inside a `jax.lax.while_loop`
-    # body, where JAX forbids `compiler_options` on a nested jit. Build an
-    # options-free twin for that path; the loop jit in `runner/decode_loop.py`
-    # supplies the options for the whole fused program. Mirrors the torchax
-    # path in `models/vllm/vllm_model_wrapper.py`.
-    run_model_no_options = _wrap_with_jit(run_model_impl)
+    # body, where JAX forbids `compiler_options` on a nested jit, so the
+    # options-free twin is built alongside the regular one; the loop jit in
+    # `runner/decode_loop.py` supplies the options for the whole fused
+    # program. Both are built on first use, keyed by the kv-cache shardings
+    # so a reallocation with a new layout rebuilds rather than reshards.
+    _step_fns: Dict[Tuple[bool, Any], Any] = {}
 
-    run_model = _wrap_with_jit(
-        run_model_impl,
-        compiler_options=get_step_fn_compiler_options(),
-    )
+    def _get_step_fn(kv_caches, with_options: bool):
+        shardings = jax.tree.map(lambda c: c.sharding, kv_caches)
+        key = (with_options, tuple(jax.tree.leaves(shardings)))
+        fn = _step_fns.get(key)
+        if fn is None:
+            options = ({
+                "compiler_options": get_step_fn_compiler_options()
+            } if with_options else {})
+            fn = _wrap_with_jit(run_model_impl, shardings, **options)
+            _step_fns[key] = fn
+        return fn
 
-    @jax.jit(
-        out_shardings=(
-            None,  # kv_cache
-            hidden_states_sharding,
-            hidden_states_sharding,  # residual
-            None,  # expert ids
-        ),
-        donate_argnums=1,  # 0 is state_leaves, 1 is kv_cache
-        static_argnums=(5, ),  # 5 is layer_name_to_kvcache_index
-    )
-    def run_draft_model(state_leaves, *args):
+    _draft_step_fns: Dict[Any, Any] = {}
+
+    def _get_draft_step_fn(kv_caches):
+        shardings = jax.tree.map(lambda c: c.sharding, kv_caches)
+        key = tuple(jax.tree.leaves(shardings))
+        fn = _draft_step_fns.get(key)
+        if fn is None:
+            fn = jax.jit(
+                run_draft_model_impl,
+                out_shardings=(
+                    shardings,
+                    hidden_states_sharding,
+                    hidden_states_sharding,  # residual
+                    None,  # expert ids
+                ),
+                donate_argnums=1,  # 0 is state_leaves, 1 is kv_cache
+                static_argnums=(5, ),  # 5 is layer_name_to_kvcache_index
+            )
+            _draft_step_fns[key] = fn
+        return fn
+
+    def run_draft_model_impl(state_leaves, *args):
         state = jax.tree_util.tree_unflatten(_state_treedef, state_leaves)
         model = nnx.merge(graphdef, state)
         return model(*args)
@@ -468,28 +506,30 @@ def get_flax_model(
     precompile_vision_encoder_fn = getattr(model, "precompile_vision_encoder",
                                            None)
     # `graphdef` and the state treedef are captured in each closure; the
-    # runner passes pre-flattened `state_leaves` as the first positional arg.
-    jitted_model_fn = run_draft_model if is_draft_model else run_model
-
+    # runner passes pre-flattened `state_leaves` as the first positional arg,
+    # and `kv_caches` as the second -- the latter is what the step fns are
+    # keyed on, so it must stay positional.
     model_supports_spec_step = supports_kw(model_class.__call__,
                                            "spec_step_idx")
+
+    def _resolve_step_fn(kv_caches, with_options: bool):
+        if is_draft_model:
+            # The draft jit carries no compiler options, so it is its own twin.
+            return _get_draft_step_fn(kv_caches)
+        return _get_step_fn(kv_caches, with_options)
 
     def wrapped_model_fn(*args, **kwargs):
         if not model_supports_spec_step:
             kwargs.pop("spec_step_idx", None)
         kwargs.pop("shared_attention_metadata", None)
-        return jitted_model_fn(*args, **kwargs)
+        return _resolve_step_fn(args[1], True)(*args, **kwargs)
 
-    # Exposed as `step_fn_no_options` below for `continue_decode`. The draft
-    # model's jit already carries no compiler options, so it is its own twin.
-    jitted_model_fn_no_options = (run_draft_model
-                                  if is_draft_model else run_model_no_options)
-
+    # Exposed as `step_fn_no_options` below for `continue_decode`.
     def wrapped_model_fn_no_options(*args, **kwargs):
         if not model_supports_spec_step:
             kwargs.pop("spec_step_idx", None)
         kwargs.pop("shared_attention_metadata", None)
-        return jitted_model_fn_no_options(*args, **kwargs)
+        return _resolve_step_fn(args[1], False)(*args, **kwargs)
 
     compute_logits_fn = run_compute_logits
     embed_input_ids_fn = run_embed_input_ids


### PR DESCRIPTION
# Description

`get_flax_model` applies one `NamedSharding(BATCH, KV_CONTEXT, KV_HEAD)` to every kv-cache leaf through the jit `out_shardings`. For hybrid models the GDN `ssm_state` leaf is `[num_blocks, num_heads, d_k, d_v]` and is allocated (`kv_cache_manager.py`) and produced (`gdn_attention.py` shard_map `out_specs`) heads-sharded on axis 1. The forced spec puts `KV_HEAD` on `d_k` instead, so XLA reshards the whole state on the way out of every step (the 257MB all-to-all per GDN layer described in #3515).

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
