### PR TITLE
Make raiden weight-sync bind failures diagnosable

### DIFF
--- a/tpu_inference/rl/raiden_worker_sync.py
+++ b/tpu_inference/rl/raiden_worker_sync.py
@@ -14,11 +14,14 @@ tunix's `weight_sync.dict_to_metadata` defines the metadata shape.
 
 from __future__ import annotations
 
+import logging
 import socket
 from typing import Any, List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
+
+logger = logging.getLogger(__name__)
 
 _ws_lib: Any = None
 _RAIDEN_IMPORT_ERROR: Optional[Exception] = None
@@ -108,16 +111,49 @@ def _bindable(arr: Any) -> bool:
 
 def _filter_bindable(names: List[str],
                      arrays: List[Any]) -> Tuple[List[str], List[Any]]:
-    """Drops leaves the native layer cannot bind (e.g. RNG-key arrays)."""
+    """Drops leaves the native layer cannot bind (e.g. RNG-key arrays).
+
+    Dropping is silent by design for the RNG-key case, but a dropped *weight*
+    is a silent partial sync -- the rollout keeps a stale copy of that tensor
+    with no error anywhere. Log what went, so the drop is at least auditable.
+    """
     keep_names: List[str] = []
     keep_arrays: List[Any] = []
+    dropped: List[str] = []
     for name, arr in zip(names, arrays):
         if _bindable(arr):
             if hasattr(arr, "block_until_ready"):
                 arr.block_until_ready()
             keep_names.append(name)
             keep_arrays.append(arr)
+        else:
+            dropped.append(name)
+    if dropped:
+        logger.warning(
+            "raiden bind: %d of %d leaves are not bindable and will NOT be "
+            "synced: %s%s", len(dropped), len(names), dropped[:8],
+            " ..." if len(dropped) > 8 else "")
     return keep_names, keep_arrays
+
+
+def _describe(names: List[str], arrays: List[Any], limit: int = 5) -> str:
+    """Type/dtype/shape of the first few leaves, for failure diagnostics.
+
+    `_bindable` swallows every exception, so when it rejects everything the
+    reason is invisible. Reporting the leaf *type* alongside dtype/shape is
+    what distinguishes the plausible causes: a framework tensor that never
+    became a `jax.Array` (torch/torchax dtype, no `.devices()`), an
+    integer/quantised leaf, or arrays sitting on a non-TPU platform.
+    """
+    out = []
+    for name, arr in list(zip(names, arrays))[:limit]:
+        out.append(f"{name}: "
+                   f"type={type(arr).__module__}.{type(arr).__name__} "
+                   f"dtype={getattr(arr, 'dtype', '?')} "
+                   f"shape={tuple(getattr(arr, 'shape', ()))}")
+    if len(names) > limit:
+        out.append(f"... and {len(names) - limit} more")
+    return "; ".join(out) if out else "<no array leaves at all>"
 
 
 def _axis_name(axis: Any) -> str:
@@ -177,11 +213,25 @@ class RaidenWorkerSync:
 
     def bind(self, state: Any) -> None:
         """Binds (or rebinds after a weight update) this worker's weights."""
-        self.names, self.arrays = _filter_bindable(*flatten_weights(state))
         if _ws_lib is None:
             raise RuntimeError(
                 f"{self.job_name}: tpu_sync is not importable, cannot bind "
                 f"weight_synchronizer. Original error: {_RAIDEN_IMPORT_ERROR}")
+        all_names, all_arrays = flatten_weights(state)
+        self.names, self.arrays = _filter_bindable(all_names, all_arrays)
+        # Binding nothing is not a benign no-op: registration succeeds, every
+        # sync round moves zero bytes, and the rollout silently serves the
+        # initial policy forever. Without this check the run instead dies
+        # further down in metadata_dict(), which reports the *absence of a
+        # sharding mesh* -- an accidental guard that names the wrong cause and
+        # sends debugging at sharding config. Fail here, with the real one.
+        if not self.names:
+            raise RuntimeError(
+                f"{self.job_name}: bind() found {len(all_names)} array leaves "
+                f"in the weight state but none are bindable, so there is "
+                f"nothing to synchronise. Bindable requires ndim >= 1, a "
+                f"floating dtype, and all devices on the tpu platform. "
+                f"Leaves seen: {_describe(all_names, all_arrays)}")
         if self._sync is None:
             self._sync = _ws_lib.WeightSynchronizer(
                 self.arrays,


### PR DESCRIPTION
## What

Diagnostics only, for two silent-failure modes in `tpu_inference/rl/raiden_worker_sync.py`.
`_bindable` and the bind logic itself are **untouched**.

## Why

**1. `_filter_bindable` drops every leaf `_bindable` rejects, with no record.** That is
correct and intended for RNG-key leaves — but a dropped *weight* is a silent partial
sync: the rollout worker keeps a stale copy of that tensor and nothing anywhere reports
it. Now logged at WARNING with the count and the first eight names.

**2. When `_bindable` rejects everything, `bind()` returns successfully having bound
nothing**, and the run dies later in `metadata_dict()` with

> no bound array carries a sharding mesh; cannot determine mesh_shape/mesh_axes for registration

— which blames the sharding mesh. The mesh is fine; there are simply no bound arrays.
`_bindable` swallows every exception, so the actual reason is invisible.

`bind()` now fails at the point the invariant breaks, and the new `_describe` helper
reports leaf `type`/`dtype`/`shape` — which is what separates the plausible causes: a
framework tensor that never became a `jax.Array` (no `.devices()`), an integer or
quantized leaf, or arrays on a non-TPU platform.

## Testing

Measured on CPU, pristine vs patched, same inputs. The module imports only
logging/socket/typing/jax/jnp, so it loads standalone; `_ws_lib` is stubbed so `bind()`
gets past the `tpu_sync` check, and leaf device platform is faked because this box has
no TPU.

| scenario | pristine | patched |
|---|---|---|
| **S1** no leaf bindable | `bind()` → ok, "bound 0 leaves"; then `metadata_dict()` raises "no bound array carries a sharding mesh" ← misleading | `bind()` raises "found 3 array leaves … none are bindable", listing type/dtype/shape per leaf |
| **S2** 2 of 5 leaves unbindable (an int leaf, a 0-d leaf) | binds 3, logs nothing ← silent | binds 3, WARNING "2 of 5 leaves are not bindable and will NOT be synced: ['bad_int', 'bad_scalar']" |
| **S3** every leaf bindable (regression control) | binds 2, no warning | binds 2, no warning ← identical |

The pristine column is the control: the old behavior is shown *actually* misreporting on
S1 and *actually* staying silent on S2. S3 confirms the change is inert when there's
nothing to report, and S2 confirms no leaf that binds today stops binding — both arms
bind the same 3.

## Base note

Originally generated against the published nightly sdist `tpu_inference
0.28.0.dev20260902` (`PKG-INFO` carries that version; `SOURCES.txt` lists
`tpu_inference/rl/raiden_worker_sync.py`; base file md5 `d0b6b7cfb0d8774051eda1b580f37585`).
This branch is rebased onto current `main` (`c824927`) and applies cleanly there.

`tpu_inference/rl/` postdates the fbsource third-party snapshot
(`eb204cdb488cd84118f2d4443b46a0049d8e438f`), so there is no internal counterpart to keep
in sync.
