### PR TITLE
[NOT READY TO REVIEW] [CI] Point Buildkite URLs at the vllm org

### DIFF
--- a/.buildkite/README.md
+++ b/.buildkite/README.md
@@ -1,6 +1,6 @@
 # Buildkite
 
-<https://buildkite.com/tpu-commons>
+<https://buildkite.com/vllm>
 
 The GitHub webhook is configured to trigger the Buildkite pipeline.
 The current step configuration of the pipeline:

--- a/.buildkite/benchmark/scripts/mlcompass_export.py
+++ b/.buildkite/benchmark/scripts/mlcompass_export.py
@@ -77,7 +77,7 @@ def get_links() -> dict[str, str]:
     job_id = os.getenv('BUILDKITE_JOB_ID')
     if build_number and job_id:
         result[
-            'buildkite'] = f'https://buildkite.com/organizations/tpu-commons/pipelines/tpu-inference-benchmark/builds/{build_number}/jobs/{job_id}/log'
+            'buildkite'] = f'https://buildkite.com/organizations/vllm/pipelines/tpu-inference-benchmark/builds/{build_number}/jobs/{job_id}/log'
     return result
 
 

--- a/.buildkite/pipeline_dev.yml
+++ b/.buildkite/pipeline_dev.yml
@@ -19,14 +19,14 @@
 # HOW TO TRIGGER THIS PIPELINE
 # ─────────────────────────────
 # Option A — Buildkite UI:
-#   Go to https://buildkite.com/tpu-commons/tpu-inference-dev
+#   Go to https://buildkite.com/vllm/tpu-inference-dev
 #   Click "New Build", set branch to your branch, click "Create Build".
 #
 # Option B — Buildkite API (requires BUILDKITE_API_TOKEN in your env):
 #   curl -s -X POST \
 #     -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
 #     -H "Content-Type: application/json" \
-#     "https://api.buildkite.com/v2/organizations/tpu-commons/pipelines/tpu-inference-dev/builds" \
+#     "https://api.buildkite.com/v2/organizations/vllm/pipelines/tpu-inference-dev/builds" \
 #     -d "{\"commit\": \"$(git rev-parse HEAD)\", \"branch\": \"$(git rev-parse --abbrev-ref HEAD)\", \"message\": \"my test\"}"
 #
 # HOW TO CUSTOMIZE

--- a/.buildkite/pipeline_kernel_tuning.yml
+++ b/.buildkite/pipeline_kernel_tuning.yml
@@ -19,14 +19,14 @@
 # HOW TO TRIGGER THIS PIPELINE
 # ─────────────────────────────
 # Option A — Buildkite UI:
-#   Go to https://buildkite.com/tpu-commons/tpu-inference-kernel-tuning
+#   Go to https://buildkite.com/vllm/tpu-inference-kernel-tuning
 #   Click "New Build", set branch to your branch, click "Create Build".
 #
 # Option B — Buildkite API (requires BUILDKITE_API_TOKEN in your env):
 #   curl -s -X POST \
 #     -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
 #     -H "Content-Type: application/json" \
-#     "https://api.buildkite.com/v2/organizations/tpu-commons/pipelines/tpu-inference-kernel-tuning/builds" \
+#     "https://api.buildkite.com/v2/organizations/vllm/pipelines/tpu-inference-kernel-tuning/builds" \
 #     -d "{\"commit\": \"$(git rev-parse HEAD)\", \"branch\": \"$(git rev-parse --abbrev-ref HEAD)\", \"message\": \"my test\"}"
 #
 steps:

--- a/.github/ISSUE_TEMPLATE/450-ci-failure.yml
+++ b/.github/ISSUE_TEMPLATE/450-ci-failure.yml
@@ -57,7 +57,7 @@ body:
     label: 📝 History of failing test
     description: |
       Since when did the test start to fail?
-      You can look up its history via [Buildkite Test Suites](https://buildkite.com/tpu-commons/tpu-inference-ci/builds?branch=main).
+      You can look up its history via [Buildkite Test Suites](https://buildkite.com/vllm/tpu-inference-ci/builds?branch=main).
 
       If you have time, identify the PR that caused the test to fail on main. You can do so via the following methods:
 

--- a/tools/kernel/tuner/v1/README.md
+++ b/tools/kernel/tuner/v1/README.md
@@ -358,7 +358,7 @@ Make sure to specify `KERNEL_TUNING_TPU_VERSION` and `KERNEL_TUNING_TPU_CORES` s
 curl -s -X POST \
   -H "Authorization: Bearer $BUILDKITE_API_TOKEN" \
   -H "Content-Type: application/json" \
-  "https://api.buildkite.com/v2/organizations/tpu-commons/pipelines/tpu-inference-kernel-tuning/builds" \
+  "https://api.buildkite.com/v2/organizations/vllm/pipelines/tpu-inference-kernel-tuning/builds" \
   -d '{
     "commit": "'"$(git rev-parse HEAD)"'",
     "branch": "'"$(git rev-parse --abbrev-ref HEAD)"'",


### PR DESCRIPTION
The Buildkite org moved from `tpu-commons` to `vllm` (https://buildkite.com/vllm); pipeline slugs are unchanged.

Rewrites every remaining `buildkite.com/tpu-commons` / `organizations/tpu-commons` reference:
- `.buildkite/pipeline_dev.yml`, `.buildkite/pipeline_kernel_tuning.yml`: header comments (UI link + API trigger recipe)
- `.buildkite/README.md`, `tools/kernel/tuner/v1/README.md`, `.github/ISSUE_TEMPLATE/450-ci-failure.yml`: doc links
- `.buildkite/benchmark/scripts/mlcompass_export.py`: the Buildkite job-log URL written into the export

`gs://tpu-commons-ci` references are a GCS bucket, not Buildkite, and are untouched.

Verified the new org with an API-triggered dev build: https://buildkite.com/vllm/vllm-torchtpu-dev/builds/1