### PR TITLE
[DO NOT MERGE] [CI] Smoke-test the vllm org cutover

### DIFF
--- a/.buildkite/cutover-smoke-test.txt
+++ b/.buildkite/cutover-smoke-test.txt
@@ -1,0 +1,5 @@
+Scratch file for verifying CI after the Buildkite org cutover.
+
+Touches no source code. It exists only because bootstrap.sh skips builds whose
+changed files are all docs, icons or CODEOWNERS, and a smoke test needs a real
+build. Delete this file and close the PR once the run is green.


### PR DESCRIPTION
Verification PR for the Buildkite org cutover (tpu-commons -> vllm). **Do not merge** — close once the run is green and delete the branch.

Adds one scratch file under `.buildkite/`. No source code is touched; the file exists only because `bootstrap.sh` skips builds where every changed path is docs/icons/CODEOWNERS.

Checking:
1. GitHub triggers a build in the vllm org
2. vllm-org agents accept and run the jobs
3. `buildkite/tpu-inference-ci/*` commit statuses post back here
4. test results reach the analytics suite (tpu-inference uploads via `BUILDKITE_ANALYTICS_TOKEN`, not OIDC)