### PR TITLE
[PCP] Page-align chunks, unshuffle K/V in the kernel, merge the single-request path

### DIFF
--- a/tests/kernels/rpa_v3_cp/ragged_paged_attention_kernel_cp_test.py
+++ b/tests/kernels/rpa_v3_cp/ragged_paged_attention_kernel_cp_test.py
@@ -426,7 +426,7 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
         n = [r[0] for r in reqs]
         L = [r[1] for r in reqs]
         R = len(reqs)
-        C = [cdiv(cdiv(ni, two_p), align) * align for ni in n]
+        C = [align_to(cdiv(ni, two_p), align) for ni in n]
         W = [2 * ci for ci in C]
         off = [sum(W[:i]) for i in range(R)]
         S = sum(W)  # live tokens per rank
@@ -487,12 +487,22 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
             q += [r * lay["C"][i], (lay["two_p"] - 1 - r) * lay["C"][i]]
         return self._pad1(q)
 
-    def _rank_order_kv(self, lay, P, kv_buf_k, kv_buf_v):
+    def _kv_operands(self, lay, page_order, kv_buf_k, kv_buf_v, dtype):
+        """The kernel's K/V operands: with `page_order` (the production
+        path), the rank-order all_gather buffer plus the kv_page_order map
+        the kernel unshuffles it through; without, the pre-gathered
+        token-order buffer and no map."""
+        if not page_order:
+            return jnp.array(kv_buf_k, dtype), jnp.array(kv_buf_v, dtype), None
+        ro_k, ro_v, order = self._rank_order_kv(lay, kv_buf_k, kv_buf_v)
+        return jnp.array(ro_k, dtype), jnp.array(ro_v, dtype), order
+
+    def _rank_order_kv(self, lay, kv_buf_k, kv_buf_v):
         """The token-order new-KV buffers scattered into the rank-order layout
         the all_gather produces (t_pad = P * S rows), plus the per-page map the
-        kernel unshuffles them through. This is the production configuration;
-        the token-order variant feeds the kernel a pre-gathered buffer."""
+        kernel unshuffles them through."""
         two_p, C, off, S = lay["two_p"], lay["C"], lay["off"], lay["S"]
+        P = two_p // 2
         t_pad = P * S
         ro_k = np.zeros((t_pad, *kv_buf_k.shape[1:]), kv_buf_k.dtype)
         ro_v = np.zeros_like(ro_k)
@@ -528,7 +538,9 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
         nq, nkv, hd = 8, 2, 128
         # Ragged lengths, mixed cache state, incl. a first-chunk request (L=0).
         reqs = [(70, 0), (33, 48), (16, 96)]
-        lay = self._multireq_layout(P, reqs, align=self.PAGE if page_order else 1)
+        lay = self._multireq_layout(P,
+                                    reqs,
+                                    align=self.PAGE if page_order else 1)
         R = lay["R"]
         c = self._cfg(dtype)
         rng = np.random.default_rng(7)
@@ -545,13 +557,8 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
             kv_buf_v[s:s + lay["n"][i]] = vi
             per_req_kv.append(
                 merge_kv(jnp.array(ki, dtype), jnp.array(vi, dtype)))
-        if page_order:
-            ro_k, ro_v, order = self._rank_order_kv(lay, P, kv_buf_k,
-                                                    kv_buf_v)
-            k, v = jnp.array(ro_k, dtype), jnp.array(ro_v, dtype)
-        else:
-            order = None
-            k, v = jnp.array(kv_buf_k, dtype), jnp.array(kv_buf_v, dtype)
+        k, v, order = self._kv_operands(lay, page_order, kv_buf_k, kv_buf_v,
+                                        dtype)
         q = self._rand(rng, (lay["S"], nq, hd), dtype)
 
         # Pre-fill the entire cache so any stray write shows up. Keep it on the
@@ -626,7 +633,9 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
         self.PAGE = 16
         nq, nkv, hd = 8, 2, 128
         reqs = [(70, 0), (33, 48), (16, 96)]
-        lay = self._multireq_layout(P, reqs, align=self.PAGE if page_order else 1)
+        lay = self._multireq_layout(P,
+                                    reqs,
+                                    align=self.PAGE if page_order else 1)
         R, C, off, two_p = lay["R"], lay["C"], lay["off"], lay["two_p"]
         rng = np.random.default_rng(11)
 
@@ -655,13 +664,8 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
                                               self._padcu([0, ni]),
                                               jnp.array([0, 0, 1], jnp.int32))
             exp.append(e[:ni])
-        if page_order:
-            ro_k, ro_v, order = self._rank_order_kv(lay, P, kv_buf_k,
-                                                    kv_buf_v)
-            k, v = jnp.array(ro_k, dtype), jnp.array(ro_v, dtype)
-        else:
-            order = None
-            k, v = jnp.array(kv_buf_k, dtype), jnp.array(kv_buf_v, dtype)
+        k, v, order = self._kv_operands(lay, page_order, kv_buf_k, kv_buf_v,
+                                        dtype)
 
         checked = 0
         for r in range(P):

--- a/tests/kernels/rpa_v3_cp/ragged_paged_attention_kernel_cp_test.py
+++ b/tests/kernels/rpa_v3_cp/ragged_paged_attention_kernel_cp_test.py
@@ -28,6 +28,7 @@ from tpu_inference.kernels.experimental.rpa_v3_cp.kernel import (
     merge_kv, ragged_paged_attention, ref_ragged_paged_attention)
 from tpu_inference.kernels.ragged_paged_attention.v3.util import (
     align_to, cdiv, get_dtype_packing)
+from tpu_inference.runner.pcp_utils import pcp_page_order
 
 jax.config.parse_flags_with_absl()
 
@@ -412,18 +413,20 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
                 self.assertArraysEqual(flat[slot], kv_merged[g])
 
     # --------------------- multi-request PCP (R > 1) -------------------------
-    def _multireq_layout(self, P, reqs):
+    def _multireq_layout(self, P, reqs, align=1):
         """Host-side metadata for R requests fused as 2R seqs.
 
         Mirrors the layout `_prepare_inputs` builds: request
         i is zigzag-chunked on its own into 2P chunks of C_i, and occupies seq
-        2i (head) and 2i+1 (tail). `reqs` is a list of (n_i, L_i).
+        2i (head) and 2i+1 (tail). `reqs` is a list of (n_i, L_i). `align`
+        rounds each chunk up to that multiple (the production layout uses the
+        KV page size, which the kv_page_order fetch requires).
         """
         two_p = 2 * P
         n = [r[0] for r in reqs]
         L = [r[1] for r in reqs]
         R = len(reqs)
-        C = [cdiv(ni, two_p) for ni in n]
+        C = [cdiv(cdiv(ni, two_p), align) * align for ni in n]
         W = [2 * ci for ci in C]
         off = [sum(W[:i]) for i in range(R)]
         S = sum(W)  # live tokens per rank
@@ -484,8 +487,29 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
             q += [r * lay["C"][i], (lay["two_p"] - 1 - r) * lay["C"][i]]
         return self._pad1(q)
 
-    @parameterized.product(P=[2, 4])
-    def test_pcp_multirequest_fused_write(self, P):
+    def _rank_order_kv(self, lay, P, kv_buf_k, kv_buf_v):
+        """The token-order new-KV buffers scattered into the rank-order layout
+        the all_gather produces (t_pad = P * S rows), plus the per-page map the
+        kernel unshuffles them through. This is the production configuration;
+        the token-order variant feeds the kernel a pre-gathered buffer."""
+        two_p, C, off, S = lay["two_p"], lay["C"], lay["off"], lay["S"]
+        t_pad = P * S
+        ro_k = np.zeros((t_pad, *kv_buf_k.shape[1:]), kv_buf_k.dtype)
+        ro_v = np.zeros_like(ro_k)
+        for i in range(lay["R"]):
+            s = lay["kv_starts"][i]
+            for t in range(two_p * C[i]):
+                ch = t // C[i]
+                rr = ch if ch < P else two_p - 1 - ch
+                h = 0 if ch < P else 1
+                g = rr * S + off[i] + h * C[i] + t % C[i]
+                ro_k[g] = kv_buf_k[s + t]
+                ro_v[g] = kv_buf_v[s + t]
+        order = pcp_page_order(C, off, P, S, t_pad, self.PAGE)
+        return ro_k, ro_v, jnp.asarray(order)
+
+    @parameterized.product(P=[2, 4], page_order=[False, True])
+    def test_pcp_multirequest_fused_write(self, P, page_order):
         """R requests in one launch: each writes its OWN strided share, once.
 
         The whole cache is pre-filled with random values and compared against a
@@ -493,13 +517,18 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
         wrong request's pages, writes twice, or spills outside its range --
         which is the failure mode `kv_write_seq_mask` and `kv_new_starts` exist
         to prevent.
+
+        page_order=True feeds the kernel the rank-order all_gather buffer plus
+        the kv_page_order map (the production path: the write must consume the
+        map-unshuffled VMEM window); False feeds a pre-gathered token-order
+        buffer.
         """
         dtype = jnp.float32
         self.PAGE = 16
         nq, nkv, hd = 8, 2, 128
         # Ragged lengths, mixed cache state, incl. a first-chunk request (L=0).
         reqs = [(70, 0), (33, 48), (16, 96)]
-        lay = self._multireq_layout(P, reqs)
+        lay = self._multireq_layout(P, reqs, align=self.PAGE if page_order else 1)
         R = lay["R"]
         c = self._cfg(dtype)
         rng = np.random.default_rng(7)
@@ -516,8 +545,13 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
             kv_buf_v[s:s + lay["n"][i]] = vi
             per_req_kv.append(
                 merge_kv(jnp.array(ki, dtype), jnp.array(vi, dtype)))
-        k = jnp.array(kv_buf_k, dtype)
-        v = jnp.array(kv_buf_v, dtype)
+        if page_order:
+            ro_k, ro_v, order = self._rank_order_kv(lay, P, kv_buf_k,
+                                                    kv_buf_v)
+            k, v = jnp.array(ro_k, dtype), jnp.array(ro_v, dtype)
+        else:
+            order = None
+            k, v = jnp.array(kv_buf_k, dtype), jnp.array(kv_buf_v, dtype)
         q = self._rand(rng, (lay["S"], nq, hd), dtype)
 
         # Pre-fill the entire cache so any stray write shows up. Keep it on the
@@ -543,6 +577,7 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
                 q_pos_offsets=self._qpos_multi(lay, r),
                 kv_new_starts=lay["kv_new_starts"],
                 kv_write_seq_mask=lay["kv_write_seq_mask"],
+                kv_page_order=order,
                 update_kv_cache=True,
                 skip_cache_attn=True,
                 use_causal_mask=True)
@@ -570,20 +605,28 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
                                 atol=self._tol(dtype),
                                 rtol=self._tol(dtype))
 
-    @parameterized.product(P=[2, 4])
-    def test_pcp_multirequest_current_phase_output(self, P):
+    @parameterized.product(P=[2, 4], page_order=[False, True])
+    def test_pcp_multirequest_current_phase_output(self, P, page_order):
         """R requests in one launch: every chunk's attention output is right.
 
         Exercises per-seq cu_q_lens, q_pos_offsets, kv_cache_lens and
         kv_new_starts together. A wrong kv_new_starts makes a request attend
         another request's K/V -- shapes stay valid, values do not, which is
         exactly what this catches.
+
+        page_order=True is the production path: the K/V buffer stays in the
+        rank order the all_gather produced and the kernel unshuffles it
+        through the kv_page_order map during its fetch. Small KV windows
+        (m_block_sizes below) split each seq's fetch across several bkv
+        windows; with the L=48 request's kv_cache_len_local not a page
+        multiple, later windows' new-KV runs start mid-page, which the map
+        fetch must handle (partial first piece).
         """
         dtype = jnp.float32
         self.PAGE = 16
         nq, nkv, hd = 8, 2, 128
         reqs = [(70, 0), (33, 48), (16, 96)]
-        lay = self._multireq_layout(P, reqs)
+        lay = self._multireq_layout(P, reqs, align=self.PAGE if page_order else 1)
         R, C, off, two_p = lay["R"], lay["C"], lay["off"], lay["two_p"]
         rng = np.random.default_rng(11)
 
@@ -612,8 +655,13 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
                                               self._padcu([0, ni]),
                                               jnp.array([0, 0, 1], jnp.int32))
             exp.append(e[:ni])
-        k = jnp.array(kv_buf_k, dtype)
-        v = jnp.array(kv_buf_v, dtype)
+        if page_order:
+            ro_k, ro_v, order = self._rank_order_kv(lay, P, kv_buf_k,
+                                                    kv_buf_v)
+            k, v = jnp.array(ro_k, dtype), jnp.array(ro_v, dtype)
+        else:
+            order = None
+            k, v = jnp.array(kv_buf_k, dtype), jnp.array(kv_buf_v, dtype)
 
         checked = 0
         for r in range(P):
@@ -641,6 +689,10 @@ class RaggedPagedAttentionPcpTest(jtu.JaxTestCase):
                 q_pos_offsets=self._qpos_multi(lay, r),
                 kv_new_starts=lay["kv_new_starts"],
                 kv_write_seq_mask=lay["kv_write_seq_mask"],
+                kv_page_order=order,
+                # Tiny KV windows: several bkv windows per seq, so new-KV
+                # runs start at unaligned offsets (see docstring).
+                m_block_sizes=(64, 32, 64, 32),
                 update_kv_cache=False,
                 skip_cache_attn=True,
                 use_causal_mask=True)

--- a/tests/layers/common/test_pcp_attention_interface.py
+++ b/tests/layers/common/test_pcp_attention_interface.py
@@ -58,26 +58,29 @@ def _to_rank_order(x, pcp, C):
         x.reshape(2 * pcp, C, *x.shape[1:])[_row_perm(pcp)].reshape(x.shape))
 
 
-def _kv_token_order(pcp, C):
-    """Single-request `kv_token_order`: token t -> its slot in rank order."""
-    order = _inv_row(pcp)[:, None] * C + np.arange(C)[None, :]
-    return jnp.asarray(order.reshape(-1), jnp.int32)
-
-
 def _pcp_meta(pcp, C, num_current):
     """The per-rank fused current-phase metadata, exactly as _prepare_inputs
-    builds it: cu = [0, C, C + tail_real] and q_pos_offsets = [head, tail]."""
+    builds it: cu = [0, C, 2C] (both halves full length -- rank-invariant, as
+    the merged path requires) and q_pos_offsets = [head, tail]."""
+    del num_current  # tails are full length; padding rows are simply unused
     two_p = 2 * pcp
     cu = np.zeros((pcp, MAX_SEQ + 1), np.int32)
     qpos = np.zeros((pcp, MAX_SEQ), np.int32)
     for r in range(pcp):
-        tail_off = (two_p - 1 - r) * C
-        tail_real = int(np.clip(num_current - tail_off, 0, C))
-        cu[r, 1] = C  # seq 0 (head) is always fully real
-        cu[r, 2:] = C + tail_real  # seq 1 (tail) is clamped
+        cu[r, 1] = C
+        cu[r, 2:] = 2 * C
         qpos[r, 0] = r * C
-        qpos[r, 1] = tail_off
+        qpos[r, 1] = (two_p - 1 - r) * C
     return jnp.asarray(cu), jnp.asarray(qpos)
+
+
+def _single_req_extras(pcp, C):
+    """kv_new_starts / kv_page_order for ONE request filling 2P*C rows, as
+    the merged path requires for any request count."""
+    t_pad = 2 * pcp * C
+    return (jnp.zeros(MAX_SEQ, jnp.int32),
+            jnp.asarray(pcp_page_order([C], [0], pcp, t_pad // pcp, t_pad,
+                                       PAGE)))
 
 
 class PcpAttentionInterfaceTest(jtu.JaxTestCase):
@@ -274,24 +277,20 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                 sm_scale=SM_SCALE)
             exp.append(np.asarray(e[:n[i]]))
 
-        # Token buffers in rank order, the request-major K/V permutation, and
-        # the per-page unshuffle map (the production helper) for the kernel's
-        # in-fetch reorder.
+        # Token buffers in rank order, plus the per-page K/V unshuffle map
+        # (the production helper) for the kernel's in-fetch reorder.
         def empty(width):
             return np.zeros((t_pad, width, HD), np.float32)
 
         q_buf, k_buf, v_buf = empty(NQ), empty(NKV), empty(NKV)
         page_order = pcp_page_order(C, off, pcp, s_pad, t_pad, PAGE)
-        kv_order = np.zeros(t_pad, np.int32)
         for i in range(R):
-            kv_base = pcp * off[i]
             for h in (0, 1):
                 for r in range(pcp):
                     c = r if h == 0 else two_p - 1 - r
                     for j in range(C[i]):
                         g = r * s_pad + off[i] + h * C[i] + j
                         t = c * C[i] + j
-                        kv_order[kv_base + t] = g
                         if t < n[i]:
                             q_buf[g] = np.asarray(cur[i][0][t], np.float32)
                             k_buf[g] = np.asarray(cur[i][1][t], np.float32)
@@ -321,7 +320,6 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                 q_pos_offsets=jnp.asarray(qpos),
                 has_cached_kv=max(L) > 0,
                 kv_new_starts=jnp.asarray(kv_new_starts),
-                kv_token_order=jnp.asarray(kv_order),
                 kv_page_order=jnp.asarray(page_order),
                 num_reqs=num_reqs_bucket or R,
             ),
