### PR TITLE
[Prefix Caching] Fix mamba cache replication issue 

### DIFF
--- a/tests/core/test_dp_scheduler.py
+++ b/tests/core/test_dp_scheduler.py
@@ -55,6 +55,7 @@ class TestDPScheduler:
         config.cache_config = MagicMock()
         config.cache_config.enable_prefix_caching = False
         config.cache_config.prefix_caching_hash_algo = "sha256"
+        config.cache_config.mamba_num_blocks = None
         return config
 
     @pytest.fixture
@@ -129,6 +130,41 @@ class TestDPScheduler:
                 # Verify processes were started
                 mock_process = mock_ctx.Process.return_value
                 assert mock_process.start.call_count == 2
+
+    def test_init_with_mamba_num_blocks_per_rank(
+        self,
+        mock_vllm_config,
+        mock_kv_cache_config,
+        mock_structured_output_manager,
+    ):
+        """Test that mamba_num_blocks is partitioned per DP rank from cache_config."""
+        mock_vllm_config.cache_config.mamba_num_blocks = 60
+        scheduler = self._create_scheduler(
+            mock_vllm_config,
+            mock_kv_cache_config,
+            mock_structured_output_manager,
+        )
+        assert len(scheduler.per_rank_kv_cache_configs) == 2
+        for rank_config in scheduler.per_rank_kv_cache_configs:
+            assert rank_config.num_blocks == 50
+            assert rank_config.mamba_num_blocks == 30
+
+    def test_init_without_mamba_num_blocks(
+        self,
+        mock_vllm_config,
+        mock_kv_cache_config,
+        mock_structured_output_manager,
+    ):
+        """Test that rank configs have no mamba_num_blocks if not configured."""
+        scheduler = self._create_scheduler(
+            mock_vllm_config,
+            mock_kv_cache_config,
+            mock_structured_output_manager,
+        )
+        assert len(scheduler.per_rank_kv_cache_configs) == 2
+        for rank_config in scheduler.per_rank_kv_cache_configs:
+            assert rank_config.num_blocks == 50
+            assert getattr(rank_config, "mamba_num_blocks", None) is None
 
     def test_init_with_prefix_caching_enabled(
         self,

--- a/tests/core/test_hybrid_coordinator.py
+++ b/tests/core/test_hybrid_coordinator.py
@@ -1,0 +1,630 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from unittest.mock import MagicMock
+
+import pytest
+import torch
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_utils import (BlockHash,
+                                         make_block_hash_with_group_id)
+from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
+                                        KVCacheGroupSpec, MambaSpec)
+from vllm.v1.request import Request, RequestStatus
+
+from tpu_inference.core.hybrid_coordinator import (
+    MambaBlockPool, MirrorMambaBlockPool, TPUDualBlockPool,
+    TPUHybridKVCacheCoordinator, TPUKVCacheManager,
+    install_hybrid_coordinator_hooks, set_mamba_num_blocks)
+
+
+def _make_mock_hybrid_kv_cache_config(
+    num_attn_blocks: int = 500,
+    mamba_num_blocks: int | None = 50,
+    block_size: int = 16,
+) -> KVCacheConfig:
+    attn_spec = FullAttentionSpec(
+        block_size=block_size,
+        num_kv_heads=8,
+        head_size=128,
+        dtype=torch.bfloat16,
+    )
+    mamba_spec = MambaSpec(
+        shapes=((3, 64), (8, 64, 16)),
+        dtypes=(torch.bfloat16, torch.float32),
+        block_size=block_size,
+        mamba_cache_mode="align",
+    )
+    groups = [
+        KVCacheGroupSpec(kv_cache_spec=attn_spec, layer_names=["attn_0"]),
+        KVCacheGroupSpec(kv_cache_spec=mamba_spec, layer_names=["mamba_0"]),
+    ]
+    cfg = KVCacheConfig(
+        num_blocks=num_attn_blocks,
+        kv_cache_tensors=[],
+        kv_cache_groups=groups,
+    )
+    if mamba_num_blocks is not None:
+        set_mamba_num_blocks(mamba_num_blocks)
+    return cfg
+
+
+class TestTPUDualBlockPool:
+
+    def test_routing_free_and_touch_to_origin_pools(self):
+        pool_attn = BlockPool(num_gpu_blocks=100,
+                              enable_caching=True,
+                              hash_block_size=16)
+        pool_mamba = BlockPool(num_gpu_blocks=20,
+                               enable_caching=True,
+                               hash_block_size=16)
+
+        dual_pool = TPUDualBlockPool(pool_attn,
+                                     pool_mamba,
+                                     mamba_group_ids={1})
+
+        # Allocate 2 from attn, 1 from mamba
+        attn_blks = pool_attn.get_new_blocks(2)
+        mamba_blks = pool_mamba.get_new_blocks(1)
+
+        assert pool_attn.get_num_free_blocks() == 100 - 1 - 2  # 1 null block
+        assert pool_mamba.get_num_free_blocks() == 20 - 1 - 1
+
+        # Test touch via dual_pool
+        dual_pool.touch([attn_blks[0], mamba_blks[0]])
+        assert attn_blks[0].ref_cnt == 2
+        assert mamba_blks[0].ref_cnt == 2
+
+        # Reset ref_cnt back to 1 for clean free
+        attn_blks[0].ref_cnt = 1
+        mamba_blks[0].ref_cnt = 1
+
+        # Free combined list via dual_pool
+        mixed_blocks = [attn_blks[0], mamba_blks[0], attn_blks[1]]
+        dual_pool.free_blocks(mixed_blocks)
+
+        # Both pools should have all blocks returned
+        assert pool_attn.get_num_free_blocks() == 100 - 1
+        assert pool_mamba.get_num_free_blocks() == 20 - 1
+
+    def test_reset_prefix_cache_clears_both(self):
+        pool_attn = BlockPool(num_gpu_blocks=100,
+                              enable_caching=True,
+                              hash_block_size=16)
+        pool_mamba = BlockPool(num_gpu_blocks=20,
+                               enable_caching=True,
+                               hash_block_size=16)
+        dual_pool = TPUDualBlockPool(pool_attn,
+                                     pool_mamba,
+                                     mamba_group_ids={1})
+
+        assert dual_pool.reset_prefix_cache() is True
+
+    def test_get_cached_block_multi_group(self):
+        pool_attn = BlockPool(num_gpu_blocks=100,
+                              enable_caching=True,
+                              hash_block_size=16)
+        pool_mamba = BlockPool(num_gpu_blocks=20,
+                               enable_caching=True,
+                               hash_block_size=16)
+        dual_pool = TPUDualBlockPool(pool_attn,
+                                     pool_mamba,
+                                     mamba_group_ids={1})
+
+        pool_attn.get_cached_block = MagicMock()
+        pool_mamba.get_cached_block = MagicMock()
+
+        blk_attn = MagicMock()
+        blk_mamba = MagicMock()
+
+        # Both hit
+        pool_attn.get_cached_block.return_value = [blk_attn]
+        pool_mamba.get_cached_block.return_value = [blk_mamba]
+
+        res = dual_pool.get_cached_block("hash1", [0, 1])
+        assert res == [blk_attn, blk_mamba]
+        pool_attn.get_cached_block.assert_called_with("hash1", [0])
+        pool_mamba.get_cached_block.assert_called_with("hash1", [1])
+
+        # Miss on mamba
+        pool_mamba.get_cached_block.return_value = None
+        assert dual_pool.get_cached_block("hash2", [0, 1]) is None
+
+        # Miss on attn
+        pool_attn.get_cached_block.return_value = None
+        pool_mamba.get_cached_block.return_value = [blk_mamba]
+        assert dual_pool.get_cached_block("hash3", [0, 1]) is None
+
+    def test_evict_blocks_targets_attention_pool_only(self):
+        pool_attn = BlockPool(num_gpu_blocks=100,
+                              enable_caching=True,
+                              hash_block_size=16)
+        pool_mamba = BlockPool(num_gpu_blocks=20,
+                               enable_caching=True,
+                               hash_block_size=16)
+        dual_pool = TPUDualBlockPool(pool_attn,
+                                     pool_mamba,
+                                     mamba_group_ids={1})
+
+        pool_attn.evict_blocks = MagicMock()
+        pool_mamba.evict_blocks = MagicMock()
+
+        dual_pool.evict_blocks({5, 20, 200})
+        pool_attn.evict_blocks.assert_called_once_with({5, 20})
+        pool_mamba.evict_blocks.assert_not_called()
+
+
+class TestMirrorMambaBlockPool:
+    """Mirroring makes G mamba groups cost one block id, not G.
+
+    A pool of N ids otherwise holds N/G checkpoints while the memory behind it
+    holds N: every mamba layer has N slots and a checkpoint needs one per
+    layer.
+    """
+
+    def _pools(self, num_gpu_blocks=12, primary_group_id=1):
+        primary = MambaBlockPool(num_gpu_blocks=num_gpu_blocks,
+                                 enable_caching=True,
+                                 hash_block_size=16,
+                                 primary_group_id=primary_group_id)
+        return primary, MirrorMambaBlockPool(primary)
+
+    def test_mirror_reuses_the_primary_block_ids(self):
+        primary, mirror = self._pools()
+
+        first = primary.get_new_blocks(2)
+        second = mirror.get_new_blocks(2)
+        third = mirror.get_new_blocks(2)
+
+        assert [b.block_id for b in second] == [b.block_id for b in first]
+        assert [b.block_id for b in third] == [b.block_id for b in first]
+        # Three groups genuinely reference each block, so the count must show
+        # it or the first free would return a block another group still uses.
+        assert all(b.ref_cnt == 3 for b in first)
+        # Only 2 ids were consumed, not 6.
+        assert primary.get_num_free_blocks() == 12 - 1 - 2
+
+    def test_mirror_refuses_to_alias_when_groups_diverge(self):
+        primary, mirror = self._pools()
+        primary.get_new_blocks(2)
+
+        # A different count means the groups are no longer in lockstep;
+        # aliasing here would point a layer at an unrelated request's slot.
+        with pytest.raises(AssertionError, match="lockstep"):
+            mirror.get_new_blocks(3)
+
+    def test_lookup_of_every_group_resolves_to_one_entry(self):
+        primary, _ = self._pools(primary_group_id=1)
+
+        req = Request(request_id="r0",
+                      prompt_token_ids=list(range(16)),
+                      sampling_params=MagicMock(),
+                      pooling_params=None)
+        req.block_hashes = [BlockHash(b"h0")]
+        blocks = primary.get_new_blocks(1)
+        primary.cache_full_blocks(request=req,
+                                  blocks=blocks,
+                                  num_cached_blocks=0,
+                                  num_full_blocks=1,
+                                  block_size=16,
+                                  kv_cache_group_id=1)
+
+        # One cached entry must satisfy a lookup spanning all three groups,
+        # returning that block once per group.
+        hit = primary.get_cached_block(BlockHash(b"h0"), [1, 2, 3])
+        assert hit is not None
+        assert len(hit) == 3
+        assert {b.block_id for b in hit} == {blocks[0].block_id}
+        assert len(primary.cached_block_hash_to_block) == 1
+
+    def test_mirror_does_not_double_cache(self):
+        primary, mirror = self._pools()
+        req = Request(request_id="r0",
+                      prompt_token_ids=list(range(16)),
+                      sampling_params=MagicMock(),
+                      pooling_params=None)
+        req.block_hashes = [BlockHash(b"h0")]
+        blocks = primary.get_new_blocks(1)
+
+        mirror.cache_full_blocks(request=req,
+                                 blocks=blocks,
+                                 num_cached_blocks=0,
+                                 num_full_blocks=1,
+                                 block_size=16,
+                                 kv_cache_group_id=2)
+
+        assert len(primary.cached_block_hash_to_block) == 0
+
+    def test_mirror_forwards_the_rest_of_the_pool_api(self):
+        primary, mirror = self._pools()
+        assert mirror.num_gpu_blocks == primary.num_gpu_blocks
+        assert mirror.null_block is primary.null_block
+        assert mirror.hash_block_size == primary.hash_block_size
+
+        blocks = primary.get_new_blocks(1)
+        mirror.get_new_blocks(1)  # second reference
+        mirror.free_blocks(blocks)
+        assert blocks[0].ref_cnt == 1
+
+    def test_no_canonicalisation_without_a_primary_group(self):
+        # A model whose mamba layers already form one group has nothing to
+        # mirror, so the pool keeps vLLM's per-group keying: a lookup spanning
+        # three group ids then needs three cached entries.
+        pool = MambaBlockPool(num_gpu_blocks=12,
+                              enable_caching=True,
+                              hash_block_size=16)
+        req = Request(request_id="r0",
+                      prompt_token_ids=list(range(16)),
+                      sampling_params=MagicMock(),
+                      pooling_params=None)
+        req.block_hashes = [BlockHash(b"h0")]
+        blocks = pool.get_new_blocks(1)
+        pool.cache_full_blocks(request=req,
+                               blocks=blocks,
+                               num_cached_blocks=0,
+                               num_full_blocks=1,
+                               block_size=16,
+                               kv_cache_group_id=1)
+
+        assert pool.get_cached_block(BlockHash(b"h0"), [1]) is not None
+        assert pool.get_cached_block(BlockHash(b"h0"), [1, 2, 3]) is None
+
+
+class TestTPUHybridKVCacheCoordinator:
+
+    def _make_multi_mamba_group_config(self, num_mamba_groups=3):
+        """The Qwen3.5 shape: vLLM splits the mamba layers across groups."""
+        attn_spec = FullAttentionSpec(block_size=16,
+                                      num_kv_heads=8,
+                                      head_size=128,
+                                      dtype=torch.bfloat16)
+        mamba_spec = MambaSpec(shapes=((3, 64), (8, 64, 16)),
+                               dtypes=(torch.bfloat16, torch.float32),
+                               block_size=16,
+                               mamba_cache_mode="align")
+        groups = [KVCacheGroupSpec(["attn_0"], attn_spec)]
+        groups += [
+            KVCacheGroupSpec([f"mamba_{i}"], mamba_spec)
+            for i in range(num_mamba_groups)
+        ]
+        set_mamba_num_blocks(50)
+        return KVCacheConfig(num_blocks=500,
+                             kv_cache_tensors=[],
+                             kv_cache_groups=groups)
+
+    def _make_coordinator(self, cfg):
+        return TPUHybridKVCacheCoordinator(
+            kv_cache_config=cfg,
+            max_model_len=1024,
+            max_in_flight_tokens=128,
+            use_eagle=False,
+            enable_caching=True,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=16,
+            hash_block_size=16,
+        )
+
+    def test_multiple_mamba_groups_are_mirrored_by_default(self):
+        coord = self._make_coordinator(self._make_multi_mamba_group_config())
+
+        assert coord.mirror_mamba_groups is True
+        assert coord.primary_mamba_group_id == 1  # group 0 is attention
+        assert coord.mamba_block_pool.primary_group_id == 1
+        # Only the primary group owns the pool; the rest are handed its ids.
+        assert coord.single_type_managers[
+            1].block_pool is coord.mamba_block_pool
+        for i in (2, 3):
+            assert isinstance(coord.single_type_managers[i].block_pool,
+                              MirrorMambaBlockPool)
+
+    def test_single_mamba_group_is_not_mirrored(self):
+        coord = self._make_coordinator(
+            self._make_multi_mamba_group_config(num_mamba_groups=1))
+
+        # Nothing to share ids with, so keep vLLM's per-group keying.
+        assert coord.mirror_mamba_groups is False
+        assert coord.mamba_block_pool.primary_group_id is None
+        assert coord.single_type_managers[
+            1].block_pool is coord.mamba_block_pool
+
+    def test_mirrored_groups_do_not_multiply_the_capacity_check(self):
+        coord = self._make_coordinator(self._make_multi_mamba_group_config())
+        req = Request(request_id="r0",
+                      prompt_token_ids=list(range(32)),
+                      sampling_params=MagicMock(),
+                      pooling_params=None)
+        req.block_hashes = [BlockHash(f"h{i}".encode()) for i in range(2)]
+
+        # 3 mamba groups asking for the same blocks is one block's worth of
+        # demand, not three: counting each would reject requests that fit.
+        empty = tuple([] for _ in coord.kv_cache_config.kv_cache_groups)
+        assert coord.can_allocate_tokens(
+            request=req,
+            num_tokens=32,
+            new_computed_blocks=empty,
+            num_encoder_tokens=0,
+            total_computed_tokens=0,
+            num_local_computed_tokens=0,
+            num_tokens_main_model=32,
+        ) is True
+
+    def test_decoupled_pool_initialization(self):
+        cfg = _make_mock_hybrid_kv_cache_config(num_attn_blocks=500,
+                                                mamba_num_blocks=50)
+        coord = TPUHybridKVCacheCoordinator(
+            kv_cache_config=cfg,
+            max_model_len=1024,
+            max_in_flight_tokens=128,
+            use_eagle=False,
+            enable_caching=True,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=16,
+            hash_block_size=16,
+        )
+
+        assert coord.attention_block_pool.num_gpu_blocks == 500
+        assert coord.mamba_block_pool.num_gpu_blocks == 50
+
+        # Manager 0 (attn) points to attention pool
+        assert coord.single_type_managers[
+            0].block_pool is coord.attention_block_pool
+        # Manager 1 (mamba) points to mamba pool
+        assert coord.single_type_managers[
+            1].block_pool is coord.mamba_block_pool
+
+    def test_can_allocate_tokens_respects_both_pools(self):
+        cfg = _make_mock_hybrid_kv_cache_config(num_attn_blocks=10,
+                                                mamba_num_blocks=5)
+        coord = TPUHybridKVCacheCoordinator(
+            kv_cache_config=cfg,
+            max_model_len=1024,
+            max_in_flight_tokens=128,
+            use_eagle=False,
+            enable_caching=True,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=16,
+            hash_block_size=16,
+        )
+
+        req = MagicMock(spec=Request)
+        req.request_id = "req-1"
+        req.num_computed_tokens = 0
+        req.status = RequestStatus.RUNNING
+
+        # Request 32 tokens (needs 2 attn blocks, 1 mamba block)
+        can_fit = coord.can_allocate_tokens(
+            request=req,
+            num_tokens=32,
+            new_computed_blocks=([], []),
+            num_encoder_tokens=0,
+            total_computed_tokens=0,
+            num_local_computed_tokens=0,
+            num_tokens_main_model=32,
+            watermark_blocks=0,
+            reserved_blocks=0,
+        )
+        assert can_fit is True
+
+        # Now exhaust attention pool
+        free_attn = coord.attention_block_pool.get_num_free_blocks()
+        allocated_attn = coord.attention_block_pool.get_new_blocks(free_attn)
+        can_fit_no_attn = coord.can_allocate_tokens(
+            request=req,
+            num_tokens=32,
+            new_computed_blocks=([], []),
+            num_encoder_tokens=0,
+            total_computed_tokens=0,
+            num_local_computed_tokens=0,
+            num_tokens_main_model=32,
+            watermark_blocks=0,
+            reserved_blocks=0,
+        )
+        assert can_fit_no_attn is False
+
+        # Free attention pool
+        coord.attention_block_pool.free_blocks(allocated_attn)
+
+        # Now exhaust mamba pool
+        free_mamba = coord.mamba_block_pool.get_num_free_blocks()
+        allocated_mamba = coord.mamba_block_pool.get_new_blocks(free_mamba)
+        can_fit_no_mamba = coord.can_allocate_tokens(
+            request=req,
+            num_tokens=32,
+            new_computed_blocks=([], []),
+            num_encoder_tokens=0,
+            total_computed_tokens=0,
+            num_local_computed_tokens=0,
+            num_tokens_main_model=32,
+            watermark_blocks=0,
+            reserved_blocks=0,
+        )
+        assert can_fit_no_mamba is False
+        coord.mamba_block_pool.free_blocks(allocated_mamba)
+
+    def test_find_longest_cache_hit_reconciles_minimum(self):
+        cfg = _make_mock_hybrid_kv_cache_config(num_attn_blocks=500,
+                                                mamba_num_blocks=50)
+        coord = TPUHybridKVCacheCoordinator(
+            kv_cache_config=cfg,
+            max_model_len=1024,
+            max_in_flight_tokens=128,
+            use_eagle=False,
+            enable_caching=True,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=16,
+            hash_block_size=16,
+        )
+
+        hashes = [BlockHash(f"hash_{i}".encode("utf-8")) for i in range(10)]
+
+        # Simulate: attn cached 5 blocks (80 tokens), mamba cached 3 blocks (48 tokens)
+        # Attn pool caches hashes 0..4 (group_id = 0)
+        attn_blocks = coord.attention_block_pool.get_new_blocks(5)
+        for i, b in enumerate(attn_blocks):
+            coord.attention_block_pool._insert_block_hash(
+                make_block_hash_with_group_id(hashes[i], 0),
+                b,
+                num_tokens=(i + 1) * 16)
+
+        # Mamba pool caches hashes 0..2 (group_id = 1)
+        mamba_blocks = coord.mamba_block_pool.get_new_blocks(3)
+        for i, b in enumerate(mamba_blocks):
+            coord.mamba_block_pool._insert_block_hash(
+                make_block_hash_with_group_id(hashes[i], 1),
+                b,
+                num_tokens=(i + 1) * 16)
+
+        hit_blocks, hit_length, uncached = coord.find_longest_cache_hit(
+            block_hashes=hashes,
+            max_cache_hit_length=160,
+        )
+
+        # Reconciled hit length must be min(80, 48) = 48 tokens (3 blocks)
+        assert hit_length == 48
+        # Attention blocks must be truncated to 3 blocks
+        assert len(hit_blocks[0]) == 3
+        # Mamba block list has length 3 (with null blocks inserted before the match)
+        assert len(hit_blocks[1]) == 3
+
+        # Test find_longest_cache_hit_per_group inherited from upstream
+        per_group_blocks, per_group_lengths = coord.find_longest_cache_hit_per_group(
+            block_hashes=hashes,
+            max_cache_hit_length=160,
+        )
+        assert per_group_lengths == (80, 48)
+        assert len(per_group_blocks[0]) == 5
+        assert len(per_group_blocks[1]) == 3
+
+
+class TestHybridCoordinatorHooks:
+
+    def test_install_hooks(self):
+        import vllm.v1.core.kv_cache_coordinator as coord_mod
+        import vllm.v1.core.kv_cache_manager as mgr_mod
+
+        install_hybrid_coordinator_hooks()
+        assert mgr_mod.KVCacheManager is TPUKVCacheManager
+        assert callable(coord_mod.get_kv_cache_coordinator)
+
+    def test_tpu_get_kv_cache_coordinator_resolves_from_global(self):
+        from tpu_inference.core.hybrid_coordinator import (
+            TPUHybridKVCacheCoordinator, set_mamba_num_blocks,
+            tpu_get_kv_cache_coordinator)
+
+        set_mamba_num_blocks(64)
+        cfg = _make_mock_hybrid_kv_cache_config(num_attn_blocks=100,
+                                                mamba_num_blocks=None)
+        assert getattr(cfg, "mamba_num_blocks", None) is None
+
+        coord_kwargs = dict(
+            max_model_len=1024,
+            max_in_flight_tokens=128,
+            use_eagle=False,
+            enable_caching=True,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=16,
+            hash_block_size=16,
+        )
+        coord = tpu_get_kv_cache_coordinator(cfg, **coord_kwargs)
+        assert isinstance(coord, TPUHybridKVCacheCoordinator)
+        assert coord.mamba_num_blocks == 64
+
+    def test_tpu_get_kv_cache_coordinator_raises_if_missing(self):
+        import pytest
+
+        import tpu_inference.core.hybrid_coordinator as hc_mod
+        from tpu_inference.core.hybrid_coordinator import \
+            tpu_get_kv_cache_coordinator
+        hc_mod._GLOBAL_MAMBA_NUM_BLOCKS = None
+
+        cfg = _make_mock_hybrid_kv_cache_config(num_attn_blocks=100,
+                                                mamba_num_blocks=None)
+        assert getattr(cfg, "mamba_num_blocks", None) is None
+
+        coord_kwargs = dict(
+            max_model_len=1024,
+            max_in_flight_tokens=128,
+            use_eagle=False,
+            enable_caching=True,
+            enable_kv_cache_events=False,
+            dcp_world_size=1,
+            pcp_world_size=1,
+            scheduler_block_size=16,
+            hash_block_size=16,
+        )
+        with pytest.raises(ValueError,
+                           match="mamba_num_blocks must be registered"):
+            tpu_get_kv_cache_coordinator(cfg, **coord_kwargs)
+
+
+class TestTPUKVCacheManager:
+
+    def test_allocate_slots_dual_pool_gating(self):
+        set_mamba_num_blocks(5)
+        cfg = _make_mock_hybrid_kv_cache_config(num_attn_blocks=10,
+                                                mamba_num_blocks=5)
+        manager = TPUKVCacheManager(
+            kv_cache_config=cfg,
+            max_model_len=1024,
+            scheduler_block_size=16,
+            hash_block_size=16,
+            enable_caching=True,
+        )
+        assert isinstance(manager.coordinator, TPUHybridKVCacheCoordinator)
+
+        req = Request(
+            request_id="req-1",
+            prompt_token_ids=list(range(32)),
+            sampling_params=MagicMock(),
+            pooling_params=None,
+        )
+        req.block_hashes = [BlockHash(f"h_{i}".encode()) for i in range(2)]
+        req.status = RequestStatus.RUNNING
+
+        # 1. Successful allocation
+        blocks = manager.allocate_slots(request=req, num_new_tokens=32)
+        assert blocks is not None
+        assert len(blocks.blocks[0]) == 2  # 2 attn blocks
+        assert len(blocks.blocks[1]) == 2  # 2 mamba blocks (1 null + 1 state)
+
+        # 2. Attention pool exhaustion -> returns None for new request
+        coord = manager.coordinator
+        free_attn = coord.attention_block_pool.get_num_free_blocks()
+        allocated_attn = coord.attention_block_pool.get_new_blocks(free_attn)
+        req2 = Request(
+            request_id="req-2",
+            prompt_token_ids=list(range(16)),
+            sampling_params=MagicMock(),
+            pooling_params=None,
+        )
+        req2.block_hashes = [BlockHash(b"h_req2")]
+        req2.status = RequestStatus.WAITING
+        blocks_no_attn = manager.allocate_slots(request=req2,
+                                                num_new_tokens=16)
+        assert blocks_no_attn is None
+        coord.attention_block_pool.free_blocks(allocated_attn)
+
+        # 3. Mamba pool exhaustion -> returns None (prevents ValueError crash in get_new_blocks)
+        free_mamba = coord.mamba_block_pool.get_num_free_blocks()
+        allocated_mamba = coord.mamba_block_pool.get_new_blocks(free_mamba)
+        req3 = Request(
+            request_id="req-3",
+            prompt_token_ids=list(range(16)),
+            sampling_params=MagicMock(),
+            pooling_params=None,
+        )
+        req3.block_hashes = [BlockHash(b"h_req3")]
+        req3.status = RequestStatus.WAITING
+        blocks_no_mamba = manager.allocate_slots(request=req3,
+                                                 num_new_tokens=16)
+        assert blocks_no_mamba is None
+        coord.mamba_block_pool.free_blocks(allocated_mamba)

