### PR TITLE
build(docker): build and package vllm-rs Rust frontend for TPU

### DIFF
--- a/.buildkite/scripts/build_vllm_tpu.sh
+++ b/.buildkite/scripts/build_vllm_tpu.sh
@@ -127,6 +127,9 @@ fi
 # --- Step 3: Execute the vLLM TPU build script ---
 echo "Ensuring 'build' package is installed..."
 pip install build
+echo "Installing Rust build requirements and building Rust frontend..."
+pip install -r requirements/build/rust.txt
+bash build_rust.sh
 echo "Executing the vLLM TPU build script..."
 bash tools/vllm-tpu/build.sh "${VLLM_TPU_VERSION}"
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -37,6 +37,7 @@ RUN apt-get update && apt-get install -y \
     bc \
     ca-certificates \
     unzip \
+    protobuf-compiler \
     build-essential \
     cmake \
     g++ \
@@ -62,7 +63,8 @@ RUN git clone $VLLM_REPO . && \
     fi
 
 RUN --mount=type=cache,target=/root/.cache/pip pip install --extra-index-url https://download.pytorch.org/whl/cpu -r requirements/tpu.txt --retries 3
-RUN --mount=type=cache,target=/root/.cache/pip pip install setuptools-rust>=1.9.0
+RUN --mount=type=cache,target=/root/.cache/pip pip install -r requirements/build/rust.txt
+RUN ./build_rust.sh
 RUN --mount=type=cache,target=/root/.cache/pip VLLM_TARGET_DEVICE="tpu" pip install --no-build-isolation -e .
 
 # Install test dependencies

--- a/docker/Dockerfile.pypi
+++ b/docker/Dockerfile.pypi
@@ -31,6 +31,7 @@ RUN apt-get update && apt-get install -y \
     rclone \
     wget \
     ca-certificates \
+    protobuf-compiler \
     build-essential \
     cmake \
     g++ \


### PR DESCRIPTION
### Summary

When vLLM introduced the Rust frontend (`vllm-rs`) in [vllm#43283](https://github.com/vllm-project/vllm/pull/43283), commit `b9f1475d4e7` added `setuptools-rust` to fix the immediate Docker build break. However, `protobuf-compiler` (`protoc`) and invoking `build_rust.sh` were omitted from the build process.

Because vLLM's `setup.py` marks Rust extensions with `optional=True` when building without precompiled binaries, `setup.py` silently skipped building the `vllm-rs` binary when the required build steps were missing, leaving the published `vllm/vllm-tpu` images without `vllm-rs`.

This PR recovers the synchronization and alignment with upstream vLLM:
1. Installs `protobuf-compiler` in `docker/Dockerfile` and `docker/Dockerfile.pypi`.
2. Installs `requirements/build/rust.txt` and runs `bash build_rust.sh` before installing vLLM.
3. Ensures `build_vllm_tpu.sh` builds `vllm-rs` before wheel packaging.

### Validation
Verified that `vllm-rs` compiles successfully in the TPU Docker build and tested end-to-end inference serving on real Google Cloud TPU hardware (v5e).