### PR TITLE
Quantize bf16 linear layers to fp8 at load time

### DIFF
--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -1259,6 +1259,9 @@ def test_quantized_bf16_row_parallel_linear(monkeypatch, model, num_devices,
         # 1024 / 512 = 2 blocks, which 8 shards of the contracting axis cannot
         # divide.
         (512, 1024, "cannot shard"),
+        # 0 is a value, not "off" -- it would otherwise reach a modulo by zero.
+        (0, 1024, "positive"),
+        (-128, 1024, "positive"),
     ])
 def test_quantized_bf16_block_size_rejected(monkeypatch, model, block_size,
                                             input_size, match):

--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -44,12 +44,27 @@ from tpu_inference.layers.vllm.custom_ops.fused_moe import _all_reduce_over_tp
 from tpu_inference.layers.vllm.interface.moe import FusedMoEFactory
 from tpu_inference.layers.vllm.quantization import get_tpu_quantization_config
 from tpu_inference.layers.vllm.quantization.unquantized import (
-    VllmUnquantizedConfig, VllmUnquantizedFusedMoEMethod,
-    VllmUnquantizedLinearMethod, _host_numpy_view, _load_weight_for_layer,
-    _load_weight_on_host)
+    VllmQuantizedBf16LinearMethod, VllmUnquantizedConfig,
+    VllmUnquantizedFusedMoEMethod, VllmUnquantizedLinearMethod,
+    _host_numpy_view, _load_weight_for_layer, _load_weight_on_host,
+    should_quantize_bf16_linear)
 
 P = PartitionSpec
 MODELS = ["Qwen/Qwen2-1.5B-Instruct"]
+
+# Qwen3.5's packed_modules_mapping, inlined so these tests don't depend on the
+# model definition.
+QWEN3_5_FUSED_MAPPING = {
+    "qkv_proj": ["q_proj", "k_proj", "v_proj"],
+    "gate_up_proj": ["gate_proj", "up_proj"],
+    "in_proj_qkvz": ["in_proj_qkv", "in_proj_z"],
+    "in_proj_ba": ["in_proj_b", "in_proj_a"],
+}
+# Every attention and gated-delta-net projection, named the way the checkpoint
+# names them rather than the way vLLM fuses them.
+QWEN3_5_ATTN_PATTERNS = (
+    r"re:.*self_attn\..*,"
+    r"re:.*linear_attn.(in_proj_qkv|in_proj_z|in_proj_b|in_proj_a|out_proj)$")
 
 
 @pytest.fixture(autouse=True)