@@ -514,6 +512,7 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
         kv_lens = pad1([kv_total, kv_total])
         kv_cache_lens = pad1([L, L])
         cu_q_lens, q_pos_offsets = _pcp_meta(pcp, C, num_current)
+        kv_new_starts, kv_page_order = _single_req_extras(pcp, C)
         distribution = jnp.array([0, 0, 2], jnp.int32)  # head + tail
 
         md = AttentionMetadata(
@@ -525,11 +524,8 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                 query_start_loc=cu_q_lens,
                 kv_cache_lens=kv_cache_lens,
                 q_pos_offsets=q_pos_offsets,
-                kv_new_starts=jnp.zeros(MAX_SEQ, jnp.int32),
-                kv_token_order=_kv_token_order(pcp, C),
-                # Empty, as the runner passes for one request: the
-                # single-request path unshuffles without the map.
-                kv_page_order=jnp.zeros(0, jnp.int32),
+                kv_new_starts=kv_new_starts,
+                kv_page_order=kv_page_order,
                 has_cached_kv=L > 0,
             ),
         )
@@ -685,6 +681,7 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
             return jnp.pad(jnp.array(xs, jnp.int32), (0, MAX_SEQ - len(xs)))
 
         cu, qpos = _pcp_meta(pcp, C, num_current)
+        kv_new_starts, kv_page_order = _single_req_extras(pcp, C)
         md = AttentionMetadata(
             input_positions=jnp.zeros(1, jnp.int32),
             seq_lens=pad1([kv_total, kv_total]),
@@ -694,11 +691,8 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                 query_start_loc=cu,
                 kv_cache_lens=pad1([L, L]),
                 q_pos_offsets=qpos,
-                kv_new_starts=jnp.zeros(MAX_SEQ, jnp.int32),
-                kv_token_order=_kv_token_order(pcp, C),
-                # Empty, as the runner passes for one request: the
-                # single-request path unshuffles without the map.
-                kv_page_order=jnp.zeros(0, jnp.int32),
+                kv_new_starts=kv_new_starts,
+                kv_page_order=kv_page_order,
                 has_cached_kv=True,
             ),
         )
@@ -756,6 +750,7 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
             return jnp.pad(jnp.array(xs, jnp.int32), (0, MAX_SEQ - len(xs)))
 
         cu, qpos = _pcp_meta(pcp, C, num_current)
+        kv_new_starts, kv_page_order = _single_req_extras(pcp, C)
         md = AttentionMetadata(
             input_positions=jnp.zeros(1, jnp.int32),
             seq_lens=pad1([kv_total, kv_total]),
@@ -765,11 +760,8 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                 query_start_loc=cu,
                 kv_cache_lens=pad1([0, 0]),
                 q_pos_offsets=qpos,
-                kv_new_starts=jnp.zeros(MAX_SEQ, jnp.int32),
-                kv_token_order=_kv_token_order(pcp, C),
-                # Empty, as the runner passes for one request: the
-                # single-request path unshuffles without the map.
-                kv_page_order=jnp.zeros(0, jnp.int32),
+                kv_new_starts=kv_new_starts,
+                kv_page_order=kv_page_order,
                 has_cached_kv=False,
             ),
         )

--- a/tests/layers/common/test_pcp_attention_interface.py
+++ b/tests/layers/common/test_pcp_attention_interface.py
@@ -58,29 +58,16 @@ def _to_rank_order(x, pcp, C):
         x.reshape(2 * pcp, C, *x.shape[1:])[_row_perm(pcp)].reshape(x.shape))
 
 
-def _pcp_meta(pcp, C, num_current):
-    """The per-rank fused current-phase metadata, exactly as _prepare_inputs
-    builds it: cu = [0, C, 2C] (both halves full length -- rank-invariant, as
-    the merged path requires) and q_pos_offsets = [head, tail]."""
-    del num_current  # tails are full length; padding rows are simply unused
-    two_p = 2 * pcp
-    cu = np.zeros((pcp, MAX_SEQ + 1), np.int32)
-    qpos = np.zeros((pcp, MAX_SEQ), np.int32)
-    for r in range(pcp):
-        cu[r, 1] = C
-        cu[r, 2:] = 2 * C
-        qpos[r, 0] = r * C
-        qpos[r, 1] = (two_p - 1 - r) * C
-    return jnp.asarray(cu), jnp.asarray(qpos)
-
-
-def _single_req_extras(pcp, C):
-    """kv_new_starts / kv_page_order for ONE request filling 2P*C rows, as
-    the merged path requires for any request count."""
+def _single_req_meta(pcp, C):
+    """cu_q_lens / q_pos_offsets / kv_new_starts / kv_page_order for ONE
+    request filling 2P*C rows, straight from the production helpers (a
+    single request is simply R = 1 of the general layout)."""
     t_pad = 2 * pcp * C
-    return (jnp.zeros(MAX_SEQ, jnp.int32),
-            jnp.asarray(pcp_page_order([C], [0], pcp, t_pad // pcp, t_pad,
-                                       PAGE)))
+    cu_row, qpos, kv_new_starts = pcp_seq_arrays([C], [0], pcp, MAX_SEQ)
+    return (jnp.asarray(np.tile(cu_row, (pcp, 1))), jnp.asarray(qpos),
+            jnp.asarray(kv_new_starts),
+            jnp.asarray(
+                pcp_page_order([C], [0], pcp, t_pad // pcp, t_pad, PAGE)))
 
 
 class PcpAttentionInterfaceTest(jtu.JaxTestCase):
@@ -277,8 +264,7 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                 sm_scale=SM_SCALE)
             exp.append(np.asarray(e[:n[i]]))
 
-        # Token buffers in rank order, plus the per-page K/V unshuffle map
-        # (the production helper) for the kernel's in-fetch reorder.
+        # Token buffers in rank order, plus the per-page K/V unshuffle map.
         def empty(width):
             return np.zeros((t_pad, width, HD), np.float32)
 
@@ -511,8 +497,8 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
         # Both fused seqs are the SAME request -> [T, T] / [P, P].
         kv_lens = pad1([kv_total, kv_total])
         kv_cache_lens = pad1([L, L])
-        cu_q_lens, q_pos_offsets = _pcp_meta(pcp, C, num_current)
-        kv_new_starts, kv_page_order = _single_req_extras(pcp, C)
+        cu_q_lens, q_pos_offsets, kv_new_starts, kv_page_order = (
+            _single_req_meta(pcp, C))
         distribution = jnp.array([0, 0, 2], jnp.int32)  # head + tail
 
         md = AttentionMetadata(
@@ -680,8 +666,7 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
         def pad1(xs):
             return jnp.pad(jnp.array(xs, jnp.int32), (0, MAX_SEQ - len(xs)))
 
-        cu, qpos = _pcp_meta(pcp, C, num_current)
-        kv_new_starts, kv_page_order = _single_req_extras(pcp, C)
+        cu, qpos, kv_new_starts, kv_page_order = _single_req_meta(pcp, C)
         md = AttentionMetadata(
             input_positions=jnp.zeros(1, jnp.int32),
             seq_lens=pad1([kv_total, kv_total]),
@@ -749,8 +734,7 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
         def pad1(xs):
             return jnp.pad(jnp.array(xs, jnp.int32), (0, MAX_SEQ - len(xs)))
 
-        cu, qpos = _pcp_meta(pcp, C, num_current)
-        kv_new_starts, kv_page_order = _single_req_extras(pcp, C)
+        cu, qpos, kv_new_starts, kv_page_order = _single_req_meta(pcp, C)
         md = AttentionMetadata(
             input_positions=jnp.zeros(1, jnp.int32),
             seq_lens=pad1([kv_total, kv_total]),

--- a/tests/layers/common/test_pcp_attention_interface.py
+++ b/tests/layers/common/test_pcp_attention_interface.py
@@ -29,7 +29,8 @@ from tpu_inference.layers.common.attention_metadata import (AttentionMetadata,
 from tpu_inference.layers.common.cp_attention import pcp_forward
 from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
                                                   ShardingAxisNameBase)
-from tpu_inference.runner.pcp_utils import pcp_seq_arrays, pcp_token_layout
+from tpu_inference.runner.pcp_utils import (pcp_page_order, pcp_seq_arrays,
+                                            pcp_token_layout)
 
 PAGE = 16  # per-rank block_size; the GLOBAL page_size dim is PAGE * pcp
 MAX_SEQ = 8
@@ -182,8 +183,9 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
     def _multi_layout(self, pcp, reqs, t_pad):
         """The layout `_prepare_inputs` builds for R live requests (the
         production helper), checked against the token bucket t_pad."""
-        C, off, acc = pcp_token_layout([r[0] for r in reqs], pcp)
+        C, off, acc = pcp_token_layout([r[0] for r in reqs], pcp, align=PAGE)
         assert t_pad % pcp == 0 and t_pad >= pcp * acc, (t_pad, pcp * acc)
+        assert (t_pad // pcp) % PAGE == 0, (t_pad, pcp, PAGE)
         return C, off, acc, t_pad // pcp
 
     def _slot(self, pcp, C, off, s_pad, i, t):
@@ -272,11 +274,14 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                 sm_scale=SM_SCALE)
             exp.append(np.asarray(e[:n[i]]))
 
-        # Token buffers in rank order, plus the request-major K/V permutation.
+        # Token buffers in rank order, the request-major K/V permutation, and
+        # the per-page unshuffle map (the production helper) for the kernel's
+        # in-fetch reorder.
         def empty(width):
             return np.zeros((t_pad, width, HD), np.float32)
 
         q_buf, k_buf, v_buf = empty(NQ), empty(NKV), empty(NKV)
+        page_order = pcp_page_order(C, off, pcp, s_pad, t_pad, PAGE)
         kv_order = np.zeros(t_pad, np.int32)
         for i in range(R):
             kv_base = pcp * off[i]
@@ -317,6 +322,7 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                 has_cached_kv=max(L) > 0,
                 kv_new_starts=jnp.asarray(kv_new_starts),
                 kv_token_order=jnp.asarray(kv_order),
+                kv_page_order=jnp.asarray(page_order),
                 num_reqs=num_reqs_bucket or R,
             ),
         )
@@ -343,7 +349,7 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
         if jax.device_count() < pcp:
             self.skipTest(f"needs >= {pcp} devices")
         reqs = [(96, 0), (48, 64), (33, 32)]
-        out, _, exp, _, C, off, s_pad, _ = self._run_multi(pcp, reqs, 256)
+        out, _, exp, _, C, off, s_pad, _ = self._run_multi(pcp, reqs, 512)
         self._assert_multi_matches(out, exp, reqs, pcp, C, off, s_pad)
 
     @parameterized.product(pcp=[2, 4])
@@ -377,7 +383,7 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
         if jax.device_count() < pcp:
             self.skipTest(f"needs >= {pcp} devices")
         reqs = [(96, 0), (48, 64), (33, 32)]
-        _, cache, _, cur, _, _, _, pps = self._run_multi(pcp, reqs, 256)
+        _, cache, _, cur, _, _, _, pps = self._run_multi(pcp, reqs, 512)
         for i, (ni, Li) in enumerate(reqs):
             ref = np.asarray(merge_kv(cur[i][1], cur[i][2]))
             for t in range(ni):
@@ -400,16 +406,17 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
         pcp = 2
         if jax.device_count() < pcp:
             self.skipTest(f"needs >= {pcp} devices")
-        # C_0 = ceil(2500/4) = 625 -> 1250 rows: two tiles, boundary at 625.
-        # C_1 = ceil(700/4) = 175 -> 350 rows: one partial tile.
+        # C_0 = ceil(2500/4) -> 640 page-aligned -> 1280 rows: two tiles,
+        # boundary at 640. C_1 -> 176 -> 352 rows: one partial tile.
         reqs = [(2500, 64), (700, 32)]
-        out, _, exp, _, C, off, s_pad, _ = self._run_multi(pcp, reqs, 3200)
+        out, _, exp, _, C, off, s_pad, _ = self._run_multi(pcp, reqs, 3264)
         self._assert_multi_matches(out, exp, reqs, pcp, C, off, s_pad)
 
     def test_multirequest_nan_probe_headroom_bucket(self):
         """Shape from the 32k E2E run that produced NaN logits: a batch whose
-        layout needs P*S = 16388 rows and so lands in the headroom bucket
-        (16512) above max_num_batched_tokens, leaving 62 dead rows per rank.
+        layout needs P*S = 16448 rows (page-aligned chunks) and so lands in
+        the headroom bucket (16512) above max_num_batched_tokens, leaving
+        dead rows per rank.
         Every REAL row must be finite; report where NaN shows up otherwise."""
         pcp = 2
         if jax.device_count() < pcp:
@@ -520,6 +527,9 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                 q_pos_offsets=q_pos_offsets,
                 kv_new_starts=jnp.zeros(MAX_SEQ, jnp.int32),
                 kv_token_order=_kv_token_order(pcp, C),
+                # Empty, as the runner passes for one request: the
+                # single-request path unshuffles without the map.
+                kv_page_order=jnp.zeros(0, jnp.int32),
                 has_cached_kv=L > 0,
             ),
         )
@@ -686,6 +696,9 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                 q_pos_offsets=qpos,
                 kv_new_starts=jnp.zeros(MAX_SEQ, jnp.int32),
                 kv_token_order=_kv_token_order(pcp, C),
+                # Empty, as the runner passes for one request: the
+                # single-request path unshuffles without the map.
+                kv_page_order=jnp.zeros(0, jnp.int32),
                 has_cached_kv=True,
             ),
         )
@@ -754,6 +767,9 @@ class PcpAttentionInterfaceTest(jtu.JaxTestCase):
                 q_pos_offsets=qpos,
                 kv_new_starts=jnp.zeros(MAX_SEQ, jnp.int32),
                 kv_token_order=_kv_token_order(pcp, C),
+                # Empty, as the runner passes for one request: the
+                # single-request path unshuffles without the map.
+                kv_page_order=jnp.zeros(0, jnp.int32),
                 has_cached_kv=False,
             ),
         )

--- a/tests/runner/test_pcp_utils.py
+++ b/tests/runner/test_pcp_utils.py
@@ -22,8 +22,12 @@ from vllm.utils.math_utils import cdiv, next_power_of_2
 from tpu_inference.runner.pcp_utils import (PCPPreprocessor, pcp_batch_layout,
                                             pcp_buffer_tokens,
                                             pcp_max_buffer_tokens,
-                                            pcp_seq_arrays, pcp_token_layout,
+                                            pcp_page_order, pcp_seq_arrays,
+                                            pcp_token_layout,
                                             pcp_token_permutation)