--- a/tests/e2e/test_mamba_prefix_caching.py
+++ b/tests/e2e/test_mamba_prefix_caching.py
@@ -20,6 +20,7 @@ process that already built one fails the engine-core handshake on TPU.
 """
 import json
 import os
+import re
 import subprocess
 import sys
 import tempfile
@@ -54,7 +55,10 @@ QUESTIONS = [
 ]
 
 
-def _generate(mode: str, out_path: str, dp_size: int = 1) -> None:
+def _generate(mode: str,
+              out_path: str,
+              dp_size: int = 1,
+              multiplier: int | None = None) -> None:
     """Generate the prompt set in this process and dump the result.
 
     Only called in the child process (see `__main__` below), so vllm is
@@ -65,13 +69,13 @@ def _generate(mode: str, out_path: str, dp_size: int = 1) -> None:
 
     additional_config = {}
     if dp_size > 1:
-        additional_config = {
-            "sharding": {
-                "sharding_strategy": {
-                    "enable_dp_attention": True
-                }
+        additional_config["sharding"] = {
+            "sharding_strategy": {
+                "enable_dp_attention": True
             }
         }
+    if multiplier is not None:
+        additional_config["custom_mamba_cache_multiplier"] = multiplier
 
     llm = LLM(
         model=MODEL_NAME,
@@ -112,7 +116,9 @@ def _generate(mode: str, out_path: str, dp_size: int = 1) -> None:
             }, f)
 
 
-def _run_case(mode: str, dp_size: int = 1) -> dict:
+def _run_case(mode: str,
+              dp_size: int = 1,
+              multiplier: int | None = None) -> dict:
     """Run one engine in a subprocess and return its result."""
     with tempfile.TemporaryDirectory() as tmp:
         out_path = os.path.join(tmp, f"{mode}_dp{dp_size}.json")
@@ -120,36 +126,69 @@ def _run_case(mode: str, dp_size: int = 1) -> dict:
                    MODEL_IMPL_TYPE="vllm",
                    SKIP_JAX_PRECOMPILE="1",
                    VLLM_XLA_CHECK_RECOMPILATION="0")