@@ -1004,3 +1019,292 @@ def test_load_weight_for_layer_stage_on_host_ignored_under_pathways(
 
     mock_on_host.assert_not_called()
     assert result.shape == STAGED_SHAPE
+
+
+@pytest.mark.parametrize(("prefix", "expected"), [
+    ("model.layers.3.self_attn.qkv_proj", True),
+    ("model.layers.3.self_attn.o_proj", True),
+    ("model.layers.0.linear_attn.in_proj_qkvz", True),
+    ("model.layers.0.linear_attn.in_proj_ba", True),
+    ("model.layers.0.linear_attn.out_proj", True),
+    ("model.layers.0.linear_attn.conv1d", False),
+    ("model.layers.0.mlp.gate", False),
+    ("model.layers.0.mlp.shared_expert.gate_up_proj", False),
+    ("model.layers.0.mlp.shared_expert_gate", False),
+    ("lm_head", False),
+])
+def test_quantize_bf16_linear_pattern_match(monkeypatch, prefix, expected):
+    """Checkpoint-level names have to reach the modules vLLM actually builds.
+
+    Nothing in the checkpoint is called `qkv_proj`, `in_proj_qkvz` or
+    `in_proj_ba`, so selecting those depends on expanding them back into the
+    shards they fuse."""
+    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS", QWEN3_5_ATTN_PATTERNS)
+    assert should_quantize_bf16_linear(prefix,
+                                       QWEN3_5_FUSED_MAPPING) is expected
+
+
+def test_quantize_bf16_linear_no_patterns_selects_nothing(monkeypatch):
+    monkeypatch.delenv("QUANTIZE_BF16_LINEAR_PATTERNS", raising=False)
+    assert not should_quantize_bf16_linear("model.layers.3.self_attn.qkv_proj",
+                                           QWEN3_5_FUSED_MAPPING)
+
+
+def test_quantize_bf16_linear_bare_pattern_matches_suffix(monkeypatch):
+    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS", "o_proj,down_proj")
+    assert should_quantize_bf16_linear("model.layers.3.self_attn.o_proj",
+                                       QWEN3_5_FUSED_MAPPING)
+    assert not should_quantize_bf16_linear("model.layers.3.self_attn.qkv_proj",
+                                           QWEN3_5_FUSED_MAPPING)
+
+
+def test_quantize_bf16_linear_partial_fused_shard_raises(monkeypatch):
+    """One fused weight cannot be half fp8, so a half-selection is an error
+    rather than a silent choice either way."""
+    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS", "in_proj_b")
+    with pytest.raises(ValueError, match="some but not all shards"):
+        should_quantize_bf16_linear("model.layers.0.linear_attn.in_proj_ba",
+                                    QWEN3_5_FUSED_MAPPING)
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("num_devices", [1, jax.local_device_count()])
+@pytest.mark.parametrize("fuse_matmuls", [False, True])
+@pytest.mark.parametrize("w8a8", [False, True])
+@pytest.mark.parametrize("block_size", [None, 128])
+def test_quantized_bf16_merged_column_parallel_linear(monkeypatch, model,
+                                                      num_devices,
+                                                      fuse_matmuls, w8a8,
+                                                      block_size):
+    """A bf16 checkpoint weight is quantized on its way to the device.
+
+    The layer keeps loading and sharding exactly as the unquantized one does;
+    what changes is that the parameter that lands on the device is fp8 with a
+    per-output-channel scale (or a blockwise one), and the result still tracks
+    the bf16 matmul."""
+    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS", QWEN3_5_ATTN_PATTERNS)
+    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_W8A8", "1" if w8a8 else "0")
+    if block_size is not None:
+        monkeypatch.setenv("QUANTIZE_BF16_LINEAR_BLOCK_SIZE", str(block_size))
+
+    mesh = test_utils.get_spmd_mesh(num_devices)
+    dtype = torch.bfloat16
+    prefix = "model.layers.0.linear_attn.in_proj_qkvz"
+    output_sizes = [512, 512]
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+
+    with set_current_vllm_config(vllm_config):
+        ref_linear = MergedColumnParallelLinear(
+            input_size=1024,
+            output_sizes=output_sizes,
+            bias=False,
+            params_dtype=dtype,
+            return_bias=False,
+        )
+
+    input_tensor = (torch.rand(10, ref_linear.input_size, dtype=dtype) /
+                    10).to('cpu')
+    weight_data = torch.rand_like(ref_linear.weight.data) / 10
+    ref_linear.weight.data = weight_data
+    ref_linear = ref_linear.to('cpu')
+    ref_linear.quant_method.process_weights_after_loading(ref_linear)
+    expected = ref_linear(input_tensor).to(torch.float32)
+
+    vllm_config.model_config.dtype = dtype
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    quant_config.packed_modules_mapping = QWEN3_5_FUSED_MAPPING
+    with set_current_vllm_config(vllm_config):
+        jax_linear = MergedColumnParallelLinear(
+            input_size=1024,
+            output_sizes=output_sizes,
+            bias=False,
+            params_dtype=dtype,
+            return_bias=False,
+            quant_config=quant_config,
+            prefix=prefix,
+        )
+        assert isinstance(jax_linear.quant_method,
+                          VllmQuantizedBf16LinearMethod)
+        jax_linear.quant_method.linear_config.fuse_matmuls = fuse_matmuls
+
+    jax_linear.weight.data = weight_data
+    jax_input_tensor = torch_view(t2j(input_tensor, use_dlpack=False))
+    jax_input_tensor.apply_jax_(jax.device_put,
+                                NamedSharding(mesh, P(None, None)))
+    with torchax.default_env():
+        jax_linear.quant_method.process_weights_after_loading(jax_linear)
+
+        weights = ([jax_linear.weight]
+                   if fuse_matmuls else list(jax_linear.weight))
+        scales = ([jax_linear.weight_scale]
+                  if fuse_matmuls else list(jax_linear.weight_scale))
+        for weight, scale in zip(weights, scales):
+            assert weight.dtype == torch.float8_e4m3fn
+            if block_size is None:
+                # One scale per output feature, not per tensor.
+                assert scale.shape == (weight.shape[-1], )
+            else:
+                # The kernel layout: [1, n_blocks, 1, out].
+                n_blocks = jax_linear.input_size // block_size
+                assert scale.shape == (1, n_blocks, 1, weight.shape[-1])
+        assert sum(w.shape[-1] for w in weights) == sum(output_sizes)
+
+        jax_output = j2t(jax_linear(jax_input_tensor).to(torch.float32))
+
+    torch.testing.assert_close(expected, jax_output, rtol=0.03, atol=0.03)
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("num_devices", [1, jax.local_device_count()])
+@pytest.mark.parametrize("block_size", [None, 128])
+def test_quantized_bf16_row_parallel_linear(monkeypatch, model, num_devices,
+                                            block_size):
+    """Row-parallel shards the contracting axis, so the per-output-channel
+    scale is replicated and the psum still sums like-scaled partial products.
+    A blockwise scale shards along that axis with the weight instead."""
+    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS", QWEN3_5_ATTN_PATTERNS)
+    if block_size is not None:
+        monkeypatch.setenv("QUANTIZE_BF16_LINEAR_BLOCK_SIZE", str(block_size))
+
+    mesh = test_utils.get_spmd_mesh(num_devices)
+    dtype = torch.bfloat16
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+
+    with set_current_vllm_config(vllm_config):
+        ref_linear = RowParallelLinear(
+            input_size=1024,
+            output_size=512,
+            bias=False,
+            params_dtype=dtype,
+            return_bias=False,
+        )
+
+    input_tensor = (torch.rand(10, ref_linear.input_size, dtype=dtype) /
+                    10).to('cpu')
+    weight_data = torch.rand_like(ref_linear.weight.data) / 10
+    ref_linear.weight.data = weight_data
+    ref_linear = ref_linear.to('cpu')
+    ref_linear.quant_method.process_weights_after_loading(ref_linear)
+    expected = ref_linear(input_tensor).to(torch.float32)
+
+    vllm_config.model_config.dtype = dtype
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    quant_config.packed_modules_mapping = QWEN3_5_FUSED_MAPPING
+    with set_current_vllm_config(vllm_config):
+        jax_linear = RowParallelLinear(
+            input_size=1024,
+            output_size=512,
+            bias=False,
+            params_dtype=dtype,
+            return_bias=False,
+            quant_config=quant_config,
+            prefix="model.layers.0.linear_attn.out_proj",
+        )
+        assert isinstance(jax_linear.quant_method,
+                          VllmQuantizedBf16LinearMethod)
+
+    jax_linear.weight.data = weight_data
+    jax_input_tensor = torch_view(t2j(input_tensor, use_dlpack=False))
+    jax_input_tensor.apply_jax_(jax.device_put,
+                                NamedSharding(mesh, P(None, None)))
+    with torchax.default_env():
+        jax_linear.quant_method.process_weights_after_loading(jax_linear)
+        assert jax_linear.weight.dtype == torch.float8_e4m3fn
+        if block_size is None:
+            assert jax_linear.weight_scale.shape == (512, )
+        else:
+            assert jax_linear.weight_scale.shape == (1, 1024 // block_size, 1,
+                                                     512)
+        jax_output = j2t(jax_linear(jax_input_tensor).to(torch.float32))
+
+    torch.testing.assert_close(expected, jax_output, rtol=0.03, atol=0.03)
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize(
+    "block_size, input_size, match",
+    [
+        # 1024 input features do not split into blocks of 384.
+        (384, 1024, "does not divide"),
+        # 1024 / 512 = 2 blocks, which 8 shards of the contracting axis cannot
+        # divide.
+        (512, 1024, "cannot shard"),
+    ])
+def test_quantized_bf16_block_size_rejected(monkeypatch, model, block_size,
+                                            input_size, match):
+    """A block size the shape or the sharding cannot support is refused at load
+    time, naming the env var rather than failing deep inside the jit."""
+    if jax.local_device_count() < 8:
+        pytest.skip("needs 8 devices to shard the contracting axis 8 ways")
+    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS", QWEN3_5_ATTN_PATTERNS)
+    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_BLOCK_SIZE", str(block_size))
+
+    mesh = test_utils.get_spmd_mesh(8)
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.model_config.dtype = torch.bfloat16
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    quant_config.packed_modules_mapping = QWEN3_5_FUSED_MAPPING
+
+    with set_current_vllm_config(vllm_config):
+        jax_linear = RowParallelLinear(
+            input_size=input_size,
+            output_size=512,
+            bias=False,
+            params_dtype=torch.bfloat16,
+            return_bias=False,
+            quant_config=quant_config,
+            prefix="model.layers.0.linear_attn.out_proj",
+        )
+    jax_linear.weight.data = torch.rand_like(jax_linear.weight.data) / 10
+    with torchax.default_env(), pytest.raises(ValueError, match=match):
+        jax_linear.quant_method.process_weights_after_loading(jax_linear)
+
+
+@pytest.mark.parametrize("model", MODELS)
+def test_unselected_linear_stays_unquantized(monkeypatch, model):
+    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS", QWEN3_5_ATTN_PATTERNS)
+    mesh = test_utils.get_spmd_mesh(1)
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.model_config.dtype = torch.bfloat16
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+    quant_config.packed_modules_mapping = QWEN3_5_FUSED_MAPPING
+
+    with set_current_vllm_config(vllm_config):
+        layer = MergedColumnParallelLinear(
+            input_size=1024,
+            output_sizes=[512, 512],
+            bias=False,
+            params_dtype=torch.bfloat16,
+            return_bias=False,
+            quant_config=quant_config,
+            prefix="model.layers.0.mlp.shared_expert.gate_up_proj",
+        )
+    assert isinstance(layer.quant_method, VllmUnquantizedLinearMethod)
+    assert not isinstance(layer.quant_method, VllmQuantizedBf16LinearMethod)

--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -1050,8 +1050,22 @@ def test_quantize_bf16_linear_no_patterns_selects_nothing(monkeypatch):
                                            QWEN3_5_FUSED_MAPPING)
 
 
