### PR TITLE
Used wait_for_transfer_completion in Raiden weights sync

### DIFF
--- a/tests/rl/test_raiden_worker_sync.py
+++ b/tests/rl/test_raiden_worker_sync.py
@@ -157,5 +157,58 @@ class TestRaidenWorkerSyncMetadataDict(unittest.TestCase):
         self.assertTrue(sync.bound)
 
 
+class TestRaidenWorkerSyncH2D(unittest.TestCase):
+
+    def test_h2d_calls_wait_for_transfer_completion_when_available(self):
+        sync = rws.RaidenWorkerSync("rollout")
+        mock_ws = unittest.mock.MagicMock()
+        sync._sync = mock_ws
+        sync.arrays = [SimpleNamespace()]
+
+        with unittest.mock.patch("jax.block_until_ready"
+                                 ) as mock_block, unittest.mock.patch.object(
+                                     sync,
+                                     "_wait_until_settled") as mock_settle:
+            sync.h2d(uuid=42)
+            mock_ws.wait_for_transfer_completion.assert_called_once_with(42)
+            mock_ws.h2d.assert_not_called()
+            mock_block.assert_called_once_with(sync.arrays)
+            mock_settle.assert_not_called()
+
+    def test_h2d_fallback_when_wait_for_transfer_completion_missing(self):
+        sync = rws.RaidenWorkerSync("rollout")
+        mock_ws = unittest.mock.MagicMock(
+            spec=["h2d"])  # lacks wait_for_transfer_completion
+        sync._sync = mock_ws
+        sync.arrays = [SimpleNamespace()]
+
+        with unittest.mock.patch("jax.block_until_ready"
+                                 ) as mock_block, unittest.mock.patch.object(
+                                     sync,
+                                     "_wait_until_settled") as mock_settle:
+            sync.h2d()
+            mock_ws.h2d.assert_called_once()
+            mock_block.assert_called_once_with(sync.arrays)
+            mock_settle.assert_called_once()
+
+    def test_h2d_fallback_does_not_settle_when_env_disabled(self):
+        sync = rws.RaidenWorkerSync("rollout")
+        mock_ws = unittest.mock.MagicMock(
+            spec=["h2d"])  # lacks wait_for_transfer_completion
+        sync._sync = mock_ws
+        sync.arrays = [SimpleNamespace()]
+
+        with unittest.mock.patch("jax.block_until_ready"
+                                 ) as mock_block, unittest.mock.patch.object(
+                                     rws.envs, "RAIDEN_H2D_SETTLE",
+                                     False), unittest.mock.patch.object(
+                                         sync,
+                                         "_wait_until_settled") as mock_settle:
+            sync.h2d()
+            mock_ws.h2d.assert_called_once()
+            mock_block.assert_called_once_with(sync.arrays)
+            mock_settle.assert_not_called()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/rl/test_vllm_sampler.py
+++ b/tests/rl/test_vllm_sampler.py
@@ -254,6 +254,19 @@ class TestRLVllmSamplerWeightSync(unittest.TestCase):
 
         asyncio.run(run_lifecycle_test())
 
+    @patch("tpu_inference.rl.vllm_sampler.RLVllmSampler._call_worker_method")
+    def test_raiden_h2d_forwards_uuid(self, mock_call_worker_method):
+        mock_call_worker_method.return_value = []
+        args = AsyncEngineArgs(model="Qwen/Qwen2.5-1.5B")
+        sampler = RLVllmSampler(engine_args=args)
+
+        async def run_test():
+            await sampler.raiden_h2d(uuid=123)
+            mock_call_worker_method.assert_called_once_with("raiden_h2d",
+                                                            uuid=123)
+
+        asyncio.run(run_test())
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tpu_inference/rl/raiden_worker_sync.py
+++ b/tpu_inference/rl/raiden_worker_sync.py
@@ -76,12 +76,13 @@ def extract_weight_state(state: Any, model: Any) -> Any:
                 pass
         return state
     if model is not None:
-        from flax import nnx
         if maxtext:
             inner = getattr(model, "model", None)
             if inner is not None:
+                from flax import nnx
                 return {"base": nnx.state(inner, nnx.Param)}
             return None
+        from flax import nnx
         return nnx.state(model, nnx.Param)
     return None
 
@@ -244,10 +245,15 @@ class RaidenWorkerSync:
             raise RuntimeError(f"{self.job_name}: bind() must run before {op}")
         return self._sync
 
-    def h2d(self) -> None:
+    def h2d(self, uuid: Optional[int] = None) -> None:
         # h2d() is async; block so a checksum/read right after sees the
         # transferred data.
-        self._require_sync("h2d()").h2d()
+        sync = self._require_sync("h2d()")
+        if hasattr(sync, "wait_for_transfer_completion"):
+            sync.wait_for_transfer_completion(uuid)
+            jax.block_until_ready(self.arrays)
+            return
+        sync.h2d()
         jax.block_until_ready(self.arrays)
         # `block_until_ready` only orders JAX computations. Raiden's H2D is
         # documented as asynchronous and writes these buffers via DMA outside

--- a/tpu_inference/rl/vllm_sampler.py
+++ b/tpu_inference/rl/vllm_sampler.py
@@ -16,7 +16,7 @@ import time
 
 os.environ["VLLM_USE_V1"] = "0"
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, Optional
 
 import numpy as np
 from vllm.engine.arg_utils import AsyncEngineArgs
@@ -393,12 +393,12 @@ class RLVllmSampler:
         """Wire-safe registration metadata for each worker's current Raiden binding."""
         return await self._call_worker_method("get_raiden_metadata")
 
-    async def raiden_h2d(self) -> list[dict]:
+    async def raiden_h2d(self, uuid: Optional[int] = None) -> list[dict]:
         """Blocks each worker until its just-landed transfer is visible on-device.
 
         Returns each worker's checksums dict (empty unless VERIFY_WEIGHTS=true).
         """
-        return await self._call_worker_method("raiden_h2d")
+        return await self._call_worker_method("raiden_h2d", uuid=uuid)
 
     async def raiden_metrics(self) -> list[dict]:
         return await self._call_worker_method("raiden_metrics")

--- a/tpu_inference/worker/tpu_worker.py
+++ b/tpu_inference/worker/tpu_worker.py
@@ -844,13 +844,13 @@ class TPUWorker(WorkerBase):
         """Re-fetches the current binding's wire-safe metadata without rebinding."""
         return self._require_raiden_sync("get_raiden_metadata").metadata_dict()
 
-    def raiden_h2d(self) -> dict:
+    def raiden_h2d(self, uuid: Optional[int] = None) -> dict:
         """Blocks until the transfer that just landed is visible on-device.
 
         Returns tensor checksums when `VERIFY_WEIGHTS=true`.
         """
         sync = self._require_raiden_sync("raiden_h2d")
-        sync.h2d()
+        sync.h2d(uuid=uuid)
         if envs.VERIFY_WEIGHTS:
             return sync.checksums()
         return {}


### PR DESCRIPTION
# Description

Previously, during Raiden rollout weights synchronization, `h2d()` called `sync.h2d()` followed by `jax.block_until_ready`. Because Raiden transfers asynchronously over DMA and host-to-device paths outside JAX's dispatch queue, subsequent inference steps could execute before tensor data was fully written.

This PR added support for `wait_for_transfer_completion(uuid)` when exposed by the underlying `WeightSynchronizer`. It ensures weight transfers and DMA writes have completed on-device before unblocking rollout workers, while gracefully falling back to the existing `h2d()` path if `wait_for_transfer_completion` is not available on the synchronizer. This is significantly more efficient than the polling.

# Tests

Ran unit tests on Cloud TPU VM:

- `tests/rl/test_raiden_worker_sync.py`
- `tests/rl/test_vllm_sampler.py`


# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