-        proc = subprocess.run(
-            [sys.executable, __file__, mode, out_path,
-             str(dp_size)],
-            env=env,
-            capture_output=True,
-            text=True,
-            timeout=1800)
+        cmd = [sys.executable, __file__, mode, out_path, str(dp_size)]
+        if multiplier is not None:
+            cmd.append(str(multiplier))
+        proc = subprocess.run(cmd,
+                              env=env,
+                              capture_output=True,
+                              text=True,
+                              timeout=1800)
         if not os.path.exists(out_path):
             raise AssertionError(
                 f"prefix-caching-{mode} (dp={dp_size}) run produced no output\n"
                 f"--- stdout ---\n{proc.stdout[-4000:]}\n"
                 f"--- stderr ---\n{proc.stderr[-4000:]}")
         with open(out_path) as f:
-            return json.load(f)
+            data = json.load(f)
+
+        # Parse compact mamba KV cache log from stdout/stderr of EngineCore
+        combined_logs = proc.stdout + proc.stderr
+        match = re.search(
+            r"Compact-mamba KV cache.*?num_gpu_blocks_override=(\d+).*?_mamba_num_blocks=(\d+)",
+            combined_logs,
+        )
+        if match:
+            data["cache_info"] = {
+                "num_gpu_blocks_override": int(match.group(1)),
+                "mamba_num_blocks": int(match.group(2)),
+            }
+        return data
 
 
-def _verify_mamba_prefix_caching(dp_size: int = 1):
+def _verify_mamba_prefix_caching(dp_size: int = 1,
+                                 multiplier: int | None = None):
     """Verify greedy output consistency with prefix caching on vs off."""
-    baseline = _run_case("off", dp_size=dp_size)
-    cached = _run_case("on", dp_size=dp_size)
+    baseline = _run_case("off", dp_size=dp_size, multiplier=multiplier)
+    cached = _run_case("on", dp_size=dp_size, multiplier=multiplier)
 
     queries = cached["metrics"].get("vllm:prefix_cache_queries", 0)
     hits = cached["metrics"].get("vllm:prefix_cache_hits", 0)
     print(
-        f"  prefix cache (dp={dp_size}): {hits:.0f}/{queries:.0f} tokens hit "
+        f"  prefix cache (dp={dp_size}, multiplier={multiplier}): {hits:.0f}/{queries:.0f} tokens hit "
         f"({hits / queries if queries else 0:.1%})")
 
     assert hits > 0, (
         f"no prefix cache hits (dp={dp_size}): the shared prefix was never "
         f"reused, so this test did not exercise mamba state reuse")