-def test_quantize_bf16_linear_bare_pattern_matches_suffix(monkeypatch):
-    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS", "o_proj,down_proj")
+def test_quantize_bf16_linear_bare_pattern_is_the_whole_name(monkeypatch):
+    """Bare patterns are exact layer names, per `is_equal_or_regex_match`.
+
+    A suffix has to be spelled as a regex, so the bare form cannot quietly
+    select more layers than it names."""
+    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS",
+                       "model.layers.3.self_attn.o_proj,o_proj")
+    assert should_quantize_bf16_linear("model.layers.3.self_attn.o_proj",
+                                       QWEN3_5_FUSED_MAPPING)
+    assert not should_quantize_bf16_linear("model.layers.4.self_attn.o_proj",
+                                           QWEN3_5_FUSED_MAPPING)
+
+
+def test_quantize_bf16_linear_regex_pattern_matches_suffix(monkeypatch):
+    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS",
+                       r"re:.*\.o_proj$,re:.*\.down_proj$")
     assert should_quantize_bf16_linear("model.layers.3.self_attn.o_proj",
                                        QWEN3_5_FUSED_MAPPING)
     assert not should_quantize_bf16_linear("model.layers.3.self_attn.qkv_proj",
@@ -1060,8 +1074,12 @@ def test_quantize_bf16_linear_bare_pattern_matches_suffix(monkeypatch):
 
 def test_quantize_bf16_linear_partial_fused_shard_raises(monkeypatch):
     """One fused weight cannot be half fp8, so a half-selection is an error
-    rather than a silent choice either way."""
-    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS", "in_proj_b")
+    rather than a silent choice either way.
+
+    The `$` is load-bearing: `re:` patterns are anchored at the start only, so
+    an unanchored `.*\\.in_proj_b` would match `in_proj_ba` itself and select the
+    fused weight outright instead of half of it."""
+    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS", r"re:.*\.in_proj_b$")
     with pytest.raises(ValueError, match="some but not all shards"):
         should_quantize_bf16_linear("model.layers.0.linear_attn.in_proj_ba",
                                     QWEN3_5_FUSED_MAPPING)
@@ -1308,3 +1326,65 @@ def test_unselected_linear_stays_unquantized(monkeypatch, model):
         )
     assert isinstance(layer.quant_method, VllmUnquantizedLinearMethod)
     assert not isinstance(layer.quant_method, VllmQuantizedBf16LinearMethod)
+
+
+@pytest.mark.parametrize("model", MODELS)
+@pytest.mark.parametrize("fuse_matmuls", [False, True])
+@pytest.mark.parametrize("bias", [False, True])
+def test_unquantized_linear_stores_no_scale(monkeypatch, model, fuse_matmuls,
+                                            bias):
+    """The shared store step hangs a scale off the layer only when the build
+    step produced one, so an unquantized layer keeps a bare bf16 weight."""
+    monkeypatch.delenv("QUANTIZE_BF16_LINEAR_PATTERNS", raising=False)
+    mesh = test_utils.get_spmd_mesh(1)
+    dtype = torch.bfloat16
+
+    engine_args = EngineArgs(
+        model=model,
+        max_model_len=64,
+        max_num_batched_tokens=64,
+        max_num_seqs=4,
+    )
+    vllm_config = engine_args.create_engine_config()
+    vllm_config.model_config.dtype = dtype
+    quant_config = get_tpu_quantization_config(vllm_config, mesh)
+
+    with set_current_vllm_config(vllm_config):
+        layer = MergedColumnParallelLinear(
+            input_size=1024,
+            output_sizes=[512, 512],
+            bias=bias,
+            params_dtype=dtype,
+            return_bias=False,
+            quant_config=quant_config,
+            prefix="model.layers.0.mlp.shared_expert.gate_up_proj",
+        )
+        assert isinstance(layer.quant_method, VllmUnquantizedLinearMethod)
+        layer.quant_method.linear_config.fuse_matmuls = fuse_matmuls
+
+    layer.weight.data = torch.rand_like(layer.weight.data) / 10
+    if bias:
+        layer.bias.data = torch.rand_like(layer.bias.data) / 10
+    with torchax.default_env():
+        layer.quant_method.process_weights_after_loading(layer)
+
+    weights = [layer.weight] if fuse_matmuls else list(layer.weight)
+    assert all(w.dtype == dtype for w in weights)
+    assert getattr(layer, "weight_scale", None) is None
+    if bias:
+        biases = [layer.bias] if fuse_matmuls else list(layer.bias)
+        assert all(b.dtype == dtype for b in biases)
+    else:
+        assert layer.bias is None
+
+
+def test_quantized_bf16_only_overrides_the_build_step():
+    """Quantizing changes what the weight is turned into, not how it is loaded
+    or stored -- keep those three steps from drifting back into a copy."""
+    for name in ("process_weights_after_loading", "_load_linear_weights",
+                 "_store_linear_weights"):
+        inherited = getattr(VllmUnquantizedLinearMethod, name)
+        assert getattr(VllmQuantizedBf16LinearMethod, name) is inherited, (
+            f"{name} should be inherited, not reimplemented")
+    assert (VllmQuantizedBf16LinearMethod._build_linear_weights
+            is not VllmUnquantizedLinearMethod._build_linear_weights)

--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -1088,11 +1088,10 @@ def test_quantize_bf16_linear_partial_fused_shard_raises(monkeypatch):
 @pytest.mark.parametrize("model", MODELS)
 @pytest.mark.parametrize("num_devices", [1, jax.local_device_count()])
 @pytest.mark.parametrize("fuse_matmuls", [False, True])
-@pytest.mark.parametrize("w8a8", [False, True])
 @pytest.mark.parametrize("block_size", [None, 128])
 def test_quantized_bf16_merged_column_parallel_linear(monkeypatch, model,
                                                       num_devices,
-                                                      fuse_matmuls, w8a8,
+                                                      fuse_matmuls,
                                                       block_size):
     """A bf16 checkpoint weight is quantized on its way to the device.
 
@@ -1101,7 +1100,6 @@ def test_quantized_bf16_merged_column_parallel_linear(monkeypatch, model,
     per-output-channel scale (or a blockwise one), and the result still tracks
     the bf16 matmul."""
     monkeypatch.setenv("QUANTIZE_BF16_LINEAR_PATTERNS", QWEN3_5_ATTN_PATTERNS)
-    monkeypatch.setenv("QUANTIZE_BF16_LINEAR_W8A8", "1" if w8a8 else "0")
     if block_size is not None:
         monkeypatch.setenv("QUANTIZE_BF16_LINEAR_BLOCK_SIZE", str(block_size))
 

--- a/tests/layers/vllm/test_unquantized.py
+++ b/tests/layers/vllm/test_unquantized.py
@@ -65,6 +65,12 @@ QWEN3_5_FUSED_MAPPING = {
 QWEN3_5_ATTN_PATTERNS = (
     r"re:.*self_attn\..*,"
     r"re:.*linear_attn.(in_proj_qkv|in_proj_z|in_proj_b|in_proj_a|out_proj)$")
+# A blockwise scale sends the matmul through gmm_v2, which tiles the token axis
+# by min(sublane size, batch) -- 8 on v6e, 16 on v7x -- and rejects a batch that
+# does not divide the tile. The 10 the unquantized tests use only survives where
+# the sublane size exceeds it, so the quantized tests take a multiple of 8. The
+# runner pads to such a size in production anyway.
+QUANTIZED_NUM_TOKENS = 16
 
 
 @pytest.fixture(autouse=True)
@@ -1125,8 +1131,9 @@ def test_quantized_bf16_merged_column_parallel_linear(monkeypatch, model,
             return_bias=False,
         )
 
-    input_tensor = (torch.rand(10, ref_linear.input_size, dtype=dtype) /
-                    10).to('cpu')
+    input_tensor = (
+        torch.rand(QUANTIZED_NUM_TOKENS, ref_linear.input_size, dtype=dtype) /
+        10).to('cpu')
     weight_data = torch.rand_like(ref_linear.weight.data) / 10
     ref_linear.weight.data = weight_data
     ref_linear = ref_linear.to('cpu')
@@ -1209,8 +1216,9 @@ def test_quantized_bf16_row_parallel_linear(monkeypatch, model, num_devices,
             return_bias=False,
         )
 
-    input_tensor = (torch.rand(10, ref_linear.input_size, dtype=dtype) /
-                    10).to('cpu')
+    input_tensor = (
+        torch.rand(QUANTIZED_NUM_TOKENS, ref_linear.input_size, dtype=dtype) /
+        10).to('cpu')
     weight_data = torch.rand_like(ref_linear.weight.data) / 10
     ref_linear.weight.data = weight_data
     ref_linear = ref_linear.to('cpu')

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -32,6 +32,10 @@ if TYPE_CHECKING:
     ENABLE_QUANTIZED_MATMUL_KERNEL: bool = False
     REQUANTIZE_BLOCK_SIZE: int | None = None
     REQUANTIZE_WEIGHT_DTYPE: str = "float8_e4m3fn"
+    QUANTIZE_BF16_LINEAR_PATTERNS: list[str] = []
+    QUANTIZE_BF16_LINEAR_DTYPE: str = "float8_e4m3fn"
+    QUANTIZE_BF16_LINEAR_W8A8: bool = True
+    QUANTIZE_BF16_LINEAR_BLOCK_SIZE: int | None = None
     MOE_REQUANTIZE_BLOCK_SIZE: int | None = None
     MOE_REQUANTIZE_WEIGHT_DTYPE: str = ""
     MOE_REQUANTIZE_CLIP_PERCENTILE: float | None = None
@@ -306,6 +310,37 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Specify dtype for quantized linear weights
     "REQUANTIZE_WEIGHT_DTYPE":
     lambda: os.getenv("REQUANTIZE_WEIGHT_DTYPE", "float8_e4m3fn"),
+    # Quantize linear layers the checkpoint left unquantized, at load time.
+    # Comma-separated list of module patterns matched against the vLLM layer
+    # prefix: a bare name matches exactly or as a dotted suffix, and a "re:"
+    # prefix makes the rest a regex that must match the whole prefix. Patterns
+    # therefore cannot contain a comma. Checkpoint-level names are accepted for
+    # layers vLLM fuses (e.g. q_proj/k_proj/v_proj for qkv_proj); every shard of
+    # a fused layer has to be selected or none of it is. Empty (default) leaves
+    # every unquantized linear in its checkpoint dtype.
+    "QUANTIZE_BF16_LINEAR_PATTERNS":
+    env_str_list("QUANTIZE_BF16_LINEAR_PATTERNS"),
+    # Weight dtype for the layers QUANTIZE_BF16_LINEAR_PATTERNS selects.
+    "QUANTIZE_BF16_LINEAR_DTYPE":
+    lambda: os.getenv("QUANTIZE_BF16_LINEAR_DTYPE", "float8_e4m3fn"),
+    # Whether those layers also quantize their activations (per-token dynamic,
+    # i.e. W8A8). Set to 0 for weight-only fp8, which halves the weight memory
+    # just the same but keeps the matmul in the activation dtype -- slower, and
+    # the fallback if W8A8 costs too much accuracy.
+    "QUANTIZE_BF16_LINEAR_W8A8":
+    env_bool("QUANTIZE_BF16_LINEAR_W8A8", default=True),
+    # 1-D block size along the input (contracting) axis for those layers, so the
+    # scale becomes one value per [block of input features, output feature]
+    # instead of one per output feature. Smaller blocks track outliers better at
+    # the cost of a fp32 scale every `block_size` weights (128 costs ~3% of the
+    # fp8 weight bytes back). Must divide the layer's input size, and the block
+    # count must divide by the TP degree of a row-parallel layer's input axis.
+    # Unset (default) means per-output-channel. Setting it routes the matmul to
+    # the blockwise gmm kernel, since the XLA matmul can only honour a blockwise
+    # scale by dequantizing the whole weight back to bf16 first.
+    "QUANTIZE_BF16_LINEAR_BLOCK_SIZE":
+    lambda: int(block_size)
+    if (block_size := os.getenv("QUANTIZE_BF16_LINEAR_BLOCK_SIZE")) else None,
     # Specify dtype for quantized MoE weights
     "MOE_REQUANTIZE_WEIGHT_DTYPE":
     lambda: os.getenv("MOE_REQUANTIZE_WEIGHT_DTYPE", ""),

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -34,7 +34,6 @@ if TYPE_CHECKING:
     REQUANTIZE_WEIGHT_DTYPE: str = "float8_e4m3fn"
     QUANTIZE_BF16_LINEAR_PATTERNS: list[str] = []
     QUANTIZE_BF16_LINEAR_DTYPE: str = "float8_e4m3fn"
-    QUANTIZE_BF16_LINEAR_W8A8: bool = True
     QUANTIZE_BF16_LINEAR_BLOCK_SIZE: int | None = None
     MOE_REQUANTIZE_BLOCK_SIZE: int | None = None
     MOE_REQUANTIZE_WEIGHT_DTYPE: str = ""
@@ -321,12 +320,6 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Weight dtype for the layers QUANTIZE_BF16_LINEAR_PATTERNS selects.
     "QUANTIZE_BF16_LINEAR_DTYPE":
     lambda: os.getenv("QUANTIZE_BF16_LINEAR_DTYPE", "float8_e4m3fn"),
-    # Whether those layers also quantize their activations (per-token dynamic,
-    # i.e. W8A8). Set to 0 for weight-only fp8, which halves the weight memory
-    # just the same but keeps the matmul in the activation dtype -- slower, and
-    # the fallback if W8A8 costs too much accuracy.
-    "QUANTIZE_BF16_LINEAR_W8A8":
-    env_bool("QUANTIZE_BF16_LINEAR_W8A8", default=True),
     # Scale those layers once per block of this many input features, instead of
     # once per output channel when unset (the default). Smaller blocks track
     # outliers better for a little more scale memory. Must divide the layer's

--- a/tpu_inference/envs.py
+++ b/tpu_inference/envs.py
@@ -310,14 +310,12 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # Specify dtype for quantized linear weights
     "REQUANTIZE_WEIGHT_DTYPE":
     lambda: os.getenv("REQUANTIZE_WEIGHT_DTYPE", "float8_e4m3fn"),
-    # Quantize linear layers the checkpoint left unquantized, at load time.
-    # Comma-separated list of module patterns matched against the vLLM layer
-    # prefix: a bare name matches exactly or as a dotted suffix, and a "re:"
-    # prefix makes the rest a regex that must match the whole prefix. Patterns
-    # therefore cannot contain a comma. Checkpoint-level names are accepted for
-    # layers vLLM fuses (e.g. q_proj/k_proj/v_proj for qkv_proj); every shard of
-    # a fused layer has to be selected or none of it is. Empty (default) leaves
-    # every unquantized linear in its checkpoint dtype.
+    # Comma-separated module patterns selecting linear layers the checkpoint
+    # left unquantized, to quantize at load time. A pattern is an exact layer
+    # name, or a "re:"-prefixed regex anchored at the start of one. Layers vLLM
+    # fuses may be named as the checkpoint names them (q_proj for qkv_proj),
+    # but every shard of a fused layer must be selected or none of it is.
+    # Empty (default) leaves every unquantized linear in its checkpoint dtype.
     "QUANTIZE_BF16_LINEAR_PATTERNS":
     env_str_list("QUANTIZE_BF16_LINEAR_PATTERNS"),
     # Weight dtype for the layers QUANTIZE_BF16_LINEAR_PATTERNS selects.
@@ -329,15 +327,10 @@ environment_variables: dict[str, Callable[[], Any]] = {
     # the fallback if W8A8 costs too much accuracy.
     "QUANTIZE_BF16_LINEAR_W8A8":
     env_bool("QUANTIZE_BF16_LINEAR_W8A8", default=True),
-    # 1-D block size along the input (contracting) axis for those layers, so the
-    # scale becomes one value per [block of input features, output feature]
-    # instead of one per output feature. Smaller blocks track outliers better at
-    # the cost of a fp32 scale every `block_size` weights (128 costs ~3% of the
-    # fp8 weight bytes back). Must divide the layer's input size, and the block
-    # count must divide by the TP degree of a row-parallel layer's input axis.
-    # Unset (default) means per-output-channel. Setting it routes the matmul to
-    # the blockwise gmm kernel, since the XLA matmul can only honour a blockwise
-    # scale by dequantizing the whole weight back to bf16 first.
+    # Scale those layers once per block of this many input features, instead of
+    # once per output channel when unset (the default). Smaller blocks track
+    # outliers better for a little more scale memory. Must divide the layer's
+    # input size and leave a block count the layer's input axis can shard.
     "QUANTIZE_BF16_LINEAR_BLOCK_SIZE":
     lambda: int(block_size)
     if (block_size := os.getenv("QUANTIZE_BF16_LINEAR_BLOCK_SIZE")) else None,

--- a/tpu_inference/layers/common/quantization/fp8.py
+++ b/tpu_inference/layers/common/quantization/fp8.py
@@ -40,11 +40,6 @@ class Fp8LinearMethod:
     This class will be shared in both vLLM and jax path.
     """
 
-    # Whether the matmul also quantizes its activation (per-token dynamic,
-    # i.e. W8A8). Subclasses that quantize an otherwise-bf16 checkpoint at load
-    # time can turn this off to stay weight-only.
-    quantize_activation: bool = True
-
     def __init__(self, linear_config: QuantLinearConfig):
         self.linear_config = linear_config
 
@@ -58,8 +53,7 @@ class Fp8LinearMethod:
             weight_scale_jax,
             self.linear_config.weight_sharding,
             mesh=self.linear_config.mesh,
-            defer_all_reduce=self.linear_config.defer_all_reduce,
-            maybe_quantize_x=self.quantize_activation)
+            defer_all_reduce=self.linear_config.defer_all_reduce)
 
         if bias is not None:
             outs += bias
