### PR TITLE
[CI] Point Buildkite URLs at the vllm org [skip ci]

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,6 +1,6 @@
 # Buildkite
 
-<https://buildkite.com/tpu-commons>
+<https://buildkite.com/vllm>
 
 The GitHub webhook is configured to trigger the Buildkite pipeline.
 The current step configuration of the pipeline:

--- a/.buildkite/benchmark/scripts/mlcompass_export.py
+++ b/.buildkite/benchmark/scripts/mlcompass_export.py
@@ -73,11 +73,12 @@ def read_metrics_file(file_path: str) -> dict[str, float]:
 
 def get_links() -> dict[str, str]:
     result = {}
+    org = os.getenv('BUILDKITE_ORGANIZATION_SLUG')
     build_number = os.getenv('BUILDKITE_BUILD_NUMBER')
     job_id = os.getenv('BUILDKITE_JOB_ID')
-    if build_number and job_id:
+    if org and build_number and job_id:
         result[
-            'buildkite'] = f'https://buildkite.com/organizations/tpu-commons/pipelines/tpu-inference-benchmark/builds/{build_number}/jobs/{job_id}/log'
+            'buildkite'] = f'https://buildkite.com/organizations/{org}/pipelines/tpu-inference-benchmark/builds/{build_number}/jobs/{job_id}/log'
     return result
 
 

--- a/.buildkite/pipeline_dev.yml
+++ b/.buildkite/pipeline_dev.yml
@@ -19,14 +19,14 @@
 # HOW TO TRIGGER THIS PIPELINE
 # ─────────────────────────────
 # Option A — Buildkite UI:
-#   Go to https://buildkite.com/tpu-commons/tpu-inference-dev
+#   Go to https://buildkite.com/vllm/tpu-inference-dev
 #   Click "New Build", set branch to your branch, click "Create Build".
 #
 # Option B — Buildkite API (requires BUILDKITE_API_TOKEN in your env):
 #   curl -s -X POST \
 #     -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
 #     -H "Content-Type: application/json" \
-#     "https://api.buildkite.com/v2/organizations/tpu-commons/pipelines/tpu-inference-dev/builds" \
+#     "https://api.buildkite.com/v2/organizations/vllm/pipelines/tpu-inference-dev/builds" \
 #     -d "{\"commit\": \"$(git rev-parse HEAD)\", \"branch\": \"$(git rev-parse --abbrev-ref HEAD)\", \"message\": \"my test\"}"
 #
 # HOW TO CUSTOMIZE

--- a/.buildkite/pipeline_kernel_tuning.yml
+++ b/.buildkite/pipeline_kernel_tuning.yml
@@ -19,14 +19,14 @@
 # HOW TO TRIGGER THIS PIPELINE
 # ─────────────────────────────
 # Option A — Buildkite UI:
-#   Go to https://buildkite.com/tpu-commons/tpu-inference-kernel-tuning
+#   Go to https://buildkite.com/vllm/tpu-inference-kernel-tuning
 #   Click "New Build", set branch to your branch, click "Create Build".
 #
 # Option B — Buildkite API (requires BUILDKITE_API_TOKEN in your env):
 #   curl -s -X POST \
 #     -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
 #     -H "Content-Type: application/json" \
-#     "https://api.buildkite.com/v2/organizations/tpu-commons/pipelines/tpu-inference-kernel-tuning/builds" \
+#     "https://api.buildkite.com/v2/organizations/vllm/pipelines/tpu-inference-kernel-tuning/builds" \
 #     -d "{\"commit\": \"$(git rev-parse HEAD)\", \"branch\": \"$(git rev-parse --abbrev-ref HEAD)\", \"message\": \"my test\"}"
 #
 steps:

--- a/.github/ISSUE_TEMPLATE/450-ci-failure.yml
+++ b/.github/ISSUE_TEMPLATE/450-ci-failure.yml
@@ -57,7 +57,7 @@ body:
     label: 📝 History of failing test
     description: |
       Since when did the test start to fail?
-      You can look up its history via [Buildkite Test Suites](https://buildkite.com/tpu-commons/tpu-inference-ci/builds?branch=main).
+      You can look up its history via [Buildkite Test Suites](https://buildkite.com/vllm/tpu-inference-ci/builds?branch=main).
 
       If you have time, identify the PR that caused the test to fail on main. You can do so via the following methods:
 

--- a/tools/kernel/tuner/v1/README.md
+++ b/tools/kernel/tuner/v1/README.md
@@ -358,7 +358,7 @@ Make sure to specify `KERNEL_TUNING_TPU_VERSION` and `KERNEL_TUNING_TPU_CORES` s
 curl -s -X POST \
   -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://api.buildkite.com/v2/organizations/tpu-commons/pipelines/tpu-inference-kernel-tuning/builds" \
+  "https://api.buildkite.com/v2/organizations/vllm/pipelines/tpu-inference-kernel-tuning/builds" \
   -d '{
     "commit": "'"$(git rev-parse HEAD)"'",
     "branch": "'"$(git rev-parse --abbrev-ref HEAD)"'",


### PR DESCRIPTION
The tpu-inference pipelines all moved from the `tpu-commons` Buildkite org into
the `vllm` org, so every `buildkite.com/organizations/tpu-commons/...` and
`buildkite.com/tpu-commons/...` link in this repo now 404s.

Rewrites the org in six places:

- `.buildkite/README.md`
- `.buildkite/benchmark/scripts/mlcompass_export.py`
- `.buildkite/pipeline_dev.yml`
- `.buildkite/pipeline_kernel_tuning.yml`
- `.github/ISSUE_TEMPLATE/450-ci-failure.yml`
- `tools/kernel/tuner/v1/README.md`

All four referenced slugs (`tpu-inference-ci`, `-dev`, `-benchmark`,
`-kernel-tuning`) were confirmed to exist in the vllm org before editing.

The MLCompass link is the one case that runs rather than being read, so it takes
the org from `BUILDKITE_ORGANIZATION_SLUG` instead of naming one. Hardcoding is
what made it stale in the first place.

`gs://tpu-commons-ci/...` bucket URIs are untouched — the bucket keeps its name.