+
+# KV page size the production layout aligns chunks to (cache block_size).
+PAGE = 16
 
 # (pcp_size, scheduled tokens per request)
 LAYOUTS = [
@@ -38,13 +42,14 @@ LAYOUTS = [
 
 def _t_pad(counts, pcp):
     """A power-of-two bucket that holds the layout and is divisible by 2P."""
-    return next_power_of_2(max(pcp_buffer_tokens(counts, pcp), 2 * pcp))
+    return next_power_of_2(
+        max(pcp_buffer_tokens(counts, pcp, align=PAGE), 2 * pcp))
 
 
 def _layout(counts, pcp):
     """(t_pad, chunk, off) of a batch in the bucket `_t_pad` picks."""
     t_pad = _t_pad(counts, pcp)
-    chunk, off = pcp_batch_layout(counts, t_pad, pcp)
+    chunk, off = pcp_batch_layout(counts, t_pad, pcp, align=PAGE)
     return t_pad, chunk, off
 
 
@@ -66,7 +71,7 @@ def test_batch_layout(pcp, counts):
         # Single request: the chunk comes from the buffer width.
         assert chunk == [t_pad // (2 * pcp)] and off == [0]
     else:
-        assert (chunk, off) == pcp_token_layout(counts, pcp)[:2]
+        assert (chunk, off) == pcp_token_layout(counts, pcp, align=PAGE)[:2]
 
 
 def test_batch_layout_rejects_short_buffer():
@@ -124,7 +129,7 @@ def test_prepare_inputs(pcp, counts):
     if len(jax.devices()) < pcp:
         pytest.skip(f"needs {pcp} devices")
     mesh = Mesh(np.array(jax.devices()[:pcp]), ("pcp", ))
-    pre = PCPPreprocessor(pcp, mesh, [1, 8])
+    pre = PCPPreprocessor(pcp, mesh, [1, 8], PAGE)
 
     t_pad, chunk, off = _layout(counts, pcp)
     n_reqs = len(counts)
@@ -170,6 +175,14 @@ def test_prepare_inputs(pcp, counts):
     assert md.has_cached_kv == (max(computed) > 0)
     assert md.num_reqs == (1 if n_reqs == 1 else 8)
     assert np.array_equal(np.asarray(md.kv_token_order), kv_order)
+    if n_reqs > 1:
+        # The kernel unshuffles through the per-page map; a single request
+        # gets an empty one and keeps the kernel-side remap.
+        assert np.array_equal(
+            np.asarray(md.kv_page_order),
+            pcp_page_order(chunk, off, pcp, t_pad // pcp, t_pad, PAGE))
+    else:
+        assert np.asarray(md.kv_page_order).shape == (0, )
     assert np.array_equal(
         np.asarray(md.kv_new_starts)[:n_seqs],
         np.repeat([pcp * o for o in off], 2))
@@ -179,7 +192,7 @@ def test_prepare_inputs_rejects_decode():
     if len(jax.devices()) < 2:
         pytest.skip("needs 2 devices")
     mesh = Mesh(np.array(jax.devices()[:2]), ("pcp", ))
-    pre = PCPPreprocessor(2, mesh, [1, 8])
+    pre = PCPPreprocessor(2, mesh, [1, 8], PAGE)
     # Rejected before any buffer is touched, so shapes do not matter.
     buf = np.zeros(16, np.int32)
     with pytest.raises(NotImplementedError):

--- a/tests/runner/test_pcp_utils.py
+++ b/tests/runner/test_pcp_utils.py
@@ -67,11 +67,8 @@ def test_token_layout(pcp, counts):
 @pytest.mark.parametrize("pcp,counts", LAYOUTS)
 def test_batch_layout(pcp, counts):
     t_pad, chunk, off = _layout(counts, pcp)
-    if len(counts) == 1:
-        # Single request: the chunk comes from the buffer width.
-        assert chunk == [t_pad // (2 * pcp)] and off == [0]
-    else:
-        assert (chunk, off) == pcp_token_layout(counts, pcp, align=PAGE)[:2]
+    # One layout for any request count: R = 1 is not a special case.
+    assert (chunk, off) == pcp_token_layout(counts, pcp, align=PAGE)[:2]
 
 
 def test_batch_layout_rejects_short_buffer():
@@ -83,7 +80,7 @@ def test_batch_layout_rejects_short_buffer():
 def test_token_permutation(pcp, counts):
     t_pad, chunk, off = _layout(counts, pcp)
     s_pad = t_pad // pcp
-    perm, kv_order = pcp_token_permutation(counts, chunk, off, t_pad, pcp)
+    perm = pcp_token_permutation(counts, chunk, off, t_pad, pcp)
     total = sum(counts)
     # Every real token lands in exactly one slot; everything else is padding.
     assert sorted(perm[perm >= 0].tolist()) == list(range(total))
@@ -91,17 +88,13 @@ def test_token_permutation(pcp, counts):
     for i, n_i in enumerate(counts):
         c_i = chunk[i]
         for tok in range(n_i):
-            slot = kv_order[pcp * off[i] + tok]
-            # kv_order undoes perm on the live rows.
-            assert perm[slot] == src_off[i] + tok
-            # Zigzag: chunk k sits on rank k (head) or 2P-1-k (tail).
+            # Zigzag: chunk k sits on rank k (head) or 2P-1-k (tail), at row
+            # rank * s_pad + off_i + half * C_i + tok % C_i.
             k = tok // c_i
             rank = k if k < pcp else 2 * pcp - 1 - k
-            assert slot // s_pad == rank
-    # Slots reserved for a request are distinct across the request.
-    for i in range(len(counts)):
-        lo, hi = pcp * off[i], pcp * off[i] + 2 * pcp * chunk[i]
-        assert len(set(kv_order[lo:hi].tolist())) == hi - lo
+            half = 0 if k < pcp else 1
+            slot = rank * s_pad + off[i] + half * c_i + tok % c_i
+            assert perm[slot] == src_off[i] + tok
 
 
 @pytest.mark.parametrize("pcp,counts", LAYOUTS)
@@ -150,7 +143,7 @@ def test_prepare_inputs(pcp, counts):
     md = pre.prepare_inputs(counts, computed, t_pad, positions, input_ids,
                             seq_lens, request_distribution, logits_indices)
 
-    perm, kv_order = pcp_token_permutation(counts, chunk, off, t_pad, pcp)
+    perm = pcp_token_permutation(counts, chunk, off, t_pad, pcp)
     live = perm >= 0
     assert np.array_equal(input_ids[live], 1000 + perm[live])
     assert np.array_equal(positions[live], perm[live])
@@ -174,15 +167,11 @@ def test_prepare_inputs(pcp, counts):
         np.asarray(md.kv_cache_lens)[:n_seqs], np.repeat(computed, 2))
     assert md.has_cached_kv == (max(computed) > 0)
     assert md.num_reqs == (1 if n_reqs == 1 else 8)
-    assert np.array_equal(np.asarray(md.kv_token_order), kv_order)
-    if n_reqs > 1:
-        # The kernel unshuffles through the per-page map; a single request
-        # gets an empty one and keeps the kernel-side remap.
-        assert np.array_equal(
-            np.asarray(md.kv_page_order),
-            pcp_page_order(chunk, off, pcp, t_pad // pcp, t_pad, PAGE))
-    else:
-        assert np.asarray(md.kv_page_order).shape == (0, )
+    # The kernel unshuffles the all-gathered K/V through the per-page map,
+    # for any request count.
+    assert np.array_equal(
+        np.asarray(md.kv_page_order),
+        pcp_page_order(chunk, off, pcp, t_pad // pcp, t_pad, PAGE))
     assert np.array_equal(
         np.asarray(md.kv_new_starts)[:n_seqs],
         np.repeat([pcp * o for o in off], 2))

--- a/tests/runner/test_pcp_utils.py
+++ b/tests/runner/test_pcp_utils.py
@@ -17,7 +17,7 @@ import jax
 import numpy as np
 import pytest
 from jax.sharding import Mesh
-from vllm.utils.math_utils import cdiv, next_power_of_2
+from vllm.utils.math_utils import cdiv, next_power_of_2, round_up
 
 from tpu_inference.runner.pcp_utils import (PCPPreprocessor, pcp_batch_layout,
                                             pcp_buffer_tokens,
@@ -55,13 +55,16 @@ def _layout(counts, pcp):
 
 @pytest.mark.parametrize("pcp,counts", LAYOUTS)
 def test_token_layout(pcp, counts):
-    chunk, off, s_live = pcp_token_layout(counts, pcp)
+    chunk, off, s_live = pcp_token_layout(counts, pcp, align=1)
     assert chunk == [cdiv(n, 2 * pcp) for n in counts]
     assert off == list(np.cumsum([0] + [2 * c for c in chunk])[:-1])
     assert s_live == sum(2 * c for c in chunk)
-    assert pcp_buffer_tokens(counts, pcp) == pcp * s_live
-    assert pcp_buffer_tokens(counts, pcp) <= pcp_max_buffer_tokens(
-        sum(counts), len(counts), pcp)
+    assert pcp_buffer_tokens(counts, pcp, align=1) == pcp * s_live
+    assert pcp_buffer_tokens(counts, pcp,
+                             align=1) <= pcp_max_buffer_tokens(sum(counts),
+                                                               len(counts),
+                                                               pcp,
+                                                               align=1)
 
 
 @pytest.mark.parametrize("pcp,counts", LAYOUTS)
@@ -73,7 +76,7 @@ def test_batch_layout(pcp, counts):
 
 def test_batch_layout_rejects_short_buffer():
     with pytest.raises(AssertionError):
-        pcp_batch_layout([100, 100], 64, 2)
+        pcp_batch_layout([100, 100], 64, 2, align=1)
 
 
 @pytest.mark.parametrize("pcp,counts", LAYOUTS)
@@ -167,8 +170,6 @@ def test_prepare_inputs(pcp, counts):
         np.asarray(md.kv_cache_lens)[:n_seqs], np.repeat(computed, 2))
     assert md.has_cached_kv == (max(computed) > 0)
     assert md.num_reqs == (1 if n_reqs == 1 else 8)
-    # The kernel unshuffles the all-gathered K/V through the per-page map,
-    # for any request count.
     assert np.array_equal(
         np.asarray(md.kv_page_order),
         pcp_page_order(chunk, off, pcp, t_pad // pcp, t_pad, PAGE))
@@ -214,13 +215,6 @@ def _per_token_order(chunk, off, pcp, s_pad):
     return order
 
 
-@pytest.mark.parametrize("pcp,ns", [(1, [1]), (2, [1, 2]), (4, [3]),
-                                    (8, [5, 7, 2])])
-def test_align_one_matches_tight_layout(pcp, ns):
-    tight = pcp_token_layout(ns, pcp)
-    assert tight == pcp_token_layout(ns, pcp, align=1)
-
-
 @pytest.mark.parametrize("pcp", [2, 4, 8])
 @pytest.mark.parametrize("align", [16, 128])
 def test_aligned_chunks_and_offsets(pcp, align):
@@ -246,9 +240,7 @@ def test_padding_bound_per_request():
 
 def _check_page_order(ns, pcp, page):
     C, off, s_live = pcp_token_layout(ns, pcp, align=page)
-    # Bucket: the next multiple of 2 * pcp * page covering the live rows.
-    q = 2 * pcp * page
-    t_pad = (pcp * s_live + q - 1) // q * q
+    t_pad = round_up(pcp * s_live, 2 * pcp * page)
     s_pad = t_pad // pcp
     got = pcp_page_order(C, off, pcp, s_pad, t_pad, page)
     assert got.shape == (t_pad // page, )
@@ -274,16 +266,9 @@ def test_page_order_matches_per_token_map(pcp, page):
 
 @pytest.mark.parametrize("pcp", [2, 4])
 def test_page_order_single_request_is_r1_of_general(pcp):
-    # One request must produce the same map whether it is "the single
-    # request" or the first of a batch: R = 1 is not a special case.
-    page = 16
-    (c, ), (o, ), s_live = pcp_token_layout([1000], pcp, align=page)
-    t_pad = pcp * s_live
-    one = pcp_page_order([c], [o], pcp, s_live, t_pad, page)
-    live = 2 * pcp * c // page
-    want = _per_token_order([c], [o], pcp, s_live)
-    for p in range(live):
-        assert one[p] * page == want[p * page]
+    # A single request is simply R = 1 of the general layout; the full
+    # contiguity/map checker must pass on it unchanged.
+    _check_page_order([1000], pcp, 16)
 
 
 def test_page_order_rejects_unaligned_chunk():

--- a/tests/runner/test_pcp_utils.py
+++ b/tests/runner/test_pcp_utils.py
@@ -186,3 +186,111 @@ def test_prepare_inputs_rejects_decode():
     buf = np.zeros(16, np.int32)
     with pytest.raises(NotImplementedError):
         pre.prepare_inputs([1], [5], 16, buf, buf, buf, buf, buf)
+
+
+# ---------------- page-aligned layout and the kv_page_order map --------------
+#
+# The kernel's kv_page_order fetch is only correct if every token-order page
+# of the new-KV buffer is CONTIGUOUS in the rank-order all_gather result and
+# the map points at its first row. These tests pin that invariant against a
+# brute-force per-token expansion of the zigzag layout.
+
+
+def _per_token_order(chunk, off, pcp, s_pad):
+    """Brute force: token-order index -> rank-order row, for every slot."""
+    two_p = 2 * pcp
+    total = two_p * sum(chunk)
+    order = np.zeros(total, np.int64)
+    ranks = np.arange(pcp)
+    base = 0
+    for c_i, o_i in zip(chunk, off):
+        j = np.arange(c_i)
+        for h in (0, 1):
+            chunk_idx = ranks if h == 0 else two_p - 1 - ranks
+            dst = ranks[:, None] * s_pad + o_i + h * c_i + j[None, :]
+            tok = chunk_idx[:, None] * c_i + j[None, :]
+            order[base + tok.ravel()] = dst.ravel()
+        base += two_p * c_i
+    return order
+
+
+@pytest.mark.parametrize("pcp,ns", [(1, [1]), (2, [1, 2]), (4, [3]),
+                                    (8, [5, 7, 2])])
+def test_align_one_matches_tight_layout(pcp, ns):
+    tight = pcp_token_layout(ns, pcp)
+    assert tight == pcp_token_layout(ns, pcp, align=1)
+
+
+@pytest.mark.parametrize("pcp", [2, 4, 8])
+@pytest.mark.parametrize("align", [16, 128])
+def test_aligned_chunks_and_offsets(pcp, align):
+    ns = [1, 130, 22061, 3000, align, 2 * pcp * align]
+    C, off, s_live = pcp_token_layout(ns, pcp, align=align)
+    for n_i, c_i in zip(ns, C):
+        assert c_i % align == 0
+        assert 2 * pcp * c_i >= n_i
+        # Tightest aligned chunk: one align-quantum less no longer covers.
+        assert 2 * pcp * (c_i - align) < n_i
+    for o_i in off:
+        assert o_i % align == 0
+    assert s_live == sum(2 * c for c in C)
+
+
+def test_padding_bound_per_request():
+    pcp, align = 2, 128
+    for n in [1, 127, 128, 129, 511, 512, 513, 22061]:
+        C, _, _ = pcp_token_layout([n], pcp, align=align)
+        waste = 2 * pcp * C[0] - n
+        assert waste < 2 * pcp * align
+
+
+def _check_page_order(ns, pcp, page):
+    C, off, s_live = pcp_token_layout(ns, pcp, align=page)
+    # Bucket: the next multiple of 2 * pcp * page covering the live rows.
+    q = 2 * pcp * page
+    t_pad = (pcp * s_live + q - 1) // q * q
+    s_pad = t_pad // pcp
+    got = pcp_page_order(C, off, pcp, s_pad, t_pad, page)
+    assert got.shape == (t_pad // page, )
+    assert got.dtype == np.int32
+    want = _per_token_order(C, off, pcp, s_pad)
+    live_pages = 2 * pcp * sum(C) // page
+    for p in range(live_pages):
+        seg = want[p * page:(p + 1) * page]
+        # The invariant the kernel fetch relies on: one contiguous run...
+        assert np.all(np.diff(seg) == 1), (p, seg[:4])
+        # ...starting exactly where the map says.
+        assert got[p] * page == seg[0], p
+    # In-range even for dead entries (the kernel clamps but still reads).
+    assert np.all((got >= 0) & (got < t_pad // page))
+
+
+@pytest.mark.parametrize("pcp", [2, 4, 8])
+@pytest.mark.parametrize("page", [16, 128])
+def test_page_order_matches_per_token_map(pcp, page):
+    _check_page_order([22061, 3000], pcp, page)
+    _check_page_order([1, 130, 4 * pcp * page + 3], pcp, page)
+
+
+@pytest.mark.parametrize("pcp", [2, 4])
+def test_page_order_single_request_is_r1_of_general(pcp):
+    # One request must produce the same map whether it is "the single
+    # request" or the first of a batch: R = 1 is not a special case.
+    page = 16
+    (c, ), (o, ), s_live = pcp_token_layout([1000], pcp, align=page)
+    t_pad = pcp * s_live
+    one = pcp_page_order([c], [o], pcp, s_live, t_pad, page)
+    live = 2 * pcp * c // page
+    want = _per_token_order([c], [o], pcp, s_live)
+    for p in range(live):
+        assert one[p] * page == want[p * page]
+
+
+def test_page_order_rejects_unaligned_chunk():
+    with pytest.raises(AssertionError):
+        pcp_page_order([24], [0], 2, 48, 96, 16)
+
+
+def test_page_order_rejects_unaligned_region():
+    with pytest.raises(AssertionError):
+        pcp_page_order([16], [0], 2, 40, 80, 16)

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
@@ -766,14 +766,12 @@ def _ragged_paged_attention_kernel_loop(
                 debug_print("[RPA debug] new_kv_len_start={}",
                             new_kv_len_start)
                 if kv_page_order_ref is not None:
-                    # PCP: the new-KV buffer is still in the rank order the
-                    # all_gather produced; kv_page_order maps each token-order
-                    # page to the page holding it there. Every zigzag chunk is
-                    # a whole number of pages, so a token-order page is
-                    # contiguous in the buffer and the run splits into at most
-                    # bkv_p + 1 page pieces (the first and last may be
-                    # partial), fetched like the cache pages above. The pieces
-                    # sum to bkv_sz_frm_new, so the single wait below still
+                    # PCP: the new-KV buffer is still in all_gather rank
+                    # order; kv_page_order maps each token-order page to the
+                    # page holding it there (contiguous, since every zigzag
+                    # chunk is a whole number of pages). At most bkv_p + 1
+                    # pieces, first and last possibly partial; they sum to
+                    # bkv_sz_frm_new, so the single wait below still
                     # accounts for every byte.
                     num_map_pages = kv_page_order_ref.shape[0]
                     first_page = new_kv_len_start // page_size
@@ -789,15 +787,13 @@ def _ragged_paged_attention_kernel_loop(
                             kv_hbm_ref.at[pl.ds(
                                 kv_page_order_ref[page_idx] * page_size +
                                 src_in_page, sz)],
-                            vmem_ref.at[pl.ds(bkv_sz_frm_cache + dst_off,
-                                              sz)],
+                            vmem_ref.at[pl.ds(bkv_sz_frm_cache + dst_off, sz)],
                             sem,
                             wait=False,
                         )
                 else:
                     _async_copy(
-                        kv_hbm_ref.at[pl.ds(new_kv_len_start,
-                                            bkv_sz_frm_new)],
+                        kv_hbm_ref.at[pl.ds(new_kv_len_start, bkv_sz_frm_new)],
                         vmem_ref.at[pl.ds(bkv_sz_frm_cache, bkv_sz_frm_new)],
                         sem,
                         wait,
@@ -2041,13 +2037,11 @@ def static_validate_inputs(
 
     if kv_page_order is not None:
         if kv_cache_lens is None or cp_group_size is None:
-            raise ValueError(
-                "PCP (kv_page_order) requires kv_cache_lens and "
-                "cp_group_size.")
+            raise ValueError("PCP (kv_page_order) requires kv_cache_lens and "
+                             "cp_group_size.")
         if kv_page_order.dtype != jnp.int32:
-            raise ValueError(
-                f"Expected int32 dtype for kv_page_order, got "
-                f"{kv_page_order.dtype}")
+            raise ValueError(f"Expected int32 dtype for kv_page_order, got "
+                             f"{kv_page_order.dtype}")
         if k.shape[0] % page_size != 0:
             raise ValueError(
                 f"PCP (kv_page_order) needs the new-KV buffer rows "
@@ -2287,9 +2281,9 @@ def ragged_paged_attention(
     pcp_ring_mesh_axis_names: all axis names of the mesh the ring runs on, in
       order. Defaults to a one-axis mesh.
     kv_new_starts: PCP only. Base offset of each sequence's current-KV block
-      inside the all-gathered new-KV buffer (`keys`/`values`). Needed when that
-      buffer, packed back to back in request order (a single request's block
-      starts at 0); leave None for the non-PCP paths.
+      inside the all-gathered new-KV buffer (`keys`/`values`), which packs the
+      requests back to back in request order (a single request's block starts
+      at 0); leave None for the non-PCP paths.
     kv_write_seq_mask: PCP only. Nonzero on the sequences that perform the fused
       strided KV-cache write. PCP fuses a request's head and tail chunk into one
       launch as two "sequences" that are really the same request (same

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
@@ -321,6 +321,7 @@ def _ragged_paged_attention_kernel_loop(
     q_pos_offset_ref: jax.Array | None,  # i32[max_num_seqs]
     kv_new_starts_ref: jax.Array | None,  # i32[max_num_seqs]
     kv_write_seq_mask_ref: jax.Array | None,  # i32[max_num_seqs]
+    kv_page_order_ref: jax.Array | None,  # i32[kv_buffer_tokens // page_size]
     # Input
     q_hbm_ref,  # [actual_num_kv_heads, max_num_tokens, num_q_heads_per_kv_head // q_packing, q_packing, head_dim]
     kv_hbm_ref,  # [max_num_tokens, num_kv_heads_x2 // kv_packing, kv_packing, head_dim]
@@ -763,24 +764,55 @@ def _ragged_paged_attention_kernel_loop(
             # Fetch new kvs.
             if not skip_current_attn:
                 new_kv_len_start = _seq_kv_new_end - kv_left_frm_new
-                if pcp_chunk_size is not None:
-                    two_p = 2 * cp_group_size
-                    chunk_idx = new_kv_len_start // pcp_chunk_size
-                    offset_in_chunk = (new_kv_len_start -
-                                       chunk_idx * pcp_chunk_size)
-                    rank_slot = jnp.where(chunk_idx < cp_group_size,
-                                          2 * chunk_idx,
-                                          2 * (two_p - 1 - chunk_idx) + 1)
-                    new_kv_len_start = (rank_slot * pcp_chunk_size +
-                                        offset_in_chunk)
                 debug_print("[RPA debug] new_kv_len_start={}",
                             new_kv_len_start)
-                _async_copy(
-                    kv_hbm_ref.at[pl.ds(new_kv_len_start, bkv_sz_frm_new)],
-                    vmem_ref.at[pl.ds(bkv_sz_frm_cache, bkv_sz_frm_new)],
-                    sem,
-                    wait,
-                )
+                if kv_page_order_ref is not None:
+                    # PCP: the new-KV buffer is still in the rank order the
+                    # all_gather produced; kv_page_order maps each token-order
+                    # page to the page holding it there. Every zigzag chunk is
+                    # a whole number of pages, so a token-order page is
+                    # contiguous in the buffer and the run splits into at most
+                    # bkv_p + 1 page pieces (the first and last may be
+                    # partial), fetched like the cache pages above. The pieces
+                    # sum to bkv_sz_frm_new, so the single wait below still
+                    # accounts for every byte.
+                    num_map_pages = kv_page_order_ref.shape[0]
+                    first_page = new_kv_len_start // page_size
+                    head_skip = new_kv_len_start % page_size
+                    for i in range(bkv_p + 1):
+                        src_in_page = head_skip if i == 0 else 0
+                        dst_off = (0 if i == 0 else i * page_size - head_skip)
+                        sz = jnp.clip(bkv_sz_frm_new - dst_off, 0,
+                                      page_size - src_in_page)
+                        page_idx = jnp.minimum(first_page + i,
+                                               num_map_pages - 1)
+                        _async_copy(
+                            kv_hbm_ref.at[pl.ds(
+                                kv_page_order_ref[page_idx] * page_size +
+                                src_in_page, sz)],
+                            vmem_ref.at[pl.ds(bkv_sz_frm_cache + dst_off,
+                                              sz)],
+                            sem,
+                            wait=False,
+                        )
+                else:
+                    if pcp_chunk_size is not None:
+                        two_p = 2 * cp_group_size
+                        chunk_idx = new_kv_len_start // pcp_chunk_size
+                        offset_in_chunk = (new_kv_len_start -
+                                           chunk_idx * pcp_chunk_size)
+                        rank_slot = jnp.where(chunk_idx < cp_group_size,
+                                              2 * chunk_idx,
+                                              2 * (two_p - 1 - chunk_idx) + 1)
+                        new_kv_len_start = (rank_slot * pcp_chunk_size +
+                                            offset_in_chunk)
+                    _async_copy(
+                        kv_hbm_ref.at[pl.ds(new_kv_len_start,
+                                            bkv_sz_frm_new)],
+                        vmem_ref.at[pl.ds(bkv_sz_frm_cache, bkv_sz_frm_new)],
+                        sem,
+                        wait,
+                    )
         else:
             fetch_sz = 0
             if not skip_cache_attn:
@@ -1814,6 +1846,7 @@ def static_validate_inputs(
     q_pos_offsets: jax.Array | None = None,  # i32[max_num_seqs] - PCP
     kv_new_starts: jax.Array | None = None,  # i32[max_num_seqs] - PCP
     kv_write_seq_mask: jax.Array | None = None,  # i32[max_num_seqs] - PCP
+    kv_page_order: jax.Array | None = None,  # i32[kv_tokens // page_size]
     pcp_chunk_size: int | None = None,
     cp_group_size: int | None = None,
     cp_rank: jax.Array | int | None = None,
@@ -2022,6 +2055,29 @@ def static_validate_inputs(
                 "kv_new_starts and pcp_chunk_size are mutually exclusive: the "
                 "rank-order remap assumes a single request's new-KV buffer.")
 
+    if kv_page_order is not None:
+        if kv_cache_lens is None or cp_group_size is None:
+            raise ValueError(
+                "PCP (kv_page_order) requires kv_cache_lens and "
+                "cp_group_size.")
+        if pcp_chunk_size is not None:
+            raise ValueError(
+                "kv_page_order and pcp_chunk_size are mutually exclusive: "
+                "both describe how to unshuffle the rank-order new-KV "
+                "buffer.")
+        if kv_page_order.dtype != jnp.int32:
+            raise ValueError(
+                f"Expected int32 dtype for kv_page_order, got "
+                f"{kv_page_order.dtype}")
+        if k.shape[0] % page_size != 0:
+            raise ValueError(
+                f"PCP (kv_page_order) needs the new-KV buffer rows "
+                f"{k.shape[0]} to be a multiple of {page_size=}.")
+        if kv_page_order.shape != (k.shape[0] // page_size, ):
+            raise ValueError(
+                f"Expected kv_page_order.shape to be "
+                f"({k.shape[0] // page_size},), got {kv_page_order.shape}")
+
     # No constraints for the following inputs.
     del sm_scale
     del mask_value
@@ -2208,6 +2264,7 @@ def ragged_paged_attention(
     q_pos_offsets: jax.Array | None = None,  # i32[max_num_seqs]
     kv_new_starts: jax.Array | None = None,  # i32[max_num_seqs]
     kv_write_seq_mask: jax.Array | None = None,  # i32[max_num_seqs]
+    kv_page_order: jax.Array | None = None,  # i32[kv_tokens // page_size]
     pcp_chunk_size: int | None = None,
     pcp_ring_axis_name: str | None = None,
     pcp_ring_mesh_axis_names: tuple[str, ...] | None = None,
@@ -2274,6 +2331,13 @@ def ragged_paged_attention(
       kv_lens/kv_cache_lens), so each of them would redundantly write the same
       strided current KV; the mask selects exactly one per request (its tail).
       Leave None to let every sequence write, as in the non-PCP path.
+    kv_page_order: PCP only. Per-page indirection map for the new-KV buffer
+      (`keys`/`values`): entry j is the page of that buffer holding token-order
+      page j. Lets the kernel fetch current K/V straight from the rank-order
+      all_gather result, page by page like the paged cache, instead of needing
+      the buffer pre-gathered into token order or a single global
+      `pcp_chunk_size`. Requires every zigzag chunk to be a whole number of
+      pages. Mutually exclusive with pcp_chunk_size.
     use_causal_mask: if true, use causal mask.
     skip_kv_mask: only set to true if use_causal_mask=False and each dynamic
       kv_len % bkv_csz == 0. Set to true can improve performance.
@@ -2331,6 +2395,7 @@ def ragged_paged_attention(
         q_pos_offsets=q_pos_offsets,
         kv_new_starts=kv_new_starts,
         kv_write_seq_mask=kv_write_seq_mask,
+        kv_page_order=kv_page_order,
         pcp_chunk_size=pcp_chunk_size,
         cp_group_size=cp_group_size,
         cp_rank=cp_rank,
@@ -2492,7 +2557,8 @@ def ragged_paged_attention(
             cp_rank if cp_group_size is not None else None,
             q_pos_offsets,
             kv_new_starts,
-            kv_write_seq_mask)
+            kv_write_seq_mask,
+            kv_page_order)
 
         num_scalers = len(scalar_prefetches)
         # None in scalar_prefetches contribute 0 pytree leaves, so

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/kernel.py
@@ -363,7 +363,6 @@ def _ragged_paged_attention_kernel_loop(
     k_scale: float | None = None,
     v_scale: float | None = None,
     static_q_len: int | None = None,
-    pcp_chunk_size: int | None = None,
     bq_sz,  # bq fetch size
     bkv_sz,  # bkv prefetch size
     bq_csz,  # bq compute size
@@ -796,16 +795,6 @@ def _ragged_paged_attention_kernel_loop(
                             wait=False,
                         )
                 else:
-                    if pcp_chunk_size is not None:
-                        two_p = 2 * cp_group_size
-                        chunk_idx = new_kv_len_start // pcp_chunk_size
-                        offset_in_chunk = (new_kv_len_start -
-                                           chunk_idx * pcp_chunk_size)
-                        rank_slot = jnp.where(chunk_idx < cp_group_size,
-                                              2 * chunk_idx,
-                                              2 * (two_p - 1 - chunk_idx) + 1)
-                        new_kv_len_start = (rank_slot * pcp_chunk_size +
-                                            offset_in_chunk)
                     _async_copy(
                         kv_hbm_ref.at[pl.ds(new_kv_len_start,
                                             bkv_sz_frm_new)],
@@ -1847,7 +1836,6 @@ def static_validate_inputs(
     kv_new_starts: jax.Array | None = None,  # i32[max_num_seqs] - PCP
     kv_write_seq_mask: jax.Array | None = None,  # i32[max_num_seqs] - PCP
     kv_page_order: jax.Array | None = None,  # i32[kv_tokens // page_size]
-    pcp_chunk_size: int | None = None,
     cp_group_size: int | None = None,
     cp_rank: jax.Array | int | None = None,
     pcp_ring_axis_name: str | None = None,
@@ -2050,21 +2038,12 @@ def static_validate_inputs(
     if kv_new_starts is not None:
         if kv_cache_lens is None:
             raise ValueError("PCP (kv_new_starts) requires kv_cache_lens.")
-        if pcp_chunk_size is not None:
-            raise ValueError(
-                "kv_new_starts and pcp_chunk_size are mutually exclusive: the "
-                "rank-order remap assumes a single request's new-KV buffer.")
 
     if kv_page_order is not None:
         if kv_cache_lens is None or cp_group_size is None:
             raise ValueError(
                 "PCP (kv_page_order) requires kv_cache_lens and "
                 "cp_group_size.")
-        if pcp_chunk_size is not None:
-            raise ValueError(
-                "kv_page_order and pcp_chunk_size are mutually exclusive: "
-                "both describe how to unshuffle the rank-order new-KV "
-                "buffer.")
         if kv_page_order.dtype != jnp.int32:
             raise ValueError(
                 f"Expected int32 dtype for kv_page_order, got "
@@ -2099,7 +2078,6 @@ def get_default_block_sizes(
     pages_per_seq,
     *,
     case: RpaCase = RpaCase.MIXED,
-    pcp_chunk_size: int | None = None,
     pcp_ring: bool = False,
     vmem_limit_bytes: int | None = None,
 ):
@@ -2171,17 +2149,6 @@ def get_default_block_sizes(
         "bkv_csz": align_to(bkv_csz, page_size),
     }
 
-    # PCP current phase (rank-ordered KV remap) needs the prefetch block to
-    # stay within one head-tail chunk of size C, i.e. bkv_sz <= C.
-    if pcp_chunk_size is not None and case == RpaCase.MIXED:
-        bkv_sz = min(bs["bkv_sz"], pcp_chunk_size)
-        while bkv_sz > page_size and pcp_chunk_size % bkv_sz != 0:
-            bkv_sz -= page_size
-        bkv_csz = min(bs["bkv_csz"], bkv_sz)
-        while bkv_csz > page_size and bkv_sz % bkv_csz != 0:
-            bkv_csz -= page_size
-        bs = {**bs, "bkv_sz": bkv_sz, "bkv_csz": bkv_csz}
-
     if pcp_ring and case == RpaCase.MIXED:
         # Ring sizing is the opposite of the default heuristic.  The default
         # picks small Q tiles because re-streaming KV per tile is nearly free
@@ -2238,7 +2205,6 @@ def get_default_block_sizes(
         "disable_semaphore_checks",
         "update_kv_cache",
         "cp_group_size",
-        "pcp_chunk_size",
         "pcp_ring_axis_name",
         "pcp_ring_mesh_axis_names",
     ),
@@ -2265,7 +2231,6 @@ def ragged_paged_attention(
     kv_new_starts: jax.Array | None = None,  # i32[max_num_seqs]
     kv_write_seq_mask: jax.Array | None = None,  # i32[max_num_seqs]
     kv_page_order: jax.Array | None = None,  # i32[kv_tokens // page_size]
-    pcp_chunk_size: int | None = None,
     pcp_ring_axis_name: str | None = None,
     pcp_ring_mesh_axis_names: tuple[str, ...] | None = None,
     use_causal_mask: bool = True,
@@ -2323,8 +2288,8 @@ def ragged_paged_attention(
       order. Defaults to a one-axis mesh.
     kv_new_starts: PCP only. Base offset of each sequence's current-KV block
       inside the all-gathered new-KV buffer (`keys`/`values`). Needed when that
-      buffer holds more than one request, packed back to back in request order;
-      leave None for a single request, where every block starts at 0.
+      buffer, packed back to back in request order (a single request's block
+      starts at 0); leave None for the non-PCP paths.
     kv_write_seq_mask: PCP only. Nonzero on the sequences that perform the fused
       strided KV-cache write. PCP fuses a request's head and tail chunk into one
       launch as two "sequences" that are really the same request (same
@@ -2335,9 +2300,9 @@ def ragged_paged_attention(
       (`keys`/`values`): entry j is the page of that buffer holding token-order
       page j. Lets the kernel fetch current K/V straight from the rank-order
       all_gather result, page by page like the paged cache, instead of needing
-      the buffer pre-gathered into token order or a single global
-      `pcp_chunk_size`. Requires every zigzag chunk to be a whole number of
-      pages. Mutually exclusive with pcp_chunk_size.
+      the buffer pre-gathered into token order. Requires every zigzag chunk to
+      be a whole number of pages. Leave None when the buffer is already in
+      token order.
     use_causal_mask: if true, use causal mask.
     skip_kv_mask: only set to true if use_causal_mask=False and each dynamic
       kv_len % bkv_csz == 0. Set to true can improve performance.
@@ -2396,7 +2361,6 @@ def ragged_paged_attention(
         kv_new_starts=kv_new_starts,
         kv_write_seq_mask=kv_write_seq_mask,
         kv_page_order=kv_page_order,
-        pcp_chunk_size=pcp_chunk_size,
         cp_group_size=cp_group_size,
         cp_rank=cp_rank,
         pcp_ring_axis_name=pcp_ring_axis_name,
@@ -2614,7 +2578,6 @@ def ragged_paged_attention(
                 k_scale=k_scale,
                 v_scale=v_scale,
                 static_q_len=static_q_len,
-                pcp_chunk_size=pcp_chunk_size,
                 bq_sz=bq_sz,
                 bkv_sz=bkv_sz,
                 bq_csz=bq_csz,
@@ -2683,7 +2646,6 @@ def ragged_paged_attention(
                 max_num_seqs,
                 pages_per_seq,
                 case=case,
-                pcp_chunk_size=pcp_chunk_size,
                 pcp_ring=pcp_ring_axis_name is not None,
                 vmem_limit_bytes=vmem_limit_bytes,
             )

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -160,10 +160,10 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
     from tpu_inference.layers.common.attention_metadata import (
         AttentionMetadata, PCPMetadata)
     from tpu_inference.layers.common.cp_attention import pcp_forward
-    from tpu_inference.runner.pcp_utils import pcp_page_order
     from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
                                                       ShardingAxisName,
                                                       ShardingAxisNameBase)
+    from tpu_inference.runner.pcp_utils import pcp_page_order, pcp_seq_arrays
 
     # The N-D axis names carry `pcp`; select them regardless of
     # NEW_MODEL_DESIGN so the benchmark does not depend on the env.
@@ -277,7 +277,7 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
                       for a in MESH_AXIS_NAMES)
         mesh = Mesh(
             np.array(jax.devices()[:pcp * tp]).reshape(shape), MESH_AXIS_NAMES)
-        two_p, C = 2 * pcp, chunk // (2 * pcp)
+        C = chunk // (2 * pcp)
         # KV_CONTEXT shards the page dim: a global page holds page*pcp tokens.
         gpage = page * pcp
         pages_per_seq = max(cdiv(max_ctx, gpage), 1)
@@ -307,25 +307,16 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
             (MAX_SEQ * pages_per_seq, ),
             jnp.int32).at[:2 * pages_per_seq].set(jnp.concatenate([pg, pg]))
         dist = jnp.array([0, 0, 2], jnp.int32)
-        # Full-length tails (rank-invariant cu), as the merged layout
-        # requires; the rows past the real tokens are padding.
-        pcp_cu = np.zeros((pcp, MAX_SEQ + 1), np.int32)
-        pcp_qp = np.zeros((pcp, MAX_SEQ), np.int32)
-        for r in range(pcp):
-            pcp_cu[r, 1] = C
-            pcp_cu[r, 2:] = 2 * C
-            pcp_qp[r, 0] = r * C
-            pcp_qp[r, 1] = (two_p - 1 - r) * C
+        # The production per-seq arrays for one request of 2P*C rows.
+        cu_row, qp_np, kvs_np = pcp_seq_arrays([C], [0], pcp, MAX_SEQ)
         pcp_spec = P(ShardingAxisName.PREFILL_CONTEXT, None)
-        pcp_cu = put(jnp.asarray(pcp_cu), pcp_spec)
-        pcp_qp = put(jnp.asarray(pcp_qp), pcp_spec)
-        # Single request: every seq's current-KV block starts at 0, and the
-        # kernel unshuffles the rank-order buffer through the per-page map.
+        pcp_cu = put(jnp.asarray(np.tile(cu_row, (pcp, 1))), pcp_spec)
+        pcp_qp = put(jnp.asarray(qp_np), pcp_spec)
         assert C % page == 0, (C, page)
-        kv_starts = put(jnp.zeros((MAX_SEQ, ), jnp.int32), P())
+        kv_starts = put(jnp.asarray(kvs_np), P())
         kv_pages = put(
-            jnp.asarray(pcp_page_order([C], [0], pcp, chunk // pcp, chunk,
-                                       page)), P())
+            jnp.asarray(
+                pcp_page_order([C], [0], pcp, chunk // pcp, chunk, page)), P())
         fns = {}
 
         def fn_for(has_cached_kv):

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -160,6 +160,7 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
     from tpu_inference.layers.common.attention_metadata import (
         AttentionMetadata, PCPMetadata)
     from tpu_inference.layers.common.cp_attention import pcp_forward
+    from tpu_inference.runner.pcp_utils import pcp_page_order
     from tpu_inference.layers.common.sharding import (MESH_AXIS_NAMES,
                                                       ShardingAxisName,
                                                       ShardingAxisNameBase)
@@ -306,28 +307,25 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
             (MAX_SEQ * pages_per_seq, ),
             jnp.int32).at[:2 * pages_per_seq].set(jnp.concatenate([pg, pg]))
         dist = jnp.array([0, 0, 2], jnp.int32)
+        # Full-length tails (rank-invariant cu), as the merged layout
+        # requires; the rows past the real tokens are padding.
         pcp_cu = np.zeros((pcp, MAX_SEQ + 1), np.int32)
         pcp_qp = np.zeros((pcp, MAX_SEQ), np.int32)
         for r in range(pcp):
-            toff = (two_p - 1 - r) * C
-            treal = int(np.clip(chunk - toff, 0, C))
             pcp_cu[r, 1] = C
-            pcp_cu[r, 2:] = C + treal
+            pcp_cu[r, 2:] = 2 * C
             pcp_qp[r, 0] = r * C
-            pcp_qp[r, 1] = toff
+            pcp_qp[r, 1] = (two_p - 1 - r) * C
         pcp_spec = P(ShardingAxisName.PREFILL_CONTEXT, None)
         pcp_cu = put(jnp.asarray(pcp_cu), pcp_spec)
         pcp_qp = put(jnp.asarray(pcp_qp), pcp_spec)
-        # Single request: every seq's current-KV block starts at 0, and
-        # kv_token_order maps token t to its slot in the rank-order buffer.
-        row_perm = [c for r in range(pcp) for c in (r, two_p - 1 - r)]
-        inv_row = np.empty(two_p, np.int64)
-        inv_row[row_perm] = np.arange(two_p)
-        kv_order = (inv_row[:, None] * C + np.arange(C)[None, :]).reshape(-1)
+        # Single request: every seq's current-KV block starts at 0, and the
+        # kernel unshuffles the rank-order buffer through the per-page map.
+        assert C % page == 0, (C, page)
         kv_starts = put(jnp.zeros((MAX_SEQ, ), jnp.int32), P())
-        kv_order = put(jnp.asarray(kv_order, jnp.int32), P())
-        # Empty page map, as the runner passes for a single request.
-        kv_pages = put(jnp.zeros((0, ), jnp.int32), P())
+        kv_pages = put(
+            jnp.asarray(pcp_page_order([C], [0], pcp, chunk // pcp, chunk,
+                                       page)), P())
         fns = {}
 
         def fn_for(has_cached_kv):
@@ -346,7 +344,6 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
                                         kv_cache_lens=kvcl,
                                         q_pos_offsets=pcp_qp,
                                         kv_new_starts=kv_starts,
-                                        kv_token_order=kv_order,
                                         kv_page_order=kv_pages,
                                         has_cached_kv=_hc),
                     )

--- a/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
+++ b/tpu_inference/kernels/experimental/rpa_v3_cp/pcp_vs_tp_benchmark.py
@@ -326,6 +326,8 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
         kv_order = (inv_row[:, None] * C + np.arange(C)[None, :]).reshape(-1)
         kv_starts = put(jnp.zeros((MAX_SEQ, ), jnp.int32), P())
         kv_order = put(jnp.asarray(kv_order, jnp.int32), P())
+        # Empty page map, as the runner passes for a single request.
+        kv_pages = put(jnp.zeros((0, ), jnp.int32), P())
         fns = {}
 
         def fn_for(has_cached_kv):
@@ -345,6 +347,7 @@ def _run_variant(mp, variant, chunk, max_ctx, kv_dtype_name, page, slack,
                                         q_pos_offsets=pcp_qp,
                                         kv_new_starts=kv_starts,
                                         kv_token_order=kv_order,
+                                        kv_page_order=kv_pages,
                                         has_cached_kv=_hc),
                     )
                     cache, out = pcp_forward(mesh,

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -22,7 +22,7 @@ import jax
     jax.tree_util.register_dataclass,
     data_fields=[
         "query_start_loc", "kv_cache_lens", "q_pos_offsets", "kv_new_starts",
-        "kv_token_order", "kv_page_order"
+        "kv_page_order"
     ],
     meta_fields=["has_cached_kv", "num_reqs"],
 )
@@ -43,22 +43,19 @@ class PCPMetadata:
     # inside the all-gathered new-KV buffer (zeros for a single request).
     # Replicated (P()).
     kv_new_starts: jax.Array
-    # (padded_num_tokens,) int32 — permutation taking the all-gathered current
-    # K/V from rank order to request-major token order.  Replicated (P()).
-    kv_token_order: jax.Array
     # (padded_num_tokens // page_size,) int32 — per-page map from token-order
     # pages of the all-gathered current K/V to the pages holding them in rank
-    # order (`pcp_page_order`).  Replicated (P()).  With several requests the
-    # kernel unshuffles through it during its KV fetch; a single request
-    # passes an empty array and keeps the kernel-side arithmetic remap or the
-    # `kv_token_order` gather.
+    # order (`pcp_page_order`).  Replicated (P()).  The kernel unshuffles
+    # through it during its KV fetch, for any request count (a single request
+    # is R = 1 of the general page-aligned zigzag pack).
     kv_page_order: jax.Array
     # STATIC (meta field): whether any request in the batch has cached KV.
     # False elides the cache phase entirely.  REQUIRED: a default would
     # silently elide the cache phase for any caller that forgot to set it.
     has_cached_kv: bool
     # STATIC (meta field): number of requests fused into this launch, padded
-    # to `runner.pcp_num_reqs_paddings`.
+    # to `runner.pcp_num_reqs_paddings`.  Every rung runs the same layout and
+    # code path; the rung only sizes the compiled variant's write mask.
     num_reqs: int = 1
 
 

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -22,7 +22,7 @@ import jax
     jax.tree_util.register_dataclass,
     data_fields=[
         "query_start_loc", "kv_cache_lens", "q_pos_offsets", "kv_new_starts",
-        "kv_token_order"
+        "kv_token_order", "kv_page_order"
     ],
     meta_fields=["has_cached_kv", "num_reqs"],
 )
@@ -46,6 +46,13 @@ class PCPMetadata:
     # (padded_num_tokens,) int32 — permutation taking the all-gathered current
     # K/V from rank order to request-major token order.  Replicated (P()).
     kv_token_order: jax.Array
+    # (padded_num_tokens // page_size,) int32 — per-page map from token-order
+    # pages of the all-gathered current K/V to the pages holding them in rank
+    # order (`pcp_page_order`).  Replicated (P()).  With several requests the
+    # kernel unshuffles through it during its KV fetch; a single request
+    # passes an empty array and keeps the kernel-side arithmetic remap or the
+    # `kv_token_order` gather.
+    kv_page_order: jax.Array
     # STATIC (meta field): whether any request in the batch has cached KV.
     # False elides the cache phase entirely.  REQUIRED: a default would
     # silently elide the cache phase for any caller that forgot to set it.

--- a/tpu_inference/layers/common/attention_metadata.py
+++ b/tpu_inference/layers/common/attention_metadata.py
@@ -45,9 +45,7 @@ class PCPMetadata:
     kv_new_starts: jax.Array
     # (padded_num_tokens // page_size,) int32 — per-page map from token-order
     # pages of the all-gathered current K/V to the pages holding them in rank
-    # order (`pcp_page_order`).  Replicated (P()).  The kernel unshuffles
-    # through it during its KV fetch, for any request count (a single request
-    # is R = 1 of the general page-aligned zigzag pack).
+    # order (`pcp_page_order`).  Replicated (P()).
     kv_page_order: jax.Array
     # STATIC (meta field): whether any request in the batch has cached KV.
     # False elides the cache phase entirely.  REQUIRED: a default would

--- a/tpu_inference/layers/common/cp_attention.py
+++ b/tpu_inference/layers/common/cp_attention.py
@@ -324,17 +324,12 @@ def pcp_forward(
             # -inf result discarded by merge_attn_states.  Skip it outright.
             context_out = context_lse = None
         else:
-            # One cache-phase seq per request spanning its head+tail run
+            # One cache-phase seq per request, spanning its head+tail run
             # (no causal mask here, so the two need not be told apart):
-            # every array is the current-phase array with the head/tail
-            # duplication undone, and the seq count is half.  One seq of
-            # 2*C_i rows also rounds up to fewer query tiles than two seqs
-            # of C_i, and the ring re-streams the request's cache once per
-            # tile.  The ring runs in lock-step across ranks, so everything
-            # passed here is rank-invariant: distribution is replicated,
-            # cu_q_lens is the same on every rank because the runner gives
-            # both halves the full chunk length, and the block count comes
-            # from the replicated global cache length.  q_pos_offsets, the
+            # each array is the current-phase one with the head/tail
+            # duplication undone.  The ring runs in lock-step across ranks,
+            # so every operand must be rank-invariant -- cu_q_lens is (both
+            # halves carry the full chunk length), and q_pos_offsets, the
             # one per-rank array, is not passed.
             cu_cache = pcp_cu_q_lens_local[0][0::2]
             kv_lens_cache = kv_lens_local[0::2]
@@ -364,10 +359,8 @@ def pcp_forward(
                 **common)
 
         # ---- Current phase ------------------------------------------------
-        # Local Q (head+tail chunks) attends the all-gathered current K/V.
-        # Every chunk is a page multiple, so the kernel unshuffles the
-        # rank-order buffer itself through the kv_page_order map during its
-        # KV fetch; no gather or reshape pass here.
+        # Local Q (head+tail chunks) attends the all-gathered current K/V;
+        # the kernel unshuffles the rank-order buffer via kv_page_order.
         k_curr = all_gather_tokens(k_local)
         v_curr = all_gather_tokens(v_local)
         # Each request's tail seq performs the fused strided KV write.

--- a/tpu_inference/layers/common/cp_attention.py
+++ b/tpu_inference/layers/common/cp_attention.py
@@ -293,7 +293,6 @@ def pcp_forward(
     """
     pcp_axis = ShardingAxisName.PREFILL_CONTEXT
     pcp_size = get_mesh_shape_product(mesh, pcp_axis)
-    C = q.shape[0] // (2 * pcp_size)
 
     q_spec = P(ShardingAxisName.ATTN_DATA, ShardingAxisName.ATTN_HEAD, None)
     kv_spec = P(ShardingAxisName.ATTN_DATA, ShardingAxisName.KV_HEAD, None)
@@ -307,13 +306,11 @@ def pcp_forward(
 
     has_cached_kv = md.pcp.has_cached_kv
     num_reqs = md.pcp.num_reqs
-    multi_req = num_reqs > 1
 
     def _shard_fn(q_local, k_local, v_local, kv_cache_local, kv_lens_local,
                   kv_cache_lens_local, page_indices_local, distribution_local,
                   pcp_cu_q_lens_local, pcp_q_pos_offsets_local,
-                  kv_new_starts_local, kv_token_order_local,
-                  kv_page_order_local):
+                  kv_new_starts_local, kv_page_order_local):
         axis_idx = lax.axis_index(pcp_axis)
         cp_rank = jnp.reshape(axis_idx, (1, )).astype(jnp.int32)
 
@@ -327,33 +324,26 @@ def pcp_forward(
             # -inf result discarded by merge_attn_states.  Skip it outright.
             context_out = context_lse = None
         else:
-            if not multi_req:
-                # Single request: one seq spanning this rank's whole local
-                # buffer (head + tail + padding).  Valid for any current-phase
-                # cu_q_lens, including the per-rank clipped-tail form that
-                # single-request callers build.
-                cu_cache = jnp.zeros_like(pcp_cu_q_lens_local[0]).at[1:].set(
-                    q_local.shape[0])
-                kv_lens_cache = kv_lens_local
-                kv_cache_lens_cache = kv_cache_lens_local
-                page_indices_cache = page_indices_local
-                distribution_cache = jnp.array([0, 0, 1], jnp.int32)
-            else:
-                # One cache-phase seq per request spanning its head+tail run
-                # (no causal mask here, so the two need not be told apart):
-                # every array is the current-phase array with the head/tail
-                # duplication undone, and the seq count is half.  The ring
-                # runs in lock-step across ranks, so everything passed here is
-                # rank-invariant; q_pos_offsets, the one per-rank array, is
-                # not passed.
-                cu_cache = pcp_cu_q_lens_local[0][0::2]
-                kv_lens_cache = kv_lens_local[0::2]
-                kv_cache_lens_cache = kv_cache_lens_local[0::2]
-                pps = page_indices_local.shape[0] // kv_lens_local.shape[0]
-                page_indices_cache = page_indices_local.reshape(
-                    -1, pps)[0::2].reshape(-1)
-                distribution_cache = jnp.zeros_like(
-                    distribution_local).at[2].set(distribution_local[2] // 2)
+            # One cache-phase seq per request spanning its head+tail run
+            # (no causal mask here, so the two need not be told apart):
+            # every array is the current-phase array with the head/tail
+            # duplication undone, and the seq count is half.  One seq of
+            # 2*C_i rows also rounds up to fewer query tiles than two seqs
+            # of C_i, and the ring re-streams the request's cache once per
+            # tile.  The ring runs in lock-step across ranks, so everything
+            # passed here is rank-invariant: distribution is replicated,
+            # cu_q_lens is the same on every rank because the runner gives
+            # both halves the full chunk length, and the block count comes
+            # from the replicated global cache length.  q_pos_offsets, the
+            # one per-rank array, is not passed.
+            cu_cache = pcp_cu_q_lens_local[0][0::2]
+            kv_lens_cache = kv_lens_local[0::2]
+            kv_cache_lens_cache = kv_cache_lens_local[0::2]
+            pps = page_indices_local.shape[0] // kv_lens_local.shape[0]
+            page_indices_cache = page_indices_local.reshape(
+                -1, pps)[0::2].reshape(-1)
+            distribution_cache = jnp.zeros_like(
+                distribution_local).at[2].set(distribution_local[2] // 2)
             context_out, _, context_lse = _rpa_cp_call(
                 q_local,
                 k_local,
@@ -375,20 +365,11 @@ def pcp_forward(
 
         # ---- Current phase ------------------------------------------------
         # Local Q (head+tail chunks) attends the all-gathered current K/V.
-        # With several requests every chunk is a page multiple, so the kernel
-        # unshuffles the rank-order buffer itself through the kv_page_order
-        # map during its KV fetch; no gather pass here.  A single request
-        # with a page-aligned chunk instead lets the kernel remap addresses
-        # (pcp_chunk_size); otherwise the gathered K/V is reordered into
-        # request-major token order here, which is what kv_new_starts
-        # indexes.
-        page_size = kv_cache_local.shape[1]
-        remap_kv = not multi_req and C >= page_size and C % page_size == 0
+        # Every chunk is a page multiple, so the kernel unshuffles the
+        # rank-order buffer itself through the kv_page_order map during its
+        # KV fetch; no gather or reshape pass here.
         k_curr = all_gather_tokens(k_local)
         v_curr = all_gather_tokens(v_local)
-        if not multi_req and not remap_kv:
-            k_curr = jnp.take(k_curr, kv_token_order_local, axis=0)
-            v_curr = jnp.take(v_curr, kv_token_order_local, axis=0)
         # Each request's tail seq performs the fused strided KV write.
         max_seqs = kv_lens_local.shape[0]
         kv_write_seq_mask = jnp.zeros(max_seqs,
@@ -406,10 +387,9 @@ def pcp_forward(
             cp_group_size=pcp_size,
             kv_cache_lens=kv_cache_lens_local,
             q_pos_offsets=pcp_q_pos_offsets_local[0],
-            kv_new_starts=None if remap_kv else kv_new_starts_local,
+            kv_new_starts=kv_new_starts_local,
             kv_write_seq_mask=kv_write_seq_mask,
-            kv_page_order=kv_page_order_local if multi_req else None,
-            pcp_chunk_size=C if remap_kv else None,
+            kv_page_order=kv_page_order_local,
             skip_cache_attn=True,
             use_causal_mask=use_causal_mask,
             update_kv_cache=update_kv_cache,
@@ -438,11 +418,10 @@ def pcp_forward(
             P(pcp_axis, None),  # pcp.query_start_loc: per-rank cu_q_lens
             P(pcp_axis, None),  # pcp.q_pos_offsets: per-rank position offsets
             P(),  # pcp.kv_new_starts: replicated
-            P(),  # pcp.kv_token_order: replicated
             P(),  # pcp.kv_page_order: replicated
         ),
         out_specs=(kv_cache_spec, q_spec),
         check_vma=False,
     )(q, k, v, kv_cache, md.seq_lens, md.pcp.kv_cache_lens, md.block_tables,
       md.request_distribution, md.pcp.query_start_loc, md.pcp.q_pos_offsets,
-      md.pcp.kv_new_starts, md.pcp.kv_token_order, md.pcp.kv_page_order)
+      md.pcp.kv_new_starts, md.pcp.kv_page_order)

--- a/tpu_inference/layers/common/cp_attention.py
+++ b/tpu_inference/layers/common/cp_attention.py
@@ -312,7 +312,8 @@ def pcp_forward(
     def _shard_fn(q_local, k_local, v_local, kv_cache_local, kv_lens_local,
                   kv_cache_lens_local, page_indices_local, distribution_local,
                   pcp_cu_q_lens_local, pcp_q_pos_offsets_local,
-                  kv_new_starts_local, kv_token_order_local):
+                  kv_new_starts_local, kv_token_order_local,
+                  kv_page_order_local):
         axis_idx = lax.axis_index(pcp_axis)
         cp_rank = jnp.reshape(axis_idx, (1, )).astype(jnp.int32)
 
@@ -373,16 +374,19 @@ def pcp_forward(
                 **common)
 
         # ---- Current phase ------------------------------------------------
-        # Local Q (head+tail chunks) attends the all-gathered current K/V.  A
-        # single request with a page-aligned chunk hands the kernel the
-        # rank-order buffer and lets it remap addresses (pcp_chunk_size);
-        # otherwise the gathered K/V is reordered into request-major token
-        # order here, which is what kv_new_starts indexes.
+        # Local Q (head+tail chunks) attends the all-gathered current K/V.
+        # With several requests every chunk is a page multiple, so the kernel
+        # unshuffles the rank-order buffer itself through the kv_page_order
+        # map during its KV fetch; no gather pass here.  A single request
+        # with a page-aligned chunk instead lets the kernel remap addresses
+        # (pcp_chunk_size); otherwise the gathered K/V is reordered into
+        # request-major token order here, which is what kv_new_starts
+        # indexes.
         page_size = kv_cache_local.shape[1]
         remap_kv = not multi_req and C >= page_size and C % page_size == 0
         k_curr = all_gather_tokens(k_local)
         v_curr = all_gather_tokens(v_local)
-        if not remap_kv:
+        if not multi_req and not remap_kv:
             k_curr = jnp.take(k_curr, kv_token_order_local, axis=0)
             v_curr = jnp.take(v_curr, kv_token_order_local, axis=0)
         # Each request's tail seq performs the fused strided KV write.
@@ -404,6 +408,7 @@ def pcp_forward(
             q_pos_offsets=pcp_q_pos_offsets_local[0],
             kv_new_starts=None if remap_kv else kv_new_starts_local,
             kv_write_seq_mask=kv_write_seq_mask,
+            kv_page_order=kv_page_order_local if multi_req else None,
             pcp_chunk_size=C if remap_kv else None,
             skip_cache_attn=True,
             use_causal_mask=use_causal_mask,
@@ -434,9 +439,10 @@ def pcp_forward(
             P(pcp_axis, None),  # pcp.q_pos_offsets: per-rank position offsets
             P(),  # pcp.kv_new_starts: replicated
             P(),  # pcp.kv_token_order: replicated
+            P(),  # pcp.kv_page_order: replicated
         ),
         out_specs=(kv_cache_spec, q_spec),
         check_vma=False,
     )(q, k, v, kv_cache, md.seq_lens, md.pcp.kv_cache_lens, md.block_tables,
       md.request_distribution, md.pcp.query_start_loc, md.pcp.q_pos_offsets,
-      md.pcp.kv_new_starts, md.pcp.kv_token_order)
+      md.pcp.kv_new_starts, md.pcp.kv_token_order, md.pcp.kv_page_order)

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -385,6 +385,14 @@ class CompilationManager:
         metadata_attn_sharding = NamedSharding(
             self.runner.mesh, PartitionSpec(ShardingAxisName.BATCH))
         pcp_size = self.runner.vllm_config.sharding_config.prefill_cp_size
+        # A bucket that cannot give every request a chunk of at least one KV
+        # page per rank can never be picked at runtime (chunks are page
+        # multiples, and the runner's bucket sizing takes the layout's row
+        # count into account), so the variant is unreachable -- for a single
+        # request too.
+        if (pcp_size > 1 and num_tokens <
+                2 * pcp_size * self.runner.block_size * pcp_num_reqs):
+            return
 
         # Keep existing pattern for complex array operations
         # Under PCP each request becomes two fused seqs, so the attention
@@ -406,28 +414,24 @@ class CompilationManager:
             # so the kernel body does not run, but the traced program still
             # slices these arrays.
             block = self.runner.block_size
-            page_order_np = np.zeros(0, np.int32)
-            if pcp_num_reqs > 1:
-                # Largest page-multiple chunk that fits every request.
-                chunk = (num_tokens // (2 * pcp_size * pcp_num_reqs) //
-                         block * block)
-                assert chunk >= block, (
-                    f"{num_tokens=} cannot hold {pcp_num_reqs} PCP requests "
-                    "with page-multiple chunks; this bucket should have been "
-                    "skipped")
-                chunks, offs, _ = pcp_token_layout([2 * pcp_size * chunk] *
-                                                   pcp_num_reqs,
-                                                   pcp_size,
-                                                   align=block)
-                # A real in-range map: the kernel prefetches these as page
-                # indices even though no seq iterates during precompile.
-                page_order_np = pcp_page_order(chunks, offs, pcp_size,
-                                               num_tokens // pcp_size,
-                                               num_tokens, block)
-            else:
-                chunk = num_tokens // (2 * pcp_size)
-                chunks, offs, _ = pcp_token_layout([2 * pcp_size * chunk],
-                                                   pcp_size)
+            # Largest page-multiple chunk that fits every request.  Any
+            # request count (1 included) runs the same layout and needs the
+            # same arrays.
+            chunk = (num_tokens // (2 * pcp_size * pcp_num_reqs) // block *
+                     block)
+            assert chunk >= block, (
+                f"{num_tokens=} cannot hold {pcp_num_reqs} PCP requests "
+                "with page-multiple chunks; this bucket should have been "
+                "skipped")
+            chunks, offs, _ = pcp_token_layout([2 * pcp_size * chunk] *
+                                               pcp_num_reqs,
+                                               pcp_size,
+                                               align=block)
+            # A real in-range map: the kernel prefetches these as page
+            # indices even though no seq iterates during precompile.
+            page_order_np = pcp_page_order(chunks, offs, pcp_size,
+                                           num_tokens // pcp_size,
+                                           num_tokens, block)
             cu_row, qpos_np, kv_starts_np = pcp_seq_arrays(
                 chunks, offs, pcp_size, attn_seqs)
             pcp = self.runner.pcp_preprocessor.metadata_to_device(
@@ -435,7 +439,6 @@ class CompilationManager:
                 qpos_np,
                 np.zeros(attn_seqs, dtype=np.int32),
                 kv_starts_np,
-                np.arange(num_tokens, dtype=np.int32),
                 page_order_np,
                 has_cached_kv=pcp_has_cached_kv,
                 num_reqs=pcp_num_reqs,
@@ -730,14 +733,8 @@ class CompilationManager:
                 _cache_rungs = (False, True) if _pcp > 1 else (False, )
                 for _has_cached_kv in _cache_rungs:
                     for _pcp_reqs in self.runner.pcp_num_reqs_paddings:
-                        # A bucket that cannot give every request a chunk of
-                        # at least one KV page per rank can never carry that
-                        # many requests at runtime (chunks are page
-                        # multiples), so the variant is unreachable.
-                        if (_pcp_reqs > 1 and num_tokens <
-                                2 * _pcp * self.runner.block_size *
-                                _pcp_reqs):
-                            continue
+                        # Unreachable-bucket variants are skipped inside
+                        # _precompile_backbone_helper.
                         self._precompile_backbone_helper(
                             f"worker{self.runner.rank} backbone",
                             input_ids=input_ids,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -23,6 +23,7 @@ import jax.numpy as jnp
 import numpy as np
 import vllm.envs as vllm_envs
 from jax.sharding import NamedSharding, PartitionSpec
+from vllm.utils.math_utils import round_down
 
 import tpu_inference.envs as envs
 from tpu_inference.core.disagg_utils import is_disagg_enabled
@@ -385,13 +386,12 @@ class CompilationManager:
         metadata_attn_sharding = NamedSharding(
             self.runner.mesh, PartitionSpec(ShardingAxisName.BATCH))
         pcp_size = self.runner.vllm_config.sharding_config.prefill_cp_size
-        # A bucket that cannot give every request a chunk of at least one KV
-        # page per rank can never be picked at runtime (chunks are page
-        # multiples, and the runner's bucket sizing takes the layout's row
-        # count into account), so the variant is unreachable -- for a single
-        # request too.
-        if (pcp_size > 1 and num_tokens <
-                2 * pcp_size * self.runner.block_size * pcp_num_reqs):
+        # Only a bucket too small for even ONE page-multiple chunk per rank
+        # is unreachable. Every rung must still compile at every remaining
+        # bucket: the bucket and the rung are picked independently at
+        # runtime, so a small bucket can arrive with the top rung.
+        if (pcp_size > 1
+                and num_tokens < 2 * pcp_size * self.runner.block_size):
             return
 
         # Keep existing pattern for complex array operations
@@ -414,24 +414,20 @@ class CompilationManager:
             # so the kernel body does not run, but the traced program still
             # slices these arrays.
             block = self.runner.block_size
-            # Largest page-multiple chunk that fits every request.  Any
-            # request count (1 included) runs the same layout and needs the
-            # same arrays.
-            chunk = (num_tokens // (2 * pcp_size * pcp_num_reqs) // block *
-                     block)
-            assert chunk >= block, (
-                f"{num_tokens=} cannot hold {pcp_num_reqs} PCP requests "
-                "with page-multiple chunks; this bucket should have been "
-                "skipped")
+            # Compilation keys on shapes and the static num_reqs rung only,
+            # so the dummy layout may hold fewer live requests than the rung
+            # (as many as the bucket fits; at least one, by the guard above).
+            live_reqs = min(pcp_num_reqs, num_tokens // (2 * pcp_size * block))
+            chunk = round_down(num_tokens // (2 * pcp_size * live_reqs), block)
             chunks, offs, _ = pcp_token_layout([2 * pcp_size * chunk] *
-                                               pcp_num_reqs,
+                                               live_reqs,
                                                pcp_size,
                                                align=block)
             # A real in-range map: the kernel prefetches these as page
             # indices even though no seq iterates during precompile.
             page_order_np = pcp_page_order(chunks, offs, pcp_size,
-                                           num_tokens // pcp_size,
-                                           num_tokens, block)
+                                           num_tokens // pcp_size, num_tokens,
+                                           block)
             cu_row, qpos_np, kv_starts_np = pcp_seq_arrays(
                 chunks, offs, pcp_size, attn_seqs)
             pcp = self.runner.pcp_preprocessor.metadata_to_device(
@@ -733,8 +729,6 @@ class CompilationManager:
                 _cache_rungs = (False, True) if _pcp > 1 else (False, )
                 for _has_cached_kv in _cache_rungs:
                     for _pcp_reqs in self.runner.pcp_num_reqs_paddings:
-                        # Unreachable-bucket variants are skipped inside
-                        # _precompile_backbone_helper.
                         self._precompile_backbone_helper(
                             f"worker{self.runner.rank} backbone",
                             input_ids=input_ids,

--- a/tpu_inference/runner/compilation_manager.py
+++ b/tpu_inference/runner/compilation_manager.py
@@ -38,7 +38,8 @@ from tpu_inference.logger import init_logger
 from tpu_inference.models.jax.jax_intermediate_tensor import \
     JaxIntermediateTensors
 from tpu_inference.runner.decode_loop import TpuSamplingState, continue_decode
-from tpu_inference.runner.pcp_utils import pcp_seq_arrays, pcp_token_layout
+from tpu_inference.runner.pcp_utils import (pcp_page_order, pcp_seq_arrays,
+                                            pcp_token_layout)
 from tpu_inference.runner.utils import SpecDecodeMetadata
 from tpu_inference.spec_decode.jax.utils import (
     concat_last_sampled_tokens_and_draft_tokens, extend_logits_simple,
@@ -404,9 +405,29 @@ class CompilationManager:
             # A well-formed dummy layout: request_distribution is all zeros,
             # so the kernel body does not run, but the traced program still
             # slices these arrays.
-            chunk = num_tokens // (2 * pcp_size * pcp_num_reqs)
-            chunks, offs, _ = pcp_token_layout([2 * pcp_size * chunk] *
-                                               pcp_num_reqs, pcp_size)
+            block = self.runner.block_size
+            page_order_np = np.zeros(0, np.int32)
+            if pcp_num_reqs > 1:
+                # Largest page-multiple chunk that fits every request.
+                chunk = (num_tokens // (2 * pcp_size * pcp_num_reqs) //
+                         block * block)
+                assert chunk >= block, (
+                    f"{num_tokens=} cannot hold {pcp_num_reqs} PCP requests "
+                    "with page-multiple chunks; this bucket should have been "
+                    "skipped")
+                chunks, offs, _ = pcp_token_layout([2 * pcp_size * chunk] *
+                                                   pcp_num_reqs,
+                                                   pcp_size,
+                                                   align=block)
+                # A real in-range map: the kernel prefetches these as page
+                # indices even though no seq iterates during precompile.
+                page_order_np = pcp_page_order(chunks, offs, pcp_size,
+                                               num_tokens // pcp_size,
+                                               num_tokens, block)
+            else:
+                chunk = num_tokens // (2 * pcp_size)
+                chunks, offs, _ = pcp_token_layout([2 * pcp_size * chunk],
+                                                   pcp_size)
             cu_row, qpos_np, kv_starts_np = pcp_seq_arrays(
                 chunks, offs, pcp_size, attn_seqs)
             pcp = self.runner.pcp_preprocessor.metadata_to_device(
@@ -415,6 +436,7 @@ class CompilationManager:
                 np.zeros(attn_seqs, dtype=np.int32),
                 kv_starts_np,
                 np.arange(num_tokens, dtype=np.int32),
+                page_order_np,
                 has_cached_kv=pcp_has_cached_kv,
                 num_reqs=pcp_num_reqs,
             )
@@ -708,10 +730,13 @@ class CompilationManager:
                 _cache_rungs = (False, True) if _pcp > 1 else (False, )
                 for _has_cached_kv in _cache_rungs:
                     for _pcp_reqs in self.runner.pcp_num_reqs_paddings:
-                        # A bucket that cannot give every request one token
-                        # per chunk never carries that many requests.
-                        if (_pcp_reqs > 1
-                                and num_tokens < 2 * _pcp * _pcp_reqs):
+                        # A bucket that cannot give every request a chunk of
+                        # at least one KV page per rank can never carry that
+                        # many requests at runtime (chunks are page
+                        # multiples), so the variant is unreachable.
+                        if (_pcp_reqs > 1 and num_tokens <
+                                2 * _pcp * self.runner.block_size *
+                                _pcp_reqs):
                             continue
                         self._precompile_backbone_helper(
                             f"worker{self.runner.rank} backbone",

--- a/tpu_inference/runner/pcp_utils.py
+++ b/tpu_inference/runner/pcp_utils.py
@@ -27,35 +27,30 @@ from vllm.utils.math_utils import cdiv
 from tpu_inference.layers.common.attention_metadata import PCPMetadata
 from tpu_inference.layers.common.sharding import ShardingAxisName
 from tpu_inference.runner import utils as runner_utils
-from tpu_inference.utils import device_array
+from tpu_inference.utils import align_to, device_array
 
 
-def pcp_token_layout(num_scheduled_tokens: list[int],
-                     pcp_size: int,
-                     align: int = 1) -> tuple[list[int], list[int], int]:
+def pcp_token_layout(num_scheduled_tokens: list[int], pcp_size: int,
+                     align: int) -> tuple[list[int], list[int], int]:
     """Returns (chunk, off, s_live): per-request chunk size ceil(n_i / 2P)
     rounded up to a multiple of `align`, the start of each request's
     head+tail slot within a rank's region, and the live rows per rank.
 
     `align` is the KV-cache page size in production: page-multiple chunks
-    keep every token-order page of the new-KV buffer contiguous in the
-    rank-order all_gather result, which is what lets the kernel unshuffle
-    K/V through the `pcp_page_order` map during its mandatory HBM->VMEM
-    copy instead of a separate gather pass. The rounding costs at most
-    2P*(align-1) padding rows per request."""
+    are what make the `pcp_page_order` map valid. The rounding costs at
+    most 2P*(align-1) padding rows per request."""
     two_p = 2 * pcp_size
     off, acc, C = [], 0, []
     for n in num_scheduled_tokens:
-        c = cdiv(cdiv(n, two_p), align) * align
+        c = align_to(cdiv(n, two_p), align)
         C.append(c)
         off.append(acc)
         acc += 2 * c
     return C, off, acc
 
 
-def pcp_buffer_tokens(num_scheduled_tokens: list[int],
-                      pcp_size: int,
-                      align: int = 1) -> int:
+def pcp_buffer_tokens(num_scheduled_tokens: list[int], pcp_size: int,
+                      align: int) -> int:
     """Rows the token buffer must hold for this batch (can exceed the raw
     token count, since every chunk rounds up independently)."""
     _, _, s_live = pcp_token_layout(num_scheduled_tokens, pcp_size, align)
@@ -63,16 +58,14 @@ def pcp_buffer_tokens(num_scheduled_tokens: list[int],
 
 
 def pcp_max_buffer_tokens(max_num_batched_tokens: int, max_num_seqs: int,
-                          pcp_size: int, align: int = 1) -> int:
+                          pcp_size: int, align: int) -> int:
     """Upper bound of `pcp_buffer_tokens` over any batch the scheduler
     admits: each request rounds up by less than 2P * align rows."""
     return max_num_batched_tokens + 2 * pcp_size * align * max_num_seqs
 
 
-def pcp_batch_layout(num_scheduled_tokens: list[int],
-                     t_pad: int,
-                     pcp_size: int,
-                     align: int = 1) -> tuple[list[int], list[int]]:
+def pcp_batch_layout(num_scheduled_tokens: list[int], t_pad: int,
+                     pcp_size: int, align: int) -> tuple[list[int], list[int]]:
     """Chunk sizes and slot offsets of a batch inside a `t_pad`-row buffer.
 
     One layout for any request count: a single request is simply R = 1 of
@@ -109,37 +102,38 @@ def pcp_seq_arrays(chunk: list[int], off: list[int], pcp_size: int,
     return cu_row, q_pos, kv_new_starts
 
 
-def pcp_page_order(chunk: list[int], off: list[int], pcp_size: int,
-                   s_pad: int, t_pad: int, page_size: int) -> np.ndarray:
+def _zigzag_slots(tok, c, off, pcp_size: int, s_pad: int) -> np.ndarray:
+    """Rank-order slot of token-order index `tok` for a request with chunk
+    size `c` starting at per-rank offset `off` (all broadcastable): zigzag
+    chunk k = tok // c sits on rank k (head half) or 2P-1-k (tail half).
+    The single source of the layout's slot formula."""
+    k = tok // c
+    half = (k >= pcp_size).astype(np.int64)
+    rank = np.where(half == 0, k, 2 * pcp_size - 1 - k)
+    return rank * s_pad + off + half * c + tok % c
+
+
+def pcp_page_order(chunk: list[int], off: list[int], pcp_size: int, s_pad: int,
+                   t_pad: int, page_size: int) -> np.ndarray:
     """Per-page unshuffle map for the all-gathered new-KV buffer.
 
     Entry j is the page of the rank-order buffer holding token-order page j
-    (request-major, the coordinate space `kv_new_starts` indexes). The
-    kernel's current-phase fetch walks this map one page-sized DMA at a
-    time, exactly like the paged cache side of a mixed fetch, so the
-    rank-order buffer never needs a separate gather pass.
-
-    Valid because every chunk is a whole number of pages (`pcp_token_layout`
-    with align=page_size): a token-order page then falls wholly inside one
-    chunk and is contiguous in the rank-order buffer. Uncovered entries
-    (dead region tails) stay 0 and are never fetched.
+    (request-major, the coordinate space `kv_new_starts` indexes); the
+    kernel unshuffles K/V through it during its KV fetch. Valid because
+    every chunk is a whole number of pages, so a token-order page falls
+    wholly inside one chunk and is contiguous in the rank-order buffer.
+    Uncovered entries (dead region tails) stay 0 and are never fetched.
     """
-    two_p = 2 * pcp_size
-    assert s_pad % page_size == 0 and t_pad == pcp_size * s_pad, (s_pad,
-                                                                  t_pad)
+    assert s_pad % page_size == 0 and t_pad == pcp_size * s_pad, (s_pad, t_pad)
     order = np.zeros(t_pad // page_size, np.int32)
-    ranks = np.arange(pcp_size)
     for c_i, off_i in zip(chunk, off):
         assert c_i % page_size == 0 and off_i % page_size == 0, (c_i, off_i)
-        cp = c_i // page_size  # pages per chunk
-        kv_base_p = pcp_size * off_i // page_size
-        j = np.arange(cp)
-        for h in (0, 1):
-            chunk_idx = ranks if h == 0 else two_p - 1 - ranks
-            buf_p = (ranks[:, None] * (s_pad // page_size) +
-                     (off_i + h * c_i) // page_size + j[None, :])
-            tok_p = chunk_idx[:, None] * cp + j[None, :]
-            order[kv_base_p + tok_p.ravel()] = buf_p.ravel()
+        # Everything is a page multiple, so this is the slot formula
+        # applied to page indices.
+        t = np.arange(2 * pcp_size * (c_i // page_size))
+        order[pcp_size * off_i // page_size + t] = _zigzag_slots(
+            t, c_i // page_size, off_i // page_size, pcp_size,
+            s_pad // page_size)
     return order
 
 
@@ -149,35 +143,26 @@ def pcp_token_permutation(num_scheduled_tokens: list[int], chunk: list[int],
     """Returns perm: perm[g] is the natural-order source of rank-order
     slot g (-1 for padding).  The K/V side needs no per-token map -- the
     kernel unshuffles the rank-order buffer through `pcp_page_order`."""
-    two_p = 2 * pcp_size
     s_pad = t_pad // pcp_size
     src_off = np.cumsum([0] + list(num_scheduled_tokens))[:-1]
     perm = np.full(t_pad, -1, np.int64)
-    ranks = np.arange(pcp_size)
     for i, n_i in enumerate(num_scheduled_tokens):
-        c_i = chunk[i]
-        j = np.arange(c_i)
-        for h in (0, 1):
-            chunk_idx = ranks if h == 0 else two_p - 1 - ranks
-            dst = (ranks[:, None] * s_pad + off[i] + h * c_i + j[None, :])
-            tok = chunk_idx[:, None] * c_i + j[None, :]
-            real = tok < n_i
-            perm[dst[real]] = src_off[i] + tok[real]
+        tok = np.arange(n_i)
+        perm[_zigzag_slots(tok, chunk[i], off[i], pcp_size,
+                           s_pad)] = src_off[i] + tok
     return perm
 
 
 class PCPPreprocessor:
     """Per-step host preprocessing for a PCP-enabled runner."""
 
-    def __init__(self, pcp_size: int, mesh: Mesh,
-                 num_reqs_paddings: list[int], page_size: int):
+    def __init__(self, pcp_size: int, mesh: Mesh, num_reqs_paddings: list[int],
+                 page_size: int):
         assert pcp_size > 1, pcp_size
         self.pcp_size = pcp_size
         self.mesh = mesh
         self.num_reqs_paddings = num_reqs_paddings
-        # KV-cache page size as the KERNEL sees it (cache_config.block_size);
-        # chunks are rounded to page multiples so the kernel can unshuffle
-        # the all-gathered current K/V through `pcp_page_order`.
+        # KV-cache page size as the KERNEL sees it (cache_config.block_size).
         self.page_size = page_size
         self._pcp_spec = NamedSharding(
             mesh, PartitionSpec(ShardingAxisName.PREFILL_CONTEXT, None))
@@ -230,16 +215,13 @@ class PCPPreprocessor:
                     f"request (num_scheduled=1, num_computed={l_i}).")
 
         num_pcp_reqs = len(counts)
-        chunk, off = pcp_batch_layout(counts, t_pad, pcp_size,
+        chunk, off = pcp_batch_layout(counts,
+                                      t_pad,
+                                      pcp_size,
                                       align=self.page_size)
         perm = pcp_token_permutation(counts, chunk, off, t_pad, pcp_size)
-        # Per-page unshuffle map for the all-gathered current K/V; the kernel
-        # walks it during its KV fetch, so the rank-order buffer needs no
-        # gather pass.  One layout for any request count: a single request is
-        # simply R = 1 here.
-        kv_page_order = pcp_page_order(chunk, off, pcp_size,
-                                       t_pad // pcp_size, t_pad,
-                                       self.page_size)
+        kv_page_order = pcp_page_order(chunk, off, pcp_size, t_pad // pcp_size,
+                                       t_pad, self.page_size)
         valid = perm >= 0
         src_idx = perm[valid]
         for buf in (positions, input_ids):
@@ -268,18 +250,11 @@ class PCPPreprocessor:
         assert np.all(np.diff(cu_row[:n_seqs + 1]) > 0), (
             f"zero-length PCP seq in cu_q_lens: {cu_row[:n_seqs + 1]}")
 
-        # The global slot of each request's last token: token n_i - 1 sits
-        # in zigzag chunk c (rank c heads, rank 2P-1-c tails), at row
-        # rank * s_pad + off_i + half * C_i + (n_i - 1) % C_i.
-        s_pad = t_pad // pcp_size
-        last = np.asarray(counts) - 1
-        c_arr = np.asarray(chunk)
-        ci = last // c_arr
-        half = (ci >= pcp_size).astype(np.int64)
-        rank = np.where(half == 0, ci, 2 * pcp_size - 1 - ci)
+        # The global slot of each request's last token.
         logits_indices[:] = -1
-        logits_indices[:num_pcp_reqs] = (rank * s_pad + np.asarray(off) +
-                                         half * c_arr + last % c_arr)
+        logits_indices[:num_pcp_reqs] = _zigzag_slots(
+            np.asarray(counts) - 1, np.asarray(chunk), np.asarray(off),
+            pcp_size, t_pad // pcp_size)
 
         return self.metadata_to_device(
             cu_row,

--- a/tpu_inference/runner/pcp_utils.py
+++ b/tpu_inference/runner/pcp_utils.py
@@ -31,36 +31,48 @@ from tpu_inference.utils import device_array
 
 
 def pcp_token_layout(num_scheduled_tokens: list[int],
-                     pcp_size: int) -> tuple[list[int], list[int], int]:
-    """Returns (chunk, off, s_live): per-request chunk size ceil(n_i / 2P),
-    the start of each request's head+tail slot within a rank's region, and
-    the live rows per rank."""
+                     pcp_size: int,
+                     align: int = 1) -> tuple[list[int], list[int], int]:
+    """Returns (chunk, off, s_live): per-request chunk size ceil(n_i / 2P)
+    rounded up to a multiple of `align`, the start of each request's
+    head+tail slot within a rank's region, and the live rows per rank.
+
+    `align` is the KV-cache page size in production: page-multiple chunks
+    keep every token-order page of the new-KV buffer contiguous in the
+    rank-order all_gather result, which is what lets the kernel unshuffle
+    K/V through the `pcp_page_order` map during its mandatory HBM->VMEM
+    copy instead of a separate gather pass. The rounding costs at most
+    2P*(align-1) padding rows per request."""
     two_p = 2 * pcp_size
     off, acc, C = [], 0, []
     for n in num_scheduled_tokens:
-        c = cdiv(n, two_p)
+        c = cdiv(cdiv(n, two_p), align) * align
         C.append(c)
         off.append(acc)
         acc += 2 * c
     return C, off, acc
 
 
-def pcp_buffer_tokens(num_scheduled_tokens: list[int], pcp_size: int) -> int:
+def pcp_buffer_tokens(num_scheduled_tokens: list[int],
+                      pcp_size: int,
+                      align: int = 1) -> int:
     """Rows the token buffer must hold for this batch (can exceed the raw
     token count, since every chunk rounds up independently)."""
-    _, _, s_live = pcp_token_layout(num_scheduled_tokens, pcp_size)
+    _, _, s_live = pcp_token_layout(num_scheduled_tokens, pcp_size, align)
     return pcp_size * s_live
 
 
 def pcp_max_buffer_tokens(max_num_batched_tokens: int, max_num_seqs: int,
-                          pcp_size: int) -> int:
+                          pcp_size: int, align: int = 1) -> int:
     """Upper bound of `pcp_buffer_tokens` over any batch the scheduler
-    admits: each request rounds up by less than 2P rows."""
-    return max_num_batched_tokens + 2 * pcp_size * max_num_seqs
+    admits: each request rounds up by less than 2P * align rows."""
+    return max_num_batched_tokens + 2 * pcp_size * align * max_num_seqs
 
 
-def pcp_batch_layout(num_scheduled_tokens: list[int], t_pad: int,
-                     pcp_size: int) -> tuple[list[int], list[int]]:
+def pcp_batch_layout(num_scheduled_tokens: list[int],
+                     t_pad: int,
+                     pcp_size: int,
+                     align: int = 1) -> tuple[list[int], list[int]]:
     """Chunk sizes and slot offsets of a batch inside a `t_pad`-row buffer.
 
     A single request fills the buffer (chunk = t_pad / 2P) because
@@ -68,7 +80,8 @@ def pcp_batch_layout(num_scheduled_tokens: list[int], t_pad: int,
     width.
     """
     two_p = 2 * pcp_size
-    chunk, off, s_live = pcp_token_layout(num_scheduled_tokens, pcp_size)
+    chunk, off, s_live = pcp_token_layout(num_scheduled_tokens, pcp_size,
+                                          align)
     assert t_pad % pcp_size == 0 and t_pad >= pcp_size * s_live, (
         f"PCP token bucket {t_pad} cannot hold {pcp_size * s_live} tokens "
         f"({len(num_scheduled_tokens)} reqs, chunks {chunk})")
@@ -102,6 +115,40 @@ def pcp_seq_arrays(chunk: list[int], off: list[int], pcp_size: int,
     return cu_row, q_pos, kv_new_starts
 
 
+def pcp_page_order(chunk: list[int], off: list[int], pcp_size: int,
+                   s_pad: int, t_pad: int, page_size: int) -> np.ndarray:
+    """Per-page unshuffle map for the all-gathered new-KV buffer.
+
+    Entry j is the page of the rank-order buffer holding token-order page j
+    (request-major, the coordinate space `kv_new_starts` indexes). The
+    kernel's current-phase fetch walks this map one page-sized DMA at a
+    time, exactly like the paged cache side of a mixed fetch, so the
+    rank-order buffer never needs a separate gather pass.
+
+    Valid because every chunk is a whole number of pages (`pcp_token_layout`
+    with align=page_size): a token-order page then falls wholly inside one
+    chunk and is contiguous in the rank-order buffer. Uncovered entries
+    (dead region tails) stay 0 and are never fetched.
+    """
+    two_p = 2 * pcp_size
+    assert s_pad % page_size == 0 and t_pad == pcp_size * s_pad, (s_pad,
+                                                                  t_pad)
+    order = np.zeros(t_pad // page_size, np.int32)
+    ranks = np.arange(pcp_size)
+    for c_i, off_i in zip(chunk, off):
+        assert c_i % page_size == 0 and off_i % page_size == 0, (c_i, off_i)
+        cp = c_i // page_size  # pages per chunk
+        kv_base_p = pcp_size * off_i // page_size
+        j = np.arange(cp)
+        for h in (0, 1):
+            chunk_idx = ranks if h == 0 else two_p - 1 - ranks
+            buf_p = (ranks[:, None] * (s_pad // page_size) +
+                     (off_i + h * c_i) // page_size + j[None, :])
+            tok_p = chunk_idx[:, None] * cp + j[None, :]
+            order[kv_base_p + tok_p.ravel()] = buf_p.ravel()
+    return order
+
+
 def pcp_token_permutation(num_scheduled_tokens: list[int], chunk: list[int],
                           off: list[int], t_pad: int,
                           pcp_size: int) -> tuple[np.ndarray, np.ndarray]:
@@ -132,11 +179,15 @@ class PCPPreprocessor:
     """Per-step host preprocessing for a PCP-enabled runner."""
 
     def __init__(self, pcp_size: int, mesh: Mesh,
-                 num_reqs_paddings: list[int]):
+                 num_reqs_paddings: list[int], page_size: int):
         assert pcp_size > 1, pcp_size
         self.pcp_size = pcp_size
         self.mesh = mesh
         self.num_reqs_paddings = num_reqs_paddings
+        # KV-cache page size as the KERNEL sees it (cache_config.block_size);
+        # chunks are rounded to page multiples so the kernel can unshuffle
+        # the all-gathered current K/V through `pcp_page_order`.
+        self.page_size = page_size
         self._pcp_spec = NamedSharding(
             mesh, PartitionSpec(ShardingAxisName.PREFILL_CONTEXT, None))
         self._repl_spec = NamedSharding(mesh, PartitionSpec())
@@ -144,22 +195,26 @@ class PCPPreprocessor:
     def metadata_to_device(self, cu_row: np.ndarray, q_pos: np.ndarray,
                            kv_cache_lens: np.ndarray,
                            kv_new_starts: np.ndarray,
-                           kv_token_order: np.ndarray, *, has_cached_kv: bool,
+                           kv_token_order: np.ndarray,
+                           kv_page_order: np.ndarray, *, has_cached_kv: bool,
                            num_reqs: int) -> PCPMetadata:
         """Place host arrays as a `PCPMetadata`; also used by the compilation
         manager so precompiled and runtime metadata share one sharding."""
         query_start_loc, q_pos_offsets = device_array(
             self.mesh, (np.tile(cu_row, (self.pcp_size, 1)), q_pos),
             sharding=self._pcp_spec)
-        kv_cache_lens, kv_new_starts, kv_token_order = device_array(
-            self.mesh, (kv_cache_lens, kv_new_starts, kv_token_order),
-            sharding=self._repl_spec)
+        (kv_cache_lens, kv_new_starts, kv_token_order,
+         kv_page_order) = device_array(
+             self.mesh,
+             (kv_cache_lens, kv_new_starts, kv_token_order, kv_page_order),
+             sharding=self._repl_spec)
         return PCPMetadata(
             query_start_loc=query_start_loc,
             kv_cache_lens=kv_cache_lens,
             q_pos_offsets=q_pos_offsets,
             kv_new_starts=kv_new_starts,
             kv_token_order=kv_token_order,
+            kv_page_order=kv_page_order,
             has_cached_kv=has_cached_kv,
             num_reqs=num_reqs,
         )
@@ -188,9 +243,21 @@ class PCPPreprocessor:
                     f"request (num_scheduled=1, num_computed={l_i}).")
 
         num_pcp_reqs = len(counts)
-        chunk, off = pcp_batch_layout(counts, t_pad, pcp_size)
+        chunk, off = pcp_batch_layout(counts, t_pad, pcp_size,
+                                      align=self.page_size)
         perm, kv_order = pcp_token_permutation(counts, chunk, off, t_pad,
                                                pcp_size)
+        # Per-page unshuffle map for the all-gathered current K/V; the kernel
+        # walks it during its KV fetch, so the rank-order buffer needs no
+        # gather pass. Single-request batches keep the kernel's arithmetic
+        # remap and need no map (the overridden t_pad-derived chunk may not
+        # be page-aligned on small buckets).
+        if num_pcp_reqs > 1:
+            kv_page_order = pcp_page_order(chunk, off, pcp_size,
+                                           t_pad // pcp_size, t_pad,
+                                           self.page_size)
+        else:
+            kv_page_order = np.zeros(0, np.int32)
         valid = perm >= 0
         src_idx = perm[valid]
         for buf in (positions, input_ids):
@@ -230,6 +297,7 @@ class PCPPreprocessor:
             kv_cache_lens_np,
             kv_new_starts_np,
             kv_order,
+            kv_page_order,
             has_cached_kv=any(l_i > 0 for l_i in computed),
             num_reqs=runner_utils.get_padded_token_len(self.num_reqs_paddings,
                                                        num_pcp_reqs),

--- a/tpu_inference/runner/pcp_utils.py
+++ b/tpu_inference/runner/pcp_utils.py
@@ -75,20 +75,14 @@ def pcp_batch_layout(num_scheduled_tokens: list[int],
                      align: int = 1) -> tuple[list[int], list[int]]:
     """Chunk sizes and slot offsets of a batch inside a `t_pad`-row buffer.
 
-    A single request fills the buffer (chunk = t_pad / 2P) because
-    pcp_forward's kernel-side K/V remap derives the chunk from the buffer
-    width.
+    One layout for any request count: a single request is simply R = 1 of
+    the general page-aligned zigzag pack.
     """
-    two_p = 2 * pcp_size
     chunk, off, s_live = pcp_token_layout(num_scheduled_tokens, pcp_size,
                                           align)
     assert t_pad % pcp_size == 0 and t_pad >= pcp_size * s_live, (
         f"PCP token bucket {t_pad} cannot hold {pcp_size * s_live} tokens "
         f"({len(num_scheduled_tokens)} reqs, chunks {chunk})")
-    if len(num_scheduled_tokens) == 1:
-        assert t_pad % two_p == 0, (t_pad, two_p)
-        chunk = [t_pad // two_p]
-        off = [0]
     return chunk, off
 
 
@@ -151,28 +145,25 @@ def pcp_page_order(chunk: list[int], off: list[int], pcp_size: int,
 
 def pcp_token_permutation(num_scheduled_tokens: list[int], chunk: list[int],
                           off: list[int], t_pad: int,
-                          pcp_size: int) -> tuple[np.ndarray, np.ndarray]:
-    """Returns (perm, kv_order): perm[g] is the natural-order source of
-    rank-order slot g (-1 for padding); kv_order maps the all-gathered
-    current K/V from rank order to request-major token order."""
+                          pcp_size: int) -> np.ndarray:
+    """Returns perm: perm[g] is the natural-order source of rank-order
+    slot g (-1 for padding).  The K/V side needs no per-token map -- the
+    kernel unshuffles the rank-order buffer through `pcp_page_order`."""
     two_p = 2 * pcp_size
     s_pad = t_pad // pcp_size
     src_off = np.cumsum([0] + list(num_scheduled_tokens))[:-1]
     perm = np.full(t_pad, -1, np.int64)
-    kv_order = np.zeros(t_pad, np.int32)
     ranks = np.arange(pcp_size)
     for i, n_i in enumerate(num_scheduled_tokens):
         c_i = chunk[i]
         j = np.arange(c_i)
-        kv_base = pcp_size * off[i]
         for h in (0, 1):
             chunk_idx = ranks if h == 0 else two_p - 1 - ranks
             dst = (ranks[:, None] * s_pad + off[i] + h * c_i + j[None, :])
             tok = chunk_idx[:, None] * c_i + j[None, :]
             real = tok < n_i
             perm[dst[real]] = src_off[i] + tok[real]
-            kv_order[kv_base + tok.ravel()] = dst.ravel()
-    return perm, kv_order
+    return perm
 
 
 class PCPPreprocessor:
@@ -195,7 +186,6 @@ class PCPPreprocessor:
     def metadata_to_device(self, cu_row: np.ndarray, q_pos: np.ndarray,
                            kv_cache_lens: np.ndarray,
                            kv_new_starts: np.ndarray,
-                           kv_token_order: np.ndarray,
                            kv_page_order: np.ndarray, *, has_cached_kv: bool,
                            num_reqs: int) -> PCPMetadata:
         """Place host arrays as a `PCPMetadata`; also used by the compilation
@@ -203,17 +193,14 @@ class PCPPreprocessor:
         query_start_loc, q_pos_offsets = device_array(
             self.mesh, (np.tile(cu_row, (self.pcp_size, 1)), q_pos),
             sharding=self._pcp_spec)
-        (kv_cache_lens, kv_new_starts, kv_token_order,
-         kv_page_order) = device_array(
-             self.mesh,
-             (kv_cache_lens, kv_new_starts, kv_token_order, kv_page_order),
-             sharding=self._repl_spec)
+        kv_cache_lens, kv_new_starts, kv_page_order = device_array(
+            self.mesh, (kv_cache_lens, kv_new_starts, kv_page_order),
+            sharding=self._repl_spec)
         return PCPMetadata(
             query_start_loc=query_start_loc,
             kv_cache_lens=kv_cache_lens,
             q_pos_offsets=q_pos_offsets,
             kv_new_starts=kv_new_starts,
-            kv_token_order=kv_token_order,
             kv_page_order=kv_page_order,
             has_cached_kv=has_cached_kv,
             num_reqs=num_reqs,
@@ -245,19 +232,14 @@ class PCPPreprocessor:
         num_pcp_reqs = len(counts)
         chunk, off = pcp_batch_layout(counts, t_pad, pcp_size,
                                       align=self.page_size)
-        perm, kv_order = pcp_token_permutation(counts, chunk, off, t_pad,
-                                               pcp_size)
+        perm = pcp_token_permutation(counts, chunk, off, t_pad, pcp_size)
         # Per-page unshuffle map for the all-gathered current K/V; the kernel
         # walks it during its KV fetch, so the rank-order buffer needs no
-        # gather pass. Single-request batches keep the kernel's arithmetic
-        # remap and need no map (the overridden t_pad-derived chunk may not
-        # be page-aligned on small buckets).
-        if num_pcp_reqs > 1:
-            kv_page_order = pcp_page_order(chunk, off, pcp_size,
-                                           t_pad // pcp_size, t_pad,
-                                           self.page_size)
-        else:
-            kv_page_order = np.zeros(0, np.int32)
+        # gather pass.  One layout for any request count: a single request is
+        # simply R = 1 here.
+        kv_page_order = pcp_page_order(chunk, off, pcp_size,
+                                       t_pad // pcp_size, t_pad,
+                                       self.page_size)
         valid = perm >= 0
         src_idx = perm[valid]
         for buf in (positions, input_ids):
@@ -286,17 +268,24 @@ class PCPPreprocessor:
         assert np.all(np.diff(cu_row[:n_seqs + 1]) > 0), (
             f"zero-length PCP seq in cu_q_lens: {cu_row[:n_seqs + 1]}")
 
-        # The global slot of each request's last token.
+        # The global slot of each request's last token: token n_i - 1 sits
+        # in zigzag chunk c (rank c heads, rank 2P-1-c tails), at row
+        # rank * s_pad + off_i + half * C_i + (n_i - 1) % C_i.
+        s_pad = t_pad // pcp_size
+        last = np.asarray(counts) - 1
+        c_arr = np.asarray(chunk)
+        ci = last // c_arr
+        half = (ci >= pcp_size).astype(np.int64)
+        rank = np.where(half == 0, ci, 2 * pcp_size - 1 - ci)
         logits_indices[:] = -1
-        logits_indices[:num_pcp_reqs] = kv_order[pcp_size * np.asarray(off) +
-                                                 np.asarray(counts) - 1]
+        logits_indices[:num_pcp_reqs] = (rank * s_pad + np.asarray(off) +
+                                         half * c_arr + last % c_arr)
 
         return self.metadata_to_device(
             cu_row,
             q_pos_np,
             kv_cache_lens_np,
             kv_new_starts_np,
-            kv_order,
             kv_page_order,
             has_cached_kv=any(l_i > 0 for l_i in computed),
             num_reqs=runner_utils.get_padded_token_len(self.num_reqs_paddings,

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1072,10 +1072,17 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         if pcp_size > 1:
             _worst = pcp_max_buffer_tokens(
                 scheduler_config.max_num_batched_tokens,
-                scheduler_config.max_num_seqs, pcp_size)
-            # 128-aligned so T_pad % pcp_size == 0 for any power-of-two pcp.
+                scheduler_config.max_num_seqs,
+                pcp_size,
+                align=self.block_size)
+            # The bucket must keep every zigzag chunk -- T_pad / (2 * pcp)
+            # in the single-request case -- a whole number of KV pages for
+            # the page-order map, and 128-alignment keeps it TPU-friendly;
+            # power-of-two buckets satisfy both on their own.
             additional_sizes = list(additional_sizes) + [
-                common_utils.align_to(_worst * self.dp_size, 128)
+                common_utils.align_to(
+                    _worst * self.dp_size,
+                    2 * pcp_size * max(128, self.block_size))
             ]
         self.num_tokens_paddings = sorted(self.num_tokens_paddings +
                                           additional_sizes)
@@ -1154,7 +1161,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
         self.pcp_preprocessor = None
         if pcp_size > 1:
             self.pcp_preprocessor = PCPPreprocessor(pcp_size, self.mesh,
-                                                    self.pcp_num_reqs_paddings)
+                                                    self.pcp_num_reqs_paddings,
+                                                    self.block_size)
 
         # Padding for logits. Without speculative decoding, each request has one position to select from.
         # With speculative decoding, each request has multiple positions to select from.
@@ -2461,7 +2469,8 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 max_num_scheduled_tokens_across_dp = max(
                     max_num_scheduled_tokens_across_dp,
                     pcp_buffer_tokens([int(c) for c in counts],
-                                      self.pcp_preprocessor.pcp_size))
+                                      self.pcp_preprocessor.pcp_size,
+                                      align=self.block_size))
 
         # Find maximum number of requests across DP ranks
         max_num_reqs_across_dp = max(

--- a/tpu_inference/runner/tpu_runner.py
+++ b/tpu_inference/runner/tpu_runner.py
@@ -1075,14 +1075,14 @@ class TPUModelRunner(KVConnectorModelRunnerMixin, LoRAModelRunnerMixin):
                 scheduler_config.max_num_seqs,
                 pcp_size,
                 align=self.block_size)
-            # The bucket must keep every zigzag chunk -- T_pad / (2 * pcp)
-            # in the single-request case -- a whole number of KV pages for
-            # the page-order map, and 128-alignment keeps it TPU-friendly;
-            # power-of-two buckets satisfy both on their own.
+            # The page-order map needs each dp shard's T_pad / pcp to be a
+            # whole number of KV pages (128-alignment keeps the bucket
+            # TPU-friendly): align the per-dp value, then scale, so the
+            # invariant holds per shard for any dp_size.
             additional_sizes = list(additional_sizes) + [
-                common_utils.align_to(
-                    _worst * self.dp_size,
-                    2 * pcp_size * max(128, self.block_size))
+                common_utils.align_to(_worst,
+                                      max(128, pcp_size * self.block_size)) *
+                self.dp_size
             ]
         self.num_tokens_paddings = sorted(self.num_tokens_paddings +
                                           additional_sizes)


### PR DESCRIPTION
Stacked on #3557 (the preprocessing module), which stacks on #3425. That PR's branch `pcp-preprocessing-module` is this PR's base, so the diff here is only the commits below. Supersedes #3556, which was opened from a fork and could not be stacked. Review the commits in order:

1. kernel: page-granular indirection for the new-KV fetch
2. page-align multi-request chunks; unshuffle K/V in the kernel
3. merge the single-request path into the general layout
4. tests
5. cleanups from a self-review: one shared zigzag slot formula, a tighter
   (correct) precompile-skip condition, per-dp headroom alignment, and
   helper reuse in the tests

## What this does

Rounds every request's zigzag chunk up to a whole number of KV pages (`C_i = round_up(ceil(n_i / 2P), block_size)`). That makes every token-order page of the all-gathered current K/V contiguous in rank order, so the kernel can unshuffle K/V through a small per-page map (`kv_page_order`) during the HBM→VMEM fetch it performs anyway — one page-sized DMA per page, exactly like the paged-cache side of a mixed fetch. The per-layer HBM→HBM gather pass (`kv_token_order` + `jnp.take` over the whole token buffer) is deleted.

With chunks page-aligned for any request count, the single-request special case (kernel arithmetic remap via `pcp_chunk_size`, the whole-buffer cache-phase span) becomes the R = 1 instance of the general layout and is deleted too: one layout, one metadata contract, one kernel fetch path (net −100 lines before tests).

## Measured (TPU v7x, Qwen3-8B shapes)

- Current-phase attention layer in isolation: **1.34–2.49× faster**; outputs bitwise identical to the gather path in every case. The deleted gather pass alone is ~450–540 µs/layer; the in-kernel map costs nothing measurable over the bare all_gather + attention.
- E2E serving (PCP2×TP4, ctx 8k): **−7% TTFT / +6% prefill tok/s** at concurrency 4–8 where multi-request batches form; exact parity on single-request steps (the condition for merging the paths).
- Padding: +2.15% attended rows at the observed batch, bounded by `2P·(block_size−1)` per request; same token bucket.
- Precompile variants: **−44–52%** (buckets that cannot give every request one page per chunk become unreachable and are skipped).

## Costs

- Up to `2P·(block_size−1)` padding rows per request (attended, since they sit inside `cu_q_lens` spans).
- The runner's headroom bucket grows from `+2P` to `+2P·block_size` slack per request, so an occasional batch lands one bucket higher.

## Testing

- Kernel CP suite (multi-request tests parameterized over the map path, including mid-page fetch starts), interface suite (single-request cases now drive the same map path), and the host-only layout-helper tests in `tests/runner/test_pcp_utils.py` — all green on TPU v7x.
- The page-contiguity invariant the kernel fetch relies on is pinned against a brute-force per-token expansion of the zigzag layout.


