### PR TITLE
[CI] Four test fixes surfaced by the Kubernetes lane

### DIFF
--- a/examples/disagg/run_disagg_single_host.sh
+++ b/examples/disagg/run_disagg_single_host.sh
@@ -39,6 +39,13 @@ print_logs_on_exit() {
       echo "File not found."
     fi
 
+    echo "--- Contents of $LOG_DIR/proxy_0.txt ---"
+    if [ -f "$LOG_DIR/proxy_0.txt" ]; then
+      cat "$LOG_DIR/proxy_0.txt"
+    else
+      echo "File not found."
+    fi
+
     echo "--- Contents of $LOG_DIR/benchmark_0.txt ---"
     if [ -f "$LOG_DIR/benchmark_0.txt" ]; then
       cat "$LOG_DIR/benchmark_0.txt"
@@ -234,13 +241,21 @@ echo "starting proxy server"
 SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
 # Start proxy server
 python $SCRIPT_DIR/toy_proxy_server.py \
---host localhost \
+--host 127.0.0.1 \
 --port 8000 \
 --prefiller-hosts ${PREFILL_HOSTS[@]} \
 --prefiller-ports ${PREFILL_PORTS[@]} \
 --decoder-hosts ${DECODE_HOSTS[@]} \
 --decoder-ports ${DECODE_PORTS[@]} \
 > $LOG_DIR/proxy_0.txt 2>&1 &
+PROXY_PID=$!
+
+# Wait for the proxy the same way we wait for prefill and decode. Without
+# this the benchmark below opens port 8000 while uvicorn is still importing,
+# and every request fails with ECONNREFUSED - 200 of 200, reported as failed
+# requests rather than as a proxy that was not up yet.
+echo "Waiting for proxy on port 8000 to start..."
+wait_for_server 8000 $PROXY_PID
 
 # run benchmark for both disagg and non-disagg
 LOG_FILE="$LOG_DIR/benchmark_0.txt"

--- a/tests/e2e/benchmarking/bench_utils.sh
+++ b/tests/e2e/benchmarking/bench_utils.sh
@@ -52,7 +52,15 @@ waitForServerReady() {
             exit 1
         fi
 
-        if grep -Eq "$error_regex" "$LOG_FILE"; then
+        # Warnings are not fatal, even when they quote an exception. JAX reports
+        # a cache entry it could not write as
+        #   UserWarning: Error writing persistent compilation cache entry for
+        #   'jit_sample': OSError: [Errno 116] Stale file handle
+        # which matches "OSError:" above and killed a healthy server. Anchoring
+        # the patterns instead would not work: engine output is prefixed, so a
+        # real traceback arrives as "(EngineCore pid=375) OSError: ...", never
+        # at the start of a line.
+        if grep -E "$error_regex" "$LOG_FILE" | grep -qv "Warning:"; then
             echo "FATAL ERROR DETECTED: The server log contains a fatal error pattern."
             # Call cleanup and exit (cleanup must be handled by the calling script's trap)
             exit 1

--- a/tests/models/jax/test_gemma4.py
+++ b/tests/models/jax/test_gemma4.py
@@ -131,16 +131,27 @@ class TestGemma4ForConditionalGeneration:
             )
         assert jax_output is not None
 
+    # model_name is the innermost parametrize on purpose, so that it varies
+    # slowest and all four pp configurations for one checkpoint run together.
+    #
+    # Stacked parametrize varies the topmost decorator fastest, so with
+    # model_name on top these sixteen cases ran round-robin - 31B, 26B-A4B,
+    # 31B-FP8, 26B-A4B-FP8, then back to 31B, four times over. Each checkpoint
+    # was therefore fetched four separate times, always with the other three
+    # in between, which is the worst possible order for a cache: whatever holds
+    # 31B has been evicted by the other three before 31B comes round again,
+    # and this block dominated the step's checkpoint-loading time. Grouped,
+    # each checkpoint is fetched once and reused three times.
+    @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
+                                                       (3, 4)])
+    @pytest.mark.parametrize("load_format",
+                             ["skip_layers_model_loader_for_test"])
     @pytest.mark.parametrize("model_name", [
         "google/gemma-4-31B-it",
         "google/gemma-4-26B-A4B-it",
         "RedHatAI/gemma-4-31B-it-FP8-Dynamic",
         "RedHatAI/gemma-4-26B-A4B-it-FP8-Dynamic",
     ])
-    @pytest.mark.parametrize("pp_rank,pp_world_size", [(0, 1), (0, 4), (1, 4),
-                                                       (3, 4)])
-    @pytest.mark.parametrize("load_format",
-                             ["skip_layers_model_loader_for_test"])
     def test_model_loading(
             self,
             model_name,

--- a/tests/test_envs.py
+++ b/tests/test_envs.py
@@ -15,6 +15,12 @@ def test_getattr_without_cache(monkeypatch: pytest.MonkeyPatch):
     assert envs.JAX_PLATFORMS == "tpu"
     assert envs.PHASED_PROFILING_DIR == "/tmp/profiling"
 
+    # Unset rather than assumed unset: on GKE the TPU device plugin injects
+    # TPU_ACCELERATOR_TYPE, TPU_WORKER_ID and friends into every TPU pod, so
+    # these are already populated there. libtpu needs them, so the environment
+    # is right and the assumption was wrong.
+    monkeypatch.delenv("TPU_NAME", raising=False)
+    monkeypatch.delenv("TPU_ACCELERATOR_TYPE", raising=False)
     assert envs.TPU_NAME is None
     assert envs.TPU_ACCELERATOR_TYPE is None
     monkeypatch.setenv("TPU_NAME", "my-tpu")


### PR DESCRIPTION
Four independent test fixes, split out of the larger Kubernetes CI change so they can land on their own. None depends on Kubernetes; each is a correctness or speed fix in its own right.

- **`tests/test_envs.py`** — unset `TPU_NAME` / `TPU_ACCELERATOR_TYPE` rather than assume they are absent. GKE's TPU device plugin injects them into every TPU pod and libtpu needs them, so the assumption was wrong.
- **`tests/models/jax/test_gemma4.py`** — move `model_name` to the innermost `parametrize` so all four pp configs for one checkpoint run together. It was fetching each of four large checkpoints four times in the worst possible order for a cache. Checkpoint loading in part2 falls **23.8 → 8.8 min** on bare metal.
- **`tests/e2e/benchmarking/bench_utils.sh`** — stop treating a `UserWarning` that quotes `OSError` as fatal. JAX reports an unwritable cache entry that way and it was killing healthy servers. A real error is still caught when a warning is present in the same log.
- **`examples/disagg/run_disagg_single_host.sh`** — wait for the proxy before benchmarking. It was opening port 8000 while uvicorn was still importing, failing all 200 requests with ECONNREFUSED.