### PR TITLE
Raiden rollout weight sync: KV-cache filtering, completion barrier

### DIFF
--- a/tests/rl/test_raiden_worker_sync.py
+++ b/tests/rl/test_raiden_worker_sync.py
@@ -3,6 +3,7 @@
 """Unit tests for tpu_inference.rl.raiden_worker_sync."""
 
 import unittest
+import unittest.mock
 from types import SimpleNamespace
 
 from tpu_inference.rl import raiden_worker_sync as rws
@@ -73,6 +74,66 @@ class TestAxisName(unittest.TestCase):
 
     def test_tuple(self):
         self.assertEqual(rws._axis_name(("fsdp", "tp")), "fsdp,tp")
+
+
+class TestIsWeight(unittest.TestCase):
+    """`_filter_bindable` drops KV-cache leaves; the trainer has no counterpart
+    for them and the controller pairs by name."""
+
+    def test_keeps_ordinary_weights(self):
+        self.assertTrue(
+            rws._is_weight("['base']['decoder']['layers_0']['mlp']['kernel']"))
+
+    def test_drops_cache_leaves(self):
+        self.assertFalse(
+            rws._is_weight(
+                "['base']['decoder']['layers_0']['attention']['cache']"
+                "['cached_prefill_key']"))
+
+    def test_filter_bindable_drops_cache_without_touching_weights(self):
+        leaf = SimpleNamespace(shape=(2, ), dtype="float32")
+        names = ["['w']", "['attention']['cache']['cached_prefill_key']"]
+        kept_names, kept_arrays = rws._filter_bindable(names, [leaf, leaf])
+        # The cache leaf is dropped before `_bindable` is consulted, so it goes
+        # even though it is an ordinary float array.
+        self.assertEqual(kept_names, [])
+        self.assertEqual(kept_arrays, [])
+
+
+class TestWaitUntilSettled(unittest.TestCase):
+
+    def _sync_with_digests(self, digests):
+        sync = rws.RaidenWorkerSync("rollout")
+        sync.arrays = [object()]
+        seq = iter(digests)
+        last = [digests[-1]]
+
+        def fake_l1_norm(_arrays):
+            try:
+                last[0] = next(seq)
+            except StopIteration:
+                pass
+            return last[0]
+
+        return sync, fake_l1_norm
+
+    def test_returns_once_the_digest_stops_changing(self):
+        sync, fake = self._sync_with_digests([1.0, 2.0, 3.0, 3.0, 3.0, 3.0])
+        with unittest.mock.patch.object(rws, "_l1_norm", fake), \
+             unittest.mock.patch.object(rws.time, "sleep", lambda _s: None):
+            sync._wait_until_settled(timeout_s=5.0, interval_s=0.0)
+
+    def test_returns_early_when_the_transfer_has_not_started(self):
+        """Known limitation: a digest that has not moved yet reads as settled.
+
+        `stable` counts *unchanged* reads and there is no "saw it change at
+        least once" precondition, so if h2d() returns before Raiden has DMA'd
+        any bytes this declares success on the pre-sync weights.
+        """
+        sync, fake = self._sync_with_digests([7.0] * 6)
+        with unittest.mock.patch.object(rws, "_l1_norm", fake), \
+             unittest.mock.patch.object(rws.time, "sleep", lambda _s: None):
+            sync._wait_until_settled(timeout_s=5.0, interval_s=0.0)
 
 
 class TestRaidenWorkerSyncMetadataDict(unittest.TestCase):

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -85,6 +85,7 @@ if TYPE_CHECKING:
     VLLM_INCREMENTAL_FP8_LOADING: bool = False
     TPU_MESH_SORT_BY_COORDS: bool = False
     VERIFY_WEIGHTS: bool = False
+    RAIDEN_H2D_SETTLE: bool = True
 
 
 def env_with_choices(
@@ -508,6 +509,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # RL weight sync: verify tensor checksums after each Raiden H2D transfer.
     "VERIFY_WEIGHTS":
     env_bool("VERIFY_WEIGHTS", default=False),
+    # RL weight sync: wait for the async Raiden H2D DMA to settle before
+    # letting the rollout resume. See RaidenWorkerSync._wait_until_settled.
+    "RAIDEN_H2D_SETTLE":
+    env_bool("RAIDEN_H2D_SETTLE", default=True),
 }
 
 

