### PR TITLE
perf(moe): avoid group-axis rotations in BF16 JAX gather-reduce

### DIFF
--- a/tests/kernels/dense_gather_reduce_test.py
+++ b/tests/kernels/dense_gather_reduce_test.py
@@ -241,6 +241,50 @@ class DenseGatherReduceTest(jtu.JaxTestCase):
             raise e
 
 
+class JaxFallbackTest(parameterized.TestCase):
+    """Exercise weighted fallback numerics without SparseCore hardware."""
+
+    @parameterized.named_parameters(
+        ("bf16_group8", jnp.bfloat16, 8, False, False),
+        ("bf16_group8_zero_nan", jnp.bfloat16, 8, True, True),
+        ("bf16_group8_propagate_nan", jnp.bfloat16, 8, False, True),
+        ("bf16_group5", jnp.bfloat16, 5, False, False),
+        ("float32_group8", jnp.float32, 8, False, False),
+        ("float32_group5", jnp.float32, 5, True, True),
+    )
+    def test_signed_weights_duplicate_indices_and_partial_width(
+            self, dtype, group_size, zero_nan, include_nan):
+        rng = np.random.default_rng(1729)
+        values = rng.standard_normal((47, 131)).astype(np.float32)
+        indices = rng.integers(-47, 47, size=group_size * 8, dtype=np.int32)
+        weights = rng.uniform(-1, 1, size=(8, group_size)).astype(np.float32)
+        # Repeated negative indices exercise normal JAX gather semantics.
+        indices[:2] = -1
+        weights[0, :2] = [0.25, -0.75]
+        if include_nan:
+            values[3] = np.nan
+            indices[2:4] = 3
+            weights[0, 2:4] = 0.0
+        x = jnp.asarray(values, dtype=dtype)
+        idx = jnp.asarray(indices)
+        w = jnp.asarray(weights)
+        actual = jax.jit(dgr_mod._jax_fallback,
+                         static_argnums=(3, 4))(x, idx, w, group_size,
+                                                zero_nan)
+        expected = reference_dense_gather_reduce(x, idx, w, group_size,
+                                                 zero_nan)
+        self.assertEqual(actual.shape, (8, 131))
+        self.assertEqual(actual.dtype, dtype)
+        np.testing.assert_allclose(actual,
+                                   expected,
+                                   atol=1e-2,
+                                   rtol=1e-2,
+                                   equal_nan=True)
+        if include_nan:
+            self.assertEqual(bool(np.isnan(np.asarray(actual[0])).all()),
+                             not zero_nan)
+
+
 class IsCompatibleTest(parameterized.TestCase):
     """Hardware-independent tests for the is_compatible() fallback gate.
 

--- a/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
+++ b/tpu_inference/kernels/sparse_core/dense_gather_reduce.py
@@ -253,6 +253,25 @@ def _jax_fallback(x,
                   topk_weights,
                   reduce_group_size,
                   topk_wgt_zero_nan=False):
+    if x.dtype == jnp.bfloat16 and reduce_group_size == 8:
+        # Gather each group position separately so the addition tree operates
+        # on independent output rows without a group-axis reduction.
+        group_indices = indices.reshape((-1, 8))
+        contributions = []
+        for k in range(8):
+            gathered = x[group_indices[:, k]].astype(jnp.float32)
+            weights = topk_weights[:, k, None]
+            weighted = gathered * weights.astype(jnp.float32)
+            if topk_wgt_zero_nan:
+                weighted = jnp.where(weights == 0.0, 0.0, weighted)
+            contributions.append(weighted)
+
+        out = (((contributions[0] + contributions[1]) +
+                (contributions[2] + contributions[3])) +
+               ((contributions[4] + contributions[5]) +
+                (contributions[6] + contributions[7])))
+        return out.astype(x.dtype)
+
     token_hidden_full = x[indices]
     cur_sorted = token_hidden_full.reshape(
         (-1, reduce_group_size, x.shape[-1]))


### PR DESCRIPTION
# Description

Specialize the BF16 group-8 JAX fallback to gather each group position separately, apply FP32 weights and combine contributions with a balanced elementwise addition tree.

### Limitation of the current abstraction

The original gather/reshape/group-axis reduction lowers to expensive vector sublane rotations. The existing SparseCore path rejects the measured v6e packed-output geometry; this change improves the JAX fallback using existing indexing/arithmetic rather than enabling SparseCore.

## Implementation

- `tpu_inference/kernels/sparse_core/dense_gather_reduce.py`
- `tests/kernels/dense_gather_reduce_test.py`

# Tests

Captured outputs and six supplemental TPU cases pass the original atol=rtol=0.01, including signed weights, duplicate/negative indices, partial widths, group-5 fallback and zero-weight NaN semantics. This is not a bitwise-parity claim. The upstream checkout passed ten CPU tests, including six new numerical fallback regressions.

All repository pre-commit checks passed for this commit, including the applicable type checker. Each implementation has one DCO-signed commit.

Targeted CPU command used in the upstream checkout:

```bash
JAX_PLATFORMS=cpu python -m pytest -q tests/kernels/dense_gather_reduce_test.py -k "JaxFallbackTest or IsCompatibleTest"
```

## Benchmarking and Profiling

**Measured on the frozen captured revisions below. These figures are not a benchmark of this PR rebased onto today's upstream main.**

| Captured case | Baseline (us) | Candidate (us) | Reduction | Speedup | Ratio CI95 |
| --- | ---: | ---: | ---: | ---: | --- |
| medium | 155.913629 | 121.469117 | **22.09%** | 1.2836x | [0.778814145, 0.779354861] |
| long | 973.648695 | 823.722840 | **15.40%** | 1.1820x | [0.845930492, 0.846096482] |

Hardware: 1 local TPUv6e chip(s); JAX 0.11.0; explicit captured geometry and seed 1729. Each result is a mean of block medians from ten independent baseline/candidate pairs, with 50 exact compiled-program execution spans per block, 20 warmups and separate host timing. The gate requires >2% lower mean device latency and bootstrap ratio CI95 upper bound <1 (10,000 resamples, seed 1729). Canonical/scaled correctness comparisons retain the original tolerance. No full-model speedup is claimed.

### Post-compilation trace evidence

All 20 raw confirmation XPlane traces per shape and their execution records are retained. The publication audit re-read each raw trace, checked the serialized executable's HLO identity, reconstructed all 50 samples and reproduced its median. Multi-chip spans require a shared host execution identity and complete device partitions; single-chip traces may use the recorded device/queue/run identity.

Representative pair 00 for the **long** case:

| Role | Exact HLO identity | Devices | Samples | Block median (us) |
| --- | --- | ---: | ---: | ---: |
| baseline | `jit__lambda` / ID `19` / PID `3449396` | 1 | 50 | 973.561758 |
| candidate | `jit__lambda` / ID `19` / PID `3446959` | 1 | 50 | 823.716758 |

[Download every confirmation trace and the verification bundle](https://github.com/JianmingTONG/tpu-inference-hierevo/releases/download/hierevo-kernel-evidence-20260909/gather-reduce.tar.gz). SHA256: `4283c1d9a9e07b22e706c490b05e4db9cf4c2fd4981477ca56777c142cf0cc88`.

After extraction, `python verify_evidence.py` (NumPy required) checks all bundle hashes and recomputes samples/statistics from the included selected events. Original `.xplane.pb` files remain the primary traces; raw output tensors and every repeated executable are not included.

### Post-compilation HLO and LLO dumps

In the mapped long-case arithmetic region, 1,536 sublane rotations disappear; 608 remain in input/weight preparation. Arithmetic adds fall from 2,048 to 896 while multiplies rise from 512 to 1,024. Static counts are not a whole-program cycle model.

| Shape | Full baseline LLO | Full candidate LLO | Compiled baseline HLO | Compiled candidate HLO |
| --- | --- | --- | --- | --- |
| long | [baseline LLO](https://github.com/JianmingTONG/tpu-inference-hierevo/releases/download/hierevo-kernel-evidence-20260909/gather-reduce-long-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/tpu-inference-hierevo/releases/download/hierevo-kernel-evidence-20260909/gather-reduce-long-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/tpu-inference-hierevo/releases/download/hierevo-kernel-evidence-20260909/gather-reduce-long-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/tpu-inference-hierevo/releases/download/hierevo-kernel-evidence-20260909/gather-reduce-long-candidate.hlo.txt.gz) |
| medium | [baseline LLO](https://github.com/JianmingTONG/tpu-inference-hierevo/releases/download/hierevo-kernel-evidence-20260909/gather-reduce-medium-baseline.llo.gz) | [candidate LLO](https://github.com/JianmingTONG/tpu-inference-hierevo/releases/download/hierevo-kernel-evidence-20260909/gather-reduce-medium-candidate.llo.gz) | [baseline HLO](https://github.com/JianmingTONG/tpu-inference-hierevo/releases/download/hierevo-kernel-evidence-20260909/gather-reduce-medium-baseline.hlo.txt.gz) | [candidate HLO](https://github.com/JianmingTONG/tpu-inference-hierevo/releases/download/hierevo-kernel-evidence-20260909/gather-reduce-medium-candidate.hlo.txt.gz) |

<details>
<summary>Representative records from the full numbered LLO dumps</summary>

These excerpts show static emitted sites selected from changed vector opcodes. Counts and excerpts support code inspection; they do not quantify dynamic cycles.

### baseline

```text
247 : {[vmem:$0x3ffe0] = vst.8x128 v62}
248 : {s3 = simm.u32 $50;  s1 = sld [smem:$0x3b];  v59 = vimm.8x128.s32 $0;  v62 = vlaneseq.8x128.u32;  [vmem:$0x3fff8] = vst.8x128 v59}
249 : {[vmem:$0x3fff0] = vst.8x128 v60}
250 : {p0 = slt.s32 s1, $95;  s2 = simm.u32 $0;  v59 = vsel.8x128 vm0, $0x1, v59;  v63 = vand.8x128.u32 $0x380, v62;  [vmem:$0x3ffd8] = vst.8x128 v63}
251 : {p0 = slt.s32 s1, $85;  s2 = simm.u32 @p0 $1;  vm0 = veq.8x128.s32 v63, $0;  [vmem:$0x3ffe8] = vst.8x128 v61}
261 : {p0 = slt.s32 s1, $15;  s2 = simm.u32 @p0 $32;  [vmem:$0x3ffd0] = vst.8x128 v0}
262 : {s2 = simm.u32 @p0 $72;  s3 = simm.u32 @p0 $6;  [vmem:$0x3ffc8] = vst.8x128 v1}
263 : {p0 = slt.s32 s1, $5;  v60 = vpack.i.8x128.f32.bf16 v61, v60;  v61 = vpack.i.8x128.f32.bf16 v60, v61;  [vmem:$0x3ffc0] = vst.8x128 v2}
```

### candidate

```text
247 : {[vmem:$0x3ffe0] = vst.8x128 v62}
248 : {s3 = simm.u32 $50;  s1 = sld [smem:$0x3b];  v59 = vimm.8x128.s32 $0;  v62 = vlaneseq.8x128.u32;  [vmem:$0x3fff8] = vst.8x128 v59}
249 : {[vmem:$0x3fff0] = vst.8x128 v60}
250 : {p0 = slt.s32 s1, $95;  s2 = simm.u32 $0;  v59 = vsel.8x128 vm0, $0x1, v59;  v63 = vand.8x128.u32 $0x380, v62;  [vmem:$0x3ffd8] = vst.8x128 v63}
251 : {p0 = slt.s32 s1, $85;  s2 = simm.u32 @p0 $1;  vm0 = veq.8x128.s32 v63, $0;  [vmem:$0x3ffe8] = vst.8x128 v61}
261 : {p0 = slt.s32 s1, $15;  s2 = simm.u32 @p0 $32;  [vmem:$0x3ffd0] = vst.8x128 v0}
262 : {s2 = simm.u32 @p0 $72;  s3 = simm.u32 @p0 $6;  [vmem:$0x3ffc8] = vst.8x128 v1}
263 : {p0 = slt.s32 s1, $5;  v60 = vpack.i.8x128.f32.bf16 v61, v60;  v61 = vpack.i.8x128.f32.bf16 v60, v61;  [vmem:$0x3ffc0] = vst.8x128 v2}
```

</details>

### Source provenance and remaining limits

- Measured baseline: `327c2c925f6fbd3d61b872f83a227d75c1824076`; exact measured patch and accepted candidate IDs/revisions are in the bundle.
- PR base: `ef56cc5d8d09378f94ebbbaa5e3647a67fa4ceea`. PR implementation commit: `643e9aeba1ec4531f80f02d68c8fa65211cdfcdb`.
- The source was ported onto current upstream and checked locally. Fresh TPU lowering/performance confirmation on that upstream revision remains outstanding; this PR is a draft for review.
- Performance is limited to the reported geometries, dtypes, runtime, partition and guarded paths. Original captures and any unsuccessful search attempts are not relabeled as new upstream measurements.
- Related work: [#3493](https://github.com/vllm-project/tpu-inference/pull/3493) enables a SparseCore implementation via FP32 buffers; [#3062](https://github.com/vllm-project/tpu-inference/pull/3062) handles SparseCore column padding. This PR changes the JAX fallback expression and leaves compatibility/dispatch unchanged. An enabled SparseCore path may bypass this optimization.
