### PR TITLE
[PCP] Move the host-side preprocessing into runner/pcp_utils.py

### DIFF
--- a/tests/layers/common/test_pcp_attention_interface.py
+++ b/tests/layers/common/test_pcp_attention_interface.py
@@ -25,12 +25,11 @@ from tpu_inference.kernels.ragged_paged_attention.v3.util import (
     align_to, cdiv, get_dtype_packing)
 from tpu_inference.layers.common import sharding as sharding_mod
 from tpu_inference.layers.common.attention_metadata import (AttentionMetadata,
-                                                            PCPMetadata,
-                                                            pcp_seq_arrays,
-                                                            pcp_token_layout)
+                                                            PCPMetadata)
 from tpu_inference.layers.common.cp_attention import pcp_forward
 from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
                                                   ShardingAxisNameBase)
+from tpu_inference.runner.pcp_utils import pcp_seq_arrays, pcp_token_layout
 
 PAGE = 16  # per-rank block_size; the GLOBAL page_size dim is PAGE * pcp
 MAX_SEQ = 8

--- a/tests/runner/test_pcp_utils.py
+++ b/tests/runner/test_pcp_utils.py
@@ -1,0 +1,186 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests for runner/pcp_utils.py; `test_prepare_inputs` needs pcp_size devices."""
+
+import jax
+import numpy as np
+import pytest
+from jax.sharding import Mesh
+from vllm.utils.math_utils import cdiv, next_power_of_2
+
+from tpu_inference.runner.pcp_utils import (PCPPreprocessor, pcp_batch_layout,
+                                            pcp_buffer_tokens,
+                                            pcp_max_buffer_tokens,
+                                            pcp_seq_arrays, pcp_token_layout,
+                                            pcp_token_permutation)
+
+# (pcp_size, scheduled tokens per request)
+LAYOUTS = [
+    (2, [5]),
+    (2, [4096]),
+    (2, [22061, 3000]),
+    (4, [7, 1, 300]),
+    (2, [1, 1]),
+    (8, [2539, 1200, 7, 3000, 64, 1, 500, 999]),
+]
+
+
+def _t_pad(counts, pcp):
+    """A power-of-two bucket that holds the layout and is divisible by 2P."""
+    return next_power_of_2(max(pcp_buffer_tokens(counts, pcp), 2 * pcp))
+
+
+def _layout(counts, pcp):
+    """(t_pad, chunk, off) of a batch in the bucket `_t_pad` picks."""
+    t_pad = _t_pad(counts, pcp)
+    chunk, off = pcp_batch_layout(counts, t_pad, pcp)
+    return t_pad, chunk, off
+
+
+@pytest.mark.parametrize("pcp,counts", LAYOUTS)
+def test_token_layout(pcp, counts):
+    chunk, off, s_live = pcp_token_layout(counts, pcp)
+    assert chunk == [cdiv(n, 2 * pcp) for n in counts]
+    assert off == list(np.cumsum([0] + [2 * c for c in chunk])[:-1])
+    assert s_live == sum(2 * c for c in chunk)
+    assert pcp_buffer_tokens(counts, pcp) == pcp * s_live
+    assert pcp_buffer_tokens(counts, pcp) <= pcp_max_buffer_tokens(
+        sum(counts), len(counts), pcp)
+
+
+@pytest.mark.parametrize("pcp,counts", LAYOUTS)
+def test_batch_layout(pcp, counts):
+    t_pad, chunk, off = _layout(counts, pcp)
+    if len(counts) == 1:
+        # Single request: the chunk comes from the buffer width.
+        assert chunk == [t_pad // (2 * pcp)] and off == [0]
+    else:
+        assert (chunk, off) == pcp_token_layout(counts, pcp)[:2]
+
+
+def test_batch_layout_rejects_short_buffer():
+    with pytest.raises(AssertionError):
+        pcp_batch_layout([100, 100], 64, 2)
+
+
+@pytest.mark.parametrize("pcp,counts", LAYOUTS)
+def test_token_permutation(pcp, counts):
+    t_pad, chunk, off = _layout(counts, pcp)
+    s_pad = t_pad // pcp
+    perm, kv_order = pcp_token_permutation(counts, chunk, off, t_pad, pcp)
+    total = sum(counts)
+    # Every real token lands in exactly one slot; everything else is padding.
+    assert sorted(perm[perm >= 0].tolist()) == list(range(total))
+    src_off = np.cumsum([0] + counts)[:-1]
+    for i, n_i in enumerate(counts):
+        c_i = chunk[i]
+        for tok in range(n_i):
+            slot = kv_order[pcp * off[i] + tok]
+            # kv_order undoes perm on the live rows.
+            assert perm[slot] == src_off[i] + tok
+            # Zigzag: chunk k sits on rank k (head) or 2P-1-k (tail).
+            k = tok // c_i
+            rank = k if k < pcp else 2 * pcp - 1 - k
+            assert slot // s_pad == rank
+    # Slots reserved for a request are distinct across the request.
+    for i in range(len(counts)):
+        lo, hi = pcp * off[i], pcp * off[i] + 2 * pcp * chunk[i]
+        assert len(set(kv_order[lo:hi].tolist())) == hi - lo
+
+
+@pytest.mark.parametrize("pcp,counts", LAYOUTS)
+def test_seq_arrays(pcp, counts):
+    _, chunk, off = _layout(counts, pcp)
+    n_slots = 2 * len(counts) + 3
+    cu_row, q_pos, kv_new_starts = pcp_seq_arrays(chunk, off, pcp, n_slots)
+    n_seqs = 2 * len(counts)
+    assert cu_row.shape == (n_slots + 1, )
+    assert np.all(np.diff(cu_row[:n_seqs + 1]) > 0)
+    assert np.all(cu_row[n_seqs:] == cu_row[n_seqs])
+    for i, c_i in enumerate(chunk):
+        assert cu_row[2 * i] == off[i]
+        assert cu_row[2 * i + 1] - cu_row[2 * i] == c_i
+        assert cu_row[2 * i + 2] - cu_row[2 * i + 1] == c_i
+        for r in range(pcp):
+            assert q_pos[r, 2 * i] == r * c_i
+            assert q_pos[r, 2 * i + 1] == (2 * pcp - 1 - r) * c_i
+        assert kv_new_starts[2 * i] == kv_new_starts[2 * i + 1] == pcp * off[i]
+    assert np.all(q_pos[:, n_seqs:] == 0)
+
+
+@pytest.mark.parametrize("pcp,counts", LAYOUTS)
+def test_prepare_inputs(pcp, counts):
+    if len(jax.devices()) < pcp:
+        pytest.skip(f"needs {pcp} devices")
+    mesh = Mesh(np.array(jax.devices()[:pcp]), ("pcp", ))
+    pre = PCPPreprocessor(pcp, mesh, [1, 8])
+
+    t_pad, chunk, off = _layout(counts, pcp)
+    n_reqs = len(counts)
+    n_slots = 2 * 8
+    # Cached prefixes on the longer requests (a cached 1-token request is a
+    # decode, rejected below).
+    computed = [(3 * i) % 40 if n > 1 else 0 for i, n in enumerate(counts)]
+    total = sum(counts)
+    # Natural-order buffers: token g carries id 1000 + g and position g.
+    input_ids = np.zeros(t_pad, np.int32)
+    input_ids[:total] = 1000 + np.arange(total)
+    positions = np.zeros(t_pad, np.int32)
+    positions[:total] = np.arange(total)
+    seq_lens = np.full(n_slots, 7, np.int32)
+    request_distribution = np.array([n_reqs, 0, 0], np.int32)
+    logits_indices = np.full(8, 5, np.int32)
+
+    md = pre.prepare_inputs(counts, computed, t_pad, positions, input_ids,
+                            seq_lens, request_distribution, logits_indices)
+
+    perm, kv_order = pcp_token_permutation(counts, chunk, off, t_pad, pcp)
+    live = perm >= 0
+    assert np.array_equal(input_ids[live], 1000 + perm[live])
+    assert np.array_equal(positions[live], perm[live])
+    assert np.all(input_ids[~live] == 0) and np.all(positions[~live] == 0)
+
+    n_seqs = 2 * n_reqs
+    assert np.array_equal(
+        seq_lens[:n_seqs],
+        np.repeat([n + c for n, c in zip(counts, computed)], 2))
+    assert np.all(seq_lens[n_seqs:] == 0)
+    assert request_distribution.tolist() == [0, 0, n_seqs]
+    # Each request's logits slot holds its last real token.
+    src_off = np.cumsum([0] + counts)[:-1]
+    assert np.array_equal(perm[logits_indices[:n_reqs]],
+                          src_off + np.asarray(counts) - 1)
+    assert np.all(logits_indices[n_reqs:] == -1)
+
+    assert md.query_start_loc.shape == (pcp, n_slots + 1)
+    assert md.q_pos_offsets.shape == (pcp, n_slots)
+    assert np.array_equal(
+        np.asarray(md.kv_cache_lens)[:n_seqs], np.repeat(computed, 2))
+    assert md.has_cached_kv == (max(computed) > 0)
+    assert md.num_reqs == (1 if n_reqs == 1 else 8)
+    assert np.array_equal(np.asarray(md.kv_token_order), kv_order)
+    assert np.array_equal(
+        np.asarray(md.kv_new_starts)[:n_seqs],
+        np.repeat([pcp * o for o in off], 2))
+
+
+def test_prepare_inputs_rejects_decode():
+    if len(jax.devices()) < 2:
+        pytest.skip("needs 2 devices")
+    mesh = Mesh(np.array(jax.devices()[:2]), ("pcp", ))
+    pre = PCPPreprocessor(2, mesh, [1, 8])
+    # Rejected before any buffer is touched, so shapes do not matter.
+    buf = np.zeros(16, np.int32)
+    with pytest.raises(NotImplementedError):
+        pre.prepare_inputs([1], [5], 16, buf, buf, buf, buf, buf)

--- a/tests/runner/test_tpu_runner_dp.py
+++ b/tests/runner/test_tpu_runner_dp.py
@@ -32,9 +32,9 @@ class TestTPUJaxRunnerDPInputsLightweight:
 
         # Basic DP configuration
         self.runner.dp_size = 2
-        # PCP is off in these DP tests; without this the MagicMock auto-attr
-        # fails the `prefill_cp_size > 1` comparison in _prepare_inputs.
+        # PCP off; a MagicMock auto-attribute would not be None.
         self.runner.vllm_config.sharding_config.prefill_cp_size = 1
+        self.runner.pcp_preprocessor = None
         self.runner.max_num_tokens = 64
         self.runner.max_num_reqs = 8
         self.runner.attn_max_num_seqs = 8
@@ -1422,6 +1422,7 @@ class TestSamplingMetadataPassthrough:
         runner.input_batch.max_decode_tokens = 1
         runner.dp_size = 2
         runner.vllm_config.sharding_config.prefill_cp_size = 1
+        runner.pcp_preprocessor = None
         runner.max_num_reqs = 8
         runner.attn_max_num_seqs = 8
         runner.max_num_blocks_per_req = 8

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -16,8 +16,6 @@ import functools
 from dataclasses import dataclass
 
 import jax
-import numpy as np
-from vllm.utils.math_utils import cdiv
 
 
 @functools.partial(
@@ -176,62 +174,3 @@ jax.tree_util.register_pytree_node(
     lambda layer_names_per_group, groups: GroupedAttentionMetadata(
         groups, layer_names_per_group),
 )
-
-
-def pcp_token_layout(num_scheduled_tokens: list[int],
-                     pcp_size: int) -> tuple[list[int], list[int], int]:
-    """Per-request zigzag chunking for multi-request PCP.
-
-    Each request is split into its own 2*pcp_size chunks, and its head+tail
-    pair occupies a fixed-width slot in every rank's region of the token
-    buffer. Returns (C, off, S):
-
-      C[i]   chunk size of request i, ceil(n_i / 2P)
-      off[i] start of request i's slot within one rank's region
-      S      live tokens per rank; the global buffer needs pcp_size * S rows
-    """
-    two_p = 2 * pcp_size
-    off, acc, C = [], 0, []
-    for n in num_scheduled_tokens:
-        c = cdiv(n, two_p)
-        C.append(c)
-        off.append(acc)
-        acc += 2 * c
-    return C, off, acc
-
-
-def pcp_seq_arrays(chunk: list[int], off: list[int], pcp_size: int,
-                   n_off: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
-    """Per-seq attention metadata for a `pcp_token_layout` result.
-
-    Request i is presented to the kernel as seqs 2i (head chunk) and 2i+1
-    (tail chunk). Returns int32 arrays (cu_row, q_pos, kv_new_starts):
-
-      cu_row[n_off + 1]          cumulative query rows per seq. Rank-invariant
-                                 (both halves are full length). Entries past
-                                 2R repeat the last value: they are never
-                                 iterated, and a repeat inside the iterated
-                                 range would be a zero-length seq, which
-                                 hangs the kernel.
-      q_pos[pcp_size, n_off]     each seq's query position offset on each
-                                 rank: rank r holds chunk r (head) and chunk
-                                 2P-1-r (tail) of every request.
-      kv_new_starts[n_off]       base of request i's block in the
-                                 request-major current K/V buffer,
-                                 2P * sum(chunk[:i]) == pcp_size * off[i].
-    """
-    n_reqs = len(chunk)
-    assert 2 * n_reqs <= n_off, (n_reqs, n_off)
-    c = np.asarray(chunk, np.int64)
-    o = np.asarray(off, np.int64)
-    ranks = np.arange(pcp_size)
-    cu_row = np.zeros(n_off + 1, np.int32)
-    cu_row[1:2 * n_reqs + 1:2] = o + c
-    cu_row[2:2 * n_reqs + 2:2] = o + 2 * c
-    cu_row[2 * n_reqs + 1:] = cu_row[2 * n_reqs]
-    q_pos = np.zeros((pcp_size, n_off), np.int32)
-    q_pos[:, 0:2 * n_reqs:2] = ranks[:, None] * c
-    q_pos[:, 1:2 * n_reqs:2] = (2 * pcp_size - 1 - ranks)[:, None] * c
-    kv_new_starts = np.zeros(n_off, np.int32)
-    kv_new_starts[:2 * n_reqs] = np.repeat(pcp_size * o, 2)
-    return cu_row, q_pos, kv_new_starts

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -28,8 +28,7 @@ import tpu_inference.envs as envs
 from tpu_inference.core.disagg_utils import is_disagg_enabled
 from tpu_inference.core.sched.utils import DEFAULT_MAX_DECODE_STEPS
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, GroupedAttentionMetadata, PCPMetadata,
-    SharedAttentionMetadata, pcp_seq_arrays, pcp_token_layout)
+    AttentionMetadata, GroupedAttentionMetadata, SharedAttentionMetadata)
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.layers.jax.sample.sampling import (
     compute_and_gather_logprobs, compute_and_gather_prompt_logprobs, sample)
@@ -39,6 +38,7 @@ from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
 from tpu_inference.runner.decode_loop import TpuSamplingState, continue_decode
+from tpu_inference.runner.pcp_utils import pcp_seq_arrays, pcp_token_layout
 from tpu_inference.runner.utils import SpecDecodeMetadata
 from tpu_inference.spec_decode.jax.utils import (
     concat_last_sampled_tokens_and_draft_tokens, extend_logits_simple,
@@ -401,11 +401,6 @@ class CompilationManager:
                                             sharding=metadata_attn_sharding)
         pcp = None
         if pcp_size > 1:
-            n_reqs = attn_seqs
-            pcp_spec = NamedSharding(
-                self.runner.mesh,
-                PartitionSpec(ShardingAxisName.PREFILL_CONTEXT, None))
-            repl = NamedSharding(self.runner.mesh, PartitionSpec())
             # A well-formed dummy layout: request_distribution is all zeros,
             # so the kernel body does not run, but the traced program still
             # slices these arrays.
@@ -413,26 +408,13 @@ class CompilationManager:
             chunks, offs, _ = pcp_token_layout([2 * pcp_size * chunk] *
                                                pcp_num_reqs, pcp_size)
             cu_row, qpos_np, kv_starts_np = pcp_seq_arrays(
-                chunks, offs, pcp_size, n_reqs)
-            cu_np = np.tile(cu_row, (pcp_size, 1))
-
-            pcp = PCPMetadata(
-                query_start_loc=device_array(self.runner.mesh,
-                                             cu_np,
-                                             sharding=pcp_spec),
-                kv_cache_lens=device_array(self.runner.mesh,
-                                           np.zeros(n_reqs, dtype=np.int32),
-                                           sharding=repl),
-                q_pos_offsets=device_array(self.runner.mesh,
-                                           qpos_np,
-                                           sharding=pcp_spec),
-                kv_new_starts=device_array(self.runner.mesh,
-                                           kv_starts_np,
-                                           sharding=repl),
-                kv_token_order=device_array(self.runner.mesh,
-                                            np.arange(num_tokens,
-                                                      dtype=np.int32),
-                                            sharding=repl),
+                chunks, offs, pcp_size, attn_seqs)
+            pcp = self.runner.pcp_preprocessor.metadata_to_device(
+                cu_row,
+                qpos_np,
+                np.zeros(attn_seqs, dtype=np.int32),
+                kv_starts_np,
+                np.arange(num_tokens, dtype=np.int32),
                 has_cached_kv=pcp_has_cached_kv,
                 num_reqs=pcp_num_reqs,
             )

--- a/tpu_inference/runner/pcp_utils.py
+++ b/tpu_inference/runner/pcp_utils.py
@@ -1,0 +1,236 @@
+# Copyright 2025 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Host-side preprocessing for prefill context parallelism (PCP).
+
+PCP splits each prefill request into 2 * pcp_size zigzag chunks; rank r
+holds chunks r (head) and 2P-1-r (tail) of every request, and the kernel
+sees request i as seqs 2i and 2i+1. The layout helpers here are pure numpy;
+`PCPPreprocessor.prepare_inputs` applies them to the runner's host buffers
+once per step.
+"""
+
+import numpy as np
+from jax.sharding import Mesh, NamedSharding, PartitionSpec
+from vllm.utils.math_utils import cdiv
+
+from tpu_inference.layers.common.attention_metadata import PCPMetadata
+from tpu_inference.layers.common.sharding import ShardingAxisName
+from tpu_inference.runner import utils as runner_utils
+from tpu_inference.utils import device_array
+
+
+def pcp_token_layout(num_scheduled_tokens: list[int],
+                     pcp_size: int) -> tuple[list[int], list[int], int]:
+    """Returns (chunk, off, s_live): per-request chunk size ceil(n_i / 2P),
+    the start of each request's head+tail slot within a rank's region, and
+    the live rows per rank."""
+    two_p = 2 * pcp_size
+    off, acc, C = [], 0, []
+    for n in num_scheduled_tokens:
+        c = cdiv(n, two_p)
+        C.append(c)
+        off.append(acc)
+        acc += 2 * c
+    return C, off, acc
+
+
+def pcp_buffer_tokens(num_scheduled_tokens: list[int], pcp_size: int) -> int:
+    """Rows the token buffer must hold for this batch (can exceed the raw
+    token count, since every chunk rounds up independently)."""
+    _, _, s_live = pcp_token_layout(num_scheduled_tokens, pcp_size)
+    return pcp_size * s_live
+
+
+def pcp_max_buffer_tokens(max_num_batched_tokens: int, max_num_seqs: int,
+                          pcp_size: int) -> int:
+    """Upper bound of `pcp_buffer_tokens` over any batch the scheduler
+    admits: each request rounds up by less than 2P rows."""
+    return max_num_batched_tokens + 2 * pcp_size * max_num_seqs
+
+
+def pcp_batch_layout(num_scheduled_tokens: list[int], t_pad: int,
+                     pcp_size: int) -> tuple[list[int], list[int]]:
+    """Chunk sizes and slot offsets of a batch inside a `t_pad`-row buffer.
+
+    A single request fills the buffer (chunk = t_pad / 2P) because
+    pcp_forward's kernel-side K/V remap derives the chunk from the buffer
+    width.
+    """
+    two_p = 2 * pcp_size
+    chunk, off, s_live = pcp_token_layout(num_scheduled_tokens, pcp_size)
+    assert t_pad % pcp_size == 0 and t_pad >= pcp_size * s_live, (
+        f"PCP token bucket {t_pad} cannot hold {pcp_size * s_live} tokens "
+        f"({len(num_scheduled_tokens)} reqs, chunks {chunk})")
+    if len(num_scheduled_tokens) == 1:
+        assert t_pad % two_p == 0, (t_pad, two_p)
+        chunk = [t_pad // two_p]
+        off = [0]
+    return chunk, off
+
+
+def pcp_seq_arrays(chunk: list[int], off: list[int], pcp_size: int,
+                   n_slots: int) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Per-seq metadata for `n_slots` seq slots: cu_row[n_slots + 1] cumulative
+    query rows (rank-invariant), q_pos[pcp_size, n_slots] per-rank query
+    position offsets, kv_new_starts[n_slots] base of each request's block in
+    the request-major current-K/V buffer."""
+    n_reqs = len(chunk)
+    assert 2 * n_reqs <= n_slots, (n_reqs, n_slots)
+    c = np.asarray(chunk, np.int64)
+    o = np.asarray(off, np.int64)
+    ranks = np.arange(pcp_size)
+    cu_row = np.zeros(n_slots + 1, np.int32)
+    cu_row[1:2 * n_reqs + 1:2] = o + c
+    cu_row[2:2 * n_reqs + 2:2] = o + 2 * c
+    cu_row[2 * n_reqs + 1:] = cu_row[2 * n_reqs]
+    q_pos = np.zeros((pcp_size, n_slots), np.int32)
+    q_pos[:, 0:2 * n_reqs:2] = ranks[:, None] * c
+    q_pos[:, 1:2 * n_reqs:2] = (2 * pcp_size - 1 - ranks)[:, None] * c
+    kv_new_starts = np.zeros(n_slots, np.int32)
+    kv_new_starts[:2 * n_reqs] = np.repeat(pcp_size * o, 2)
+    return cu_row, q_pos, kv_new_starts
+
+
+def pcp_token_permutation(num_scheduled_tokens: list[int], chunk: list[int],
+                          off: list[int], t_pad: int,
+                          pcp_size: int) -> tuple[np.ndarray, np.ndarray]:
+    """Returns (perm, kv_order): perm[g] is the natural-order source of
+    rank-order slot g (-1 for padding); kv_order maps the all-gathered
+    current K/V from rank order to request-major token order."""
+    two_p = 2 * pcp_size
+    s_pad = t_pad // pcp_size
+    src_off = np.cumsum([0] + list(num_scheduled_tokens))[:-1]
+    perm = np.full(t_pad, -1, np.int64)
+    kv_order = np.zeros(t_pad, np.int32)
+    ranks = np.arange(pcp_size)
+    for i, n_i in enumerate(num_scheduled_tokens):
+        c_i = chunk[i]
+        j = np.arange(c_i)
+        kv_base = pcp_size * off[i]
+        for h in (0, 1):
+            chunk_idx = ranks if h == 0 else two_p - 1 - ranks
+            dst = (ranks[:, None] * s_pad + off[i] + h * c_i + j[None, :])
+            tok = chunk_idx[:, None] * c_i + j[None, :]
+            real = tok < n_i
+            perm[dst[real]] = src_off[i] + tok[real]
+            kv_order[kv_base + tok.ravel()] = dst.ravel()
+    return perm, kv_order
+
+
+class PCPPreprocessor:
+    """Per-step host preprocessing for a PCP-enabled runner."""
+
+    def __init__(self, pcp_size: int, mesh: Mesh,
+                 num_reqs_paddings: list[int]):
+        assert pcp_size > 1, pcp_size
+        self.pcp_size = pcp_size
+        self.mesh = mesh
+        self.num_reqs_paddings = num_reqs_paddings
+        self._pcp_spec = NamedSharding(
+            mesh, PartitionSpec(ShardingAxisName.PREFILL_CONTEXT, None))
+        self._repl_spec = NamedSharding(mesh, PartitionSpec())
+
+    def metadata_to_device(self, cu_row: np.ndarray, q_pos: np.ndarray,
+                           kv_cache_lens: np.ndarray,
+                           kv_new_starts: np.ndarray,
+                           kv_token_order: np.ndarray, *, has_cached_kv: bool,
+                           num_reqs: int) -> PCPMetadata:
+        """Place host arrays as a `PCPMetadata`; also used by the compilation
+        manager so precompiled and runtime metadata share one sharding."""
+        query_start_loc, q_pos_offsets = device_array(
+            self.mesh, (np.tile(cu_row, (self.pcp_size, 1)), q_pos),
+            sharding=self._pcp_spec)
+        kv_cache_lens, kv_new_starts, kv_token_order = device_array(
+            self.mesh, (kv_cache_lens, kv_new_starts, kv_token_order),
+            sharding=self._repl_spec)
+        return PCPMetadata(
+            query_start_loc=query_start_loc,
+            kv_cache_lens=kv_cache_lens,
+            q_pos_offsets=q_pos_offsets,
+            kv_new_starts=kv_new_starts,
+            kv_token_order=kv_token_order,
+            has_cached_kv=has_cached_kv,
+            num_reqs=num_reqs,
+        )
+
+    def prepare_inputs(
+        self,
+        num_scheduled_tokens: list[int],
+        num_computed_tokens: list[int],
+        t_pad: int,
+        positions: np.ndarray,
+        input_ids: np.ndarray,
+        seq_lens: np.ndarray,
+        request_distribution: np.ndarray,
+        logits_indices: np.ndarray,
+    ) -> PCPMetadata:
+        """Permute `positions`/`input_ids` into rank order in place, overwrite
+        `seq_lens`, `request_distribution` and `logits_indices` with their
+        PCP values, and return the attention metadata."""
+        pcp_size = self.pcp_size
+        counts = num_scheduled_tokens
+        computed = num_computed_tokens
+        for n_i, l_i in zip(counts, computed):
+            if n_i == 1 and l_i > 0:
+                raise NotImplementedError(
+                    "PCP supports prefill-only batches; got a decode "
+                    f"request (num_scheduled=1, num_computed={l_i}).")
+
+        num_pcp_reqs = len(counts)
+        chunk, off = pcp_batch_layout(counts, t_pad, pcp_size)
+        perm, kv_order = pcp_token_permutation(counts, chunk, off, t_pad,
+                                               pcp_size)
+        valid = perm >= 0
+        src_idx = perm[valid]
+        for buf in (positions, input_ids):
+            src = buf.copy()
+            buf[:] = 0
+            buf[valid] = src[src_idx]
+
+        n_seqs = 2 * num_pcp_reqs
+        n_slots = len(seq_lens)
+        assert n_seqs <= n_slots, (
+            f"PCP needs {n_seqs} attention seq slots, have {n_slots}")
+
+        def per_seq(xs):
+            return np.repeat(np.asarray(xs, np.int32), 2)
+
+        seq_lens[:n_seqs] = per_seq(
+            [l_i + n_i for n_i, l_i in zip(counts, computed)])
+        seq_lens[n_seqs:] = 0
+        request_distribution[:] = (0, 0, n_seqs)
+        kv_cache_lens_np = np.zeros(n_slots, np.int32)
+        kv_cache_lens_np[:n_seqs] = per_seq(computed)
+
+        cu_row, q_pos_np, kv_new_starts_np = pcp_seq_arrays(
+            chunk, off, pcp_size, n_slots)
+        # A zero-length seq hangs the kernel.
+        assert np.all(np.diff(cu_row[:n_seqs + 1]) > 0), (
+            f"zero-length PCP seq in cu_q_lens: {cu_row[:n_seqs + 1]}")
+
+        # The global slot of each request's last token.
+        logits_indices[:] = -1
+        logits_indices[:num_pcp_reqs] = kv_order[pcp_size * np.asarray(off) +
+                                                 np.asarray(counts) - 1]
+
+        return self.metadata_to_device(
+            cu_row,
+            q_pos_np,
+            kv_cache_lens_np,
+            kv_new_starts_np,
+            kv_order,
+            has_cached_kv=any(l_i > 0 for l_i in computed),
+            num_reqs=runner_utils.get_padded_token_len(self.num_reqs_paddings,
+                                                       num_pcp_reqs),
+        )

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -53,8 +53,7 @@ import tpu_inference.envs as envs
 from tpu_inference import utils as common_utils
 from tpu_inference.core.sched.utils import DEFAULT_MAX_DECODE_STEPS
 from tpu_inference.layers.common.attention_metadata import (
-    AttentionMetadata, GroupedAttentionMetadata, PCPMetadata,
-    SharedAttentionMetadata, pcp_seq_arrays, pcp_token_layout)
+    AttentionMetadata, GroupedAttentionMetadata, SharedAttentionMetadata)
 from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
                                                   MESH_AXIS_NAMES_2D,
                                                   ShardingAxisName,
@@ -77,6 +76,8 @@ from tpu_inference.runner.input_batch import CachedRequestState, InputBatch
 from tpu_inference.runner.kv_cache_manager import KVCacheManager
 from tpu_inference.runner.lora_utils import LoraUtils
 from tpu_inference.runner.multimodal_manager import MultiModalManager
+from tpu_inference.runner.pcp_utils import (PCPPreprocessor, pcp_buffer_tokens,
+                                            pcp_max_buffer_tokens)
 from tpu_inference.runner.persistent_batch_manager import \
     PersistentBatchManager
 from tpu_inference.runner.speculative_decoding_manager import (
@@ -1068,12 +1069,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             max_token_size=scheduler_config.max_num_batched_tokens *
             self.dp_size,
             padding_gap=envs.VLLM_TPU_BUCKET_PADDING_GAP)
-        # PCP rounds every request's chunk size up independently, so the token
-        # buffer the layout needs can exceed max_num_batched_tokens by up to
-        # 2 * pcp_size * max_num_seqs; add a bucket with exactly that headroom.
         if pcp_size > 1:
-            _worst = (scheduler_config.max_num_batched_tokens +
-                      2 * pcp_size * scheduler_config.max_num_seqs)
+            _worst = pcp_max_buffer_tokens(
+                scheduler_config.max_num_batched_tokens,
+                scheduler_config.max_num_seqs, pcp_size)
             # 128-aligned so T_pad % pcp_size == 0 for any power-of-two pcp.
             additional_sizes = list(additional_sizes) + [
                 common_utils.align_to(_worst * self.dp_size, 128)
@@ -1152,6 +1151,10 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
             self.pcp_num_reqs_paddings = [1, _max_seqs]
         else:
             self.pcp_num_reqs_paddings = [1]
+        self.pcp_preprocessor = None
+        if pcp_size > 1:
+            self.pcp_preprocessor = PCPPreprocessor(pcp_size, self.mesh,
+                                                    self.pcp_num_reqs_paddings)
 
         # Padding for logits. Without speculative decoding, each request has one position to select from.
         # With speculative decoding, each request has multiple positions to select from.
@@ -2449,18 +2452,16 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         max_num_scheduled_tokens_across_dp = max(
             num_scheduled_tokens_per_dp_rank.values())
 
-        # PCP rounds each request's chunk size up independently, so size the
-        # bucket off the layout's padded requirement, not the raw token count.
-        pcp_size = self.vllm_config.sharding_config.prefill_cp_size
-        if pcp_size > 1:
+        # The PCP layout can need more rows than the raw token count.
+        if self.pcp_preprocessor is not None:
             for dp_rank in range(dp_size):
                 counts = scheduled_tokens_per_dp_rank[dp_rank]
                 if not counts:
                     continue
-                _, _, s_live = pcp_token_layout([int(c) for c in counts],
-                                                pcp_size)
                 max_num_scheduled_tokens_across_dp = max(
-                    max_num_scheduled_tokens_across_dp, pcp_size * s_live)
+                    max_num_scheduled_tokens_across_dp,
+                    pcp_buffer_tokens([int(c) for c in counts],
+                                      self.pcp_preprocessor.pcp_size))
 
         # Find maximum number of requests across DP ranks
         max_num_reqs_across_dp = max(
@@ -2898,128 +2899,21 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         request_distribution = np.array(_request_distribution,
                                         dtype=np.int32).ravel()
 
-        # Prefill context parallelism (prefill-only batches): zigzag-chunk
-        # each request independently and lay the tokens out in rank order.
         pcp_metadata = None
-        pcp_size = self.vllm_config.sharding_config.prefill_cp_size
-        if pcp_size > 1:
+        if self.pcp_preprocessor is not None:
             assert dp_size == 1, "PCP with DP > 1 is not supported."
-            counts = [int(c) for c in scheduled_tokens_per_dp_rank[0]]
-            req_idxs = [int(i) for i in req_indices_dp[0]]
-            computed = [
-                int(self.input_batch.num_computed_tokens_cpu[i])
-                for i in req_idxs
-            ]
-            # Prefill-only: a decode request would occupy 2P query rows to
-            # carry one token.
-            for n_i, l_i in zip(counts, computed):
-                if n_i == 1 and l_i > 0:
-                    raise NotImplementedError(
-                        "PCP supports prefill-only batches; got a decode "
-                        f"request (num_scheduled=1, num_computed={l_i}).")
-
-            num_pcp_reqs = len(counts)
-            two_p = 2 * pcp_size
-            # The layout covers the live requests only: both attention phases
-            # iterate the seq count from request_distribution, so the slots
-            # padding the count up to `PCPMetadata.num_reqs` need no rows.
-            chunk, off, s_live = pcp_token_layout(counts, pcp_size)
-            t_pad = padded_num_scheduled_tokens_per_dp_rank
-            assert t_pad % pcp_size == 0 and t_pad >= pcp_size * s_live, (
-                f"PCP token bucket {t_pad} cannot hold {pcp_size * s_live} "
-                f"tokens ({num_pcp_reqs} reqs, chunks {chunk})")
-            s_pad = t_pad // pcp_size
-            if num_pcp_reqs == 1:
-                # Single request: chunk = t_pad / 2P, filling every rank's
-                # slice.  pcp_forward's kernel-side K/V remap derives the chunk
-                # from the buffer width, so the layout must match it.
-                assert t_pad % two_p == 0, (t_pad, two_p)
-                chunk = [t_pad // two_p]
-                off = [0]
-
-            # `perm[g]` is the token-order source of global rank-order slot g
-            # (-1 for padding); `kv_order` is the inverse map for the
-            # all-gathered current K/V, into request-major token order.
-            src_off = np.cumsum([0] + counts)[:-1]
-            perm = np.full(t_pad, -1, np.int64)
-            kv_order = np.zeros(t_pad, np.int32)
-            ranks = np.arange(pcp_size)
-            for i in range(num_pcp_reqs):
-                c_i = chunk[i]
-                j = np.arange(c_i)
-                kv_base = pcp_size * off[i]  # == kv_new_starts of request i
-                for h in (0, 1):
-                    chunk_idx = ranks if h == 0 else two_p - 1 - ranks
-                    dst = (ranks[:, None] * s_pad + off[i] + h * c_i +
-                           j[None, :])
-                    tok = chunk_idx[:, None] * c_i + j[None, :]
-                    real = tok < counts[i]
-                    perm[dst[real]] = src_off[i] + tok[real]
-                    kv_order[kv_base + tok.ravel()] = dst.ravel()
-
-            valid = perm >= 0
-            for buf in (positions, input_ids_view):
-                src = np.asarray(buf).copy()
-                buf[:] = 0
-                buf[valid] = src[perm[valid]]
-
-            # Attention metadata: request i occupies seqs 2i (head), 2i+1
-            # (tail), carrying identical request-level values.
-            n_seqs = 2 * num_pcp_reqs
-            n_off = np.asarray(seq_lens_view).shape[0]  # attn_max_num_seqs
-            assert n_seqs <= n_off, (
-                f"PCP needs {n_seqs} attention seq slots, have {n_off}")
-
-            def per_seq(xs):
-                return np.repeat(np.asarray(xs, np.int32), 2)
-
-            seq_lens_view[:n_seqs] = per_seq(
-                [l_i + n_i for n_i, l_i in zip(counts, computed)])
-            seq_lens_view[n_seqs:] = 0
-            request_distribution[:] = (0, 0, n_seqs)
-            kv_cache_lens_np = np.zeros(n_off, np.int32)
-            kv_cache_lens_np[:n_seqs] = per_seq(computed)
-
-            # cu_q_lens is rank-invariant (both halves are full length); only
-            # q_pos_offsets varies by rank.
-            cu_row, pcp_qpos_np, kv_new_starts_np = pcp_seq_arrays(
-                chunk, off, pcp_size, n_off)
-            # A zero-length seq inside the iterated range hangs the kernel.
-            assert np.all(np.diff(cu_row[:n_seqs + 1]) > 0), (
-                f"zero-length PCP seq in cu_q_lens: {cu_row[:n_seqs + 1]}")
-            pcp_cu_np = np.tile(cu_row, (pcp_size, 1))
-
-            # logits_indices: the global slot of each request's last token.
-            logits_indices_view[:] = -1
-            for i in range(num_pcp_reqs):
-                last = counts[i] - 1
-                c = last // chunk[i]
-                rank = c if c < pcp_size else two_p - 1 - c
-                h = 0 if c < pcp_size else 1
-                logits_indices_view[i] = (rank * s_pad + off[i] +
-                                          h * chunk[i] + last % chunk[i])
-
-            pcp_spec = NamedSharding(
-                self.mesh, PartitionSpec(ShardingAxisName.PREFILL_CONTEXT,
-                                         None))
-            repl = NamedSharding(self.mesh, PartitionSpec())
-            (pcp_query_start_loc,
-             pcp_q_pos_offsets) = device_array(self.mesh,
-                                               (pcp_cu_np, pcp_qpos_np),
-                                               sharding=pcp_spec)
-            (pcp_kv_cache_lens, pcp_kv_new_starts,
-             pcp_kv_token_order) = device_array(
-                 self.mesh, (kv_cache_lens_np, kv_new_starts_np, kv_order),
-                 sharding=repl)
-            pcp_metadata = PCPMetadata(
-                query_start_loc=pcp_query_start_loc,
-                kv_cache_lens=pcp_kv_cache_lens,
-                q_pos_offsets=pcp_q_pos_offsets,
-                kv_new_starts=pcp_kv_new_starts,
-                kv_token_order=pcp_kv_token_order,
-                has_cached_kv=any(l_i > 0 for l_i in computed),
-                num_reqs=runner_utils.get_padded_token_len(
-                    self.pcp_num_reqs_paddings, num_pcp_reqs),
+            pcp_metadata = self.pcp_preprocessor.prepare_inputs(
+                num_scheduled_tokens=[
+                    int(c) for c in scheduled_tokens_per_dp_rank[0]
+                ],
+                num_computed_tokens=self.input_batch.num_computed_tokens_cpu[
+                    req_indices_dp[0]].tolist(),
+                t_pad=padded_num_scheduled_tokens_per_dp_rank,
+                positions=positions,
+                input_ids=input_ids_view,
+                seq_lens=seq_lens_view,
+                request_distribution=request_distribution,
+                logits_indices=logits_indices_view,
             )
         spec_decode_metadata = None
         if self.speculative_config:
@@ -3086,7 +2980,7 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                         out=block_tables_view[req_offset:req_offset +
                                               _num_reqs])
 
-            if pcp_size > 1:
+            if self.pcp_preprocessor is not None:
                 # Each request is two fused seqs (head, tail) and the kernel
                 # indexes page_indices by seq, so the tail must carry a copy
                 # of its request's block table or its KV write lands on page 0.


### PR DESCRIPTION
> **Stacked on #3425.** That PR's branch is mirrored at `pcp-multirequest-pr` in this repository and is this PR's base, so the diff here is only this PR's single commit. Supersedes #3514, which was opened from a fork and could not be stacked.

# Description

Pure code motion, no behaviour change. Follows a review suggestion on #3425 to move the CP preprocessing logic into its own file in the runner folder.

Today the per-step PCP work that `_prepare_inputs` does inline — validating the batch as prefill-only, zigzag-chunking each request, permuting the token buffers into rank order, building the per-seq attention metadata and logits indices, and assembling `PCPMetadata` — is one of the largest single blocks in `tpu_runner.py`, and the pure layout helpers it uses sit in `layers/common/attention_metadata.py` next to the dataclass they build.

After this PR:

- **New `tpu_inference/runner/pcp_utils.py`** holds all of it. `PCPPreprocessor.prepare_inputs` is the old inline block; `_prepare_inputs` reduces to a single call. The layout helpers (`pcp_token_layout`, `pcp_seq_arrays`) move here from `attention_metadata.py`, which keeps only the `PCPMetadata` dataclass — the layer-side contract stays under `layers/`, everything that builds it is runner-side. This mirrors how speculative decoding, structured decoding and multimodal preprocessing already live in their own runner modules.
- The token permutation becomes `pcp_token_permutation`, and `pcp_batch_layout` folds the buffer-fit assert together with the single-request chunk override, so each step of the layout can be checked on its own without a runner. The logits indices are read off `kv_token_order`, which already records each request's last-token slot, instead of re-deriving the zigzag formula.
- `PCPPreprocessor.metadata_to_device` is the one place that places host arrays as a `PCPMetadata` (which fields are sharded over the PCP axis, which are replicated). The compilation manager builds its precompile dummy through it rather than carrying a second copy of that recipe, so warmup and runtime metadata cannot drift apart.
- The token-bucket sizing uses `pcp_buffer_tokens`, and the headroom bucket uses its closed-form bound `pcp_max_buffer_tokens`, so the bound lives next to the function it bounds.

`git diff --color-moved` shows the move; the runner-side call site is the only logic that is new.

# Tests

- New `tests/runner/test_pcp_utils.py` (32 tests, numpy plus one mesh test): every real token lands in exactly one slot, `kv_token_order` undoes the permutation on the live rows, the zigzag rank assignment, `cu_q_lens` / `q_pos_offsets` / `kv_new_starts` per seq, the headroom bound, the logits slots, and `prepare_inputs` end to end on a mesh (skipped with fewer devices than `pcp_size`).
- On v7x: `tests/kernels/rpa_v3_cp/ragged_paged_attention_kernel_cp_test.py` (38 passed, 1 skipped) and `tests/layers/common/test_pcp_attention_interface.py` (23 passed) — identical counts to #3425 without this change — plus the new runner suite (32 passed) and `tests/runner/test_tpu_runner_dp.py` (27 passed).
- End-to-end greedy-token diff of a PCP=2 x TP=4 server against TP=8 (Qwen3-8B, 8k prompts, up to 8 requests per step, 2 repetitions): 16/16 prompts identical. TTFT at 8k for concurrency 1/2/4/8 is within 4 ms of #3425's head at every point on both the single-request and multi-request arms.

# Checklist

Before submitting this PR, please make sure:
- I have performed a self-review of my code.
- I have necessary comments in my code, particularly in hard-to-understand areas.
- I have made or will make corresponding changes to any relevant documentation.
