### PR TITLE
Route dense Qwen3.5/3.8 to the vLLM implementation

### DIFF
--- a/tpu_inference/models/common/model_loader.py
+++ b/tpu_inference/models/common/model_loader.py
@@ -59,6 +59,7 @@ _VLLM_PREFERRED_ARCHITECTURES: frozenset[str] = frozenset({
     "Qwen3MoeForCausalLM",
     "KimiK25ForConditionalGeneration",
     "Qwen3_5MoeForConditionalGeneration",
+    "Qwen3_5ForConditionalGeneration",
 })
 
 # List of architectures that don't have pipeline parallelism support in jax yet.


### PR DESCRIPTION
## What

One line: adds `Qwen3_5ForConditionalGeneration` to the frozenset of architectures routed
to the vLLM implementation.

## Why

`Qwen/Qwen3.8-27B` declares `architectures: ["Qwen3_5ForConditionalGeneration"]`
(`model_type: qwen3_5`) — the dense sibling of the MoE entry already listed here. Without
it the loader falls through to the `flax_nnx` path, which has no native JAX Qwen3.5 model
and no `_MODEL_REGISTRY` entry, so the model simply cannot load.

vLLM 0.28.0 supports this architecture natively.

## Testing

Measured on that snapshot, unpatched vs patched, same inputs:

| architecture | unpatched | patched | |
|---|---|---|---|
| `Qwen3_5ForConditionalGeneration` | `flax_nnx` | `vllm` | ← the fix |
| `Qwen3_5MoeForConditionalGeneration` | `vllm` | `vllm` | already listed |
| `Qwen3ForCausalLM` | `flax_nnx` | `flax_nnx` | has a JAX model |
| `LlamaForCausalLM` | `flax_nnx` | `flax_nnx` | control |

The `flax_nnx` dead end is measured, not assumed:
`_get_model_architecture(Qwen3_5ForConditionalGeneration)` raises
`UnsupportedArchitectureError` on **both** arms, while the control `Qwen3ForCausalLM`
resolves to its class. The fully populated JAX registry holds 14 architectures, none of
them Qwen3.5.

Validated CPU-side against the real 27B checkpoint headers (fetched via HTTP range
requests against the safetensors index — every true tensor shape for ~150 KB instead of
54 GB): all 1199 tensors are claimed by a submodule, and at TP=8 all 7936 parameters are
exactly tiled by their writes, with zero gaps, overlaps, or uncovered bytes.

## Reviewer notes

Two further paths this reaches, which I'd like a second opinion on:

- It also applies under `load_format=runai_streamer` — `_get_model_architecture` raises
  for this architecture, so resolution falls through to the same frozenset.
- It applies to a speculative **draft** model: `spec_decode/jax/dflash.py` and
  `spec_decode/jax/eagle3.py` both call `resolve_model_architecture` directly.

Both look correct to me, but they're a wider blast radius than the one-line diff suggests.