@@ -82,8 +76,7 @@ class Fp8LinearMethod:
                 weight_scale,
                 self.linear_config.weight_sharding,
                 mesh=mesh,
-                defer_all_reduce=self.linear_config.defer_all_reduce,
-                maybe_quantize_x=self.quantize_activation)
+                defer_all_reduce=self.linear_config.defer_all_reduce)
 
             if bias is not None:
                 out += bias[i]

--- a/tpu_inference/layers/common/quantization/fp8.py
+++ b/tpu_inference/layers/common/quantization/fp8.py
@@ -40,6 +40,11 @@ class Fp8LinearMethod:
     This class will be shared in both vLLM and jax path.
     """
 
+    # Whether the matmul also quantizes its activation (per-token dynamic,
+    # i.e. W8A8). Subclasses that quantize an otherwise-bf16 checkpoint at load
+    # time can turn this off to stay weight-only.
+    quantize_activation: bool = True
+
     def __init__(self, linear_config: QuantLinearConfig):
         self.linear_config = linear_config
 
@@ -53,7 +58,8 @@ class Fp8LinearMethod:
             weight_scale_jax,
             self.linear_config.weight_sharding,
             mesh=self.linear_config.mesh,
-            defer_all_reduce=self.linear_config.defer_all_reduce)
+            defer_all_reduce=self.linear_config.defer_all_reduce,
+            maybe_quantize_x=self.quantize_activation)
 
         if bias is not None:
             outs += bias
@@ -76,7 +82,8 @@ class Fp8LinearMethod:
                 weight_scale,
                 self.linear_config.weight_sharding,
                 mesh=mesh,
-                defer_all_reduce=self.linear_config.defer_all_reduce)
+                defer_all_reduce=self.linear_config.defer_all_reduce,
+                maybe_quantize_x=self.quantize_activation)
 
             if bias is not None:
                 out += bias[i]

--- a/tpu_inference/layers/vllm/quantization/fp8.py
+++ b/tpu_inference/layers/vllm/quantization/fp8.py
@@ -55,8 +55,9 @@ from tpu_inference.layers.vllm.quantization.base import VllmQuantizationMethod
 from tpu_inference.layers.vllm.quantization.configs import (
     VllmQuantConfig, VllmQuantLinearConfig)
 from tpu_inference.layers.vllm.quantization.unquantized import (
-    VllmUnquantizedFusedMoEMethod, VllmUnquantizedLinearMethod,
-    _load_weight_for_layer)
+    VllmQuantizedBf16LinearMethod, VllmUnquantizedFusedMoEMethod,
+    VllmUnquantizedLinearMethod, _load_weight_for_layer,
+    should_quantize_bf16_linear)
 from tpu_inference.logger import init_logger
 
 P = PartitionSpec
@@ -114,6 +115,9 @@ class VllmFp8Config(vllm_fp8.Fp8Config, VllmQuantConfig):
                         ignored_layers=self.ignored_layers,
                         fused_mapping=self.packed_modules_mapping,
                 ):
+                    if should_quantize_bf16_linear(
+                            prefix, self.packed_modules_mapping):
+                        return VllmQuantizedBf16LinearMethod(linear_config)
                     return VllmUnquantizedLinearMethod(linear_config)
                 return VllmFp8LinearMethod(self, linear_config)
             case RoutedExperts():

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import re
 from typing import Any, Callable, Mapping, Optional, Sequence
 
 import jax
@@ -34,6 +33,8 @@ from vllm.model_executor.layers.quantization import \
     register_quantization_config
 from vllm.model_executor.layers.quantization.base_config import (
     QuantizationConfig, QuantizeMethodBase)
+from vllm.model_executor.layers.quantization.utils.config_utils import \
+    is_equal_or_regex_match
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead, UnquantizedEmbeddingMethod, VocabParallelEmbedding)
 
@@ -209,18 +210,14 @@ def _load_weight_for_layer(
 def _prefix_matches(prefix: str, patterns: Sequence[str]) -> bool:
     """Match a layer prefix against one of the QUANTIZE_BF16_LINEAR_PATTERNS.
 