+
+    # Verify decoupled dual KV cache pools
+    if "cache_info" in cached:
+        info = cached["cache_info"]
+        attn_blocks = info.get("num_gpu_blocks_override")
+        mamba_blocks = info.get("mamba_num_blocks")
+        print(
+            f"  KV Cache pools (dp={dp_size}): Attention={attn_blocks} blocks, "
+            f"Mamba={mamba_blocks} blocks")
+        if mamba_blocks is not None and attn_blocks is not None:
+            assert attn_blocks > mamba_blocks, (
+                f"Attention pool ({attn_blocks}) must be larger than compact Mamba pool ({mamba_blocks})"
+            )
+            if multiplier is not None:
+                # `custom_mamba_cache_multiplier` blocks per request in the
+                # batch, plus the null block (less, if the joint HBM budget
+                # forced a re-split).
+                assert mamba_blocks <= multiplier * 8 + 1
 
     mismatched = [
         i for i, (
@@ -163,8 +202,8 @@ def _verify_mamba_prefix_caching(dp_size: int = 1):
 
     assert not mismatched, (
         f"{len(mismatched)}/{len(QUESTIONS)} prompts changed when prefix "
-        f"caching was enabled (dp={dp_size}); linear-attention state is not "
-        f"being reused correctly")
+        f"caching was enabled (dp={dp_size}, multiplier={multiplier}); linear-attention "
+        f"state is not being reused correctly")
 
 
 def test_mamba_prefix_caching_matches_baseline():
@@ -177,7 +216,15 @@ def test_mamba_prefix_caching_dp_matches_baseline():
     _verify_mamba_prefix_caching(dp_size=2)
 
 
+def test_mamba_prefix_caching_with_tight_checkpoint_budget():
+    """Verify that with only the resident blocks per request (2 instead of the
+    default 8), eviction triggers in Mamba, the coordinator reconciles
+    min(L_attn, L_mamba), and generation remains bit-exact."""
+    _verify_mamba_prefix_caching(dp_size=1, multiplier=2)
+
+
 if __name__ == "__main__":
     # Child entry point for `_run_case`.
     dp = int(sys.argv[3]) if len(sys.argv) > 3 else 1
-    _generate(sys.argv[1], sys.argv[2], dp)
+    multiplier = int(sys.argv[4]) if len(sys.argv) > 4 else None
+    _generate(sys.argv[1], sys.argv[2], dp, multiplier=multiplier)

--- a/tests/platforms/test_tpu_platform.py
+++ b/tests/platforms/test_tpu_platform.py
@@ -306,6 +306,33 @@ class TestTpuPlatform:
     @patch(
         "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
     )
+    def test_check_and_update_config_rejects_mamba_cache_mode_all(
+            self, mock_update, mock_sharding, vllm_config):
+        """'all' keeps a state per block of the sequence, not per request.
+
+        The TPU pool is sized for resident state only, so accepting 'all'
+        would hand out block ids past the end of each layer's array -- which
+        JAX clips silently instead of raising. Fail at config time instead.
+        """
+        vllm_config.parallel_config.pipeline_parallel_size = 1
+        vllm_config.scheduler_config.is_multimodal_model = False
+        vllm_config.compilation_config.mode = "dummy"
+        vllm_config.compilation_config.backend = ""
+        vllm_config.model_config.is_hybrid = True
+        vllm_config.cache_config.enable_prefix_caching = True
+        vllm_config.cache_config.mamba_cache_mode = "all"
+        vllm_config.speculative_config = None
+
+        with pytest.raises(NotImplementedError,
+                           match="'all' is not supported on TPU"):
+            TpuPlatform.check_and_update_config(vllm_config)
+
+    @patch("tpu_inference.platforms.tpu_platform.envs.TPU_MULTIHOST_BACKEND",
+           "")
+    @patch("tpu_inference.platforms.tpu_platform.ShardingConfigManager")
+    @patch(
+        "tpu_inference.core.sched.dp_scheduler.update_vllm_config_for_dp_scheduler"
+    )
     def test_check_and_update_config_hybrid_prefix_match_unit_raises(
             self, mock_update, mock_sharding, vllm_config):
         vllm_config.parallel_config.pipeline_parallel_size = 1

--- a/tests/runner/test_kv_cache_manager.py
+++ b/tests/runner/test_kv_cache_manager.py
@@ -1329,29 +1329,23 @@ class TestKVCacheManager:
                                     *,
                                     attn_page,
                                     unpadded_mamba,
-                                    num_attn_groups=1,
-                                    num_mamba_groups=3,
                                     num_attn_layers=15,
-                                    num_mamba_layers=45,
-                                    group_size=15):
+                                    num_mamba_layers=45):
         """Helper: invoke `_maybe_set_compact_mamba_num_blocks_override` with
-        the Qwen3.5-shaped layer counts (15 attn + 45 mamba layers, grouped
-        into 1 attn group + 3 mamba groups, 15 layers per kv-cache group)."""
+        the Qwen3.5-shaped layer counts (15 attn + 45 mamba layers). Sizing is
+        expressed in layer counts, so it holds whether vLLM splits the mamba
+        layers into 3 groups or collapses them into 1."""
         manager._maybe_set_compact_mamba_num_blocks_override(
             attn_page_size_bytes=attn_page,
             unpadded_mamba_page_size_bytes=unpadded_mamba,
-            num_attn_groups=num_attn_groups,
-            num_mamba_groups=num_mamba_groups,
             num_attn_layers=num_attn_layers,
             num_mamba_layers=num_mamba_layers,
-            group_size=group_size,
         )
 
-    def test_compact_mamba_override_caps_mamba_at_max_num_reqs(self):
-        """With HBM available, compact-mamba caps each mamba layer at
-        `max_num_reqs + 1` slots (rounded up to the sharding divisor) and
-        sets `num_gpu_blocks_override` for the attention pool that fits
-        the remaining HBM."""
+    def test_compact_mamba_override_sizes_mamba_by_active_slots(self):
+        """Without prefix caching a request needs exactly one mamba slot, so
+        the pool is `max_num_reqs + 1` (the +1 is the null block) and the
+        attention pool takes every byte that is left."""
         from tpu_inference.runner.kv_cache_manager import KVCacheManager
         manager = KVCacheManager(self.runner)
         manager.use_mla = False  # divisor is computed from ATTN_DATA.
@@ -1364,6 +1358,7 @@ class TestKVCacheManager:
 
         self.runner.cache_config.gpu_memory_utilization = 1.0
         self.runner.cache_config.num_gpu_blocks_override = None
+        self.runner.model_config.max_model_len = 2048
         self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
         self.runner.max_num_reqs = max_num_reqs
 
@@ -1374,13 +1369,11 @@ class TestKVCacheManager:
                                              attn_page=attn_page,
                                              unpadded_mamba=unpadded_mamba)
 
-        # Mamba is capped at max_num_reqs + 1 (the +1 is the null block).
         assert manager._mamba_num_blocks == max_num_reqs + 1
         # Attention pool is sized to fill the remaining per-tensor budget.
         # group_size=15 ⇒ avail_per_tensor = 304 GiB / 15.
         # mamba_per_tensor = 3 × 257 × 4 MiB.
-        # attn_per_tensor = avail_per_tensor − mamba_per_tensor.
-        # N_attn = attn_per_tensor / (1 × 1 MiB), divisor=1.
+        # N_attn = (avail_per_tensor − mamba_per_tensor) / (1 × 1 MiB).
         avail_per_tensor = (304 * 2**30) // 15
         expected_attn = (avail_per_tensor - 3 *
                          (max_num_reqs + 1) * unpadded_mamba) // attn_page
@@ -1412,15 +1405,19 @@ class TestKVCacheManager:
         assert manager._mamba_num_blocks is None
         assert self.runner.cache_config.num_gpu_blocks_override is None
 
-    def test_compact_mamba_override_respects_user_pinned_override(self):
-        """When the user pins `num_gpu_blocks_override` explicitly,
-        compact-mamba must not clobber it (their explicit choice wins)."""
+    def test_compact_mamba_override_keeps_pinned_attention_pool(self):
+        """A user-pinned `num_gpu_blocks_override` is the attention pool's
+        size, full stop. Mamba is still sized compactly around it — its slots
+        are per-request, so handing it the pinned attention count instead
+        would burn HBM on slots no request can reach."""
         from tpu_inference.runner.kv_cache_manager import KVCacheManager
         manager = KVCacheManager(self.runner)
         manager.use_mla = False
         manager._hybrid_uniform_page_size_bytes = 2**20
 
+        self.runner.cache_config.gpu_memory_utilization = 1.0
         self.runner.cache_config.num_gpu_blocks_override = 999
+        self.runner.model_config.max_model_len = 2048
         self.runner.scheduler_config = MagicMock(max_num_seqs=256)
         self.runner.max_num_reqs = 256
 
@@ -1431,10 +1428,266 @@ class TestKVCacheManager:
                                              attn_page=2**20,
                                              unpadded_mamba=4 * 2**20)
 
-        # User's override survives; mamba sizing is left alone so
-        # `initialize_kv_cache` allocates the uniform `num_blocks`.
-        assert manager._mamba_num_blocks is None
         assert self.runner.cache_config.num_gpu_blocks_override == 999
+        assert manager._mamba_num_blocks == 257
+
+    def test_compact_mamba_override_align_mode_default_multiplier(self):
+        """In align mode a request gets `DEFAULT_MAMBA_CACHE_MULTIPLIER`
+        mamba blocks — one to generate from, the rest to checkpoint prefixes
+        into — and the attention pool takes the remaining HBM."""
+        from tpu_inference.runner.kv_cache_manager import (
+            DEFAULT_MAMBA_CACHE_MULTIPLIER, KVCacheManager)
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        total_hbm = 800 * (2**30)
+        attn_page = 2**20
+        unpadded_mamba = 2 * (2**20)
+        max_num_reqs = 256
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = None
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.model_config.max_model_len = 2048
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, total_hbm // 4)] * 4):
+            self._run_compact_mamba_override(manager,
+                                             attn_page=attn_page,
+                                             unpadded_mamba=unpadded_mamba)
+
+        expected_mamba = max_num_reqs * DEFAULT_MAMBA_CACHE_MULTIPLIER + 1
+        assert manager._mamba_num_blocks == expected_mamba
+        assert self.runner.cache_config.mamba_num_blocks == expected_mamba
+
+        avail_per_tensor = total_hbm // 15
+        expected_attn = (avail_per_tensor -
+                         3 * expected_mamba * unpadded_mamba) // attn_page
+        assert (
+            self.runner.cache_config.num_gpu_blocks_override == expected_attn)
+
+    def test_compact_mamba_override_align_mode_custom_multiplier(self):
+        """`custom_mamba_cache_multiplier` replaces the default blocks per
+        request."""
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        total_hbm = 800 * (2**30)
+        attn_page = 2**20
+        unpadded_mamba = 2 * (2**20)
+        max_num_reqs = 256
+        multiplier = 3
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = None
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.model_config.max_model_len = 2048
+        self.runner.vllm_config.additional_config[
+            "custom_mamba_cache_multiplier"] = multiplier
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, total_hbm // 4)] * 4):
+            self._run_compact_mamba_override(manager,
+                                             attn_page=attn_page,
+                                             unpadded_mamba=unpadded_mamba)
+
+        expected_mamba = max_num_reqs * multiplier + 1
+        assert manager._mamba_num_blocks == expected_mamba
+        assert self.runner.cache_config.mamba_num_blocks == expected_mamba
+
+    def test_compact_mamba_override_align_mode_rebalances_over_budget(self):
+        """When the two pools together burst HBM, the one that can serve more
+        concurrent requests is scaled down. Here the mamba pool is sized for
+        every request in the batch while the attention pool can only back a
+        fraction of them, so mamba gives HBM back until both pools serve the
+        same number of requests."""
+        from tpu_inference.runner.kv_cache_manager import (
+            DEFAULT_MAMBA_CACHE_MULTIPLIER, KVCacheManager)
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        total_hbm = 304 * (2**30)
+        attn_page = 2**20
+        unpadded_mamba = 2 * (2**20)
+        max_num_reqs = 256
+        max_model_len = 2048
+        block_size = self.runner.cache_config.block_size  # 16
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = None
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.model_config.max_model_len = max_model_len
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, total_hbm // 4)] * 4):
+            self._run_compact_mamba_override(manager,
+                                             attn_page=attn_page,
+                                             unpadded_mamba=unpadded_mamba)
+
+        # Per-request cost: a full-length request needs
+        # max_model_len / block_size attention blocks and
+        # DEFAULT_MAMBA_CACHE_MULTIPLIER mamba blocks (× 3 mamba groups).
+        avail_per_tensor = total_hbm // 15
+        attn_blocks_per_req = max_model_len // block_size
+        servable_reqs = avail_per_tensor // (
+            attn_blocks_per_req * attn_page +
+            DEFAULT_MAMBA_CACHE_MULTIPLIER * 3 * unpadded_mamba)
+        expected_mamba = servable_reqs * DEFAULT_MAMBA_CACHE_MULTIPLIER + 1
+        expected_attn = (avail_per_tensor -
+                         3 * expected_mamba * unpadded_mamba) // attn_page
+
+        assert servable_reqs < max_num_reqs  # the case under test
+        assert manager._mamba_num_blocks == expected_mamba
+        assert (
+            self.runner.cache_config.num_gpu_blocks_override == expected_attn)
+        # Both pools now back roughly the same number of concurrent requests.
+        assert abs(expected_attn // attn_blocks_per_req -
+                   expected_mamba // DEFAULT_MAMBA_CACHE_MULTIPLIER) <= 1
+
+    def test_compact_mamba_override_raises_when_mamba_floor_eats_the_budget(
+            self):
+        """No usable fallback exists once mamba's floor takes everything.
+
+        Returning without sizing leaves `_mamba_num_blocks` unset, and align
+        mode then sizes the mamba arrays at the *attention* pool -- the
+        over-allocation this pass exists to prevent. The engine would die in a
+        JAX allocation with no hint of the cause, so raise here instead.
+        """
+        import pytest
+
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        # 8 requests need 2 resident blocks each in align mode; at 3 mamba
+        # groups' worth of layers that alone exceeds the tiny budget.
+        total_hbm = 64 * (2**20)
+        max_num_reqs = 8
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = None
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.model_config.max_model_len = 2048
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, total_hbm // 4)] * 4):
+            with pytest.raises(ValueError, match="Cannot fit both KV pools"):
+                self._run_compact_mamba_override(manager,
+                                                 attn_page=2**20,
+                                                 unpadded_mamba=2 * (2**20))
+
+    def test_compact_mamba_override_align_mode_floors_at_resident_slots(self):
+        """The re-split never takes mamba below what the active batch needs
+        resident: `2 + num_spec` blocks per request in align mode, matching
+        vLLM's own `MambaSpec.max_memory_usage_bytes` accounting."""
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        # 2000 MiB per tensor: far too little to give every request 8 mamba
+        # blocks (that alone would cost 513 × 3 × 2 MiB) plus an attention
+        # pool, so the re-split runs and bottoms out at the floor.
+        total_hbm = 2000 * (2**20) * 15
+        attn_page = 2**20
+        unpadded_mamba = 2 * (2**20)
+        max_num_reqs = 64
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = None
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.model_config.max_model_len = 2048
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, total_hbm // 4)] * 4):
+            self._run_compact_mamba_override(manager,
+                                             attn_page=attn_page,
+                                             unpadded_mamba=unpadded_mamba)
+
+        # 2 resident blocks per request + the null block.
+        assert manager._mamba_num_blocks == 2 * max_num_reqs + 1
+        assert self.runner.cache_config.num_gpu_blocks_override > 0
+
+    def test_compact_mamba_override_align_mode_pinned_attention_shrinks_mamba(
+            self):
+        """With attention pinned, mamba takes whatever HBM is left over —
+        the user's pin is not overridden."""
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        # avail_per_tensor = 2000 MiB, pinned attention costs 500 MiB, so
+        # mamba gets 1500 MiB / (3 groups × 2 MiB) = 250 blocks — less than
+        # the 8 × 64 + 1 = 513 it would ask for.
+        total_hbm = 2000 * (2**20) * 15
+        attn_page = 2**20
+        unpadded_mamba = 2 * (2**20)
+        max_num_reqs = 64
+        pinned_attn = 500
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = pinned_attn
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.model_config.max_model_len = 2048
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, total_hbm // 4)] * 4):
+            self._run_compact_mamba_override(manager,
+                                             attn_page=attn_page,
+                                             unpadded_mamba=unpadded_mamba)
+
+        assert manager._mamba_num_blocks == 250
+        assert self.runner.cache_config.mamba_num_blocks == 250
+        assert self.runner.cache_config.num_gpu_blocks_override == pinned_attn
+
+    def test_compact_mamba_override_pinned_attention_exceeding_hbm_raises(
+            self):
+        """A pinned attention pool that leaves no room for even the resident
+        mamba slots is a configuration error, not something to silently
+        shrink around."""
+        import pytest
+
+        from tpu_inference.runner.kv_cache_manager import KVCacheManager
+        manager = KVCacheManager(self.runner)
+        manager.use_mla = False
+
+        avail_per_device = 10 * (2**30) // 4  # 10 GiB total HBM
+        attn_page = 2**20
+        unpadded_mamba = 2 * (2**20)
+        max_num_reqs = 256
+
+        self.runner.cache_config.gpu_memory_utilization = 1.0
+        self.runner.cache_config.num_gpu_blocks_override = 100_000  # huge
+        self.runner.cache_config.mamba_cache_mode = "align"
+        self.runner.model_config.max_model_len = 2048
+        self.runner.scheduler_config = MagicMock(max_num_seqs=max_num_reqs)
+        self.runner.max_num_reqs = max_num_reqs
+
+        with patch(
+                "tpu_inference.runner.kv_cache_manager.utils.hbm_usage_bytes",
+                return_value=[(0, avail_per_device)] * 4):
+            with pytest.raises(ValueError, match="exceeds available HBM"):
+                self._run_compact_mamba_override(manager,
+                                                 attn_page=attn_page,
+                                                 unpadded_mamba=unpadded_mamba)
 
     def test_get_kv_cache_spec_pure_attention_no_cache_config_updates(self):
         mock_attn = MagicMock(spec=MambaBase)