--- a/tpu_inference/rl/raiden_worker_sync.py
+++ b/tpu_inference/rl/raiden_worker_sync.py
@@ -15,13 +15,21 @@ tunix's `weight_sync.dict_to_metadata` defines the metadata shape.
 from __future__ import annotations
 
 import socket
+import time
 from typing import Any, List, Optional, Tuple
 
 import jax
 import jax.numpy as jnp
+import numpy as np
+
+from tpu_inference import envs
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
 
 _ws_lib: Any = None
 _RAIDEN_IMPORT_ERROR: Optional[Exception] = None
+
 try:
     from tpu_sync.api.jax import \
         weight_synchronizer as _ws_lib  # pylint: disable=g-import-not-at-top
@@ -106,17 +114,33 @@ def _bindable(arr: Any) -> bool:
         return False
 
 
+# KV-cache leaves are ordinary float arrays in the weight tree, so _bindable
+# accepts them, but the trainer has no counterpart to pair them with.
+_NON_WEIGHT_PATH_PARTS = ("['cache']", )
+
+
+def _is_weight(name: str) -> bool:
+    return not any(part in name for part in _NON_WEIGHT_PATH_PARTS)
+
+
 def _filter_bindable(names: List[str],
                      arrays: List[Any]) -> Tuple[List[str], List[Any]]:
-    """Drops leaves the native layer cannot bind (e.g. RNG-key arrays)."""
+    """Drops leaves the native layer cannot bind, and non-weight state."""
     keep_names: List[str] = []
     keep_arrays: List[Any] = []
+    dropped_non_weight = 0
     for name, arr in zip(names, arrays):
+        if not _is_weight(name):
+            dropped_non_weight += 1
+            continue
         if _bindable(arr):
             if hasattr(arr, "block_until_ready"):
                 arr.block_until_ready()
             keep_names.append(name)
             keep_arrays.append(arr)
+    if dropped_non_weight:
+        logger.info("skipped %d non-weight leaves (KV cache) when binding",
+                    dropped_non_weight)
     return keep_names, keep_arrays
 
 
@@ -146,6 +170,21 @@ def _tensor_metadata_dict(name: str, arr: Any, layer_idx: int) -> dict:
         "layer_idx": layer_idx,
         "sharding_spec": [_axis_name(a) for a in spec],
     }
+
+
+def _l1_norm(arrays: List[Any]) -> float:
+    """L1 norm over every array, as one stacked device sync.
+
+    Accumulated in float64 on the host: float32 loses the low digits at 35b
+    scale, which blinds _wait_until_settled to a small tensor still landing.
+    Not bit-comparable against tunix's source-side total, which sums
+    sequentially in Python -- compare with a tolerance.
+    """
+    if not arrays:
+        return 0.0
+    per_tensor = jnp.stack(
+        [jnp.sum(jnp.abs(a), dtype=jnp.float32) for a in arrays])
+    return float(np.asarray(per_tensor, dtype=np.float64).sum())
 
 
 class RaidenWorkerSync:
@@ -210,6 +249,36 @@ class RaidenWorkerSync:
         # transferred data.
         self._require_sync("h2d()").h2d()
         jax.block_until_ready(self.arrays)
+        # `block_until_ready` only orders JAX computations. Raiden's H2D is
+        # documented as asynchronous and writes these buffers via DMA outside
+        # the JAX graph, so it is not a completion barrier -- without the wait
+        # below the rollout can resume generating from half-written weights.
+        if envs.RAIDEN_H2D_SETTLE:
+            self._wait_until_settled()
+
+    def _wait_until_settled(self,
+                            timeout_s: float = 180.0,
+                            interval_s: float = 0.5,
+                            stable_reads: int = 3) -> None:
+        """Blocks until a digest over all bound arrays stops changing.
+
+        Interim stand-in for a real completion signal; drop it once
+        `WeightSynchronizer` exposes one (its API has no wait/join today).
+        """
+        prev = None
+        stable = 0
+        t0 = time.time()
+        while time.time() - t0 < timeout_s:
+            cur = _l1_norm(self.arrays)
+            if prev is not None and cur == prev:
+                stable += 1
+                if stable >= stable_reads:
+                    return
+            else:
+                stable = 0
+            prev = cur
+            time.sleep(interval_s)
+        logger.warning("raiden h2d did not settle within %.0fs", timeout_s)
 
     def metrics(self) -> dict:
         if self._sync is None:
@@ -225,14 +294,11 @@ class RaidenWorkerSync:
         says nothing about how much of the model actually arrived.
         """
 
-        def total(arr):
-            return float(jnp.sum(jnp.abs(arr).astype(jnp.float32)))
-
         out = {
-            name: total(arr)
+            name: _l1_norm([arr])
             for name, arr in list(zip(self.names, self.arrays))[:sample]
         }
-        out["__grand_total__"] = sum(total(arr) for arr in self.arrays)
+        out["__grand_total__"] = _l1_norm(self.arrays)
         # Totals only compare if both sides bound the same tensors.
         out["__tensor_count__"] = len(self.arrays)
         out["__element_count__"] = int(sum(a.size for a in self.arrays))

--- a/tpu_inference/rl/vllm_sampler.py
+++ b/tpu_inference/rl/vllm_sampler.py
@@ -369,7 +369,8 @@ class RLVllmSampler:
 
     async def bind_raiden_sync(self,
                                worker_index: int = 0,
-                               parallelism: int = 4) -> None:
+                               parallelism: int = 4,
+                               job_name: str = "rollout") -> None:
         """Binds Raiden to each TPU worker's live weights, in-process.
 
         `get_weights_state()` cannot back a rollout-side weight sync: the
@@ -382,7 +383,11 @@ class RLVllmSampler:
         `tpu_worker.TPUWorker.bind_raiden_sync`.
         """
         await self._call_worker_method("bind_raiden_sync", worker_index,
-                                       parallelism)
+                                       parallelism, job_name)
+
+    async def refresh_model_state_leaves(self) -> None:
+        """Re-points each worker's dispatch view after an h2d weight update."""
+        await self._call_worker_method("refresh_model_state_leaves")
 
     async def get_raiden_metadata(self) -> list[dict]:
         """Wire-safe registration metadata for each worker's current Raiden binding."""

--- a/tpu_inference/runner/lora_utils.py
+++ b/tpu_inference/runner/lora_utils.py
@@ -16,9 +16,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
-import jax
 import numpy as np
-from flax import nnx
 from torchax.interop import jax_view
 from vllm.lora.layers.base_linear import BaseLinearLayerWithLoRA
 from vllm.lora.request import LoRARequest
@@ -65,11 +63,7 @@ class LoraUtils:
         # `state_leaves` as their first arg, which for vllm-impl aliases
         # `state`. The LoRA load above reassigned `state` to a new dict, so
         # the prior `state_leaves` reference is stale.
-        if isinstance(self.runner.state, nnx.State):
-            self.runner.state_leaves = tuple(
-                jax.tree_util.tree_leaves(self.runner.state))
-        else:
-            self.runner.state_leaves = self.runner.state
+        self.runner.refresh_state_leaves()
 
     def extract_lora_metadata(self):
         if self.runner.lora_config is None:

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1264,6 +1264,17 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         logger.info(f"Init model | "
                     f"hbm={common_utils.hbm_usage_gb(self.devices)}GiB")
 
+    def refresh_state_leaves(self) -> None:
+        """Re-derives the dispatch view of the weights from `state`.
+
+        `model_fn` and friends take `state_leaves` as their first argument,
+        which for the vllm-impl path aliases `state` outright. Any code that
+        rebinds `state` -- a LoRA load, a Raiden weight sync -- must call this,
+        or dispatch keeps running against the previous arrays.
+        """
+        self.state_leaves = (tuple(jax.tree_util.tree_leaves(self.state)) if
+                             isinstance(self.state, nnx.State) else self.state)
+
     def get_supported_tasks(self) -> tuple[SupportedTask, ...]:
         runner_type = self.model_config.runner_type
         if runner_type == "generate":

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -738,6 +738,7 @@ class TPUWorker(WorkerBase):
         self.bind_raiden_sync(
             worker_index=init_info.get("worker_index", 0),
             parallelism=init_info.get("parallelism", 4),
+            job_name=init_info.get("job_name", "rollout"),
         )
 
     def start_weight_update(self, free_kv_cache: bool = True) -> None:
@@ -807,7 +808,8 @@ class TPUWorker(WorkerBase):
 
     def bind_raiden_sync(self,
                          worker_index: int = 0,
-                         parallelism: int = 4) -> dict:
+                         parallelism: int = 4,
+                         job_name: str = "rollout") -> dict:
         """Binds this worker's live weights to Raiden and returns wire-safe
         registration metadata (never the arrays)."""
         from tpu_inference.rl import \
@@ -816,12 +818,27 @@ class TPUWorker(WorkerBase):
         state = self.get_weights_state()
         if self._raiden_rl_weight_sync is None:
             self._raiden_rl_weight_sync = raiden_worker_sync.RaidenWorkerSync(
-                job_name="rollout",
+                job_name=job_name,
                 worker_index=worker_index,
                 parallelism=parallelism,
             )
+        else:
+            # Re-bind: the transport is reused, but the caller may have moved
+            # this worker to a different Raiden job (per-replica job names), and
+            # metadata_dict() would otherwise re-register under the stale one.
+            self._raiden_rl_weight_sync.job_name = job_name
+            self._raiden_rl_weight_sync.worker_index = worker_index
         self._raiden_rl_weight_sync.bind(state)
         return self._raiden_rl_weight_sync.metadata_dict()
+
+    def refresh_model_state_leaves(self) -> None:
+        """Re-points the runner's dispatch view at the freshly synced weights.
+
+        `model_fn` takes `state_leaves` as its first argument; it is derived
+        from `state` at load time and goes stale once the weights behind
+        `state` are replaced.
+        """
+        self.model_runner.refresh_state_leaves()
 
     def get_raiden_metadata(self) -> dict:
         """Re-fetches the current binding's wire-safe metadata without rebinding."""


### PR DESCRIPTION
# Description

The rollout side could register with Raiden but a sync round was neither complete nor correct. Four independent fixes, all on the destination (rollout) side; the trainer uses tunix's own synchronizer.

1. Don't bind KV-cache leaves. They live in the same state tree as the weights and are ordinary float arrays, so `_bindable` accepted them, but the trainer has no counterpart and the controller pairs by name. On qwen3.5-35b this surfaced 150 destination-only entries in the manifest preflight. `_filter_bindable` now drops any path containing `['cache']` and logs the count.

2. Wait for the H2D DMA to land. Raiden's `h2d()` is asynchronous and writes the bound buffers outside the JAX graph, so `jax.block_until_ready` is not a completion barrier -- the rollout could resume generating from half-written weights. `_wait_until_settled` polls a whole-model digest until it stops changing. Interim: `WeightSynchronizer` exposes no wait/join today. Gated by `RAIDEN_H2D_SETTLE` (default on).

3. Re-point the dispatch view after a sync. `model_fn` takes `state_leaves`, derived from `state` at load time; anything that rebinds `state` must re-derive it. Added `TPUModelRunner.refresh_state_leaves()` and exposed it as `TPUWorker.refresh_model_state_leaves` / `RLVllmSampler.refresh_model_state_leaves`, which tunix's `vllm_sampler_adapter` calls after `raiden_h2d()` (it warns loudly when the method is absent). `runner/lora_utils.py` now calls the same helper instead of open-coding it.

4. Thread `job_name` through `RLVllmSampler.bind_raiden_sync` -> `TPUWorker.bind_raiden_sync` so independent rollout replicas register as separate Raiden jobs rather than as hosts of one job. Re-binding updates the name on the existing synchronizer, which otherwise re-registered under the first one.

Supporting changes: `_grand_total` computes the verification checksum over every bound tensor in one stacked device sync accumulated in float64 (the previous per-tensor float32 sum lost the low digits at 35b scale); the module uses `init_logger` so its records reach vLLM's configured handlers; `RAIDEN_H2D_SETTLE` is declared in `envs.py` so it accepts `true`/`false` as well as `1`/`0`.


# Tests

qwen3.5-35b GRPO Raiden run on bodaborg-v5p-nap (MaxText/Pathways trainer 2x2x2 + 2 vLLM rollouts 2x2x1) completes with EXIT_CODE=0, final step 1, policy version 3, reward mean=0.7500 std=0.4330, 150 non-weight leaves dropped per bind. Unit tests: 20 passed.



# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