-    A bare pattern matches the whole prefix or a dotted suffix of it, so
-    `o_proj` selects every layer named that. A `re:`-prefixed pattern is a
-    regex that has to match the prefix in full, following the convention
-    compressed-tensors uses for its own ignore lists.
+    Patterns follow the same convention as the `ignore` /
+    `modules_to_not_convert` lists these names are usually copied from: a bare
+    pattern is the whole layer name, and a `re:`-prefixed one is a regex
+    anchored at the start. To select every layer with a given suffix, spell the
+    regex out -- `re:.*\\.o_proj`.
     """
-    for pattern in patterns:
-        if pattern.startswith("re:"):
-            if re.fullmatch(pattern[len("re:"):], prefix):
-                return True
-        elif prefix == pattern or prefix.endswith(f".{pattern}"):
-            return True
-    return False
+    return any(
+        is_equal_or_regex_match(prefix, pattern) for pattern in patterns)
 
 
 def should_quantize_bf16_linear(
@@ -358,6 +355,19 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
         if not _tensor_is_in_cpu(layer.weight):
             # Already processed and sharded.
             return
+        weight, bias = self._load_linear_weights(layer)
+        self._store_linear_weights(
+            layer, self._build_linear_weights(layer, weight, bias))
+
+    def _load_linear_weights(
+            self,
+            layer: torch.nn.Module) -> tuple[jax.Array, jax.Array | None]:
+        """Move the layer's weight and bias onto the mesh, freeing the host copy.
+
+        How a weight is loaded does not depend on what is done to it afterwards,
+        so subclasses inherit this unchanged and override
+        `_build_linear_weights` instead.
+        """
         # Under Pathways, shard weights directly onto the TPU mesh to avoid
         # placing a full unsharded copy on a single device (OOM).
         loading_sharding = NamedSharding(
@@ -379,6 +389,15 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
             delattr(layer, 'bias')
         else:
             bias = None
+        return weight, bias
+
+    def _build_linear_weights(self, layer: torch.nn.Module, weight: jax.Array,
+                              bias: jax.Array | None) -> LinearWeights:
+        """Put the loaded weight into the layout its matmul expects.
+
+        The one step that differs between an unquantized layer and one quantized
+        at load time; loading, sharding and assignment are common to both.
+        """
 
         @jax.jit
         def process_unquantized_linear_weights(
@@ -397,7 +416,17 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
                 reorder_size=self.linear_config.n_shards,
             )
 
-        weights = process_unquantized_linear_weights(weight, bias)
+        return process_unquantized_linear_weights(weight, bias)
+
+    def _store_linear_weights(self, layer: torch.nn.Module,
+                              weights: LinearWeights) -> None:
+        """Shard the processed weights and hang them off the layer.
+
+        A scale is stored only when `_build_linear_weights` produced one, which
+        is what lets the quantized and unquantized paths share this step --
+        `shard_linear_weights` and `process_linear_weights` both leave a `None`
+        field alone.
+        """
         weights = torch_view(
             shard_linear_weights(
                 weights,
@@ -407,11 +436,16 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
             ))
         if self.linear_config.fuse_matmuls:
             layer.weight = Parameter(weights.weight, requires_grad=False)
-            if bias is not None:
+            if weights.weight_scale is not None:
+                layer.weight_scale = Parameter(weights.weight_scale,
+                                               requires_grad=False)
+            if weights.bias is not None:
                 layer.bias = Parameter(weights.bias, requires_grad=False)
         else:
             layer.weight = to_parameter_list(weights.weight)
-            if bias is not None:
+            if weights.weight_scale is not None:
+                layer.weight_scale = to_parameter_list(weights.weight_scale)
+            if weights.bias is not None:
                 layer.bias = to_parameter_list(weights.bias)
 
     def apply(self,
@@ -455,9 +489,10 @@ class VllmQuantizedBf16LinearMethod(common_fp8.Fp8LinearMethod,
 
     Selected by QUANTIZE_BF16_LINEAR_PATTERNS. The weight arrives in the
     checkpoint dtype and is loaded exactly as the unquantized path loads it, so
-    everything about weight loading and sharding is inherited; the only
-    difference is that it is quantized on its way to the device, and the matmul
-    then comes from the fp8 path rather than the unquantized one.
+    everything about weight loading and sharding is inherited -- the one step
+    that differs is `_build_linear_weights`, which quantizes the weight on its
+    way to the device. The matmul then comes from the fp8 path rather than the
+    unquantized one.
 
     The scale is per output channel by default: a single value per column of the
     [in, out] weight, which stays valid under both column-parallel sharding (the
@@ -512,30 +547,9 @@ class VllmQuantizedBf16LinearMethod(common_fp8.Fp8LinearMethod,
                 f"Use a block size that leaves a multiple of {in_shards} "
                 f"blocks.")
 
-    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
-        if not _tensor_is_in_cpu(layer.weight):
-            # Already processed and sharded.
-            return
-        loading_sharding = NamedSharding(
-            self.linear_config.mesh,
-            PartitionSpec(*self.linear_config.weight_sharding[::-1]))
-        weight = _load_weight_for_layer(layer, "weight", loading_sharding)
-        weight = jnp.transpose(weight)
+    def _build_linear_weights(self, layer: torch.nn.Module, weight: jax.Array,
+                              bias: jax.Array | None) -> LinearWeights:
         self._check_block_size(layer, weight.shape[0])
-
-        # Free CPU memory immediately
-        layer.weight.untyped_storage().resize_(0)
-        delattr(layer, 'weight')
-        if layer.bias is not None and not layer.skip_bias_add:
-            if layer.return_bias:
-                logger.warning_once("Bias might return incorrect value.")
-            bias_sharding = NamedSharding(self.linear_config.mesh,
-                                          self.linear_config.bias_sharding)
-            bias = _load_weight_for_layer(layer, "bias", bias_sharding)
-            layer.bias.untyped_storage().resize_(0)
-            delattr(layer, 'bias')
-        else:
-            bias = None
 
         @jax.jit
         def quantize_linear_weights(
@@ -564,25 +578,7 @@ class VllmQuantizedBf16LinearMethod(common_fp8.Fp8LinearMethod,
                 enable_kernel=self.block_size is not None,
             )
 
-        weights = quantize_linear_weights(weight, bias)
-        weights = torch_view(
-            shard_linear_weights(
-                weights,
-                mesh=self.linear_config.mesh,
-                weight_p_spec=self.linear_config.weight_sharding,
-                bias_p_spec=self.linear_config.bias_sharding,
-            ))
-        if self.linear_config.fuse_matmuls:
-            layer.weight = Parameter(weights.weight, requires_grad=False)
-            layer.weight_scale = Parameter(weights.weight_scale,
-                                           requires_grad=False)
-            if bias is not None:
-                layer.bias = Parameter(weights.bias, requires_grad=False)
-        else:
-            layer.weight = to_parameter_list(weights.weight)
-            layer.weight_scale = to_parameter_list(weights.weight_scale)
-            if bias is not None:
-                layer.bias = to_parameter_list(weights.bias)
+        return quantize_linear_weights(weight, bias)
 
     def apply(self,
               layer: torch.nn.Module,

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -511,13 +511,11 @@ class VllmQuantizedBf16LinearMethod(common_fp8.Fp8LinearMethod,
     def __init__(self, linear_config: VllmQuantLinearConfig):
         VllmUnquantizedLinearMethod.__init__(self, linear_config)
         self.weight_dtype = to_jax_dtype(envs.QUANTIZE_BF16_LINEAR_DTYPE)
-        self.quantize_activation = envs.QUANTIZE_BF16_LINEAR_W8A8
         self.block_size = envs.QUANTIZE_BF16_LINEAR_BLOCK_SIZE
         logger.info_once(
-            "Quantizing unquantized linear layers matching %s to %s (%s, %s).",
+            "Quantizing unquantized linear layers matching %s to %s (%s).",
             ", ".join(envs.QUANTIZE_BF16_LINEAR_PATTERNS),
             envs.QUANTIZE_BF16_LINEAR_DTYPE,
-            "W8A8" if self.quantize_activation else "weight-only",
             f"blocks of {self.block_size} input features"
             if self.block_size else "per output channel")
 

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -12,7 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Any, Callable, Optional
+import re
+from typing import Any, Callable, Mapping, Optional, Sequence
 
 import jax
 import jax.numpy as jnp
@@ -36,6 +37,7 @@ from vllm.model_executor.layers.quantization.base_config import (
 from vllm.model_executor.layers.vocab_parallel_embedding import (
     ParallelLMHead, UnquantizedEmbeddingMethod, VocabParallelEmbedding)
 
+from tpu_inference import envs
 from tpu_inference.layers.common.moe import \
     FusedMoEMethodBase as TpuFusedMoEMethodBase
 from tpu_inference.layers.common.process_weights.linear_weights import (
@@ -44,6 +46,8 @@ from tpu_inference.layers.common.process_weights.linear_weights import (
 from tpu_inference.layers.common.process_weights.moe_weights import (
     FusedMoEWeights, process_unquantized_moe_weights, shard_moe_weights)
 from tpu_inference.layers.common.quant_methods import UNQUANTIZED
+from tpu_inference.layers.common.quantization import fp8 as common_fp8
+from tpu_inference.layers.common.quantization import quantize_tensor
 from tpu_inference.layers.common.quantization import \
     unquantized as common_unquantized
 from tpu_inference.layers.common.sharding import ShardingAxisName
@@ -58,7 +62,8 @@ from tpu_inference.layers.vllm.quantization.configs import (
 from tpu_inference.logger import init_logger
 from tpu_inference.models.common.pathways_dummy_loader import (
     create_dummy_weights_on_tpu, is_pathways_dummy_load)
-from tpu_inference.utils import _NUMPY_UNSUPPORTED_DTYPES, to_jax_dtype
+from tpu_inference.utils import (_NUMPY_UNSUPPORTED_DTYPES,
+                                 get_mesh_shape_product, to_jax_dtype)
 
 P = PartitionSpec
 
@@ -201,6 +206,55 @@ def _load_weight_for_layer(
     return jax.device_put(np_tensor, sharding).astype(dtype)
 
 
+def _prefix_matches(prefix: str, patterns: Sequence[str]) -> bool:
+    """Match a layer prefix against one of the QUANTIZE_BF16_LINEAR_PATTERNS.
+
+    A bare pattern matches the whole prefix or a dotted suffix of it, so
+    `o_proj` selects every layer named that. A `re:`-prefixed pattern is a
+    regex that has to match the prefix in full, following the convention
+    compressed-tensors uses for its own ignore lists.
+    """
+    for pattern in patterns:
+        if pattern.startswith("re:"):
+            if re.fullmatch(pattern[len("re:"):], prefix):
+                return True
+        elif prefix == pattern or prefix.endswith(f".{pattern}"):
+            return True
+    return False
+
+
+def should_quantize_bf16_linear(
+        prefix: str, fused_mapping: Mapping[str, list[str]]) -> bool:
+    """Whether this unquantized linear layer is one we quantize at load time.
+
+    Patterns may name the layers the way the checkpoint does, which for the
+    layers vLLM fuses is not the way the module is named -- `qkv_proj` holds
+    q/k/v and `in_proj_qkvz` holds `in_proj_qkv` and `in_proj_z`. A fused module
+    is quantized only when every shard it covers is selected, since one weight
+    cannot be half fp8.
+    """
+    patterns = envs.QUANTIZE_BF16_LINEAR_PATTERNS
+    if not patterns:
+        return False
+    if _prefix_matches(prefix, patterns):
+        return True
+
+    proj_name = prefix.split(".")[-1]
+    if proj_name not in fused_mapping:
+        return False
+
+    matched = [
+        _prefix_matches(prefix.replace(proj_name, shard), patterns)
+        for shard in fused_mapping[proj_name]
+    ]
+    if any(matched) and not all(matched):
+        raise ValueError(
+            f"QUANTIZE_BF16_LINEAR_PATTERNS selects some but not all shards of "
+            f"{prefix} ({fused_mapping[proj_name]}); it is a single fused "
+            f"weight, so it has to be selected as a whole or not at all.")
+    return all(matched)
+
+
 @register_quantization_config(UNQUANTIZED)
 class VllmUnquantizedConfig(QuantizationConfig, VllmQuantConfig):
 
@@ -229,6 +283,9 @@ class VllmUnquantizedConfig(QuantizationConfig, VllmQuantConfig):
         match layer:
             case vllm_linear.LinearBase():
                 linear_config = self.get_linear_config(layer)
+                if should_quantize_bf16_linear(prefix,
+                                               self.packed_modules_mapping):
+                    return VllmQuantizedBf16LinearMethod(linear_config)
                 return VllmUnquantizedLinearMethod(linear_config)
             case RoutedExperts():
                 moe_config = self.get_moe_config(layer)
@@ -384,6 +441,183 @@ class VllmUnquantizedLinearMethod(vllm_linear.UnquantizedLinearMethod,
                     bias_jax = [jax_view(b) for b in layer.bias]
                 out_jax = self._apply_split(x_jax, weight_jax, bias_jax)
                 out: torch.Tensor = torch_view(out_jax)
+
+            if out_sharding := self.linear_config.get_output_sharding(out):
+                out.shard_(NamedSharding(self.linear_config.mesh,
+                                         out_sharding))
+
+        return out
+
+
+class VllmQuantizedBf16LinearMethod(common_fp8.Fp8LinearMethod,
+                                    VllmUnquantizedLinearMethod):
+    """Quantizes a linear weight the checkpoint left unquantized, at load time.
+
+    Selected by QUANTIZE_BF16_LINEAR_PATTERNS. The weight arrives in the
+    checkpoint dtype and is loaded exactly as the unquantized path loads it, so
+    everything about weight loading and sharding is inherited; the only
+    difference is that it is quantized on its way to the device, and the matmul
+    then comes from the fp8 path rather than the unquantized one.
+
+    The scale is per output channel by default: a single value per column of the
+    [in, out] weight, which stays valid under both column-parallel sharding (the
+    scale shards with the output axis) and row-parallel sharding (the scale is
+    identical across contracting shards, so the psum is still a sum of
+    like-scaled partial products). QUANTIZE_BF16_LINEAR_BLOCK_SIZE splits the
+    input axis into blocks instead, giving a [in // block, out] scale; that also
+    survives both shardings, but only the blockwise gmm kernel can consume it
+    directly, so setting it switches the matmul over to that kernel.
+    """
+
+    if "VllmQuantizedBf16LinearMethod" not in vllm_linear.WEIGHT_LOADER_V2_SUPPORTED:
+        vllm_linear.WEIGHT_LOADER_V2_SUPPORTED.append(
+            "VllmQuantizedBf16LinearMethod")
+
+    def __init__(self, linear_config: VllmQuantLinearConfig):
+        VllmUnquantizedLinearMethod.__init__(self, linear_config)
+        self.weight_dtype = to_jax_dtype(envs.QUANTIZE_BF16_LINEAR_DTYPE)
+        self.quantize_activation = envs.QUANTIZE_BF16_LINEAR_W8A8
+        self.block_size = envs.QUANTIZE_BF16_LINEAR_BLOCK_SIZE
+        logger.info_once(
+            "Quantizing unquantized linear layers matching %s to %s (%s, %s).",
+            ", ".join(envs.QUANTIZE_BF16_LINEAR_PATTERNS),
+            envs.QUANTIZE_BF16_LINEAR_DTYPE,
+            "W8A8" if self.quantize_activation else "weight-only",
+            f"blocks of {self.block_size} input features"
+            if self.block_size else "per output channel")
+
+    def _check_block_size(self, layer: torch.nn.Module,
+                          in_features: int) -> None:
+        """Reject block sizes this layer's shape or sharding cannot support.
+
+        Both failures would otherwise surface far from their cause -- as a
+        reshape error inside the jit, or as an indivisible-sharding error when
+        the scale is placed -- so name the env var while we still can.
+        """
+        if self.block_size is None:
+            return
+        name = type(layer).__name__
+        if in_features % self.block_size:
+            raise ValueError(
+                f"QUANTIZE_BF16_LINEAR_BLOCK_SIZE={self.block_size} does not "
+                f"divide the {in_features} input features of {name}.")
+        n_blocks = in_features // self.block_size
+        in_shards = get_mesh_shape_product(
+            self.linear_config.mesh, self.linear_config.weight_sharding[0])
+        if n_blocks > 1 and n_blocks % in_shards:
+            raise ValueError(
+                f"QUANTIZE_BF16_LINEAR_BLOCK_SIZE={self.block_size} splits the "
+                f"{in_features} input features of {name} into {n_blocks} "
+                f"blocks, which its input axis cannot shard {in_shards} ways. "
+                f"Use a block size that leaves a multiple of {in_shards} "
+                f"blocks.")
+
+    def process_weights_after_loading(self, layer: torch.nn.Module) -> None:
+        if not _tensor_is_in_cpu(layer.weight):
+            # Already processed and sharded.
+            return
+        loading_sharding = NamedSharding(
+            self.linear_config.mesh,
+            PartitionSpec(*self.linear_config.weight_sharding[::-1]))
+        weight = _load_weight_for_layer(layer, "weight", loading_sharding)
+        weight = jnp.transpose(weight)
+        self._check_block_size(layer, weight.shape[0])
+
+        # Free CPU memory immediately
+        layer.weight.untyped_storage().resize_(0)
+        delattr(layer, 'weight')
+        if layer.bias is not None and not layer.skip_bias_add:
+            if layer.return_bias:
+                logger.warning_once("Bias might return incorrect value.")
+            bias_sharding = NamedSharding(self.linear_config.mesh,
+                                          self.linear_config.bias_sharding)
+            bias = _load_weight_for_layer(layer, "bias", bias_sharding)
+            layer.bias.untyped_storage().resize_(0)
+            delattr(layer, 'bias')
+        else:
+            bias = None
+
+        @jax.jit
+        def quantize_linear_weights(
+            weight: jax.Array,
+            bias: jax.Array | None,
+        ) -> LinearWeights:
+            # axis=0 is the input features: with no block size that leaves one
+            # scale per output feature, and with one it leaves a scale per
+            # [block of input features, output feature].
+            weight, weight_scale = quantize_tensor(self.weight_dtype,
+                                                   weight,
+                                                   axis=0,
+                                                   block_size=self.block_size)
+            return process_linear_weights(
+                LinearWeights(
+                    weight=weight,
+                    weight_scale=weight_scale,
+                    zero_point=None,
+                    bias=bias,
+                ),
+                fused=self.linear_config.fuse_matmuls,
+                output_sizes=self.linear_config.output_sizes,
+                reorder_size=self.linear_config.n_shards,
+                # A blockwise scale is only usable by the gmm kernel, which
+                # wants it shaped [1, n_blocks, 1, out].
+                enable_kernel=self.block_size is not None,
+            )
+
+        weights = quantize_linear_weights(weight, bias)
+        weights = torch_view(
+            shard_linear_weights(
+                weights,
+                mesh=self.linear_config.mesh,
+                weight_p_spec=self.linear_config.weight_sharding,
+                bias_p_spec=self.linear_config.bias_sharding,
+            ))
+        if self.linear_config.fuse_matmuls:
+            layer.weight = Parameter(weights.weight, requires_grad=False)
+            layer.weight_scale = Parameter(weights.weight_scale,
+                                           requires_grad=False)
+            if bias is not None:
+                layer.bias = Parameter(weights.bias, requires_grad=False)
+        else:
+            layer.weight = to_parameter_list(weights.weight)
+            layer.weight_scale = to_parameter_list(weights.weight_scale)
+            if bias is not None:
+                layer.bias = to_parameter_list(weights.bias)
+
+    def apply(self,
+              layer: torch.nn.Module,
+              x: torch.Tensor,
+              bias: Optional[torch.Tensor] = None) -> torch.Tensor:
+        assert isinstance(layer, vllm_linear.LinearBase)
+
+        with jax.named_scope(layer._get_name()):
+            if in_sharding := self.linear_config.get_input_sharding(x):
+                x.shard_(NamedSharding(self.linear_config.mesh, in_sharding))
+
+            x_jax = jax_view(x)
+            bias_jax = jax_view(
+                bias) if bias is not None and not layer.skip_bias_add else None
+            if self.linear_config.fuse_matmuls:
+                out_jax = self._apply_fused(x_jax, jax_view(layer.weight),
+                                            jax_view(layer.weight_scale),
+                                            bias_jax)
+            else:
+                assert isinstance(layer.weight, torch.nn.ParameterList)
+                assert isinstance(layer.weight_scale, torch.nn.ParameterList)
+                # jax_view cannot handle ParameterList directly, so explicitly
+                # convert to list.
+                weight_and_scale = [
+                    (jax_view(w), jax_view(s))
+                    for w, s in zip(layer.weight, layer.weight_scale)
+                ]
+                if bias_jax is not None:
+                    assert isinstance(layer.bias, torch.nn.ParameterList)
+                    bias_jax = [jax_view(b) for b in layer.bias]
+                out_jax = self._apply_split(x_jax,
+                                            weight_and_scale,
+                                            bias_jax,
+                                            mesh=self.linear_config.mesh)
+            out: torch.Tensor = torch_view(out_jax)
 
             if out_sharding := self.linear_config.get_output_sharding(out):
                 out.shard_(NamedSharding(self.linear_config.mesh,

--- a/tpu_inference/layers/vllm/quantization/unquantized.py
+++ b/tpu_inference/layers/vllm/quantization/unquantized.py
@@ -521,14 +521,20 @@ class VllmQuantizedBf16LinearMethod(common_fp8.Fp8LinearMethod,
 
     def _check_block_size(self, layer: torch.nn.Module,
                           in_features: int) -> None:
-        """Reject block sizes this layer's shape or sharding cannot support.
+        """Reject block sizes this layer cannot use.
 
-        Both failures would otherwise surface far from their cause -- as a
-        reshape error inside the jit, or as an indivisible-sharding error when
-        the scale is placed -- so name the env var while we still can.
+        Non-positive, or a size this layer's shape or sharding cannot support.
+        All three would otherwise surface far from their cause -- a modulo by
+        zero, a reshape error inside the jit, or an indivisible-sharding error
+        when the scale is placed -- so name the env var while we still can.
         """
         if self.block_size is None:
             return
+        if self.block_size <= 0:
+            raise ValueError(
+                f"QUANTIZE_BF16_LINEAR_BLOCK_SIZE={self.block_size} is not a "
+                f"positive number of input features. Unset it to scale per "
+                f"output channel.")
         name = type(layer).__name__
         if in_features % self.block_size:
             raise ValueError(
@@ -572,7 +578,9 @@ class VllmQuantizedBf16LinearMethod(common_fp8.Fp8LinearMethod,
                 output_sizes=self.linear_config.output_sizes,
                 reorder_size=self.linear_config.n_shards,
                 # A blockwise scale is only usable by the gmm kernel, which
-                # wants it shaped [1, n_blocks, 1, out].
+                # wants it shaped [1, n_blocks, 1, out]. VllmFp8LinearMethod
+                # requires that same pairing of its kernel and block-size
+                # flags, so derive it here instead of taking a second flag.
                 enable_kernel=self.block_size is not None,
             )
 


### PR DESCRIPTION
# Description

Qwen3.8-2.4T-A95B-FP8 quantizes only its 512 routed experts and lists
978 modules in `modules_to_not_convert`, so every attention and gated-delta-net
projection arrives bf16 and costs 4.27 GiB/chip.

Add `BF16_LINEAR_REQUANTIZE_PATTERNS`, which selects those layers by name and
quantizes their weights to fp8 on the way to the device, giving back 2.13
GiB/chip. We are doing this for NPI (Sunfish), which has way fewer bf16 flops than fp8 flops.

Selected layers get `VllmQuantizedBf16LinearMethod`, which inherits weight
loading and sharding from the unquantized path unchanged and only swaps in the
fp8 apply. Scales are per output channel by default, which stays valid under
both column-parallel and row-parallel sharding;
`BF16_LINEAR_REQUANTIZE_BLOCK_SIZE` switches to 1-D blocks along the input
axis. Both default off, so nothing changes unless the patterns are set.

The names follow the `<SCOPE>_REQUANTIZE_<KNOB>` convention the rest of
`envs.py` uses. The scope is `BF16_LINEAR` rather than plain `LINEAR` because
the bare `REQUANTIZE_WEIGHT_DTYPE` / `REQUANTIZE_BLOCK_SIZE` are already the
linear knobs for checkpoints that arrived quantized, and a `LINEAR_` pair
beside them would differ only by a prefix that does not say which case it
means.

Along the way, `process_weights_after_loading` is split into
`_load_linear_weights` / `_build_linear_weights` / `_store_linear_weights` on
`VllmUnquantizedLinearMethod`. This is a purely mechanical refactor to avoid code duplication for `VllmQuantizedBf16LinearMethod`

# Tests

`tests/layers/vllm/test_unquantized.py` covers pattern matching (exact, `re:`,
fused-shard expansion, the all-or-nothing guard), numerics against the bf16
matmul for merged-column-parallel and row-parallel layers across 1 and 8
devices with and without a block size, the block-size validation errors, and
that unselected layers still take the unquantized path and store no scale.

```
pytest tests/layers/vllm/test_unquantized.py tests/layers/vllm/test_fp8.py
```
382 passed, 100 skipped on v7x-8.

Also Tested E2E with Qwen3.8-2.4T-A95B-FP8 on v7x-32 with
```
'BF16_LINEAR_REQUANTIZE_PATTERNS=re:.*self_attn\..*,re:.*linear_attn.(in_proj_qkv|in_proj_z|in_proj_b|in_proj_a|out_proj)$$' \
'BF16_LINEAR_REQUANTIZE_BLOCK_SIZE=512' \
```
Verified quality with GPQA.


# Checklist

Before submitting this PR, please make sure:
- [x] I have performed a self-review of my code.
- [x] I have necessary comments in my code, particularly in hard-to-understand areas.
- [x] I have made or will make corresponding changes to any relevant documentation.