--- a/tpu_inference/core/hybrid_coordinator.py
+++ b/tpu_inference/core/hybrid_coordinator.py
@@ -1,0 +1,633 @@
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Iterable, Sequence
+from typing import Any
+
+from vllm.v1.core.block_pool import BlockPool
+from vllm.v1.core.kv_cache_coordinator import (HybridKVCacheCoordinator,
+                                               KVCacheCoordinator)
+from vllm.v1.core.kv_cache_coordinator import \
+    get_kv_cache_coordinator as orig_get_kv_cache_coordinator
+from vllm.v1.core.kv_cache_manager import KVCacheBlocks, KVCacheManager
+from vllm.v1.core.kv_cache_utils import BlockHash, KVCacheBlock
+from vllm.v1.core.single_type_kv_cache_manager import (
+    CrossAttentionManager, get_manager_for_kv_cache_spec)
+from vllm.v1.kv_cache_interface import KVCacheConfig, MambaSpec
+from vllm.v1.request import Request, RequestStatus
+
+from tpu_inference.logger import init_logger
+
+logger = init_logger(__name__)
+
+# ==============================================================================
+# Decoupled Mamba Block Capacity Lifecycle:
+# ------------------------------------------------------------------------------
+# 1. PRODUCER (tpu_inference/runner/kv_cache_manager.py):
+#    During device HBM memory profiling, KVCacheManager calculates the physical
+#    compact Mamba block capacity and writes it to two places:
+#      - cache_config.mamba_num_blocks = int(mamba_num_blocks)
+#      - set_mamba_num_blocks(int(mamba_num_blocks))
+#
+# 2. PARTITIONER / PROPAGATION:
+#    - DP Serving (tpu_inference/core/sched/dp_scheduler.py):
+#      DPScheduler reads the total capacity from `vllm_config.cache_config.mamba_num_blocks`
+#      and shards it per rank:
+#        rank_kv_config.num_blocks = kv_cache_config.num_blocks // dp_size
+#        rank_kv_config.mamba_num_blocks = mamba_num_blocks // dp_size
+#      In the worker subprocess (_scheduler_worker_process), each rank sets:
+#        set_mamba_num_blocks(kv_cache_config.mamba_num_blocks)
+#        cache_config.mamba_num_blocks = kv_cache_config.mamba_num_blocks
+#    - Non-DP Serving (DP=1):
+#      Runs in the same process where KVCacheManager registered the total capacity via
+#      set_mamba_num_blocks().
+#
+# 3. CONSUMER (TPUHybridKVCacheCoordinator):
+#    Resolves mamba_num_blocks directly from get_mamba_num_blocks() (or an explicit
+#    argument) and initializes an independent Mamba BlockPool, failing fast if not set.
+# ==============================================================================
+_HOOKS_INSTALLED: bool = False
+_GLOBAL_MAMBA_NUM_BLOCKS: int | None = None
+
+
+def set_mamba_num_blocks(num_blocks: int) -> None:
+    """Register the TPU runner's computed Mamba block pool capacity."""
+    global _GLOBAL_MAMBA_NUM_BLOCKS
+    _GLOBAL_MAMBA_NUM_BLOCKS = int(num_blocks)
+
+
+def get_mamba_num_blocks() -> int | None:
+    """Get the registered Mamba block pool capacity."""
+    return _GLOBAL_MAMBA_NUM_BLOCKS
+
+
+def is_mamba_spec(spec: Any) -> bool:
+    """Check if a KV cache spec represents a Mamba layer."""
+    if isinstance(spec, MambaSpec):
+        return True
+    if hasattr(spec, "kv_cache_specs"):
+        return any(
+            isinstance(s, MambaSpec) for s in spec.kv_cache_specs.values())
+    return False
+
+
+def is_mamba_group(group: Any) -> bool:
+    """Check if a KV cache group contains Mamba layers."""
+    spec = getattr(group, "kv_cache_spec", group)
+    return is_mamba_spec(spec)
+
+
+class MambaBlockPool(BlockPool):
+    """The decoupled mamba pool, shared by every mamba kv-cache group.
+
+    When there is more than one mamba group the coordinator mirrors them onto
+    this pool's ids (see MirrorMambaBlockPool), and `primary_group_id` is the
+    group those shared cache entries are keyed to.
+    """
+
+    def __init__(self, *args, primary_group_id: int | None = None, **kwargs):
+        super().__init__(*args, **kwargs)
+        # When mamba groups are mirrored, every group's cache entry is keyed
+        # to this one group id
+        self.primary_group_id = primary_group_id
+        # A one-slot buffer holding the block the
+        # primary mamba group most recently pulled off the free queue
+        self._last_allocation: list[KVCacheBlock] = []
+
+    def replay_last_allocation(self, num_blocks: int) -> list[KVCacheBlock]:
+        """Hand a mirrored group the ids the primary group just allocated."""
+        if num_blocks != len(self._last_allocation):
+            raise AssertionError(
+                f"Mirrored mamba group asked for {num_blocks} blocks but the "
+                f"primary group just allocated {len(self._last_allocation)}. "
+                f"The groups are no longer in lockstep; mirroring would alias "
+                f"unrelated state.")
+        for block in self._last_allocation:
+            block.ref_cnt += 1
+        return list(self._last_allocation)
+
+    def _canonical_group_ids(self, kv_cache_group_ids: list[int]) -> list[int]:
+        if self.primary_group_id is None:
+            return kv_cache_group_ids
+        return [self.primary_group_id] * len(kv_cache_group_ids)
+
+    def get_new_blocks(self, num_blocks: int) -> list[KVCacheBlock]:
+        blocks = super().get_new_blocks(num_blocks)
+        self._last_allocation = list(blocks)
+        return blocks
+
+    def get_cached_block(self, block_hash: BlockHash,
+                         kv_cache_group_ids: list[int]):
+        return super().get_cached_block(
+            block_hash, self._canonical_group_ids(kv_cache_group_ids))
+
+
+class MirrorMambaBlockPool:
+    """A secondary mamba group's view of the primary group's block pool.
+    """
+
+    def __init__(self, primary: MambaBlockPool):
+        self._primary = primary
+
+    def __getattr__(self, name: str) -> Any:
+        return getattr(self._primary, name)
+
+    def get_new_blocks(self, num_blocks: int) -> list[KVCacheBlock]:
+        return self._primary.replay_last_allocation(num_blocks)
+
+    def cache_full_blocks(self, *args, **kwargs) -> None:
+        # The primary group cached these blocks under the shared key already
+        return None
+
+
+class TPUDualBlockPool(BlockPool):
+    """A composite BlockPool that coordinates separate Attention and Mamba pools.
+
+    This ensures that:
+    - Attention and Mamba managers allocate from distinct physical pools with decoupled sizes.
+    - Freeing, evicting, and touching blocks routes each block to its originating pool without cross-contamination.
+    - Any external consumer accessing block_pool from KVCacheManager or scheduler sees a coherent BlockPool interface.
+    """
+
+    def __init__(
+        self,
+        attention_pool: BlockPool,
+        mamba_pool: BlockPool,
+        mamba_group_ids: set[int] | None = None,
+    ):
+        self.attention_pool = attention_pool
+        self.mamba_pool = mamba_pool
+        self.mamba_group_ids = mamba_group_ids or set()
+        self.mamba_block_identities: set[int] = {
+            id(b)
+            for b in mamba_pool.blocks
+        }
+
+        # Mirror essential attributes from attention_pool (primary pool)
+        self.num_gpu_blocks = attention_pool.num_gpu_blocks
+        self.enable_caching = attention_pool.enable_caching
+        self.hash_block_size = attention_pool.hash_block_size
+        self.enable_kv_cache_events = attention_pool.enable_kv_cache_events
+        self.metrics_collector = attention_pool.metrics_collector
+        self.null_block = attention_pool.null_block
+        self.blocks = attention_pool.blocks
+        self.free_block_queue = attention_pool.free_block_queue
+        self.cached_block_hash_to_block = attention_pool.cached_block_hash_to_block
+        self.cached_block_hashes_by_block = attention_pool.cached_block_hashes_by_block
+        self.kv_event_queue = attention_pool.kv_event_queue
+
+    def free_blocks(self, ordered_blocks: Iterable[KVCacheBlock]) -> None:
+        attn_blocks: list[KVCacheBlock] = []
+        mamba_blocks: list[KVCacheBlock] = []
+        for block in ordered_blocks:
+            if id(block) in self.mamba_block_identities:
+                mamba_blocks.append(block)
+            else:
+                attn_blocks.append(block)
+        if attn_blocks:
+            self.attention_pool.free_blocks(attn_blocks)
+        if mamba_blocks:
+            self.mamba_pool.free_blocks(mamba_blocks)
+
+    def touch(self, blocks: Sequence[KVCacheBlock]) -> None:
+        attn_blocks: list[KVCacheBlock] = []
+        mamba_blocks: list[KVCacheBlock] = []
+        for block in blocks:
+            if id(block) in self.mamba_block_identities:
+                mamba_blocks.append(block)
+            else:
+                attn_blocks.append(block)
+        if attn_blocks:
+            self.attention_pool.touch(attn_blocks)
+        if mamba_blocks:
+            self.mamba_pool.touch(mamba_blocks)
+
+    def get_num_free_blocks(self) -> int:
+        return self.attention_pool.get_num_free_blocks()
+
+    def get_usage(self) -> float:
+        return max(self.attention_pool.get_usage(),
+                   self.mamba_pool.get_usage())
+
+    def reset_prefix_cache(self) -> bool:
+        r1 = self.attention_pool.reset_prefix_cache()
+        r2 = self.mamba_pool.reset_prefix_cache()
+        return r1 and r2
+
+    def take_events(self):
+        return self.attention_pool.take_events() + self.mamba_pool.take_events(
+        )
+
+    def evict_blocks(self, block_ids: set[int]) -> None:
+        """Evict invalid blocks from cache on KV transfer failures.
+
+        Note: Block IDs are assumed to belong to attention_pool, as external
+        KV transfer load failures only apply to Attention KV cache.
+        """
+        attn_ids = {
+            bid
+            for bid in block_ids if bid < len(self.attention_pool.blocks)
+        }
+        if attn_ids:
+            self.attention_pool.evict_blocks(attn_ids)
+
+    def get_cached_block(
+            self, block_hash: BlockHash,
+            kv_cache_group_ids: list[int]) -> list[KVCacheBlock] | None:
+        cached_blocks: list[KVCacheBlock] = []
+        for gid in kv_cache_group_ids:
+            pool = (self.mamba_pool
+                    if gid in self.mamba_group_ids else self.attention_pool)
+            block = pool.get_cached_block(block_hash, [gid])
+            if not block:
+                return None
+            cached_blocks.extend(block)
+        return cached_blocks
+
+
+class TPUHybridKVCacheCoordinator(HybridKVCacheCoordinator):
+    """Decoupled KV cache coordinator for hybrid models under Mamba align mode on TPU.
+
+    Attention layers use a large pool (e.g. ~34,000 blocks) to maximize context length
+    and concurrency, while Mamba layers use a dedicated, compact pool (e.g. 2,048 blocks)
+    for active recurrent states and prefix checkpoints.
+    Prefix cache hits are independently queried from each pool and reconciled via min(),
+    preventing any cache eviction desync.
+    """
+
+    def __init__(
+        self,
+        kv_cache_config: KVCacheConfig,
+        *args,
+        mamba_num_blocks: int | None = None,
+        **kwargs,
+    ):
+        super().__init__(kv_cache_config, *args, **kwargs)
+
+        # Base __init__ initialized self.block_pool with kv_cache_config.num_blocks (Attention pool)
+        self.attention_block_pool = self.block_pool
+
+        # Identify Mamba and Attention group IDs
+        self.mamba_group_ids = {
+            i
+            for i, g in enumerate(kv_cache_config.kv_cache_groups)
+            if is_mamba_group(g)
+        }
+        self.attention_group_ids = {
+            i
+            for i, g in enumerate(kv_cache_config.kv_cache_groups)
+            if not is_mamba_group(g)
+        }
+
+        assert len(self.mamba_group_ids) > 0, (
+            f"[TPUHybridKVCacheCoordinator] No Mamba groups identified in "
+            f"kv_cache_groups: {kv_cache_config.kv_cache_groups}")
+
+        # Resolve mamba_num_blocks
+        if mamba_num_blocks is None:
+            mamba_num_blocks = get_mamba_num_blocks()
+        if mamba_num_blocks is None:
+            raise ValueError(
+                "[TPUHybridKVCacheCoordinator] mamba_num_blocks must be registered "
+                "via set_mamba_num_blocks().")
+        self.mamba_num_blocks = int(mamba_num_blocks)
+
+        logger.info(
+            "[TPUHybridKVCacheCoordinator] Initializing dual block pools: "
+            "attn_blocks=%d, mamba_blocks=%d (mamba_groups=%s)",
+            self.attention_block_pool.num_gpu_blocks,
+            self.mamba_num_blocks,
+            sorted(self.mamba_group_ids),
+        )
+        self.mirror_mamba_groups = len(self.mamba_group_ids) > 1
+        self.primary_mamba_group_id = min(self.mamba_group_ids)
+
+        # Allocate dedicated Mamba block pool
+        self.mamba_block_pool = MambaBlockPool(
+            num_gpu_blocks=self.mamba_num_blocks,
+            enable_caching=self.enable_caching,
+            hash_block_size=self.hash_block_size,
+            enable_kv_cache_events=self.attention_block_pool.
+            enable_kv_cache_events,
+            metrics_collector=self.attention_block_pool.metrics_collector,
+            primary_group_id=(self.primary_mamba_group_id
+                              if self.mirror_mamba_groups else None),
+        )
+        self._mirror_pool = (MirrorMambaBlockPool(self.mamba_block_pool)
+                             if self.mirror_mamba_groups else None)
+        if self.mirror_mamba_groups:
+            logger.info(
+                "[TPUHybridKVCacheCoordinator] Mirroring %d mamba groups onto "
+                "group %d's block ids: the %d-block pool now holds %d "
+                "checkpoints instead of %d.", len(self.mamba_group_ids),
+                self.primary_mamba_group_id, self.mamba_num_blocks,
+                self.mamba_num_blocks,
+                self.mamba_num_blocks // len(self.mamba_group_ids))
+
+        # Unify null_block instance across both pools so TPUDualBlockPool,
+        # attention pool, and Mamba managers share the exact same null block.
+        self.mamba_block_pool.null_block = self.attention_block_pool.null_block
+
+        # Re-bind Mamba managers to mamba_block_pool
+        new_managers = list(self.single_type_managers)
+        for i in self.mamba_group_ids:
+            old_mgr = self.single_type_managers[i]
+            pool = self.mamba_block_pool
+            if self.mirror_mamba_groups and i != self.primary_mamba_group_id:
+                pool = self._mirror_pool
+            new_managers[i] = get_manager_for_kv_cache_spec(
+                kv_cache_spec=kv_cache_config.kv_cache_groups[i].kv_cache_spec,
+                max_in_flight_tokens=getattr(old_mgr, "max_in_flight_tokens",
+                                             128),
+                max_model_len=self.max_model_len,
+                block_pool=pool,
+                enable_caching=self.enable_caching,
+                kv_cache_group_id=i,
+                dcp_world_size=getattr(self, "dcp_world_size", 1),
+                pcp_world_size=getattr(self, "pcp_world_size", 1),
+                scheduler_block_size=self.scheduler_block_size,
+                needs_kv_cache_zeroing=self.kv_cache_config.
+                needs_kv_cache_zeroing,
+            )
+        self.single_type_managers = tuple(new_managers)
+
+        for i in self.mamba_group_ids:
+            expected = self.mamba_block_pool
+            if self.mirror_mamba_groups and i != self.primary_mamba_group_id:
+                expected = self._mirror_pool
+            assert self.single_type_managers[i].block_pool is expected, (
+                f"Manager {i} block_pool was not re-bound to the mamba pool!")
+        for i in self.attention_group_ids:
+            assert self.single_type_managers[
+                i].block_pool is self.attention_block_pool, (
+                    f"Manager {i} block_pool is not attention_block_pool!")
+
+        # Replace self.block_pool with TPUDualBlockPool
+        self.block_pool = TPUDualBlockPool(
+            self.attention_block_pool,
+            self.mamba_block_pool,
+            mamba_group_ids=self.mamba_group_ids,
+        )
+
+        # Re-verify and split groups so attention_groups binds to updated managers
+        self.verify_and_split_kv_cache_groups()
+
+    def can_allocate_tokens(
+        self,
+        request: Request,
+        num_tokens: int,
+        new_computed_blocks: tuple[Sequence[KVCacheBlock], ...],
+        num_encoder_tokens: int,
+        total_computed_tokens: int,
+        num_local_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+        watermark_blocks: int = 0,
+        reserved_blocks: int = 0,
+    ) -> bool:
+        attn_blocks_needed = 0
+        mamba_blocks_needed = 0
+
+        for i, manager in enumerate(self.single_type_managers):
+            is_mamba = i in self.mamba_group_ids
+            if isinstance(manager, CrossAttentionManager):
+                needed = manager.get_num_blocks_to_allocate(
+                    request.request_id,
+                    num_encoder_tokens,
+                    [],
+                    0,
+                    0,
+                    num_encoder_tokens,
+                    apply_admission_cap=apply_admission_cap,
+                )
+            else:
+                needed = manager.get_num_blocks_to_allocate(
+                    request.request_id,
+                    num_tokens,
+                    new_computed_blocks[i],
+                    total_computed_tokens,
+                    num_local_computed_tokens,
+                    num_tokens_main_model,
+                    apply_admission_cap=apply_admission_cap,
+                )
+
+            if is_mamba:
+                # Mirrored groups reuse the primary's ids
+                if (self.mirror_mamba_groups
+                        and i != self.primary_mamba_group_id):
+                    continue
+                mamba_blocks_needed += needed
+            else:
+                attn_blocks_needed += needed
+
+        avail_attn = (self.attention_block_pool.get_num_free_blocks() -
+                      reserved_blocks)
+        if attn_blocks_needed + watermark_blocks > avail_attn:
+            return False
+
+        avail_mamba = self.mamba_block_pool.get_num_free_blocks()
+        if mamba_blocks_needed > avail_mamba:
+            return False
+
+        return True
+
+    def get_num_blocks_to_allocate(
+        self,
+        request_id: str,
+        num_tokens: int,
+        new_computed_blocks: tuple[Sequence[KVCacheBlock], ...],
+        num_encoder_tokens: int,
+        total_computed_tokens: int,
+        num_local_computed_tokens: int,
+        num_tokens_main_model: int,
+        apply_admission_cap: bool = False,
+    ) -> int:
+        """Returns attention blocks needed. Used by scheduler for in-flight prefill reservation."""
+        num_blocks_to_allocate = 0
+        for i, manager in enumerate(self.single_type_managers):
+            if i in self.mamba_group_ids:
+                continue
+            if isinstance(manager, CrossAttentionManager):
+                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+                    request_id,
+                    num_encoder_tokens,
+                    [],
+                    0,
+                    0,
+                    num_encoder_tokens,
+                    apply_admission_cap=apply_admission_cap,
+                )
+            else:
+                num_blocks_to_allocate += manager.get_num_blocks_to_allocate(
+                    request_id,
+                    num_tokens,
+                    new_computed_blocks[i],
+                    total_computed_tokens,
+                    num_local_computed_tokens,
+                    num_tokens_main_model,
+                    apply_admission_cap=apply_admission_cap,
+                )
+        return num_blocks_to_allocate
+
+
+class TPUKVCacheManager(KVCacheManager):
+    """KVCacheManager subclass that coordinates allocation across decoupled pools."""
+
+    def allocate_slots(
+        self,
+        request: Request,
+        num_new_tokens: int,
+        num_new_computed_tokens: int = 0,
+        new_computed_blocks: KVCacheBlocks | None = None,
+        num_lookahead_tokens: int = 0,
+        num_external_computed_tokens: int = 0,
+        delay_cache_blocks: bool = False,
+        num_encoder_tokens: int = 0,
+        full_sequence_must_fit: bool = False,
+        reserved_blocks: int = 0,
+        has_scheduled_reqs: bool = True,
+    ) -> KVCacheBlocks | None:
+        if not isinstance(self.coordinator, TPUHybridKVCacheCoordinator):
+            return super().allocate_slots(
+                request=request,
+                num_new_tokens=num_new_tokens,
+                num_new_computed_tokens=num_new_computed_tokens,
+                new_computed_blocks=new_computed_blocks,
+                num_lookahead_tokens=num_lookahead_tokens,
+                num_external_computed_tokens=num_external_computed_tokens,
+                delay_cache_blocks=delay_cache_blocks,
+                num_encoder_tokens=num_encoder_tokens,
+                full_sequence_must_fit=full_sequence_must_fit,
+                reserved_blocks=reserved_blocks,
+                has_scheduled_reqs=has_scheduled_reqs,
+            )
+
+        if num_new_tokens == 0 and num_external_computed_tokens == 0:
+            raise ValueError(
+                "num_new_tokens must be greater than 0 when there are no "
+                "external computed tokens")
+
+        if new_computed_blocks is not None:
+            new_computed_block_list = new_computed_blocks.blocks
+        else:
+            new_computed_block_list = self.empty_kv_cache_blocks.blocks
+
+        num_local_computed_tokens = (request.num_computed_tokens +
+                                     num_new_computed_tokens)
+        total_computed_tokens = min(
+            num_local_computed_tokens + num_external_computed_tokens,
+            self.max_model_len,
+        )
+
+        watermark_blocks = 0
+        if has_scheduled_reqs and request.status in (
+                RequestStatus.WAITING,
+                RequestStatus.PREEMPTED,
+        ):
+            watermark_blocks = self.watermark_blocks
+
+        if full_sequence_must_fit:
+            full_num_tokens = min(request.num_tokens, self.max_model_len)
+            can_fit = self.coordinator.can_allocate_tokens(
+                request=request,
+                num_tokens=full_num_tokens,
+                new_computed_blocks=new_computed_block_list,
+                num_encoder_tokens=num_encoder_tokens,
+                total_computed_tokens=total_computed_tokens,
+                num_local_computed_tokens=num_local_computed_tokens,
+                num_tokens_main_model=full_num_tokens,
+                apply_admission_cap=True,
+                watermark_blocks=watermark_blocks,
+                reserved_blocks=0,
+            )
+            if not can_fit:
+                return None
+
+        num_tokens_main_model = total_computed_tokens + num_new_tokens
+        num_tokens_need_slot = min(
+            num_tokens_main_model + num_lookahead_tokens, self.max_model_len)
+
+        self.coordinator.remove_skipped_blocks(
+            request.request_id,
+            max(0, total_computed_tokens - request.num_in_flight_tokens),
+            num_prompt_tokens=request.num_prompt_tokens,
+        )
+
+        can_fit = self.coordinator.can_allocate_tokens(
+            request=request,
+            num_tokens=num_tokens_need_slot,
+            new_computed_blocks=new_computed_block_list,
+            num_encoder_tokens=num_encoder_tokens,
+            total_computed_tokens=num_local_computed_tokens +
+            num_external_computed_tokens,
+            num_local_computed_tokens=num_local_computed_tokens,
+            num_tokens_main_model=num_tokens_main_model,
+            apply_admission_cap=False,
+            watermark_blocks=watermark_blocks,
+            reserved_blocks=reserved_blocks,
+        )
+        if not can_fit:
+            return None
+
+        if (new_computed_block_list is not self.empty_kv_cache_blocks.blocks
+                or num_external_computed_tokens > 0):
+            self.coordinator.allocate_new_computed_blocks(
+                request_id=request.request_id,
+                new_computed_blocks=new_computed_block_list,
+                num_local_computed_tokens=num_local_computed_tokens,
+                num_external_computed_tokens=num_external_computed_tokens,
+            )
+
+        new_blocks = self.coordinator.allocate_new_blocks(
+            request.request_id,
+            num_tokens_need_slot,
+            num_tokens_main_model,
+            num_encoder_tokens,
+        )
+
+        if not self.enable_caching or delay_cache_blocks:
+            return self.create_kv_cache_blocks(new_blocks)
+
+        num_tokens_to_cache = min(
+            total_computed_tokens + num_new_tokens,
+            request.num_tokens,
+        )
+        self.coordinator.cache_blocks(request, num_tokens_to_cache)
+
+        return self.create_kv_cache_blocks(new_blocks)
+
+
+def tpu_get_kv_cache_coordinator(
+    kv_cache_config: KVCacheConfig,
+    *args,
+    **kwargs,
+) -> KVCacheCoordinator:
+    enable_caching = kwargs.get("enable_caching", False)
+    has_mamba = any(is_mamba_group(g) for g in kv_cache_config.kv_cache_groups)
+    if enable_caching and has_mamba:
+        return TPUHybridKVCacheCoordinator(kv_cache_config, *args, **kwargs)
+    return orig_get_kv_cache_coordinator(kv_cache_config, *args, **kwargs)
+
+
+def install_hybrid_coordinator_hooks(vllm_config: Any | None = None) -> None:
+    """Installs hooks into vLLM to use TPUHybridKVCacheCoordinator and TPUKVCacheManager."""
+    global _HOOKS_INSTALLED
+    import sys
+
+    import vllm.v1.core.kv_cache_coordinator as coord_mod
+    import vllm.v1.core.kv_cache_manager as mgr_mod
+
+    coord_mod.get_kv_cache_coordinator = tpu_get_kv_cache_coordinator
+    mgr_mod.get_kv_cache_coordinator = tpu_get_kv_cache_coordinator
+    mgr_mod.KVCacheManager = TPUKVCacheManager
+
+    if "vllm.v1.core.sched.scheduler" in sys.modules:
+        sys.modules[
+            "vllm.v1.core.sched.scheduler"].KVCacheManager = TPUKVCacheManager
+    if "vllm.v1.core.sched.async_scheduler" in sys.modules:
+        sys.modules[
+            "vllm.v1.core.sched.async_scheduler"].KVCacheManager = TPUKVCacheManager
+
+    _HOOKS_INSTALLED = True
+    logger.info(
+        "[tpu_inference] Installed TPUHybridKVCacheCoordinator hooks into vLLM"
+    )

--- a/tpu_inference/core/sched/dp_scheduler.py
+++ b/tpu_inference/core/sched/dp_scheduler.py
@@ -159,6 +159,16 @@ def _scheduler_worker_process(
     import gc
     atexit._clear()
     gc.enable()
+    cache_config = getattr(vllm_config, "cache_config", None)
+    if getattr(cache_config, "mamba_cache_mode", "none") == "align":
+        from tpu_inference.core.hybrid_coordinator import (
+            install_hybrid_coordinator_hooks, set_mamba_num_blocks)
+        install_hybrid_coordinator_hooks(vllm_config)
+        mamba_num_blocks = getattr(kv_cache_config, "mamba_num_blocks", None)
+        if mamba_num_blocks is not None:
+            set_mamba_num_blocks(mamba_num_blocks)
+            cache_config.mamba_num_blocks = mamba_num_blocks
+
     # Initialize the scheduler in this process
     import inspect
     sig = inspect.signature(original_scheduler_cls)
@@ -585,10 +595,16 @@ class DPScheduler(SchedulerInterface):
         multiprocessing.active_children()
 
     def _create_per_rank_configs(self, kv_cache_config: KVCacheConfig) -> None:
+        # mamba_num_blocks is computed during device HBM profiling and written to
+        # vllm_config.cache_config. Symmetrically partition across DP ranks.
+        mamba_num_blocks = getattr(self.vllm_config.cache_config,
+                                   "mamba_num_blocks", None)
         self.per_rank_kv_cache_configs: List[KVCacheConfig] = []
         for _ in range(self.dp_size):
             rank_kv_config = copy.deepcopy(kv_cache_config)
             rank_kv_config.num_blocks = kv_cache_config.num_blocks // self.dp_size
+            if mamba_num_blocks is not None:
+                rank_kv_config.mamba_num_blocks = mamba_num_blocks // self.dp_size
             self.per_rank_kv_cache_configs.append(rank_kv_config)
 
     def _send_command(self,

--- a/tpu_inference/platforms/tpu_platform.py
+++ b/tpu_inference/platforms/tpu_platform.py
@@ -339,6 +339,13 @@ class TpuPlatform(Platform):
         cls._initialize_sharding_config(vllm_config)
 
         cache_config = vllm_config.cache_config
+        if (cache_config and getattr(cache_config, "mamba_cache_mode", "none")
+                == "all"):
+            raise NotImplementedError(
+                "mamba_cache_mode 'all' is not supported on TPU; the mamba "
+                "pool is sized for resident state only. Use 'align' (the "
+                "default when prefix caching is enabled) or 'none'.")
+
         # Hybrid (mamba/linear-attention) models cannot use prefix caching with
         # speculative decoding because verify windows need consecutive state slots.
         if (cache_config and getattr(cache_config, "mamba_cache_mode", "none")
@@ -369,6 +376,10 @@ class TpuPlatform(Platform):
                     "supported on TPU with mamba prefix caching because the "
                     "TPU runner does not implement KV cache block copies; "
                     "leave --prefix-match-unit unset.")
+            elif cache_config.enable_prefix_caching:
+                from tpu_inference.core.hybrid_coordinator import \
+                    install_hybrid_coordinator_hooks
+                install_hybrid_coordinator_hooks(vllm_config)
 
         # vLLM's mm_device_do_normalize skips do_rescale/do_normalize in the
         # CPU processor and instead normalizes inside the vLLM model's vision

--- a/tpu_inference/runner/kv_cache_manager.py
+++ b/tpu_inference/runner/kv_cache_manager.py
@@ -28,6 +28,7 @@ from vllm.model_executor.layers.mla import MLAAttention
 from vllm.models.deepseek_v4.attention import (DeepseekV4Attention,
                                                DeepseekV4IndexerCache)
 from vllm.models.deepseek_v4.compressor import CompressorStateCache
+from vllm.utils.math_utils import cdiv
 from vllm.v1.attention.backend import AttentionType
 from vllm.v1.attention.backends.mla.sparse_swa import DeepseekV4SWACache
 from vllm.v1.kv_cache_interface import (FullAttentionSpec, KVCacheConfig,
@@ -59,6 +60,12 @@ logger = init_logger(__name__)
 # default layout (order) used by kv cache manager
 # N=num_blocks, H=num_heads and D=head_size
 DEFAULT_KV_CACHE_LAYOUT = "NHD"
+
+# Mamba blocks reserved per request in align mode (prefix caching): one for
+# the state a request generates from, the rest for the prefix checkpoints it
+# leaves behind for later requests to resume from. Override per-run with
+# `--additional-config '{"custom_mamba_cache_multiplier": N}'`.
+DEFAULT_MAMBA_CACHE_MULTIPLIER = 8
 
 
 def is_cache_for_ds_v4(attn_module: AttentionLayerBase) -> bool:
@@ -282,84 +289,52 @@ class KVCacheManager:
         self.runner.cache_config.mamba_page_size_padded = int(
             uniform_page_size_bytes)
 
-        # Cap each mamba layer at `max_num_reqs+1` slots and grow the
-        # attention pool with the freed HBM. See
-        # `_maybe_set_compact_mamba_num_blocks_override`.
+        # Size the mamba and attention pools out of the profiled HBM budget.
+        # See `_maybe_set_compact_mamba_num_blocks_override`.
         self._maybe_set_compact_mamba_num_blocks_override(
-            attn_page_size_bytes, int(unpadded_mamba_page_size),
-            num_attn_groups, num_mamba_groups, num_attn, num_mamba, group_size)
+            attn_page_size_bytes, int(unpadded_mamba_page_size), num_attn,
+            num_mamba)
 
     def _maybe_set_compact_mamba_num_blocks_override(
             self, attn_page_size_bytes: int,
-            unpadded_mamba_page_size_bytes: int, num_attn_groups: int,
-            num_mamba_groups: int, num_attn_layers: int, num_mamba_layers: int,
-            group_size: int) -> None:
-        """Cap mamba layers at `max_num_reqs+1` slots and pin
-        `num_gpu_blocks_override` so the freed HBM grows the attention pool.
+            unpadded_mamba_page_size_bytes: int, num_attn_layers: int,
+            num_mamba_layers: int) -> None:
+        """Give mamba a fixed per-request slot budget and attention the rest.
 
-        Tradeoff vs. the uniform num_blocks layout
-        ------------------------------------------
-        Mamba state is recurrent: one slot per *active* request, regardless
-        of context length. The uniform layout gives every layer the same
-        `num_blocks`, leaving `num_blocks − max_num_reqs` mamba slots idle
-        forever. The compact layout caps mamba at `max_num_reqs + 1` (the
-        `+1` is vLLM's null block), which is strictly better for any model
-        where `num_blocks > max_num_reqs` — i.e. all production hybrid
-        configs we run.
-        Cost: a small bookkeeping invariant in the GDN op (it must index
-        mamba state by per-request slot id rather than by `block_tables`,
-        since the mamba leading dim is now smaller than the attn pool).
-        See `gdn_attention_op.gdn_attention_core_tpu`.
-        Skipped if the user pinned `num_gpu_blocks_override` or
-        `hbm_usage_bytes` cannot read HBM (e.g. CPU-only tests). In those
-        cases vLLM keeps its uniform sizing; the page-size padding done in
-        the caller still keeps the per-layer block-ID range correct.
+            mamba_num_blocks = blocks_per_request * max_num_reqs + 1
+            attn_num_blocks  = (HBM left over) / attn_page
 
-        Sizing math
-        -----------
-        Each kv-cache tensor is shared across `num_attn_groups +
-        num_mamba_groups` layers; there are `group_size` such tensors.
-        Per-tensor budget `B = avail / group_size`. With
-        `N_mamba = max_num_reqs + 1`,
-            N_attn = floor((B − num_mamba_groups × N_mamba × mamba_unpadded)
-                            / (num_attn_groups × attn_page))
-        rounded down to the sharding divisor.
+        with the `+1` covering the block pool's null block. 
+
+        Both pools have to fit in `gpu_memory_utilization x HBM` together.
+        When they don't, the pool that can serve the most concurrent requests
+        is the over-provisioned one, so it is the one scaled down: dividing
+        each pool by its per-request block cost puts both on the same
+        "requests served" scale, and the budget is re-split so neither side
+        reserves capacity the other cannot back.
+
 
         Args:
             attn_page_size_bytes: TPU-actual bytes per block per attention
                 layer (accounts for dtype packing like fp8).
             unpadded_mamba_page_size_bytes: bytes per slot per mamba layer
-                (`prod(shape) × dtype_size`, no padding).
-            num_attn_groups: # vLLM kv-cache groups holding attention layers.
-            num_mamba_groups: # vLLM kv-cache groups holding mamba layers.
-            num_attn_layers: total attention layers (logging only).
-            num_mamba_layers: total mamba layers (logging only).
-            group_size: layers per kv-cache group; equals the # of
-                `KVCacheTensor`s vLLM allocates per kv-cache group.
+                (`prod(shape) x dtype_size`, no padding).
+            num_attn_layers: total attention layers. 
+            num_mamba_layers: total mamba layers.
 
         Returns:
-            None. On success: sets `cache_config.num_gpu_blocks_override`
-            and `_mamba_num_blocks` so `initialize_kv_cache` allocates the
-            smaller mamba arrays. On any preconditions-fail path: leaves
-            both unset.
+            None. On success: sets `_mamba_num_blocks` (and publishes it to
+            the scheduler-side coordinator) plus, unless the user pinned it,
+            `cache_config.num_gpu_blocks_override`.
+
+        Raises:
+            ValueError: the user pinned a `num_gpu_blocks_override` that
+                leaves too little HBM for even the minimum mamba pool.
         """
         cache_config = self.runner.cache_config
-        if cache_config.num_gpu_blocks_override is not None:
-            return
-
-        if getattr(cache_config, "mamba_cache_mode", "none") == "align":
-            # Mamba prefix caching addresses recurrent state by block id from
-            # the mamba block table, so every layer's mamba array must span
-            # the whole block pool. The compact layout deliberately makes it
-            # smaller than the pool, which would put valid block ids out of
-            # range. Fall back to the uniform sizing, which already charges
-            # each block for its mamba pages.
-            logger.info(
-                "Compact-mamba sizing skipped: mamba_cache_mode='align' "
-                "needs one mamba slot per block id. Attention capacity is "
-                "lower than with prefix caching off; raise --block-size to "
-                "trade prefix-cache granularity for capacity.")
-            return
+        is_align_mode = (getattr(cache_config, "mamba_cache_mode",
+                                 "none") == "align")
+        pinned_attn_blocks = cache_config.num_gpu_blocks_override
 
         devices = self.runner.mesh.devices.flatten()
         try:
@@ -395,73 +370,132 @@ class KVCacheManager:
         # defensive against an empty mesh shape that produces 0.
         divisor = max(divisor, 1)
 
-        # Mamba slot budget: one slot *group* per persistent-batch slot plus
-        # the null block, rounded up to the sharding divisor.
-        # `runner.max_num_reqs` already includes the DP multiplier
-        # (= `dp_size × scheduler_config.max_num_seqs`).
-        # With speculative decoding each request owns `num_spec + 1`
-        # consecutive slots so the GDN kernel can checkpoint the state after
-        # every speculative window position (see
-        # `InputBatch.mamba_state_indices_cpu` for the rollback scheme).
+        def round_up(blocks: int) -> int:
+            return ((blocks + divisor - 1) // divisor) * divisor
+
+        def round_down(blocks: int) -> int:
+            return (blocks // divisor) * divisor
+
+        # max_num_reqs already includes the DP multiplier
+        max_num_reqs = self.runner.max_num_reqs
         num_spec = 0
         if self.runner.vllm_config.speculative_config is not None:
             num_spec = (self.runner.vllm_config.speculative_config.
                         num_speculative_tokens)
         mamba_slot_stride = num_spec + 1
-        mamba_num_blocks = self.runner.max_num_reqs * mamba_slot_stride + 1
-        mamba_num_blocks = (
-            (mamba_num_blocks + divisor - 1) // divisor) * divisor
+        min_blocks_per_req = mamba_slot_stride + (1 if is_align_mode else 0)
+        if is_align_mode:
+            multiplier = int(
+                self.runner.vllm_config.additional_config.get(
+                    "custom_mamba_cache_multiplier",
+                    DEFAULT_MAMBA_CACHE_MULTIPLIER))
+            mamba_blocks_per_req = max(multiplier, min_blocks_per_req)
+        else:
+            mamba_blocks_per_req = min_blocks_per_req
+        attn_blocks_per_req = max(
+            1,
+            cdiv(self.runner.model_config.max_model_len,
+                 cache_config.block_size))
 
-        # Attention block count: fits into HBM left after mamba.
-        # `attn_page_size_bytes` is per-block per-attention-layer; the
-        # per-tensor cost is `num_attn_groups × N_attn × attn_page` because
-        # one tensor backs `num_attn_groups` attention layers.
-        avail_per_tensor = avail // group_size
-        mamba_per_tensor = (num_mamba_groups * mamba_num_blocks *
-                            unpadded_mamba_page_size_bytes)
-        attn_per_tensor_avail = avail_per_tensor - mamba_per_tensor
-        if attn_per_tensor_avail <= 0:
-            # Mamba already saturates the budget — pathological
-            # configuration (e.g., mamba_unpadded × max_num_reqs alone
-            # exceeds gpu_memory_utilization × total_hbm). Skip the
-            # override and let vLLM fall back to its uniform sizing; if
-            # the model genuinely doesn't fit, vLLM will OOM with the
-            # uniform layout too and we want that signal to surface.
-            logger.warning(
-                "Compact-mamba sizing skipped: mamba alone (mamba_num_blocks="
-                "%d × num_mamba_groups=%d × mamba_unpadded=%d) exceeds "
-                "per-tensor budget %d. Lower `gpu_memory_utilization` or "
-                "`max_num_seqs`.", mamba_num_blocks, num_mamba_groups,
-                unpadded_mamba_page_size_bytes, avail_per_tensor)
-            return
+        mamba_bytes_per_block = (num_mamba_layers *
+                                 unpadded_mamba_page_size_bytes)
+        attn_bytes_per_block = num_attn_layers * attn_page_size_bytes
+        mamba_bytes_per_req = mamba_blocks_per_req * mamba_bytes_per_block
+        attn_bytes_per_req = attn_blocks_per_req * attn_bytes_per_block
 
-        attn_num_blocks = attn_per_tensor_avail // (num_attn_groups *
-                                                    attn_page_size_bytes)
-        attn_num_blocks = (attn_num_blocks // divisor) * divisor
-        if attn_num_blocks <= 0:
-            logger.warning(
-                "Compact-mamba sizing skipped: attn_num_blocks=0 after "
-                "rounding to divisor=%d (avail_per_tensor=%d, "
-                "mamba_per_tensor=%d). Lower `gpu_memory_utilization` or "
-                "`max_num_seqs`.", divisor, avail_per_tensor, mamba_per_tensor)
-            return
+        # Minimum mamba pool: every persistent-batch slot resident, plus the
+        # null block. Below this the runner cannot hold the active batch.
+        min_mamba_blocks = round_up(max_num_reqs * min_blocks_per_req + 1)
+        mamba_num_blocks = round_up(max_num_reqs * mamba_blocks_per_req + 1)
 
-        cache_config.num_gpu_blocks_override = int(attn_num_blocks)
+        if pinned_attn_blocks is not None:
+            # The attention pool size is the user's explicit choice
+            spare = avail - pinned_attn_blocks * attn_bytes_per_block
+            if spare < mamba_num_blocks * mamba_bytes_per_block:
+                mamba_num_blocks = round_down(
+                    max(spare, 0) // mamba_bytes_per_block)
+            if mamba_num_blocks < min_mamba_blocks:
+                attn_gib = (pinned_attn_blocks * attn_bytes_per_block) / (2**
+                                                                          30)
+                mamba_gib = (min_mamba_blocks * mamba_bytes_per_block) / (2**
+                                                                          30)
+                raise ValueError(
+                    f"User-specified KV cache configuration exceeds available "
+                    f"HBM under gpu_memory_utilization={gpu_mem_util:.2f}: "
+                    f"attention ({pinned_attn_blocks} blocks) requires "
+                    f"{attn_gib:.2f} GiB and the minimum mamba pool "
+                    f"({min_mamba_blocks} blocks, {min_blocks_per_req} per "
+                    f"request) "
+                    f"requires {mamba_gib:.2f} GiB, together more than the "
+                    f"{avail / (2**30):.2f} GiB available. Decrease "
+                    f"`num_gpu_blocks_override` or `max_num_seqs`, or raise "
+                    f"`gpu_memory_utilization` if there is HBM to spare.")
+            attn_num_blocks = pinned_attn_blocks
+        else:
+            attn_num_blocks = round_down(
+                max(avail - mamba_num_blocks * mamba_bytes_per_block, 0) //
+                attn_bytes_per_block)
+            # Re-split the budget at the request count both can serve.
+            if (mamba_num_blocks > min_mamba_blocks
+                    and attn_num_blocks // attn_blocks_per_req
+                    < mamba_num_blocks // mamba_blocks_per_req):
+                servable_reqs = min(
+                    max_num_reqs,
+                    avail // (attn_bytes_per_req + mamba_bytes_per_req))
+                mamba_num_blocks = max(
+                    min_mamba_blocks,
+                    round_up(servable_reqs * mamba_blocks_per_req + 1))
+                attn_num_blocks = round_down(
+                    max(avail - mamba_num_blocks * mamba_bytes_per_block, 0) //
+                    attn_bytes_per_block)
+                logger.info(
+                    "Mamba and attention pools together exceed the HBM "
+                    "budget; re-split at %d concurrent requests "
+                    "(mamba=%d blocks, attn=%d blocks).", servable_reqs,
+                    mamba_num_blocks, attn_num_blocks)
+
+            if attn_num_blocks <= 0:
+                # Mamba alone exceeds the HBM budget
+                raise ValueError(
+                    f"Cannot fit both KV pools under "
+                    f"gpu_memory_utilization={gpu_mem_util:.2f}: the mamba "
+                    f"pool needs {mamba_num_blocks} blocks "
+                    f"({min_blocks_per_req} per request x "
+                    f"{max_num_reqs} requests) across {num_mamba_layers} "
+                    f"layers at {unpadded_mamba_page_size_bytes} B/block, "
+                    f"which leaves nothing of the {avail / (2**30):.2f} GiB "
+                    f"available for attention. That is already the minimum "
+                    f"mamba needs resident, so lower `max_num_seqs`, raise "
+                    f"`gpu_memory_utilization`, or free HBM by shrinking the "
+                    f"model's footprint.")
+            cache_config.num_gpu_blocks_override = int(attn_num_blocks)
+
         self._mamba_num_blocks = int(mamba_num_blocks)
+        cache_config.mamba_num_blocks = int(mamba_num_blocks)
+        from tpu_inference.core.hybrid_coordinator import set_mamba_num_blocks
+        set_mamba_num_blocks(int(mamba_num_blocks))
 
         attn_bytes = num_attn_layers * attn_num_blocks * attn_page_size_bytes
         mamba_bytes = (num_mamba_layers * mamba_num_blocks *
                        unpadded_mamba_page_size_bytes)
+        attn_reqs = attn_num_blocks // attn_blocks_per_req
+        mamba_reqs = mamba_num_blocks // mamba_blocks_per_req
         logger.info(
-            "Compact-mamba KV cache: num_gpu_blocks_override=%d (attn), "
-            "_mamba_num_blocks=%d. HBM split: attn=%d layers × %d blocks "
-            "× %d B = %.2f GiB; mamba=%d layers × %d slots × %d B = "
-            "%.2f GiB; total=%.2f GiB / avail=%.2f GiB.", attn_num_blocks,
-            mamba_num_blocks, num_attn_layers, attn_num_blocks,
-            attn_page_size_bytes, attn_bytes / (2**30), num_mamba_layers,
-            mamba_num_blocks, unpadded_mamba_page_size_bytes,
+            "Compact-mamba KV cache%s: num_gpu_blocks_override=%d (attn%s), "
+            "_mamba_num_blocks=%d (%d blocks/request). HBM split: attn=%d "
+            "layers x %d blocks x %d B = %.2f GiB; mamba=%d layers x %d slots "
+            "x %d B = %.2f GiB; total=%.2f GiB / avail=%.2f GiB. At "
+            "max_model_len=%d that backs %d concurrent requests on the "
+            "attention side (%d blocks each) and %d on the mamba side, out of "
+            "max_num_reqs=%d.", " (align mode)" if is_align_mode else "",
+            attn_num_blocks,
+            ", user-pinned" if pinned_attn_blocks is not None else "",
+            mamba_num_blocks, mamba_blocks_per_req, num_attn_layers,
+            attn_num_blocks, attn_page_size_bytes, attn_bytes / (2**30),
+            num_mamba_layers, mamba_num_blocks, unpadded_mamba_page_size_bytes,
             mamba_bytes / (2**30), (attn_bytes + mamba_bytes) / (2**30),
-            avail / (2**30))
+            avail / (2**30), self.runner.model_config.max_model_len, attn_reqs,
+            attn_blocks_per_req, mamba_reqs, max_num_reqs)
 
     def get_kv_cache_spec(self):
         # TODO(xiang): this hack tricks engine core to init successfully
@@ -859,13 +893,10 @@ class KVCacheManager:
 
             mamba_cache_mode = getattr(self.runner.cache_config,
                                        "mamba_cache_mode", "none")
-            if mamba_cache_mode == "align":
-                # Mamba prefix caching ("align" mode) addresses recurrent
-                # state by block ID from the mamba block table, so every
-                # layer's mamba array must span the full block pool.
-                mamba_num_blocks = tensor_num_blocks
-            elif self._mamba_num_blocks is not None:
+            if self._mamba_num_blocks is not None:
                 mamba_num_blocks = self._mamba_num_blocks
+            elif mamba_cache_mode == "align":
+                mamba_num_blocks = tensor_num_blocks
             else:
                 # Mamba state is recurrent: one slot per *active* request,
                 # regardless of context length.  Falling back to
@@ -889,6 +920,7 @@ class KVCacheManager:
                     self.runner.max_num_reqs, mamba_slot_stride, divisor)
             if self.actual_mamba_num_blocks is None:
                 self.actual_mamba_num_blocks = mamba_num_blocks
+            kv_cache_config.mamba_num_blocks = int(mamba_num_blocks)
 
             offset = getattr(kv_cache_tensor, 'offset', 0)
             layer_stride = getattr(kv_cache_tensor, 'layer_stride', 0)


### PR DESCRIPTION
> [!NOTE]
> **This PR re-lands #3517 in addition to its own changes.**
> #3517 ("Decoupled Dual Block Pools for Hybrid Mamba/GDN Prefix Caching in
> Align Mode") was reverted from main by #3551, and this PR builds directly on
> it. 

## Summary

This PR mirrors mamba kv-cache groups onto one set of block ids, which effective reduces the mamba cache usage by 3x for Qwen3.5-397B. 

vLLM gives each kv-cache group its own block ids, so a model whose mamba layers are split into G groups spends G ids per logical checkpoint. Qwen3.5-397B has 45 mamba layers in 3 groups, so a pool of N ids held **N/3** checkpoints while the memory behind it holds N — every mamba layer has N slots and a checkpoint needs one slot in each. The split exists so an upstream `KVCacheTensor` can reinterpret one block's bytes as a different layer per group; TPU cannot overlay typed JAX arrays and already allocates one array per layer, so it bought nothing and cost the factor of 3.

Non-primary mamba groups are now bound to a `MirrorMambaBlockPool` that hands them the ids the primary group just allocated, and the pool canonicalises cache keys to the primary group so a lookup spanning all three groups resolves to one entry. `can_allocate_tokens` no longer counts mirrored demand. The lockstep between groups is an ordering property, so `replay_last_allocation` asserts the counts match rather than trusting it — aliasing the wrong id would corrupt state silently.

Effect on Qwen3.5-397B-A17B-FP8 (65-block pool per rank, multiplier 16, 371 requests of an agentic multi-turn trace):

| | before | after |
|---|---:|---:|
| prefill residency | 63 of 65 blocks | 19 |
| retained checkpoints | 10–13 | 52–61 |
| mamba lookup hit rate | 9.9% | 66–95% |
| engine prefix cache hit rate | 79.3% | 92.9% |
| prefill work | 89% of prompt tokens | 6.7% |

This PR also makes the following smaller changes. 

### 1. Simplify the mamba block reservation

The align-mode pool was sized by a chain of special cases: an absolute `custom_mamba_cache_size` checkpoint budget on top of active slots. Replaced with a per-request budget:

```
mamba_num_blocks = blocks_per_request * max_num_reqs + 1
```

`blocks_per_request` is `DEFAULT_MAMBA_CACHE_MULTIPLIER` (8) in align mode, overridable with `--additional-config '{"custom_mamba_cache_multiplier": N}'`. **This flag replaces `custom_mamba_cache_size`**, which is removed. Without prefix caching there is nothing to checkpoint, so the multiplier does not apply.  

### 2. Fix align-mode mamba over-allocation (HBM OOM)

`initialize_kv_cache` sized the mamba arrays at `tensor_num_blocks` — the *attention* pool — whenever `mamba_cache_mode == "align"`, blowing the budget the sizing pass had just computed. On Qwen3.5-397B-A17B-FP8 the pass budgeted 388 mamba blocks (69.4 GiB) and allocation then asked for 29588 (14.70 GiB per layer per device), dying on the first of 45 layers:

```
RESOURCE_EXHAUSTED: Attempting to allocate 14.45G. That was not possible. There are 903.14M free.
```

Align mode could not start on that model before this change.


## Benchmarks

Agentic benchmark, Qwen3.5-397B-A17B-FP8, TP=8 with DP attention (`attn_dp_size=4`) + expert parallel, `--max-num-seqs=16`, `--max-model-len=65536`, `--block-size=256`, `--prefix-cache-retention-interval 256`.

Total tokens/sec, across the five client workloads:

| client | mult8 | **mult16** | mult16 + `DP_SCHED_BATCH_PREFILL=true` |
|---|---:|---:|---:|
| `--num-groups 1 --concurrency 1 --group-size 8` | 38,379 | 38,110 | 35,118 |  
| `--num-groups 1 --concurrency 1` | 60,538 | 60,474 | 54,366 |  
| `--num-groups 2 --concurrency 2` | 75,271 | 76,691 | 68,307 |  
| `--num-groups 4 --concurrency 4` | 68,814 | **83,846** | 66,995 |  
| `--num-groups 8 --concurrency 8` | 31,206 | **51,580** | 43,025 | 

**Best configuration: `custom_mamba_cache_multiplier: 16`, DP+EP, `DP_SCHED_BATCH_PREFILL=false`.**

### Server command

```bash
NUM_PRECOMPILE_WORKERS=8 MODEL_IMPL_TYPE=vllm USE_MOE_EP_KERNEL=0 \
ATTN_BUCKETIZED_NUM_REQS=true ATTN_CUSTOM_NUM_REQS_BUCKETS=4 \
ONEHOT_MOE_PERMUTE_THRESHOLD=32768 VLLM_MOE_CHUNK_SIZE=256 SLICE_ROPE_CACHE=1 \
DP_SCHED_BATCH_PREFILL=false NEW_MODEL_DESIGN=1 \
LIBTPU_INIT_ARGS=' --xla_tpu_use_minor_sharding_for_major_trivial_input=true --xla_tpu_enable_sparse_core_collective_offload_reduce_scatter=false --xla_tpu_ars_combiner_threshold_in_bytes=0 --xla_tpu_enable_async_collective_merger=false --xla_tpu_check_legacy_constraints_in_reduce_scatter_legalizer=false' \
vllm serve Qwen/Qwen3.5-397B-A17B-FP8 \
  --max-model-len=65536 --max-num-batched-tokens=2048 --max-num-seqs=16 \
  --enable-prefix-caching \
  --gpu-memory-utilization=0.9 --tensor-parallel-size=8 --async-scheduling --port=8000 \
  --language-model-only --enable-auto-tool-choice --tool-call-parser=qwen3_coder \
  --reasoning-parser=qwen3 --default-chat-template-kwargs '{"enable_thinking": false}' \
  '--limit-mm-per-prompt={"image": 0, "video": 0}' --kv-cache-dtype=bfloat16 \
  --additional_config='{"sharding": {"sharding_strategy": {"enable_dp_attention": true, "attn_dp_size": 4}}, "custom_mamba_cache_multiplier": 16}' \
  --block-size=256 --enable-chunked-prefill \
  --prefix-cache-retention-interval 256 \
  --enable-expert-parallel
```

### Client command

```bash
python scripts/vllm/benchmarking/agentic_benchmark/benchmark_agentic.py \
  --model Qwen/Qwen3.5-397B-A17B-FP8 \
  --model-path-or-id Qwen/Qwen3.5-397B-A17B-FP8 \
  --trace-file gs://wenxindong-vm/rl/mlperf2026/agentic_benchmark/gbs1024_trace_file_tool_time.jsonl \
  --global-prefix-len 6476 \
  --num-groups 4 --concurrency 4
```

## Quality (lm_eval)

gsm8k against the running server (mirroring on, align mode, prefix caching on):

| Task | Filter | n-shot | Metric | Value | Stderr |
|---|---|---:|---|---:|---:|
| gsm8k | flexible-extract | 5 | exact_match | **0.99** | ±0.01 |
| gsm8k | strict-match | 5 | exact_match | **0.99** | ±0.01 |

```bash
lm_eval --model local-chat-completions \
  --model_args base_url="http://localhost:8000/v1/chat/completions",model="Qwen/Qwen3.5-397B-A17B-FP8",eos_string="<|im_end|>",num_concurrent=1,max_retries=3,tokenized_requests=False \
  --tasks gsm8k --gen_kwargs max_gen_toks=2048 --apply_chat_template --fewshot_as_multiturn \
  --limit 100
```


